### PR TITLE
Fix RADE PTT release delay and duplicate activation guard

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -243,9 +243,11 @@ MainWindow::MainWindow(QWidget* parent)
         // On RX resume, native tiles will restart and m_hasNativeWaterfall
         // will be set again by the first arriving tile.
 #ifdef HAVE_RADE
-        if (m_audio.isRadeMode()) {
-            if (!tx && m_radeEngine && m_radeEngine->isActive())
+        if (m_radeSliceId >= 0 && m_radeEngine && m_radeEngine->isActive()) {
+            if (!tx) {
+                m_audio.setRadeMode(false);
                 m_radeEngine->resetTx();
+            }
         }
 #endif
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
@@ -1818,6 +1820,14 @@ void MainWindow::onFrequencyChanged(double mhz)
 #ifdef HAVE_RADE
 void MainWindow::activateRADE(int sliceId)
 {
+    // Guard against duplicate activation (VfoWidget + RxApplet both selecting RADE)
+    if (m_radeSliceId == sliceId && m_radeEngine && m_radeEngine->isActive())
+        return;
+
+    // If RADE is already active on a different slice, deactivate it first
+    if (m_radeSliceId >= 0 && m_radeSliceId != sliceId)
+        deactivateRADE();
+
     auto* s = m_radioModel.slice(sliceId);
     if (!s) return;
 


### PR DESCRIPTION
## Summary

Two fixes for RADE TX that cause the radio to stay keyed for seconds after PTT release. Applies on top of the worker thread commit (e286aad).

## Bug 1: setRadeMode(false) missing on MOX off

The moxChanged handler only calls `resetTx()` without `setRadeMode(false)`. After PTT release, mic audio continues routing through RADEEngine → sendModemTxAudio → VITA-49 packets indefinitely.

**Fix:** `m_audio.setRadeMode(false)` before `resetTx()`.

## Bug 2: Duplicate activateRADE from VfoWidget + RxApplet

Both mode combos can select RADE, calling `activateRADE()` twice → duplicate signal connections → 2x VITA-49 packet rate → PTT release delay.

**Fix:** Guard at top of `activateRADE()`: same slice → return early; different slice → deactivate first.

## Test plan

- [x] RADE TX → PTT release instant
- [x] Both combos select RADE → no duplicate connections
- [x] Switch RADE between slices → clean cycle

Tested on FLEX-6600 fw v4.1.5 (macOS arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)