### PR TITLE
Add GPG release signing workflow and commit signing policy

### DIFF
--- a/.github/workflows/sign-release.yml
+++ b/.github/workflows/sign-release.yml
@@ -1,0 +1,91 @@
+name: Sign Release Artifacts
+
+# GPG signs Linux AppImage and source archives only.
+# macOS artifacts are signed via Apple codesign + notarization.
+# Windows artifacts will be signed via a separate authority.
+
+on:
+  workflow_run:
+    workflows: ["AppImage"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to sign (e.g. v1.0.0)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  sign:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p artifacts
+          gh release download "${{ steps.tag.outputs.tag }}" \
+            --dir artifacts --pattern '*.AppImage'
+
+      - name: Generate source archive
+        run: |
+          git archive --format=tar.gz --prefix="AetherSDR-${{ steps.tag.outputs.tag }}/" \
+            HEAD > "artifacts/AetherSDR-${{ steps.tag.outputs.tag }}-source.tar.gz"
+
+      - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          KEY_FP=$(gpg --list-secret-keys --with-colons | grep fpr | head -1 | cut -d: -f10)
+          echo "${KEY_FP}:6:" | gpg --import-ownertrust
+
+      - name: Generate SHA256SUMS
+        working-directory: artifacts
+        run: |
+          sha256sum * > SHA256SUMS.txt
+
+      - name: Sign artifacts (detached .asc)
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        working-directory: artifacts
+        run: |
+          for file in *.AppImage *.tar.gz; do
+            [ -f "$file" ] || continue
+            gpg --batch --yes --pinentry-mode loopback \
+              --passphrase "$GPG_PASSPHRASE" \
+              --detach-sign --armor "$file"
+            echo "Signed: $file -> ${file}.asc"
+          done
+          gpg --batch --yes --pinentry-mode loopback \
+            --passphrase "$GPG_PASSPHRASE" \
+            --detach-sign --armor SHA256SUMS.txt
+
+      - name: Upload signatures to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ steps.tag.outputs.tag }}" \
+            artifacts/*.asc artifacts/SHA256SUMS.txt \
+            artifacts/*-source.tar.gz \
+            --clobber

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,6 +237,50 @@ widgets for consistency.
 - Reference issues: `Fixes #42` or `Closes #42`.
 - Blank line then longer description if needed.
 
+### Commit Signing
+
+All commits to `main` must be GPG-signed. Unsigned commits will be rejected
+by branch protection. Each contributor uses their own personal GPG key — do
+NOT use the project release signing key for commits.
+
+#### Quick Setup
+
+1. **Generate a GPG key** (if you don't already have one):
+   ```bash
+   gpg --quick-gen-key "Your Name <your-email@example.com>" ed25519 sign 0
+   ```
+
+2. **Add the key to your GitHub account:**
+   ```bash
+   # Copy your public key
+   gpg --armor --export <KEY_ID>
+   ```
+   Paste the output at [GitHub → Settings → SSH and GPG keys → New GPG key](https://github.com/settings/gpg/new).
+
+3. **Configure git to sign commits:**
+   ```bash
+   git config --global user.signingkey <KEY_ID>
+   git config --global commit.gpgsign true
+   ```
+
+4. **Verify it works:**
+   ```bash
+   git commit --allow-empty -m "Test signed commit"
+   git log --show-signature -1
+   ```
+
+Your commits will show a green "Verified" badge on GitHub.
+
+#### Troubleshooting
+
+If `gpg` prompts for a passphrase but hangs in a terminal, set the GPG TTY:
+
+```bash
+echo 'export GPG_TTY=$(tty)' >> ~/.bashrc   # or ~/.zshrc
+```
+
+For GUI-based passphrase entry, install `pinentry-gnome3` or `pinentry-qt`.
+
 ---
 
 ## What We Will Not Accept

--- a/README.md
+++ b/README.md
@@ -315,6 +315,24 @@ The codebase is modular — each subsystem (core protocol, models, GUI widgets) 
 
 ---
 
+## Verifying Downloads
+
+Linux AppImages and source archives are GPG-signed. macOS artifacts are Apple
+notarized. Each release includes detached signatures (`.asc`) and a signed
+`SHA256SUMS.txt`. All commits on `main` are signed by their authors.
+
+```bash
+# Import the public key
+curl -sSL https://raw.githubusercontent.com/ten9876/AetherSDR/main/docs/RELEASE-SIGNING-KEY.pub.asc | gpg --import
+
+# Verify a download
+gpg --verify AetherSDR-v1.0.0-x86_64.AppImage.asc AetherSDR-v1.0.0-x86_64.AppImage
+```
+
+See [docs/VERIFYING-RELEASES.md](docs/VERIFYING-RELEASES.md) for full instructions.
+
+---
+
 ## License
 
 AetherSDR is free and open-source software licensed under the [GNU General Public License v3](LICENSE).

--- a/docs/VERIFYING-RELEASES.md
+++ b/docs/VERIFYING-RELEASES.md
@@ -1,0 +1,79 @@
+# Verifying AetherSDR Releases
+
+## Signing Overview
+
+| Platform | Signing Method |
+|----------|---------------|
+| Linux AppImage | GPG detached signature (`.asc`) |
+| Source archive | GPG detached signature (`.asc`) |
+| macOS DMG | Apple codesign + notarization |
+| macOS .pkg | Apple codesign + notarization |
+| Windows .exe | Separate signing authority (planned) |
+
+Each release also includes a GPG-signed `SHA256SUMS.txt` covering all
+Linux and source artifacts.
+
+## GPG Key Fingerprint
+
+<!-- TODO: Replace with actual fingerprint after key generation -->
+
+    XXXX XXXX XXXX XXXX XXXX  XXXX XXXX XXXX XXXX XXXX
+
+## Import the Public Key
+
+From the repository:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/ten9876/AetherSDR/main/docs/RELEASE-SIGNING-KEY.pub.asc | gpg --import
+```
+
+Or from keys.openpgp.org:
+
+```bash
+gpg --keyserver keys.openpgp.org --recv-keys <KEY_ID>
+```
+
+## Verify a Linux Download
+
+### Option 1: Verify the artifact directly
+
+```bash
+gpg --verify AetherSDR-v1.0.0-x86_64.AppImage.asc AetherSDR-v1.0.0-x86_64.AppImage
+```
+
+### Option 2: Verify checksums first, then check the file
+
+```bash
+gpg --verify SHA256SUMS.txt.asc SHA256SUMS.txt
+sha256sum -c SHA256SUMS.txt
+```
+
+Expected output should show **"Good signature from AetherSDR Release Signing"**.
+
+GPG is typically pre-installed on Linux. If not:
+
+```bash
+# Arch
+sudo pacman -S gnupg
+
+# Debian/Ubuntu
+sudo apt install gnupg
+```
+
+## macOS Users
+
+The DMG and .pkg are Apple notarized. macOS Gatekeeper verifies the Apple
+signature automatically — no manual steps required.
+
+## Windows Users
+
+Windows signing is planned via a separate authority. Until then, Windows
+SmartScreen may show a warning on the `.exe` installer. This is expected
+for open-source projects without an EV code signing certificate.
+
+## Commit Signing
+
+All commits on `main` must be GPG-signed by their author. GitHub displays
+a green "Verified" badge on signed commits. Contributors should set up
+commit signing with their personal GPG key — see
+[CONTRIBUTING.md](../CONTRIBUTING.md#commit-signing) for setup instructions.


### PR DESCRIPTION
- sign-release.yml: signs Linux AppImage and source archives (macOS/Windows
  use their own platform signing)
- docs/VERIFYING-RELEASES.md: user-facing verification guide
- CONTRIBUTING.md: commit signing setup instructions for contributors
- README.md: verifying downloads section

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
