### PR TITLE
4-channel CAT + multi-slice overlay support

### DIFF
--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -273,6 +273,13 @@ QString RigctlProtocol::cmdSetPtt(const QString& arg)
 
     bool tx = (ptt != 0);
     QMetaObject::invokeMethod(m_model, [this, tx]() {
+        // When keying TX, move the TX badge to this protocol's bound slice
+        // so the correct slice is used for transmission.
+        if (tx) {
+            auto* slice = currentSlice();
+            if (slice && !slice->isTxSlice())
+                slice->setTxSlice(true);
+        }
         m_model->setTransmit(tx);
     }, Qt::QueuedConnection);
     return rprt(0);

--- a/src/core/RigctlPty.cpp
+++ b/src/core/RigctlPty.cpp
@@ -61,6 +61,7 @@ bool RigctlPty::start()
 
     // Set up protocol handler
     m_protocol = new RigctlProtocol(m_model);
+    m_protocol->setSliceIndex(m_sliceIndex);
 
     // Watch for data on the master FD
     m_notifier = new QSocketNotifier(m_masterFd, QSocketNotifier::Read, this);

--- a/src/core/RigctlPty.h
+++ b/src/core/RigctlPty.h
@@ -27,6 +27,13 @@ public:
     QString slavePath() const { return m_slavePath; }
     QString symlinkPath() const { return m_symlinkPath; }
 
+    // Which slice index this PTY's protocol will control.
+    void setSliceIndex(int idx) { m_sliceIndex = idx; }
+    int  sliceIndex() const     { return m_sliceIndex; }
+
+    // Override the default symlink path (e.g. /tmp/AetherSDR-CAT-B).
+    void setSymlinkPath(const QString& path) { m_symlinkPath = path; }
+
 signals:
     void started(const QString& path);
     void stopped();
@@ -37,6 +44,7 @@ private slots:
 private:
     RadioModel*      m_model;
     RigctlProtocol*  m_protocol{nullptr};
+    int              m_sliceIndex{0};
     int              m_masterFd{-1};
     int              m_slaveFd{-1};
     QString          m_slavePath;

--- a/src/core/RigctlServer.cpp
+++ b/src/core/RigctlServer.cpp
@@ -70,6 +70,7 @@ void RigctlServer::onNewConnection()
         auto* socket = m_server->nextPendingConnection();
         socket->setSocketOption(QAbstractSocket::LowDelayOption, 1);  // TCP_NODELAY
         auto* protocol = new RigctlProtocol(m_model);
+        protocol->setSliceIndex(m_sliceIndex);
 
         ClientState cs;
         cs.socket = socket;

--- a/src/core/RigctlServer.h
+++ b/src/core/RigctlServer.h
@@ -26,6 +26,10 @@ public:
     quint16 port() const;
     int clientCount() const { return m_clients.size(); }
 
+    // Which slice index this server's connections will control.
+    void setSliceIndex(int idx) { m_sliceIndex = idx; }
+    int  sliceIndex() const     { return m_sliceIndex; }
+
 signals:
     void clientCountChanged(int count);
 
@@ -44,6 +48,7 @@ private:
     RadioModel*      m_model;
     QTcpServer*      m_server{nullptr};
     QList<ClientState> m_clients;
+    int              m_sliceIndex{0};
 };
 
 } // namespace AetherSDR

--- a/src/gui/CatApplet.cpp
+++ b/src/gui/CatApplet.cpp
@@ -1,4 +1,5 @@
 #include "CatApplet.h"
+#include "SliceColors.h"
 #include "core/RigctlServer.h"
 #include "core/RigctlPty.h"
 #include "core/AudioEngine.h"
@@ -12,13 +13,10 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QLineEdit>
-#include <QCheckBox>
-#include <QComboBox>
 #include <QProgressBar>
 #include <QApplication>
 #include "core/AppSettings.h"
 #include <QFrame>
-#include <QSlider>
 
 namespace AetherSDR {
 
@@ -43,15 +41,6 @@ static QWidget* appletTitleBar(const QString& text)
                        "font-size: 10px; font-weight: bold; }");
     lbl->setGeometry(6, 1, 240, 14);
     return bar;
-}
-
-static QFrame* separator()
-{
-    auto* line = new QFrame;
-    line->setFrameShape(QFrame::HLine);
-    line->setStyleSheet("color: #203040;");
-    line->setFixedHeight(1);
-    return line;
 }
 
 CatApplet::CatApplet(QWidget* parent) : QWidget(parent)
@@ -87,142 +76,120 @@ void CatApplet::buildUI()
     static constexpr const char* kDimLabel =
         "QLabel { color: #8090a0; font-size: 11px; }";
 
-    static constexpr int kLabelW = 40;
-
     static constexpr const char* kInsetStyle =
-        "QLineEdit { font-size: 11px; background: #0a0a18; border: 1px solid #1e2e3e;"
-        " border-radius: 3px; padding: 1px 4px; color: #c8d8e8; }";
-
-    // ── Slice selector ──────────────────────────────────────────────────────
-    auto* sliceRow = new QHBoxLayout;
-    sliceRow->setSpacing(4);
-    auto* sliceLabel = new QLabel("Slice:");
-    sliceLabel->setStyleSheet(kDimLabel);
-    sliceLabel->setFixedWidth(kLabelW);
-    sliceRow->addWidget(sliceLabel);
-    m_sliceSelect = new QComboBox;
-    // Populated dynamically in setRadioModel()
-    m_sliceSelect->setCurrentIndex(0);
-    AetherSDR::applyComboStyle(m_sliceSelect);
-    sliceRow->addWidget(m_sliceSelect, 1);
-    root->addLayout(sliceRow);
-
-    // ── Virtual Serial Port ──────────────────────────────────────────────────
-    auto* ptyRow1 = new QHBoxLayout;
-    ptyRow1->setSpacing(4);
-    auto* ttyLabel = new QLabel("TTY:");
-    ttyLabel->setStyleSheet(kDimLabel);
-    ttyLabel->setFixedWidth(kLabelW);
-    ptyRow1->addWidget(ttyLabel);
-
-    m_ptyEnable = new QPushButton("Enable");
-    m_ptyEnable->setCheckable(true);
-    m_ptyEnable->setStyleSheet(kGreenToggle);
-    m_ptyEnable->setFixedSize(60, 22);
-    ptyRow1->addWidget(m_ptyEnable);
-
-    auto* pathLabel = new QLabel("Path:");
-    pathLabel->setStyleSheet(kDimLabel);
-    ptyRow1->addWidget(pathLabel);
-    m_ptyPath = new QLineEdit(
-        settings.value("CatTtyPath", "/tmp/AetherSDR-CAT").toString());
-    m_ptyPath->setStyleSheet(
         "QLineEdit { font-size: 10px; background: #0a0a18; border: 1px solid #1e2e3e;"
-        " border-radius: 3px; padding: 0px 2px; color: #c8d8e8; }");
-    ptyRow1->addWidget(m_ptyPath, 1);
+        " border-radius: 3px; padding: 0px 2px; color: #c8d8e8; }";
 
-    connect(m_ptyPath, &QLineEdit::editingFinished, this, [this]() {
-        auto& ss = AppSettings::instance();
-        ss.setValue("CatTtyPath", m_ptyPath->text());
-        ss.save();
-    });
+    // ── Global enable row: [Enable TCP] [Enable TTY] Base port: [____] ───────
+    auto* enableRow = new QHBoxLayout;
+    enableRow->setSpacing(4);
 
-    root->addLayout(ptyRow1);
-
-    connect(m_ptyEnable, &QPushButton::toggled, this, [this](bool on) {
-        if (!m_pty) return;
-        if (on)
-            m_pty->start();
-        else
-            m_pty->stop();
-        updatePtyStatus();
-    });
-
-    // ── rigctld TCP ──────────────────────────────────────────────────────────
-    auto* tcpRow = new QHBoxLayout;
-    tcpRow->setSpacing(4);
-    auto* tcpLabel = new QLabel("rigctld:");
-    tcpLabel->setStyleSheet(kDimLabel);
-    tcpLabel->setFixedWidth(kLabelW);
-    tcpRow->addWidget(tcpLabel);
-
-    m_tcpEnable = new QPushButton("Enable");
+    m_tcpEnable = new QPushButton("Enable TCP");
     m_tcpEnable->setCheckable(true);
     m_tcpEnable->setStyleSheet(kGreenToggle);
-    m_tcpEnable->setFixedSize(60, 22);
-    tcpRow->addWidget(m_tcpEnable);
+    m_tcpEnable->setFixedSize(76, 22);
+    enableRow->addWidget(m_tcpEnable);
 
-    auto* portLabel = new QLabel("Port:");
+    m_ptyEnable = new QPushButton("Enable TTY");
+    m_ptyEnable->setCheckable(true);
+    m_ptyEnable->setStyleSheet(kGreenToggle);
+    m_ptyEnable->setFixedSize(76, 22);
+    enableRow->addWidget(m_ptyEnable);
+
+    enableRow->addStretch();
+
+    auto* portLabel = new QLabel("Base:");
     portLabel->setStyleSheet(kDimLabel);
-    tcpRow->addWidget(portLabel);
+    enableRow->addWidget(portLabel);
 
-    // Port + status in a single inset container (matches TTY path inset)
-    auto* portContainer = new QWidget;
-    portContainer->setStyleSheet(
-        "QWidget#portInset { background: #0a0a18; border: 1px solid #1e2e3e;"
-        " border-radius: 3px; }");
-    portContainer->setObjectName("portInset");
-    auto* portLayout = new QHBoxLayout(portContainer);
-    portLayout->setContentsMargins(2, 0, 4, 0);
-    portLayout->setSpacing(0);
+    m_basePort = new QLineEdit(settings.value("CatTcpPort", "4532").toString());
+    m_basePort->setStyleSheet(kInsetStyle);
+    m_basePort->setFixedWidth(40);
+    m_basePort->setAlignment(Qt::AlignCenter);
+    enableRow->addWidget(m_basePort);
 
-    m_tcpPort = new QLineEdit(settings.value("CatTcpPort", "4532").toString());
-    m_tcpPort->setFixedWidth(36);
-    m_tcpPort->setAlignment(Qt::AlignCenter);
-    m_tcpPort->setStyleSheet(
-        "QLineEdit { font-size: 10px; background: transparent; border: none;"
-        " padding: 0px; color: #c8d8e8; }");
-    portLayout->addWidget(m_tcpPort);
+    root->addLayout(enableRow);
 
-    portLayout->addStretch();
-    m_tcpStatus = new QLabel("(stopped)");
-    m_tcpStatus->setStyleSheet("QLabel { font-size: 10px; color: #506070; }");
-    m_tcpStatus->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    portLayout->addWidget(m_tcpStatus);
-
-    tcpRow->addWidget(portContainer, 1);
-    root->addLayout(tcpRow);
-
-    connect(m_tcpEnable, &QPushButton::toggled, this, [this](bool on) {
-        if (!m_server) return;
-        if (on) {
-            int port = m_tcpPort->text().toInt();
-            if (port < 1024 || port > 65535) port = 4532;
-            auto& ss = AppSettings::instance();
-            ss.setValue("CatTcpPort", QString::number(port));
-            ss.save();
-            m_server->start(static_cast<quint16>(port));
-        } else {
-            m_server->stop();
-        }
-        updateTcpStatus();
-    });
-
-    connect(m_tcpPort, &QLineEdit::editingFinished, this, [this]() {
-        int port = m_tcpPort->text().toInt();
+    connect(m_basePort, &QLineEdit::editingFinished, this, [this]() {
+        int port = m_basePort->text().toInt();
         if (port < 1024 || port > 65535) {
             port = 4532;
-            m_tcpPort->setText("4532");
+            m_basePort->setText("4532");
         }
         auto& ss = AppSettings::instance();
         ss.setValue("CatTcpPort", QString::number(port));
         ss.save();
-        if (m_server && m_server->isRunning()) {
-            m_server->stop();
-            m_server->start(static_cast<quint16>(port));
-            updateTcpStatus();
+        // If running, restart all servers with new base port
+        if (m_tcpEnable->isChecked()) {
+            for (int i = 0; i < kChannels; ++i) {
+                if (m_servers[i]) {
+                    m_servers[i]->stop();
+                    m_servers[i]->start(static_cast<quint16>(port + i));
+                }
+            }
+            updateAllChannelStatus();
         }
     });
+
+    // ── TCP toggle: start/stop all 4 servers ─────────────────────────────────
+    connect(m_tcpEnable, &QPushButton::toggled, this, [this](bool on) {
+        int basePort = m_basePort->text().toInt();
+        if (basePort < 1024 || basePort > 65535) basePort = 4532;
+        auto& ss = AppSettings::instance();
+        ss.setValue("CatTcpPort", QString::number(basePort));
+        ss.save();
+        for (int i = 0; i < kChannels; ++i) {
+            if (!m_servers[i]) continue;
+            if (on)
+                m_servers[i]->start(static_cast<quint16>(basePort + i));
+            else
+                m_servers[i]->stop();
+        }
+        updateAllChannelStatus();
+    });
+
+    // ── PTY toggle: start/stop all 4 PTYs ───────────────────────────────────
+    connect(m_ptyEnable, &QPushButton::toggled, this, [this](bool on) {
+        for (int i = 0; i < kChannels; ++i) {
+            if (!m_ptys[i]) continue;
+            if (on)
+                m_ptys[i]->start();
+            else
+                m_ptys[i]->stop();
+        }
+        updateAllChannelStatus();
+    });
+
+    // ── Per-channel status rows ──────────────────────────────────────────────
+    static const char kLetters[] = "ABCD";
+
+    for (int i = 0; i < kChannels; ++i) {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(4);
+
+        // Coloured badge
+        m_rows[i].badge = new QLabel(QString(kLetters[i]));
+        m_rows[i].badge->setFixedWidth(16);
+        m_rows[i].badge->setAlignment(Qt::AlignCenter);
+        m_rows[i].badge->setStyleSheet(
+            QStringLiteral("QLabel { color: %1; font-size: 11px; font-weight: bold; }")
+                .arg(kSliceColors[i].hexActive));
+        row->addWidget(m_rows[i].badge);
+
+        // TCP status
+        m_rows[i].tcpStatus = new QLabel("(stopped)");
+        m_rows[i].tcpStatus->setStyleSheet("QLabel { color: #506070; font-size: 10px; }");
+        m_rows[i].tcpStatus->setFixedWidth(100);
+        row->addWidget(m_rows[i].tcpStatus);
+
+        // PTY path
+        m_rows[i].ptyPath = new QLabel(
+            QStringLiteral("/tmp/AetherSDR-CAT-%1").arg(kLetters[i]));
+        m_rows[i].ptyPath->setStyleSheet("QLabel { color: #506070; font-size: 10px; }");
+        row->addWidget(m_rows[i].ptyPath, 1);
+
+        root->addLayout(row);
+    }
 
     // ── DAX Section ─────────────────────────────────────────────────────────
     outer->addWidget(appletTitleBar("DAX Audio Channels"));
@@ -257,7 +224,7 @@ void CatApplet::buildUI()
         chLabel->setFixedWidth(40);
         row->addWidget(chLabel);
 
-        m_daxRxStatus[i] = new QLabel("—");
+        m_daxRxStatus[i] = new QLabel(QStringLiteral("\u2014"));
         m_daxRxStatus[i]->setStyleSheet(kStatusLabel);
         m_daxRxStatus[i]->setFixedWidth(40);
         row->addWidget(m_daxRxStatus[i]);
@@ -281,7 +248,7 @@ void CatApplet::buildUI()
     txLabel->setFixedWidth(40);
     txRow->addWidget(txLabel);
 
-    m_daxTxStatus = new QLabel("—");
+    m_daxTxStatus = new QLabel(QStringLiteral("\u2014"));
     m_daxTxStatus->setStyleSheet(kStatusLabel);
     m_daxTxStatus->setFixedWidth(40);
     txRow->addWidget(m_daxTxStatus);
@@ -301,108 +268,73 @@ void CatApplet::setRadioModel(RadioModel* model)
     m_model = model;
     if (model) {
         connect(model, &RadioModel::connectionStateChanged,
-                this, &CatApplet::onConnectionStateChanged);
-        connect(model, &RadioModel::infoChanged,
-                this, [this]() {
-            // Rebuild slice list from radio's max slices
-            int maxSlices = m_model->maxSlices();
-            m_sliceSelect->clear();
-            static const char letters[] = "ABCDEFGH";
-            for (int i = 0; i < maxSlices && i < 8; ++i)
-                m_sliceSelect->addItem(QString("Slice %1").arg(letters[i]));
-        });
+                this, [this](bool) { updateAllChannelStatus(); });
 
         // Wire slice add/remove for DAX channel tracking
         connect(model, &RadioModel::sliceAdded, this, [this](SliceModel* s) {
-            wireSliceDax(s);
-        });
-        connect(model, &RadioModel::sliceRemoved, this, [this](int) {
-            updateDaxSliceAssignments();
+            connect(s, &SliceModel::daxChannelChanged, this, [this]() {
+                // Update DAX status labels
+                for (int i = 0; i < 4; ++i)
+                    m_daxRxStatus[i]->setText(QStringLiteral("\u2014"));
+                if (!m_model) return;
+                static const char letters[] = "ABCDEFGH";
+                for (auto* sl : m_model->slices()) {
+                    int ch = sl->daxChannel();
+                    if (ch >= 1 && ch <= 4) {
+                        m_daxRxStatus[ch - 1]->setText(
+                            QString("Slice %1").arg(letters[sl->sliceId()]));
+                    }
+                }
+            });
         });
 
         // Wire TX state for TX status label
         connect(model->transmitModel(), &TransmitModel::moxChanged, this, [this]() {
-            updateDaxTxStatus();
-        });
-    }
-}
-
-void CatApplet::wireSliceDax(SliceModel* s)
-{
-    connect(s, &SliceModel::daxChannelChanged, this, [this]() {
-        updateDaxSliceAssignments();
-    });
-    updateDaxSliceAssignments();
-}
-
-void CatApplet::updateDaxSliceAssignments()
-{
-    // Clear all
-    for (int i = 0; i < 4; ++i)
-        m_daxRxStatus[i]->setText("—");
-
-    if (!m_model) return;
-
-    static const char letters[] = "ABCDEFGH";
-    for (auto* s : m_model->slices()) {
-        int ch = s->daxChannel();
-        if (ch >= 1 && ch <= 4) {
-            int idx = ch - 1;
-            QString name = QString("Slice %1").arg(letters[s->sliceId()]);
-            m_daxRxStatus[idx]->setText(name);
-        }
-    }
-}
-
-void CatApplet::updateDaxTxStatus()
-{
-    if (!m_model) {
-        m_daxTxStatus->setText("—");
-        return;
-    }
-
-    bool isTx = m_model->transmitModel()->isMox();
-    if (isTx) {
-        // Find the TX slice
-        static const char letters[] = "ABCDEFGH";
-        for (auto* s : m_model->slices()) {
-            if (s->isTxSlice()) {
-                m_daxTxStatus->setText(QString("Slice %1").arg(letters[s->sliceId()]));
-                return;
+            if (!m_model) { m_daxTxStatus->setText(QStringLiteral("\u2014")); return; }
+            bool isTx = m_model->transmitModel()->isMox();
+            if (isTx) {
+                static const char letters[] = "ABCDEFGH";
+                for (auto* s : m_model->slices()) {
+                    if (s->isTxSlice()) {
+                        m_daxTxStatus->setText(QString("Slice %1").arg(letters[s->sliceId()]));
+                        return;
+                    }
+                }
+                m_daxTxStatus->setText("TX");
+            } else {
+                m_daxTxStatus->setText("Ready");
             }
-        }
-        m_daxTxStatus->setText("TX");
-    } else {
-        m_daxTxStatus->setText("Ready");
+        });
     }
 }
 
-void CatApplet::setRigctlServer(RigctlServer* server)
+void CatApplet::setRigctlServers(RigctlServer** servers, int count)
 {
-    m_server = server;
-    if (server) {
-        connect(server, &RigctlServer::clientCountChanged, this, &CatApplet::updateTcpStatus);
-
-        // Auto-start if was enabled
-        if (m_tcpEnable->isChecked()) {
-            server->start(static_cast<quint16>(m_tcpPort->text().toInt()));
-            updateTcpStatus();
+    for (int i = 0; i < kChannels && i < count; ++i) {
+        m_servers[i] = servers[i];
+        if (servers[i]) {
+            connect(servers[i], &RigctlServer::clientCountChanged,
+                    this, [this, i]() { updateChannelStatus(i); });
         }
     }
 }
 
-void CatApplet::setRigctlPty(RigctlPty* pty)
+void CatApplet::setRigctlPtys(RigctlPty** ptys, int count)
 {
-    m_pty = pty;
-    if (pty) {
-        connect(pty, &RigctlPty::started, this, [this](const QString& path) {
-            m_ptyPath->setText(path);
-        });
-        connect(pty, &RigctlPty::stopped, this, [this]() {
-            m_ptyPath->setText("—");
-        });
-
-        // Auto-start handled by MainWindow via Autostart menu items
+    for (int i = 0; i < kChannels && i < count; ++i) {
+        m_ptys[i] = ptys[i];
+        if (ptys[i]) {
+            connect(ptys[i], &RigctlPty::started, this,
+                    [this, i](const QString& path) {
+                        m_rows[i].ptyPath->setText(path);
+                    });
+            connect(ptys[i], &RigctlPty::stopped, this,
+                    [this, i]() {
+                        static const char kLetters[] = "ABCD";
+                        m_rows[i].ptyPath->setText(
+                            QStringLiteral("/tmp/AetherSDR-CAT-%1").arg(kLetters[i]));
+                    });
+        }
     }
 }
 
@@ -411,44 +343,46 @@ void CatApplet::setAudioEngine(AudioEngine* audio)
     m_audio = audio;
 }
 
-void CatApplet::onConnectionStateChanged(bool /*connected*/)
+void CatApplet::updateChannelStatus(int ch)
 {
-    // DAX auto-start deferred — needs PipeWire virtual devices (issue #15)
-}
+    if (ch < 0 || ch >= kChannels) return;
 
-void CatApplet::updateTcpStatus()
-{
-    if (!m_server || !m_server->isRunning()) {
-        m_tcpStatus->setText("(stopped)");
-        return;
-    }
-    int n = m_server->clientCount();
-    m_tcpStatus->setText(QStringLiteral("(%1 client%2)")
-                             .arg(n)
-                             .arg(n == 1 ? "" : "s"));
-}
-
-void CatApplet::updatePtyStatus()
-{
-    if (!m_pty || !m_pty->isRunning()) {
-        m_ptyPath->setText("—");
+    auto* srv = m_servers[ch];
+    if (!srv || !srv->isRunning()) {
+        m_rows[ch].tcpStatus->setText("(stopped)");
+        m_rows[ch].tcpStatus->setStyleSheet("QLabel { color: #506070; font-size: 10px; }");
     } else {
-        m_ptyPath->setText(m_pty->symlinkPath());
+        int n = srv->clientCount();
+        m_rows[ch].tcpStatus->setText(
+            QStringLiteral(":%1 (%2 client%3)")
+                .arg(srv->port())
+                .arg(n)
+                .arg(n == 1 ? "" : "s"));
+        m_rows[ch].tcpStatus->setStyleSheet(
+            n > 0 ? QStringLiteral("QLabel { color: %1; font-size: 10px; }")
+                         .arg(kSliceColors[ch].hexActive)
+                   : "QLabel { color: #8090a0; font-size: 10px; }");
     }
+}
+
+void CatApplet::updateAllChannelStatus()
+{
+    for (int i = 0; i < kChannels; ++i)
+        updateChannelStatus(i);
 }
 
 void CatApplet::setTcpEnabled(bool on)
 {
     QSignalBlocker b(m_tcpEnable);
     m_tcpEnable->setChecked(on);
-    updateTcpStatus();
+    updateAllChannelStatus();
 }
 
 void CatApplet::setPtyEnabled(bool on)
 {
     QSignalBlocker b(m_ptyEnable);
     m_ptyEnable->setChecked(on);
-    updatePtyStatus();
+    updateAllChannelStatus();
 }
 
 } // namespace AetherSDR

--- a/src/gui/CatApplet.h
+++ b/src/gui/CatApplet.h
@@ -17,17 +17,20 @@ class RigctlServer;
 class RigctlPty;
 class AudioEngine;
 
-// CAT Applet — settings panel for rigctld TCP server, virtual serial port,
-// and DAX audio channel management.
+// CAT Applet — 4-channel rigctld TCP + PTY control panel.
+// Each channel (A-D) is bound to a slice index (0-3) and provides
+// an independent rigctld TCP port + PTY symlink.
 class CatApplet : public QWidget {
     Q_OBJECT
 
 public:
+    static constexpr int kChannels = 4;
+
     explicit CatApplet(QWidget* parent = nullptr);
 
     void setRadioModel(RadioModel* model);
-    void setRigctlServer(RigctlServer* server);
-    void setRigctlPty(RigctlPty* pty);
+    void setRigctlServers(RigctlServer** servers, int count);
+    void setRigctlPtys(RigctlPty** ptys, int count);
     void setAudioEngine(AudioEngine* audio);
 
     // Sync Enable button state (called by MainWindow on autostart)
@@ -36,34 +39,31 @@ public:
 
 private:
     void buildUI();
-    void updateTcpStatus();
-    void updatePtyStatus();
-    void onConnectionStateChanged(bool connected);
-    void wireSliceDax(SliceModel* s);
-    void updateDaxSliceAssignments();
-    void updateDaxTxStatus();
+    void updateChannelStatus(int ch);
+    void updateAllChannelStatus();
 
     RadioModel*    m_model{nullptr};
-    RigctlServer*  m_server{nullptr};
-    RigctlPty*     m_pty{nullptr};
+    RigctlServer*  m_servers[kChannels]{};
+    RigctlPty*     m_ptys[kChannels]{};
     AudioEngine*   m_audio{nullptr};
 
-    // TCP section
+    // Global controls
     QPushButton* m_tcpEnable{nullptr};
-    QLineEdit*   m_tcpPort{nullptr};
-    QLabel*      m_tcpStatus{nullptr};
-
-    // PTY section
     QPushButton* m_ptyEnable{nullptr};
-    QLineEdit*   m_ptyPath{nullptr};
+    QLineEdit*   m_basePort{nullptr};
 
-    // Slice selector
-    QComboBox*   m_sliceSelect{nullptr};
+    // Per-channel status labels
+    struct ChannelRow {
+        QLabel* badge{nullptr};      // coloured "A"/"B"/"C"/"D"
+        QLabel* tcpStatus{nullptr};  // ":4532 (1 client)" or "(stopped)"
+        QLabel* ptyPath{nullptr};    // "/tmp/AetherSDR-CAT-A"
+    };
+    ChannelRow m_rows[kChannels];
 
-    // DAX section
+    // DAX section (unchanged from upstream)
     QPushButton*  m_daxEnable{nullptr};
-    QProgressBar* m_daxRxLevel[4]{};
-    QLabel*       m_daxRxStatus[4]{};
+    QProgressBar* m_daxRxLevel[kChannels]{};
+    QLabel*       m_daxRxStatus[kChannels]{};
     QProgressBar* m_daxTxLevel{nullptr};
     QLabel*       m_daxTxStatus{nullptr};
 };

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -384,12 +384,20 @@ MainWindow::MainWindow(QWidget* parent)
     // ── EQ applet: graphic equalizer ─────────────────────────────────────────
     m_appletPanel->eqApplet()->setEqualizerModel(m_radioModel.equalizerModel());
 
-    // ── CAT applet: rigctld + PTY ──────────────────────────────────────────────
+    // ── 4-channel CAT: rigctld + PTY (A-D, each bound to a slice) ────────────
+    static const char kLetters[] = "ABCD";
+    for (int i = 0; i < kCatChannels; ++i) {
+        m_rigctlServers[i] = new RigctlServer(&m_radioModel, this);
+        m_rigctlServers[i]->setSliceIndex(i);
+        m_rigctlPtys[i] = new RigctlPty(&m_radioModel, this);
+        m_rigctlPtys[i]->setSliceIndex(i);
+        m_rigctlPtys[i]->setSymlinkPath(
+            QString("/tmp/AetherSDR-CAT-%1").arg(kLetters[i]));
+    }
     m_appletPanel->catApplet()->setRadioModel(&m_radioModel);
-    m_appletPanel->catApplet()->setRigctlServer(&m_rigctlServer);
-    m_appletPanel->catApplet()->setRigctlPty(&m_rigctlPty);
+    m_appletPanel->catApplet()->setRigctlServers(m_rigctlServers, kCatChannels);
+    m_appletPanel->catApplet()->setRigctlPtys(m_rigctlPtys, kCatChannels);
     m_appletPanel->catApplet()->setAudioEngine(&m_audio);
-    // DAX audio channels deferred — needs PipeWire virtual devices (issue #15)
 
     // ── Status bar telemetry ──────────────────────────────────────────────────
     connect(&m_radioModel, &RadioModel::networkQualityChanged,
@@ -792,27 +800,29 @@ void MainWindow::onConnectionStateChanged(bool connected)
         if (!m_userExpandedPanel)
             m_connPanel->setCollapsed(true);
 
-        // Auto-start rigctld TCP server if enabled
+        // Auto-start 4-channel CAT (rigctld TCP + PTY) if enabled
         auto& as = AppSettings::instance();
         if (as.value("AutoStartRigctld", "False").toString() == "True") {
-            const int port = as.value("CatTcpPort", "4532").toInt();
-            if (!m_rigctlServer.isRunning()) {
-                m_rigctlServer.start(static_cast<quint16>(port));
-                qDebug() << "AutoStart: rigctld started on port" << port;
-                // Sync the CatApplet Enable button
-                if (m_appletPanel && m_appletPanel->catApplet())
-                    m_appletPanel->catApplet()->setTcpEnabled(true);
+            const int basePort = as.value("CatTcpPort", "4532").toInt();
+            for (int i = 0; i < kCatChannels; ++i) {
+                if (m_rigctlServers[i] && !m_rigctlServers[i]->isRunning()) {
+                    m_rigctlServers[i]->start(static_cast<quint16>(basePort + i));
+                    qDebug() << "AutoStart: rigctld channel" << i
+                             << "on port" << (basePort + i);
+                }
             }
+            if (m_appletPanel && m_appletPanel->catApplet())
+                m_appletPanel->catApplet()->setTcpEnabled(true);
         }
-        // Auto-start CAT virtual serial port if enabled
         if (as.value("AutoStartCAT", "False").toString() == "True") {
-            if (!m_rigctlPty.isRunning()) {
-                m_rigctlPty.start();
-                qDebug() << "AutoStart: PTY started";
-                // Sync the CatApplet Enable button
-                if (m_appletPanel && m_appletPanel->catApplet())
-                    m_appletPanel->catApplet()->setPtyEnabled(true);
+            for (int i = 0; i < kCatChannels; ++i) {
+                if (m_rigctlPtys[i] && !m_rigctlPtys[i]->isRunning()) {
+                    m_rigctlPtys[i]->start();
+                    qDebug() << "AutoStart: PTY channel" << i;
+                }
             }
+            if (m_appletPanel && m_appletPanel->catApplet())
+                m_appletPanel->catApplet()->setPtyEnabled(true);
         }
         // Apply saved display settings after panadapter is created
         m_displaySettingsPushed = false;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -56,8 +56,10 @@ private:
     RadioModel        m_radioModel;
     AudioEngine       m_audio;
     BandSettings      m_bandSettings;
-    RigctlServer      m_rigctlServer{&m_radioModel};
-    RigctlPty         m_rigctlPty{&m_radioModel};
+    // 4-channel CAT: each channel (A-D) binds to a slice index (0-3)
+    static constexpr int kCatChannels = 4;
+    RigctlServer*     m_rigctlServers[kCatChannels]{};
+    RigctlPty*        m_rigctlPtys[kCatChannels]{};
     SmartLinkClient   m_smartLink;
     WanConnection     m_wanConnection;
 

--- a/src/gui/SliceColors.h
+++ b/src/gui/SliceColors.h
@@ -1,0 +1,24 @@
+#pragma once
+
+// Shared per-slice colour definitions used by SpectrumWidget, VfoWidget, and
+// RxApplet to ensure all slice markers/badges use identical colours.
+// Index by sliceId % 4.
+
+namespace AetherSDR {
+
+struct SliceColorEntry {
+    int r, g, b;           // active colour (bright)
+    int dr, dg, db;        // inactive / dim colour
+    const char* hexActive; // for CSS stylesheets
+};
+
+inline constexpr SliceColorEntry kSliceColors[] = {
+    {0x00, 0xd4, 0xff,  0x00, 0x60, 0x80, "#00d4ff"},  // A = cyan
+    {0xff, 0x40, 0xff,  0x80, 0x20, 0x80, "#ff40ff"},  // B = magenta
+    {0x40, 0xff, 0x40,  0x20, 0x80, 0x20, "#40ff40"},  // C = green
+    {0xff, 0xff, 0x00,  0x80, 0x80, 0x00, "#ffff00"},  // D = yellow
+};
+
+inline constexpr int kSliceColorCount = 4;
+
+} // namespace AetherSDR


### PR DESCRIPTION
## Summary

- Replace single rigctld server/PTY with **4 independent channels** (A-D), each bound to a slice index (0-3)
- Each channel provides its own **rigctld TCP port** (4532-4535) and **PTY symlink** (`/tmp/AetherSDR-CAT-A` through `-D`)
- **PTT auto TX-switch**: when a channel keys TX, the TX badge automatically moves to that channel's bound slice
- **Multi-slice spectrum overlay**: all active slices displayed simultaneously on the spectrum/waterfall with per-slice coloured markers; click to switch active slice
- **Multi-client stream filtering**: PanadapterStream filters FFT/waterfall by client_handle for Multi-Flex support
- CatApplet UI rewritten with global Enable TCP/TTY toggles and per-channel status rows with coloured slice badges

## Motivation

External programs like WSJT-X (FT8), Varac, fldigi, etc. each need their own independent CAT control channel. With 4 channels, each program connects to its own port/PTY and controls its own slice — PTT on channel B automatically transmits on slice B.

The multi-slice overlay enables seeing all slice markers simultaneously on the spectrum display, which is essential when running multiple digital modes on different slices.

## Changes

### 4-Channel CAT (commit 1)

| File | Change |
|------|--------|
| `RigctlServer.h/.cpp` | Add `setSliceIndex()`, pass to protocol on new connection |
| `RigctlPty.h/.cpp` | Add `setSliceIndex()` + `setSymlinkPath()` for custom symlinks |
| `RigctlProtocol.cpp` | `cmdSetPtt()` moves TX to bound slice before keying |
| `MainWindow.h/.cpp` | Create 4 server + 4 PTY instances; autostart loop |
| `CatApplet.h/.cpp` | 4-channel UI with per-channel status, coloured badges |
| `SliceColors.h` | New: shared per-slice colour definitions |

### Multi-slice overlay (commit 2)

| File | Change |
|------|--------|
| `SpectrumWidget.h/.cpp` | `SliceOverlay` struct replaces single VFO state; multi-marker rendering with per-slice colours; click-to-switch-slice |
| `PanadapterStream.h/.cpp` | `setOwnedStreamIds()` for Multi-Flex stream filtering; full-frame waterfall tile assembly |
| `RadioModel.h/.cpp` | `addSlice()` to create slices on current panadapter |
| `SliceModel.h/.cpp` | `daxChannel` property + `txSlice` tracking |
| `MainWindow.cpp` | `pushSliceOverlay()`, `setActiveSlice()` multi-slice wiring |
| `RxApplet.cpp`, `VfoWidget.cpp` | Shared `ComboStyle` refactor |

## Test plan

- [ ] Build succeeds on Linux and macOS
- [ ] 4 TCP ports open on connect (4532-4535)
- [ ] 4 PTY symlinks created (`/tmp/AetherSDR-CAT-A` through `-D`)
- [ ] `echo "f" | nc localhost 4532` returns slice A frequency
- [ ] `echo "f" | nc localhost 4533` returns slice B frequency
- [ ] Channel B `T 1` → TX badge moves to slice B → transmit
- [ ] CatApplet shows 4 channel rows with port, client count, PTY path
- [ ] Multiple slices visible on spectrum with coloured markers
- [ ] Click inactive slice marker → switches active slice
- [ ] Multi-Flex: other client's FFT/waterfall not shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)