### PR TITLE
Switch CI + CodeQL to Docker container (#442 step 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,34 +9,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: ghcr.io/ten9876/aethersdr-ci:latest
 
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake ninja-build pkg-config \
-            qt6-base-dev qt6-multimedia-dev qt6-websockets-dev libgl1-mesa-dev \
-            libasound2-dev autoconf automake libtool
 
       - name: Cache Opus build
         uses: actions/cache@v4
         with:
           path: build/build_opus-prefix
           key: opus-${{ hashFiles('third_party/radae/cmake/BuildOpus.cmake') }}
-
-      - name: Cache CMake build
-        uses: actions/cache@v4
-        with:
-          path: |
-            build/CMakeFiles
-            build/AetherSDR_autogen
-            build/**/*.o
-            build/**/*.obj
-          key: cmake-${{ runner.os }}-${{ hashFiles('CMakeLists.txt', 'src/**/*.cpp', 'src/**/*.h') }}
-          restore-keys: |
-            cmake-${{ runner.os }}-
 
       - name: Configure
         run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    container: ghcr.io/ten9876/aethersdr-ci:latest
     permissions:
       security-events: write
 
@@ -20,13 +21,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake ninja-build pkg-config \
-            qt6-base-dev qt6-multimedia-dev qt6-websockets-dev libgl1-mesa-dev \
-            libasound2-dev autoconf automake libtool
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
Use ghcr.io/ten9876/aethersdr-ci:latest instead of apt-get install.
Remove Install dependencies step and stale CMake object cache.
Keep Opus cache (saves ~30s per run).

Expected CI time: ~3 min consistently.

Closes #442

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
