### PR TITLE
Add click-and-drag VFO tuning inside filter passband (#404)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -846,6 +846,16 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
             ev->accept();
             return;
         }
+
+        // Click inside the filter passband → start VFO drag (#404)
+        const int left = std::min(loX, hiX);
+        const int right = std::max(loX, hiX);
+        if (mx > left + GRAB && mx < right - GRAB) {
+            m_draggingVfo = true;
+            setCursor(Qt::SizeHorCursor);
+            ev->accept();
+            return;
+        }
     }
 
     // Click in FFT area → start pan drag (tune on double-click only)
@@ -944,6 +954,14 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         }
         update();
         emit filterChangeRequested(ao->filterLowHz, ao->filterHighHz);
+        ev->accept();
+        return;
+    }
+
+    if (m_draggingVfo) {
+        const int mx = static_cast<int>(ev->position().x());
+        const double mhz = snapToStep(xToMhz(mx), m_stepHz);
+        emit frequencyClicked(mhz);
         ev->accept();
         return;
     }
@@ -1118,6 +1136,12 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
     }
     if (m_draggingBandwidth) {
         m_draggingBandwidth = false;
+        setCursor(Qt::CrossCursor);
+        ev->accept();
+        return;
+    }
+    if (m_draggingVfo) {
+        m_draggingVfo = false;
         setCursor(Qt::CrossCursor);
         ev->accept();
         return;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -363,6 +363,8 @@ private:
     // Filter edge drag state
     enum class FilterEdge { None, Low, High };
     FilterEdge m_draggingFilter{FilterEdge::None};
+    // VFO passband drag state (#404)
+    bool m_draggingVfo{false};
     // dBm scale strip drag state
     static constexpr int DBM_STRIP_W = 36;  // width of the dBm scale strip
     static constexpr int DBM_ARROW_H = 14;  // height of each arrow button


### PR DESCRIPTION
Click inside the filter passband and drag left/right to tune the VFO,
snapped to step size. Matches SmartSDR behavior. Filter edge drag
(resize) takes priority within the ±5px grab zone.

Closes #404

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
