### PR TITLE
Fix 9 bugs and add configurable band plan size

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -203,7 +203,6 @@ void AudioEngine::generateWisdom(std::function<void(int,int,const std::string&)>
 void AudioEngine::setNr2Enabled(bool on)
 {
     if (m_nr2Enabled == on) return;
-    m_nr2Enabled = on;
     if (on) {
         // Disable RN2/BNR if on — they're mutually exclusive
         if (m_rn2Enabled) setRn2Enabled(false);
@@ -217,11 +216,15 @@ void AudioEngine::setNr2Enabled(bool on)
         if (m_nr2->hasPlanFailed()) {
             qCWarning(lcAudio) << "AudioEngine: NR2 FFTW plan creation failed — disabling";
             m_nr2.reset();
-            m_nr2Enabled = false;
             emit nr2EnabledChanged(false);
             return;
         }
+        // Set flag AFTER object is fully constructed — feedAudioData checks
+        // both m_nr2Enabled and m_nr2, and audio can arrive during
+        // setBnrEnabled(false) above if it processes events.
+        m_nr2Enabled = true;
     } else {
+        m_nr2Enabled = false;
         m_nr2.reset();
     }
     qCDebug(lcAudio) << "AudioEngine: NR2" << (on ? "enabled" : "disabled");
@@ -231,20 +234,21 @@ void AudioEngine::setNr2Enabled(bool on)
 void AudioEngine::setRn2Enabled(bool on)
 {
     if (m_rn2Enabled == on) return;
-    m_rn2Enabled = on;
     if (on) {
+        // Disable NR2/BNR first — they're mutually exclusive
+        if (m_nr2Enabled) setNr2Enabled(false);
+        if (m_bnrEnabled) setBnrEnabled(false);
         m_rn2 = std::make_unique<RNNoiseFilter>();
         if (!m_rn2->isValid()) {
             qCWarning(lcAudio) << "AudioEngine: RN2 rnnoise_create() failed — disabling";
             m_rn2.reset();
-            m_rn2Enabled = false;
             emit rn2EnabledChanged(false);
             return;
         }
-        // Disable NR2/BNR if on — they're mutually exclusive
-        if (m_nr2Enabled) setNr2Enabled(false);
-        if (m_bnrEnabled) setBnrEnabled(false);
+        // Set flag AFTER object is fully constructed
+        m_rn2Enabled = true;
     } else {
+        m_rn2Enabled = false;
         m_rn2.reset();
     }
     qCDebug(lcAudio) << "AudioEngine: RN2 (RNNoise)" << (on ? "enabled" : "disabled");
@@ -256,7 +260,6 @@ void AudioEngine::setRn2Enabled(bool on)
 void AudioEngine::setBnrEnabled(bool on)
 {
     if (m_bnrEnabled == on) return;
-    m_bnrEnabled = on;
     if (on) {
         // Mutual exclusion with NR2 and RN2
         if (m_nr2Enabled) setNr2Enabled(false);
@@ -273,6 +276,8 @@ void AudioEngine::setBnrEnabled(bool on)
         m_bnrDown = std::make_unique<Resampler>(48000, 24000, 16384);
         m_bnrOutBuf.clear();
         m_bnrPrimed = false;
+        // Set flag AFTER objects are fully constructed
+        m_bnrEnabled = true;
 
         // Try connecting — if the container is still booting, retry with a timer.
         if (!m_bnr->connectToServer(m_bnrAddress)) {
@@ -305,6 +310,7 @@ void AudioEngine::setBnrEnabled(bool on)
             retryTimer->start();
         }
     } else {
+        m_bnrEnabled = false;
         if (m_bnr) m_bnr->disconnect();
         m_bnr.reset();
         m_bnrUp.reset();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1054,17 +1054,29 @@ MainWindow::MainWindow(QWidget* parent)
     });
 
     // ── FlexControl tuning knob ─────────────────────────────────────────
-    connect(&m_flexControl, &FlexControlManager::tuneSteps,
-            this, [this](int steps) {
+    // Coalesce rapid encoder steps into a single command every 20ms.
+    // Without this, each step sends a separate TCP command, flooding the
+    // radio and causing the UI to lag behind the knob.
+    m_flexCoalesceTimer.setSingleShot(true);
+    m_flexCoalesceTimer.setInterval(20);
+    connect(&m_flexCoalesceTimer, &QTimer::timeout, this, [this]() {
+        if (m_flexPendingSteps == 0) return;
         auto* s = activeSlice();
-        if (!s || s->isLocked()) return;
+        if (!s || s->isLocked()) { m_flexPendingSteps = 0; return; }
         int stepHz = spectrum() ? spectrum()->stepSize() : 100;
-        double newMhz = s->frequency() + steps * stepHz / 1e6;
+        double newMhz = s->frequency() + m_flexPendingSteps * stepHz / 1e6;
+        m_flexPendingSteps = 0;
         QString panId = m_panStack ? m_panStack->activePanId() : m_radioModel.panId();
         if (!panId.isEmpty())
             m_radioModel.sendCommand(
                 QString("slice m %1 pan=%2").arg(newMhz, 0, 'f', 6).arg(panId));
         if (spectrum()) spectrum()->setVfoFrequency(newMhz);
+    });
+    connect(&m_flexControl, &FlexControlManager::tuneSteps,
+            this, [this](int steps) {
+        m_flexPendingSteps += steps;
+        if (!m_flexCoalesceTimer.isActive())
+            m_flexCoalesceTimer.start();
     });
 
     connect(&m_flexControl, &FlexControlManager::buttonPressed,
@@ -1600,7 +1612,22 @@ void MainWindow::buildMenuBar()
         toggleConnectionDialog();
     });
 
-    settingsMenu->addAction("FlexControl...");
+#ifdef HAVE_SERIALPORT
+    auto* flexControlAction = settingsMenu->addAction("FlexControl...");
+    connect(flexControlAction, &QAction::triggered, this, [this] {
+        auto* dlg = new RadioSetupDialog(&m_radioModel, &m_audio, this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        if (auto* tabs = dlg->findChild<QTabWidget*>()) {
+            for (int i = 0; i < tabs->count(); ++i) {
+                if (tabs->tabText(i) == "Serial") {
+                    tabs->setCurrentIndex(i);
+                    break;
+                }
+            }
+        }
+        dlg->show();
+    });
+#endif
     auto* networkAction = settingsMenu->addAction("Network...");
     connect(networkAction, &QAction::triggered, this, [this] {
         NetworkDiagnosticsDialog dlg(&m_radioModel, this);
@@ -1900,6 +1927,9 @@ void MainWindow::buildMenuBar()
         if (!action->isSeparator() && action != radioSetup && action != chooseRadio
             && action != networkAction && action != memoryAction && action != spotsAction
             && action != usbCablesAction
+#ifdef HAVE_SERIALPORT
+            && action != flexControlAction
+#endif
 #ifdef HAVE_MIDI
             && action != midiAction
 #endif
@@ -1960,15 +1990,25 @@ void MainWindow::buildMenuBar()
     });
     viewMenu->addSeparator();
 
-    auto* bandPlanAct = viewMenu->addAction("Band Plan Overlay");
-    bandPlanAct->setCheckable(true);
-    bandPlanAct->setChecked(
-        AppSettings::instance().value("ShowBandPlan", "True").toString() == "True");
-    connect(bandPlanAct, &QAction::toggled, this, [this](bool on) {
-        for (auto* a : m_panStack->allApplets()) a->spectrumWidget()->setShowBandPlan(on);
-        AppSettings::instance().setValue("ShowBandPlan", on ? "True" : "False");
-        AppSettings::instance().save();
-    });
+    // Band Plan submenu — Off / Small / Medium / Large / Huge
+    auto* bandPlanMenu = viewMenu->addMenu("Band Plan");
+    int savedBpSize = AppSettings::instance().value("BandPlanFontSize", "").toInt();
+    if (savedBpSize == 0 && AppSettings::instance().value("ShowBandPlan", "True").toString() == "True")
+        savedBpSize = 6;  // migrate old boolean setting
+    auto* bpGroup = new QActionGroup(bandPlanMenu);
+    struct BpOption { const char* label; int pt; };
+    for (auto [label, pt] : {BpOption{"Off", 0}, {"Small", 6}, {"Medium", 10}, {"Large", 12}, {"Huge", 16}}) {
+        auto* act = bandPlanMenu->addAction(label);
+        act->setCheckable(true);
+        act->setChecked(pt == savedBpSize);
+        bpGroup->addAction(act);
+        connect(act, &QAction::triggered, this, [this, pt] {
+            for (auto* a : m_panStack->allApplets())
+                a->spectrumWidget()->setBandPlanFontSize(pt);
+            AppSettings::instance().setValue("BandPlanFontSize", QString::number(pt));
+            AppSettings::instance().save();
+        });
+    }
 
     auto* singleClickTuneAct = viewMenu->addAction("Single-Click to Tune");
     singleClickTuneAct->setCheckable(true);
@@ -3262,13 +3302,16 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
 
     // ── TNF signals ──────────────────────────────────────────────────────
+    // QPointer guards against dangling sw when a pan is removed (#381)
+    QPointer<SpectrumWidget> swGuard(sw);
     auto* tnf = m_radioModel.tnfModel();
-    auto rebuildTnfMarkers = [this, sw]() {
+    auto rebuildTnfMarkers = [this, swGuard]() {
+        if (!swGuard) return;
         auto* t = m_radioModel.tnfModel();
         QVector<SpectrumWidget::TnfMarker> markers;
         for (const auto& e : t->tnfs())
             markers.append({e.id, e.freqMhz, e.widthHz, e.depthDb, e.permanent});
-        sw->setTnfMarkers(markers);
+        swGuard->setTnfMarkers(markers);
     };
     connect(tnf, &TnfModel::tnfChanged,  this, rebuildTnfMarkers);
     connect(tnf, &TnfModel::tnfRemoved,  this, rebuildTnfMarkers);
@@ -3297,7 +3340,6 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 
     // ── Spot markers ─────────────────────────────────────────────────────
     auto* spots = m_radioModel.spotModel();
-    QPointer<SpectrumWidget> swGuard(sw);
     auto rebuildSpots = [this, swGuard]() {
         if (!swGuard) return;  // widget destroyed (layout change)
         auto* s = m_radioModel.spotModel();
@@ -3490,6 +3532,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         if (m_radioModel.slices().size() < m_radioModel.maxSlices())
             m_radioModel.addSliceOnPan(panId);
     });
+    // Disconnect first to avoid duplicate sends on re-wire (#381)
+    disconnect(menu, &SpectrumOverlayMenu::addTnfClicked, this, nullptr);
     connect(menu, &SpectrumOverlayMenu::addTnfClicked,
             this, [this]() {
         auto* s = activeSlice();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -134,6 +134,8 @@ private:
 #ifdef HAVE_SERIALPORT
     SerialPortController m_serialPort;
     FlexControlManager   m_flexControl;
+    QTimer               m_flexCoalesceTimer;
+    int                  m_flexPendingSteps{0};
 #endif
 #ifdef HAVE_MIDI
     MidiControlManager   m_midiControl;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -108,7 +108,12 @@ void SpectrumWidget::loadSettings()
     m_wfBlackLevel   = s.value(settingsKey("DisplayWfBlackLevel"), "15").toInt();
     m_wfAutoBlack    = s.value(settingsKey("DisplayWfAutoBlack"), "True").toString() == "True";
     m_wfLineDuration = s.value(settingsKey("DisplayWfLineDuration"), "100").toInt();
-    m_showBandPlan   = s.value("ShowBandPlan", "True").toString() == "True";
+    // Migrate old ShowBandPlan bool → BandPlanFontSize int
+    if (s.value("BandPlanFontSize").toString().isEmpty()) {
+        m_bandPlanFontSize = s.value("ShowBandPlan", "True").toString() == "True" ? 6 : 0;
+    } else {
+        m_bandPlanFontSize = s.value("BandPlanFontSize", "6").toInt();
+    }
     m_singleClickTune = s.value("SingleClickTune", "False").toString() == "True";
 
     // Sync overlay menu sliders with restored settings
@@ -1299,7 +1304,12 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
         steps = m_scrollAccum / 15;
         m_scrollAccum -= steps * 15;
     } else {
-        steps = ev->angleDelta().y() / 120;
+        // Standard mouse wheel: angleDelta is in 1/8° units, one notch = 120.
+        // Some desktops (KDE Plasma, Cinnamon) send high-resolution deltas
+        // (e.g. 960 per notch). Accumulate and divide to normalize. (#390)
+        m_angleAccum += ev->angleDelta().y();
+        steps = m_angleAccum / 120;
+        m_angleAccum -= steps * 120;
     }
     if (steps == 0) { ev->ignore(); return; }
 
@@ -1478,7 +1488,7 @@ void SpectrumWidget::paintEvent(QPaintEvent*)
 
     drawGrid(p, specRect);
     drawSpectrum(p, specRect);
-    if (m_showBandPlan) drawBandPlan(p, specRect);
+    if (m_bandPlanFontSize > 0) drawBandPlan(p, specRect);
     drawDbmScale(p, specRect);
 
     // Draggable divider bar
@@ -1720,7 +1730,7 @@ void SpectrumWidget::drawBandPlan(QPainter& p, const QRect& specRect)
 {
     const double startMhz = m_centerMhz - m_bandwidthMhz / 2.0;
     const double endMhz   = m_centerMhz + m_bandwidthMhz / 2.0;
-    const int bandH = 8;
+    const int bandH = m_bandPlanFontSize + 4;  // scale strip height with font
     const int bandY = specRect.bottom() - bandH + 1;
 
     for (int i = 0; i < kBandPlanCount; ++i) {
@@ -1750,7 +1760,7 @@ void SpectrumWidget::drawBandPlan(QPainter& p, const QRect& specRect)
         // Label: mode + lowest license class allowed
         if (x2 - x1 > 20) {
             QFont f = p.font();
-            f.setPointSize(6);
+            f.setPointSize(m_bandPlanFontSize);
             f.setBold(true);
             p.setFont(f);
 

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -102,9 +102,11 @@ public:
     int  rfGainValue() const { return m_rfGainValue; }
     void setWnbActive(bool on) { m_wnbActive = on; update(); }
     void setRfGain(int gain) { m_rfGainValue = gain; update(); }
-    void setShowBandPlan(bool on) { m_showBandPlan = on; update(); }
+    void setShowBandPlan(bool on) { m_bandPlanFontSize = on ? 6 : 0; update(); }
+    void setBandPlanFontSize(int pt) { m_bandPlanFontSize = pt; update(); }
     void setSingleClickTune(bool on) { m_singleClickTune = on; }
-    bool showBandPlan() const { return m_showBandPlan; }
+    bool showBandPlan() const { return m_bandPlanFontSize > 0; }
+    int  bandPlanFontSize() const { return m_bandPlanFontSize; }
 
     // ── Display control setters ───────────────────────────────────────────
     // FFT controls (save to AppSettings on each change)
@@ -310,6 +312,7 @@ private:
     // Tuning step size for click-snap and wheel scroll (Hz)
     int m_stepHz{100};
     int m_scrollAccum{0};   // trackpad pixel scroll accumulator (macOS)
+    int m_angleAccum{0};    // mouse wheel angle accumulator (#390)
 
     // ── FFT display controls (radio-side via "display pan set") ──────────
     int   m_panIndex{0};             // per-pan settings index (0, 1, 2, 3)
@@ -373,7 +376,7 @@ private:
     // On-screen indicators (WNB, RF Gain)
     bool m_wnbActive{false};
     int  m_rfGainValue{0};
-    bool m_showBandPlan{true};
+    int  m_bandPlanFontSize{6};  // 0 = off
     bool m_singleClickTune{false};
     QPoint m_clickPressPos;        // for single-click-to-tune drag threshold
     bool m_showTxInWaterfall{false};  // default matches radio default (off)

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -162,7 +162,9 @@ static const QString kModeBtn =
 
 static const QString kSliderStyle =
     "QSlider::groove:horizontal { background: #1a2a3a; height: 4px; border-radius: 2px; }"
-    "QSlider::handle:horizontal { background: #c8d8e8; width: 12px; margin: -4px 0; border-radius: 6px; }";
+    "QSlider::handle:horizontal { background: #c8d8e8; width: 12px; margin: -4px 0; border-radius: 6px; }"
+    "QSlider::groove:vertical { background: #1a2a3a; width: 4px; border-radius: 2px; }"
+    "QSlider::handle:vertical { background: #c8d8e8; height: 12px; margin: 0 -4px; border-radius: 6px; }";
 
 static const QString kLabelStyle =
     "QLabel { background: transparent; border: none; color: #8aa8c0; font-size: 13px; }";
@@ -1962,6 +1964,11 @@ void VfoWidget::setSlice(SliceModel* slice)
         QSignalBlocker sb(m_daxCmb);
         m_daxCmb->setCurrentIndex(ch);
         m_updatingFromModel = false;
+    });
+    connect(m_slice, &SliceModel::lockedChanged, this, [this](bool locked) {
+        QSignalBlocker b(m_lockVfoBtn);
+        m_lockVfoBtn->setChecked(locked);
+        m_lockVfoBtn->setText(locked ? "\xF0\x9F\x94\x92" : "\xF0\x9F\x94\x93");
     });
 
     syncFromSlice();

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -50,6 +50,10 @@ void TransmitModel::applyTransmitStatus(const QMap<QString, QString>& kvs)
         bool v = kvs["tune"] == "1";
         if (m_tune != v) { m_tune = v; changed = true; tuneChanged_ = true; }
     }
+    if (kvs.contains("mox")) {
+        bool v = kvs["mox"] == "1";
+        if (m_mox != v) { m_mox = v; changed = true; }
+    }
 
     // ── Mic / monitor / processor keys ──────────────────────────────────────
     bool micChanged = false;


### PR DESCRIPTION
Bug fixes:
- Fix NR2/RN2/BNR crash on DSP mode switch — set enabled flag AFTER
  object construction, not before (SEGV in SpectralNR::process)
- Fix FlexControl UI lag — coalesce rapid encoder steps into single
  TCP command every 20ms (#379)
- Wire FlexControl menu to Radio Setup Serial tab instead of showing
  "not implemented" (#380)
- Fix TNF crash — use QPointer for SpectrumWidget in rebuildTnfMarkers
  lambda to prevent dangling pointer on pan removal (#381)
- Fix duplicate tnf create commands — disconnect before reconnect (#381)
- Fix FlexControl ToggleMox/ToggleTune — parse mox= from radio status
  so isMox() returns correct state for toggle (#382)
- Fix VFO lock icon not updating from FlexControl/external sources —
  connect SliceModel::lockedChanged in VfoWidget::setSlice (#384)
- Fix 8x scroll step on KDE/Cinnamon — accumulate angleDelta like
  pixelDelta to normalize across desktop environments (#390, #405)
- Fix ESC gain slider black thumb — add vertical handle/groove QSS
  rules to kSliderStyle (#394)

Enhancement:
- Configurable band plan overlay size: View → Band Plan submenu with
  Off/Small(6)/Medium(10)/Large(12)/Huge(16) options (#406)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
