### PR TITLE
Speed up CI: cache Opus build and CMake object files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,24 @@ jobs:
             qt6-base-dev qt6-multimedia-dev qt6-websockets-dev libgl1-mesa-dev \
             libasound2-dev autoconf automake libtool
 
+      - name: Cache Opus build
+        uses: actions/cache@v4
+        with:
+          path: build/build_opus-prefix
+          key: opus-${{ hashFiles('third_party/radae/cmake/BuildOpus.cmake') }}
+
+      - name: Cache CMake build
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/CMakeFiles
+            build/AetherSDR_autogen
+            build/**/*.o
+            build/**/*.obj
+          key: cmake-${{ runner.os }}-${{ hashFiles('CMakeLists.txt', 'src/**/*.cpp', 'src/**/*.h') }}
+          restore-keys: |
+            cmake-${{ runner.os }}-
+
       - name: Configure
         run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 


### PR DESCRIPTION
Opus build (~2 min) cached by BuildOpus.cmake hash — only rebuilds
when the Opus build script changes. CMake object files cached by
source hash with fallback to latest — incremental rebuilds on
subsequent runs.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
