### PR TITLE
Allow 4-part version numbers in release workflow (e.g. 0.7.12.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Validate version format
         run: |
-          if ! echo "${{ inputs.version }}" | grep -qP '^\d+\.\d+\.\d+$'; then
-            echo "::error::Version must be in X.Y.Z format (e.g. 0.7.13)"
+          if ! echo "${{ inputs.version }}" | grep -qP '^\d+\.\d+\.\d+(\.\d+)?$'; then
+            echo "::error::Version must be in X.Y.Z or X.Y.Z.P format (e.g. 0.7.13 or 0.7.12.1)"
             exit 1
           fi
 


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
