### PR TITLE
Fix low SSB voice output level on PC audio TX

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -331,9 +331,13 @@ void AudioEngine::onTxAudioReady()
         const int16_t* pcm = reinterpret_cast<const int16_t*>(m_txAccumulator.constData());
 
         // Convert int16 stereo → float32 stereo (128 pairs = 256 floats)
+        // Apply +24 dB gain: USB mic input levels are typically -20 to -30 dBFS,
+        // but SmartSDR expects near full-scale float audio on the DAX TX stream.
+        // Without this gain, SSB voice output is barely audible.
+        constexpr float TX_GAIN = 16.0f;
         float floatBuf[TX_SAMPLES_PER_PACKET * 2];
         for (int i = 0; i < TX_SAMPLES_PER_PACKET * 2; ++i)
-            floatBuf[i] = pcm[i] / 32768.0f;
+            floatBuf[i] = std::clamp(pcm[i] / 32768.0f * TX_GAIN, -1.0f, 1.0f);
 
         // Build and send VITA-49 packet
         QByteArray packet = buildVitaTxPacket(floatBuf, TX_SAMPLES_PER_PACKET);


### PR DESCRIPTION
## Summary

- USB microphones output -20 to -30 dBFS, but SmartSDR expects near full-scale float on DAX TX
- SSB voice is barely audible without gain compensation
- Apply +24 dB gain (16x) with clamp during int16 → float32 conversion in TX VITA-49 builder

## Change

One-line change in `src/core/AudioEngine.cpp`:

```cpp
// Before:
floatBuf[i] = pcm[i] / 32768.0f;

// After:
constexpr float TX_GAIN = 16.0f;
floatBuf[i] = std::clamp(pcm[i] / 32768.0f * TX_GAIN, -1.0f, 1.0f);
```

## Test plan

- [x] SSB voice TX at normal level with Zoom H2n USB mic
- [x] No clipping distortion at normal speech levels
- [x] Tested on FLEX-6600 fw v4.1.5 (macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)