### PR TITLE
Add pkgconf and cmake to macOS installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ sudo apt install qt6-base-dev qt6-multimedia-dev cmake ninja-build pkg-config
 sudo dnf install qt6-qtbase-devel qt6-qtmultimedia-devel cmake ninja-build
 
 # macOS (Homebrew)
-brew install qt@6 ninja portaudio
+brew install qt@6 ninja portaudio pkgconf cmake
 ```
 
 ### Build & Run


### PR DESCRIPTION
To be able to build on MacOS, pkgconf and cmake are also required.

Tested successfully on MacOS Tahoe M-Series.

73 de HB9HJQ