### PR TITLE
Add curl to CI Docker image (Opus model download)

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     g++ \
     git \
     patch \
+    curl \
     qt6-base-dev \
     qt6-multimedia-dev \
     qt6-websockets-dev \


### PR DESCRIPTION
- Switch CI + CodeQL to Docker container (#442 step 2)
- Add curl to CI Docker image (Opus model download)
