### PR TITLE
Fix RADE PTT release delay and duplicate activation guard

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -243,9 +243,15 @@ MainWindow::MainWindow(QWidget* parent)
         // On RX resume, native tiles will restart and m_hasNativeWaterfall
         // will be set again by the first arriving tile.
 #ifdef HAVE_RADE
-        if (m_audio.isRadeMode()) {
-            if (!tx && m_radeEngine && m_radeEngine->isActive())
+        if (m_radeSliceId >= 0 && m_radeEngine && m_radeEngine->isActive()) {
+            if (!tx) {
+                // MOX off: always disable RADE TX to stop sending packets.
+                // Without this, mic continues routing through RADEEngine
+                // after PTT release → radio stays keyed for seconds.
+                m_audio.setRadeMode(false);
                 m_radeEngine->resetTx();
+            }
+            // MOX on: setActiveSlice already set radeMode based on active slice
         }
 #endif
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
@@ -1810,6 +1816,14 @@ void MainWindow::onFrequencyChanged(double mhz)
 #ifdef HAVE_RADE
 void MainWindow::activateRADE(int sliceId)
 {
+    // Guard against duplicate activation (VfoWidget + RxApplet both selecting RADE)
+    if (m_radeSliceId == sliceId && m_radeEngine && m_radeEngine->isActive())
+        return;
+
+    // If RADE is already active on a different slice, deactivate it first
+    if (m_radeSliceId >= 0 && m_radeSliceId != sliceId)
+        deactivateRADE();
+
     auto* s = m_radioModel.slice(sliceId);
     if (!s) return;
 


### PR DESCRIPTION
## Summary

Two fixes for RADE TX that cause the radio to stay keyed for seconds after PTT release.

## Bug 1: setRadeMode(false) missing on MOX off

The moxChanged handler only called `m_radeEngine->resetTx()` without `m_audio.setRadeMode(false)`. After PTT release, mic audio continued routing through RADEEngine → sendModemTxAudio → VITA-49 packets. Radio kept transmitting until its internal buffer drained.

**Fix:** Call `m_audio.setRadeMode(false)` before `resetTx()` in the moxChanged handler.

## Bug 2: Duplicate activateRADE from VfoWidget + RxApplet

Both the VfoWidget mode combo (top-left) and RxApplet mode combo (right panel) can select RADE. Selecting RADE in both calls `activateRADE()` twice, creating duplicate signal connections:
- `txRawPcmReady` → `feedTxAudio` ×2
- `txModemReady` → `sendModemTxAudio` ×2

This doubles the VITA-49 packet rate (same dual-source bug as DAX TX PTT delay). On MOX off, `setRadeMode(false)` stops one path but the duplicate connections keep sending.

**Fix:** Guard at the top of `activateRADE()`:
- Same slice already active → return early
- Different slice → deactivateRADE first, then activate new

## Test plan

- [x] Select RADE in both VfoWidget and RxApplet → TX → PTT release instant
- [x] Select RADE in only one combo → TX → PTT release instant
- [x] Switch RADE between slices → clean deactivate/activate cycle

Tested on FLEX-6600 fw v4.1.5 (macOS arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)