### PR TITLE
Fix DAX TX audio routing and add DAX autostart persistence

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -383,6 +383,11 @@ void AudioEngine::onTxAudioReady()
     // DAX TX mode: VirtualAudioBridge is the TX audio source.
     if (m_daxTxMode) return;
 
+    // Don't send mic audio when not transmitting — it accumulates in
+    // the radio's DAX TX buffer and plays back when TX starts, causing
+    // mic bleed into digital modes.
+    if (!m_transmitting) return;
+
     m_txAccumulator.append(data);
 
     // Process complete packets (128 stereo pairs = 512 bytes of int16 PCM)
@@ -513,6 +518,11 @@ void AudioEngine::sendModemTxAudio(const QByteArray& float32pcm)
 void AudioEngine::feedDaxTxAudio(const QByteArray& float32pcm)
 {
     if (m_txStreamId == 0) return;
+
+    // Block DAX audio when mic is actively sending (voice mode TX).
+    // This prevents dual-source jitter on the same VITA-49 stream.
+    // During RX and digital TX, DAX flows freely.
+    if (m_transmitting && !m_daxTxMode) return;
     m_txFloatAccumulator.append(float32pcm);
     constexpr int FLOAT_BYTES_PER_PKT = TX_SAMPLES_PER_PACKET * 2 * sizeof(float);
     while (m_txFloatAccumulator.size() >= FLOAT_BYTES_PER_PKT) {

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -74,6 +74,8 @@ public:
     // DAX TX: VirtualAudioBridge feeds float32 PCM for VITA-49 TX
     void setDaxTxMode(bool on) { m_daxTxMode = on; }
     bool isDaxTxMode() const { return m_daxTxMode; }
+    void setTransmitting(bool tx) { m_transmitting = tx; }
+    void clearTxAccumulators() { m_txAccumulator.clear(); m_txFloatAccumulator.clear(); }
     void feedDaxTxAudio(const QByteArray& float32pcm);
 
     // Plays RADE decoded speech (int16 stereo 24kHz) bypassing m_radeMode block
@@ -142,6 +144,7 @@ private:
     QByteArray    m_txFloatAccumulator;  // accumulate float32 PCM for RADE modem TX
     bool          m_radeMode{false};     // RADE digital voice mode active
     bool          m_daxTxMode{false};    // DAX TX mode: VirtualAudioBridge handles TX
+    bool          m_transmitting{false}; // true when radio is in TX (MOX on)
 
     QAudioDevice m_outputDevice;
     QAudioDevice m_inputDevice;

--- a/src/gui/CatApplet.cpp
+++ b/src/gui/CatApplet.cpp
@@ -208,6 +208,19 @@ void CatApplet::buildUI()
     daxEnRow->addWidget(m_daxEnable);
     outer->addLayout(daxEnRow);
 
+    // DAX enable button → save setting + notify MainWindow
+    {
+        const QSignalBlocker b(m_daxEnable);
+        m_daxEnable->setChecked(
+            settings.value("AutoStartDAX", "False").toString() == "True");
+    }
+    connect(m_daxEnable, &QPushButton::toggled, this, [this](bool on) {
+        auto& ss = AppSettings::instance();
+        ss.setValue("AutoStartDAX", on ? "True" : "False");
+        ss.save();
+        emit daxToggled(on);
+    });
+
     // RX channel meters (DAX 1-4)
     const QString kMeterStyle =
         "QProgressBar { background: #0a0a18; border: 1px solid #1e2e3e;"
@@ -383,6 +396,12 @@ void CatApplet::setPtyEnabled(bool on)
     QSignalBlocker b(m_ptyEnable);
     m_ptyEnable->setChecked(on);
     updateAllChannelStatus();
+}
+
+void CatApplet::setDaxEnabled(bool on)
+{
+    QSignalBlocker b(m_daxEnable);
+    m_daxEnable->setChecked(on);
 }
 
 } // namespace AetherSDR

--- a/src/gui/CatApplet.h
+++ b/src/gui/CatApplet.h
@@ -36,6 +36,10 @@ public:
     // Sync Enable button state (called by MainWindow on autostart)
     void setTcpEnabled(bool on);
     void setPtyEnabled(bool on);
+    void setDaxEnabled(bool on);
+
+signals:
+    void daxToggled(bool on);
 
 private:
     void buildUI();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -244,6 +244,7 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_radioModel.transmitModel(), &TransmitModel::moxChanged,
             this, [this](bool tx) {
         spectrum()->setTransmitting(tx);
+        m_audio.setTransmitting(tx);
         // On RX resume, native tiles will restart and m_hasNativeWaterfall
         // will be set again by the first arriving tile.
 #ifdef HAVE_RADE
@@ -253,13 +254,8 @@ MainWindow::MainWindow(QWidget* parent)
         }
 #endif
 #ifdef Q_OS_MAC
-        if (m_daxBridge) {
+        if (m_daxBridge)
             m_daxBridge->setTransmitting(tx);
-            // On TX→RX transition, re-enable mic for next voice TX.
-            // (m_daxTxMode was set dynamically when DAX TX audio arrived)
-            if (!tx)
-                m_audio.setDaxTxMode(false);
-        }
 #endif
     });
 
@@ -742,6 +738,17 @@ MainWindow::MainWindow(QWidget* parent)
     m_appletPanel->catApplet()->setRigctlPtys(m_rigctlPtys, kCatChannels);
     m_appletPanel->catApplet()->setAudioEngine(&m_audio);
 
+#ifdef Q_OS_MAC
+    // DAX enable button in CatApplet → start/stop DAX bridge
+    connect(m_appletPanel->catApplet(), &CatApplet::daxToggled,
+            this, [this](bool on) {
+        if (on)
+            startDax();
+        else
+            stopDax();
+    });
+#endif
+
     // ── Status bar telemetry ──────────────────────────────────────────────────
     connect(&m_radioModel, &RadioModel::networkQualityChanged,
             this, [this](const QString& quality, int pingMs) {
@@ -1211,10 +1218,17 @@ void MainWindow::onConnectionStateChanged(bool connected)
 #ifdef Q_OS_MAC
         // Delay DAX bridge start until RadioModel's SmartConnect sequence
         // is fully complete (streams created, UDP bound, slices discovered).
+        // Auto-start DAX bridge if enabled in settings.
         // Starting too early causes our mic_selection=PC and dax=1 to be
         // overridden by RadioModel's own setup, and DAX stream IDs won't
         // be registered in PanadapterStream yet.
-        QTimer::singleShot(3000, this, [this]() { startDax(); });
+        if (AppSettings::instance().value("AutoStartDAX", "False").toString() == "True") {
+            QTimer::singleShot(3000, this, [this]() {
+                startDax();
+                if (m_appletPanel && m_appletPanel->catApplet())
+                    m_appletPanel->catApplet()->setDaxEnabled(true);
+            });
+        }
 #endif
     } else {
         m_connStatusLabel->setText("Disconnected");
@@ -1254,6 +1268,26 @@ void MainWindow::onSliceAdded(SliceModel* s)
             m_radioModel.createAudioStream();
         }
     }
+
+#ifdef Q_OS_MAC
+    // Update m_daxTxMode when TX slice or its mode changes.
+    // Digital modes (DIGU/DIGL/RTTY) use DAX bridge; voice modes use mic.
+    auto updateDaxTxMode = [this]() {
+        bool isDigital = false;
+        for (auto* sl : m_radioModel.slices()) {
+            if (sl->isTxSlice()) {
+                const QString& m = sl->mode();
+                isDigital = (m == "DIGU" || m == "DIGL" || m == "RTTY"
+                          || m == "DFM"  || m == "NFM");
+                break;
+            }
+        }
+        m_audio.setDaxTxMode(isDigital);
+    };
+    connect(s, &SliceModel::modeChanged, this, updateDaxTxMode);
+    connect(s, &SliceModel::txSliceChanged, this, updateDaxTxMode);
+    updateDaxTxMode();  // set initial state from current TX slice mode
+#endif
 
     // Push overlay for this slice to the spectrum widget
     pushSliceOverlay(s);
@@ -1541,6 +1575,7 @@ void MainWindow::deactivateRADE()
     spectrum()->vfoWidget()->setRadeActive(false);
 
     m_audio.setRadeMode(false);
+    m_audio.clearTxAccumulators();  // flush stale RADE modem data
 
     if (m_radeEngine) {
         disconnect(&m_audio, &AudioEngine::txRawPcmReady,
@@ -1604,12 +1639,14 @@ void MainWindow::startDax()
             m_daxBridge, &VirtualAudioBridge::feedDaxAudio);
 
     // Wire DAX TX: apps → HAL plugin → shm → VirtualAudioBridge → VITA-49
-    // When DAX TX audio arrives, block mic to prevent dual-source PTT delay.
-    // When DAX TX stops, re-enable mic for voice SSB.
+    // Always forward to feedDaxTxAudio — the gate is inside AudioEngine:
+    // feedDaxTxAudio blocks only when mic is actively sending (voice TX),
+    // preventing dual-source jitter. During RX and digital TX, DAX flows
+    // freely — this keeps VARAC/WSJT-X pre-PTT audio in the radio's
+    // buffer so TX starts instantly with no delay.
     connect(m_daxBridge, &VirtualAudioBridge::txAudioReady,
             this, [this](const QByteArray& pcm) {
-        if (!m_audio.isDaxTxMode())
-            m_audio.setDaxTxMode(true);  // block mic while DAX TX active
+        if (m_audio.isRadeMode()) return;
         m_audio.feedDaxTxAudio(pcm);
     });
 


### PR DESCRIPTION
## Summary

Fix TX audio routing issues when switching between voice, digital, and RADE modes. Add DAX bridge autostart persistence.

## Audio routing fixes

| Problem | Cause | Fix |
|---------|-------|-----|
| Mic audio bleeds into DIGU TX | `onTxAudioReady` sends mic regardless of mode | Gate on `m_daxTxMode` (set by TX slice mode) |
| Mic audio during RX accumulates in radio buffer | `onTxAudioReady` sends continuously | Gate on `m_transmitting` |
| SSB voice jitters after digital TX | DAX bridge + mic send simultaneously | Gate DAX in `feedDaxTxAudio`: block when `m_transmitting && !m_daxTxMode` |
| VARAC 0.5s TX delay | Pre-PTT audio discarded during RX | Let DAX flow during RX (gate only blocks during voice TX) |
| RADE modem audio persists after mode switch | Stale data in `m_txFloatAccumulator` | `clearTxAccumulators()` on RADE deactivation |
| RADE + DAX bridge dual-source | Both send on same VITA-49 stream | Block DAX bridge when `isRadeMode()` |

## Audio routing truth table

| State | Mic sends? | DAX sends? | RADE sends? |
|-------|------------|------------|-------------|
| RX, any mode | ✗ | ✓ (radio ignores, pre-buffers) | ✗ |
| TX, voice (USB/LSB) | ✓ | ✗ | ✗ |
| TX, digital (DIGU) | ✗ | ✓ | ✗ |
| TX, RADE | ✗ | ✗ | ✓ |

## DAX autostart

- CatApplet DAX Enable button wired to `startDax()`/`stopDax()` with `AutoStartDAX` persistence
- Auto-start on connect when setting is True
- Button state synced on autostart

## Files changed

| File | Change |
|------|--------|
| `src/core/AudioEngine.cpp` | `m_transmitting` gate in `onTxAudioReady`, voice-TX gate in `feedDaxTxAudio` |
| `src/core/AudioEngine.h` | `m_transmitting` flag, `setTransmitting()`, `clearTxAccumulators()` |
| `src/gui/MainWindow.cpp` | Mode-based `m_daxTxMode` via `updateDaxTxMode` lambda, DAX autostart, RADE accumulator flush |
| `src/gui/CatApplet.cpp` | DAX Enable button connect + persistence |
| `src/gui/CatApplet.h` | `setDaxEnabled()`, `daxToggled` signal |

## Test plan

- [x] SSB voice TX: clean audio, no jitter
- [x] DIGU TX (VARAC): no mic bleed, minimal delay (~0.5s = VARAC internal)
- [x] RADE TX: clean modem output
- [x] RADE → USB switch: no stale modem audio
- [x] DIGU → USB switch: mic works immediately
- [x] DAX Enable persists across app restarts

Tested on FLEX-6600 fw v4.1.5 (macOS arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)