### PR TITLE
Fix RADE mode affecting other slices (per-slice isolation)

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -108,7 +108,9 @@ QByteArray AudioEngine::resampleStereo(const QByteArray& pcm)
 void AudioEngine::feedAudioData(const QByteArray& pcm)
 {
     if (!m_audioSink) return;  // PC audio disabled
-    if (m_radeMode) return;    // RADE mode: raw SSB audio is blocked; decoded speech via feedDecodedSpeech()
+    // Note: m_radeMode no longer blocks feedAudioData globally.
+    // The RADE slice's raw OFDM noise is muted at the slice level (audio_mute=1)
+    // so it doesn't reach the speaker. Other slices' audio plays normally.
 
     auto writeAudio = [this](const QByteArray& data) {
         if (!m_audioDevice || !m_audioDevice->isOpen()) return;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -656,9 +656,9 @@ MainWindow::MainWindow(QWidget* parent)
 
 #ifdef HAVE_RADE
     connect(m_appletPanel->rxApplet(), &RxApplet::radeActivated,
-            this, [this](bool on) { if (on) activateRADE(); else deactivateRADE(); });
+            this, [this](bool on, int sliceId) { if (on) activateRADE(sliceId); else deactivateRADE(); });
     connect(spectrum()->vfoWidget(), &VfoWidget::radeActivated,
-            this, [this](bool on) { if (on) activateRADE(); else deactivateRADE(); });
+            this, [this](bool on, int sliceId) { if (on) activateRADE(sliceId); else deactivateRADE(); });
 #endif
 
     // ── Tuning step size → spectrum widget ─────────────────────────────────
@@ -1455,6 +1455,16 @@ void MainWindow::setActiveSlice(int sliceId)
     if (m_bandSettings.currentBand().isEmpty())
         m_bandSettings.setCurrentBand(BandSettings::bandForFrequency(s->frequency()));
 
+
+#ifdef HAVE_RADE
+    // Switch RADE audio mode based on whether the active slice is the RADE slice.
+    // When on the RADE slice: mic → RADEEngine, speaker blocked (muted at slice level).
+    // When on a non-RADE slice: mic → normal VITA-49, speaker plays normally.
+    if (m_radeSliceId >= 0 && m_radeEngine && m_radeEngine->isActive()) {
+        m_audio.setRadeMode(sliceId == m_radeSliceId);
+    }
+#endif
+
     qDebug() << "MainWindow: active slice set to" << sliceId;
 }
 
@@ -1555,9 +1565,9 @@ void MainWindow::onFrequencyChanged(double mhz)
 }
 
 #ifdef HAVE_RADE
-void MainWindow::activateRADE()
+void MainWindow::activateRADE(int sliceId)
 {
-    auto* s = activeSlice();
+    auto* s = m_radioModel.slice(sliceId);
     if (!s) return;
 
     // Set radio mode to DIGU/DIGL (passthrough for OFDM modem)
@@ -1568,6 +1578,11 @@ void MainWindow::activateRADE()
         s->setFilterWidth(-3500, 0);
     else
         s->setFilterWidth(0, 3500);
+
+    // Remember which slice and its previous mute state
+    m_radeSliceId = sliceId;
+    m_radePrevMute = s->audioMute();
+    s->setAudioMute(true);
 
     // Create and start RADE engine
     if (!m_radeEngine) {
@@ -1589,8 +1604,13 @@ void MainWindow::activateRADE()
     });
 
     // RX path: DAX RX audio -> RADEEngine -> decoded speech -> speaker
+    // Filter by the RADE slice's DAX channel so other slices' DAX audio is ignored
+    int daxCh = s->daxChannel();
     connect(m_radioModel.panStream(), &PanadapterStream::daxAudioReady,
-            m_radeEngine, &RADEEngine::feedRxAudio);
+            m_radeEngine, [this, daxCh](int channel, const QByteArray& pcm) {
+        if (channel == daxCh)
+            m_radeEngine->feedRxAudio(channel, pcm);
+    });
     connect(m_radeEngine, &RADEEngine::rxSpeechReady,
             &m_audio, &AudioEngine::feedDecodedSpeech);
 
@@ -1610,11 +1630,18 @@ void MainWindow::activateRADE()
     connect(m_radeEngine, &RADEEngine::freqOffsetChanged,
             vfo, &VfoWidget::setRadeFreqOffset);
 
-    qInfo() << "MainWindow: RADE mode activated";
+    qInfo() << "MainWindow: RADE mode activated on slice" << sliceId;
 }
 
 void MainWindow::deactivateRADE()
 {
+    // Restore audio mute state on the RADE slice
+    if (m_radeSliceId >= 0) {
+        if (auto* s = m_radioModel.slice(m_radeSliceId))
+            s->setAudioMute(m_radePrevMute);
+        m_radeSliceId = -1;
+    }
+
     spectrum()->vfoWidget()->setRadeActive(false);
 
     m_audio.setRadeMode(false);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -121,7 +121,9 @@ private:
 
 #ifdef HAVE_RADE
     RADEEngine* m_radeEngine{nullptr};
-    void activateRADE();
+    int  m_radeSliceId{-1};
+    bool m_radePrevMute{false};
+    void activateRADE(int sliceId);
     void deactivateRADE();
 #endif
 

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -380,10 +380,10 @@ void RxApplet::buildUI()
             QString mode = m_modeCombo->currentText();
 #ifdef HAVE_RADE
             if (mode == "RADE") {
-                emit radeActivated(true);
+                emit radeActivated(true, m_slice ? m_slice->sliceId() : -1);
                 return;
             }
-            emit radeActivated(false);
+            emit radeActivated(false, m_slice ? m_slice->sliceId() : -1);
 #endif
             if (m_slice) m_slice->setMode(mode);
         });

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -55,7 +55,7 @@ signals:
     void rn2CycleToggled(bool on);
 #ifdef HAVE_RADE
     // Emitted when user selects/deselects RADE digital voice mode
-    void radeActivated(bool on);
+    void radeActivated(bool on, int sliceId);
 #endif
 
 protected:

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -926,10 +926,10 @@ void VfoWidget::buildTabContent()
             QString mode = m_modeCombo->currentText();
 #ifdef HAVE_RADE
             if (mode == "RADE") {
-                emit radeActivated(true);
+                emit radeActivated(true, m_slice ? m_slice->sliceId() : -1);
                 return;
             }
-            emit radeActivated(false);
+            emit radeActivated(false, m_slice ? m_slice->sliceId() : -1);
 #endif
             if (!m_updatingFromModel && m_slice)
                 m_slice->setMode(mode);

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -56,7 +56,7 @@ Q_SIGNALS:
     void rn2Toggled(bool on);
     void pcAudioToggled(bool on);
 #ifdef HAVE_RADE
-    void radeActivated(bool on);
+    void radeActivated(bool on, int sliceId);
 #endif
 
 protected:


### PR DESCRIPTION
Fixes #128

## Summary

RADE activation was global — selecting RADE on any slice changed all slices' audio behavior. This broke multi-slice workflows (e.g. VARAC on slice A + RADE on slice B).

## Changes

| Component | Before | After |
|-----------|--------|-------|
| `activateRADE` | Uses `activeSlice()` | Uses specific `sliceId` from signal |
| `feedAudioData` | Globally blocked by `m_radeMode` | Never blocked; RADE slice muted via `audio_mute=1` |
| `m_radeMode` | Set once in `activateRADE` | Dynamic: follows active slice in `setActiveSlice()` |
| DAX RX → RADEEngine | All channels forwarded | Only RADE slice's DAX channel |
| `deactivateRADE` | No mute restore | Restores previous `audio_mute` state |

## Workflow

1. Slice A: USB (SSB voice), Slice B: RADE
2. Active on B → `m_radeMode=true`, mic → RADEEngine, slice B muted
3. Switch to A → `m_radeMode=false`, mic → normal VITA-49, RX plays normally
4. Switch back to B → `m_radeMode=true`, RADE resumes

## Test plan

- [x] Slice A (DIGU/VARAC) unaffected when slice B activates RADE
- [x] VARAC RX/TX latency unchanged
- [x] RADE TX/RX works on slice B
- [x] Switching A↔B toggles audio routing correctly
- [x] deactivateRADE restores slice mute state

Tested on FLEX-6600 fw v4.1.5 (macOS arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)