### PR TITLE
Fix CodeQL git safe directory error in Docker container

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Fix git ownership for container
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:


### PR DESCRIPTION
Git inside a container sees different file ownership and refuses to
operate. Add safe.directory config before CodeQL initialization.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
