### PR TITLE
Fix CI Docker image: add missing packages (patch, fftw3, portaudio, serialport)

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -3,18 +3,22 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Build dependencies for AetherSDR CI
-# Matches the packages installed in ci.yml and codeql.yml
+# Must include everything CMakeLists.txt can find_package() for
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     ninja-build \
     pkg-config \
     g++ \
     git \
+    patch \
     qt6-base-dev \
     qt6-multimedia-dev \
     qt6-websockets-dev \
+    qt6-serialport-dev \
     libgl1-mesa-dev \
     libasound2-dev \
+    libfftw3-dev \
+    portaudio19-dev \
     autoconf \
     automake \
     libtool \


### PR DESCRIPTION
- Switch CI + CodeQL to Docker container (#442 step 2)
- Fix CI Docker image: add missing packages (patch, fftw3, portaudio, serialport)
