### PR TITLE
Add DXCC-aware spot coloring from ADIF logbook (#330, PR #476)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,10 @@ set(CORE_SOURCES
     src/core/SerialPortController.cpp
     src/core/FlexControlManager.cpp
     src/core/OpusCodec.cpp
+    src/core/CtyDatParser.cpp
+    src/core/AdifParser.cpp
+    src/core/DxccWorkedStatus.cpp
+    src/core/DxccColorProvider.cpp
 )
 
 if(APPLE)
@@ -461,6 +465,7 @@ endif()
 if(FFTW3_FOUND)
     target_compile_definitions(AetherSDR PRIVATE HAVE_FFTW3)
     target_include_directories(AetherSDR PRIVATE ${FFTW3_INCLUDE_DIRS})
+    target_link_directories(AetherSDR PRIVATE ${FFTW3_LIBRARY_DIRS})
     target_link_libraries(AetherSDR PRIVATE ${FFTW3_LIBRARIES})
     # Copy DLL to build dir on Windows
     if(WIN32 AND FFTW3_DLL)

--- a/cty.dat
+++ b/cty.dat
@@ -1,0 +1,1589 @@
+Sov Mil Order of Malta:   15:  28:  EU:   41.90:   -12.43:    -1.0:  1A:
+    1A;
+Spratly Islands:          26:  50:  AS:    9.88:  -114.23:    -8.0:  1S:
+    9M0,BM9S,BN9S,BO9S,BP9S,BQ9S,BU9S,BV9S,BW9S,BX9S;
+Monaco:                   14:  27:  EU:   43.73:    -7.40:    -1.0:  3A:
+    3A;
+Agalega & St. Brandon:    39:  53:  AF:  -10.45:   -56.67:    -4.0:  3B6:
+    3B6,3B7;
+Mauritius:                39:  53:  AF:  -20.35:   -57.50:    -4.0:  3B8:
+    3B8;
+Rodriguez Island:         39:  53:  AF:  -19.70:   -63.42:    -4.0:  3B9:
+    3B9;
+Equatorial Guinea:        36:  47:  AF:    1.70:   -10.33:    -1.0:  3C:
+    3C;
+Annobon Island:           36:  52:  AF:   -1.43:    -5.62:    -1.0:  3C0:
+    3C0;
+Fiji:                     32:  56:  OC:  -17.78:  -177.92:   -12.0:  3D2:
+    3D2;
+Conway Reef:              32:  56:  OC:  -22.00:  -175.00:   -12.0:  3D2/c:
+    =3D2CCC;
+Rotuma Island:            32:  56:  OC:  -12.48:  -177.08:   -12.0:  3D2/r:
+    =3D2RI;
+Kingdom of Eswatini:      38:  57:  AF:  -26.65:   -31.48:    -2.0:  3DA:
+    3DA;
+Tunisia:                  33:  37:  AF:   35.40:    -9.32:    -1.0:  3V:
+    3V,TS;
+Vietnam:                  26:  49:  AS:   15.80:  -107.90:    -7.0:  3W:
+    3W,XV;
+Guinea:                   35:  46:  AF:   11.00:    10.68:     0.0:  3X:
+    3X;
+Bouvet:                   38:  67:  AF:  -54.42:    -3.38:    -1.0:  3Y/b:
+    =3Y/LB5SH,=3Y0K,=3Y7GIA;
+Peter 1 Island:           12:  72:  SA:  -68.77:    90.58:     4.0:  3Y/p:
+    =3Y0X;
+Azerbaijan:               21:  29:  AS:   40.45:   -47.37:    -4.0:  4J:
+    4J,4K;
+Georgia:                  21:  29:  AS:   42.00:   -45.00:    -4.0:  4L:
+    4L;
+Montenegro:               15:  28:  EU:   42.50:   -19.28:    -1.0:  4O:
+    4O;
+Sri Lanka:                22:  41:  AS:    7.60:   -80.70:    -5.5:  4S:
+    4P,4Q,4R,4S;
+ITU HQ:                   14:  28:  EU:   46.17:    -6.05:    -1.0:  4U1I:
+    =4U0ITU,=4U1ITU,=4U1WRC,=VERSION;
+United Nations HQ:        05:  08:  NA:   40.75:    73.97:     5.0:  4U1U:
+    =4U1UN;
+Vienna Intl Ctr:          15:  28:  EU:   48.20:   -16.30:    -1.0:  *4U1V:
+    =4U0IARU,=4U0R,=4U1A,=4U1VIC,=4U2U,=4UNR,=4Y1A,=C7A;
+Timor - Leste:            28:  54:  OC:   -8.80:  -126.05:    -9.0:  4W:
+    4W;
+Israel:                   20:  39:  AS:   31.32:   -34.82:    -2.0:  4X:
+    4X,4Z;
+Libya:                    34:  38:  AF:   27.20:   -16.60:    -2.0:  5A:
+    5A;
+Cyprus:                   20:  39:  AS:   35.00:   -33.00:    -2.0:  5B:
+    5B,C4,H2,P3;
+Tanzania:                 37:  53:  AF:   -5.75:   -33.92:    -3.0:  5H:
+    5H,5I;
+Nigeria:                  35:  46:  AF:    9.87:    -7.55:    -1.0:  5N:
+    5N,5O;
+Madagascar:               39:  53:  AF:  -19.00:   -46.58:    -3.0:  5R:
+    5R,5S,6X;
+Mauritania:               35:  46:  AF:   20.60:    10.50:     0.0:  5T:
+    5T;
+Niger:                    35:  46:  AF:   17.63:    -9.43:    -1.0:  5U:
+    5U;
+Togo:                     35:  46:  AF:    8.40:    -1.28:     0.0:  5V:
+    5V;
+Samoa:                    32:  62:  OC:  -13.93:   171.70:   -13.0:  5W:
+    5W;
+Uganda:                   37:  48:  AF:    1.92:   -32.60:    -3.0:  5X:
+    5X;
+Kenya:                    37:  48:  AF:    0.32:   -38.15:    -3.0:  5Z:
+    5Y,5Z;
+Senegal:                  35:  46:  AF:   15.20:    14.63:     0.0:  6W:
+    6V,6W;
+Jamaica:                  08:  11:  NA:   18.20:    77.47:     5.0:  6Y:
+    6Y;
+Yemen:                    21:  39:  AS:   15.65:   -48.12:    -3.0:  7O:
+    7O;
+Lesotho:                  38:  57:  AF:  -29.22:   -27.88:    -2.0:  7P:
+    7P;
+Malawi:                   37:  53:  AF:  -14.00:   -34.00:    -2.0:  7Q:
+    7Q;
+Algeria:                  33:  37:  AF:   28.00:    -2.00:    -1.0:  7X:
+    7R,7T,7U,7V,7W,7X,7Y;
+Barbados:                 08:  11:  NA:   13.18:    59.53:     4.0:  8P:
+    8P;
+Maldives:                 22:  41:  AS:    4.15:   -73.45:    -5.0:  8Q:
+    8Q;
+Guyana:                   09:  12:  SA:    6.02:    59.45:     4.0:  8R:
+    8R;
+Croatia:                  15:  28:  EU:   45.18:   -15.30:    -1.0:  9A:
+    9A;
+Ghana:                    35:  46:  AF:    7.70:     1.57:     0.0:  9G:
+    9G;
+Malta:                    15:  28:  EU:   35.88:   -14.42:    -1.0:  9H:
+    9H;
+Zambia:                   36:  53:  AF:  -14.22:   -26.73:    -2.0:  9J:
+    9I,9J;
+Kuwait:                   21:  39:  AS:   29.38:   -47.38:    -3.0:  9K:
+    9K,NLD;
+Sierra Leone:             35:  46:  AF:    8.50:    13.25:     0.0:  9L:
+    9L;
+West Malaysia:            28:  54:  AS:    3.95:  -102.23:    -8.0:  9M2:
+    9M,9W;
+East Malaysia:            28:  54:  OC:    2.68:  -113.32:    -8.0:  9M6:
+    9M6,9M8,9W6,9W8,=9M4CHQ;
+Nepal:                    22:  42:  AS:   27.70:   -85.33:   -5.75:  9N:
+    9N;
+Dem. Rep. of the Congo:   36:  52:  AF:   -3.12:   -23.03:    -1.0:  9Q:
+    9O,9P,9Q,9R,9S,9T;
+Burundi:                  36:  52:  AF:   -3.17:   -29.78:    -2.0:  9U:
+    9U;
+Singapore:                28:  54:  AS:    1.37:  -103.78:    -8.0:  9V:
+    9V,S6;
+Rwanda:                   36:  52:  AF:   -1.75:   -29.82:    -2.0:  9X:
+    9X;
+Trinidad & Tobago:        09:  11:  SA:   10.38:    61.28:     4.0:  9Y:
+    9Y,9Z;
+Botswana:                 38:  57:  AF:  -22.00:   -24.00:    -2.0:  A2:
+    8O,A2;
+Tonga:                    32:  62:  OC:  -21.22:   175.13:   -13.0:  A3:
+    A3;
+Oman:                     21:  39:  AS:   23.60:   -58.55:    -4.0:  A4:
+    A4;
+Bhutan:                   22:  41:  AS:   27.40:   -90.18:    -6.0:  A5:
+    A5;
+United Arab Emirates:     21:  39:  AS:   24.00:   -54.00:    -4.0:  A6:
+    A6;
+Qatar:                    21:  39:  AS:   25.25:   -51.13:    -3.0:  A7:
+    A7;
+Bahrain:                  21:  39:  AS:   26.03:   -50.53:    -3.0:  A9:
+    A9;
+Pakistan:                 21:  41:  AS:   30.00:   -70.00:    -5.0:  AP:
+    6P,6Q,6R,6S,AP,AQ,AR,AS;
+Scarborough Reef:         27:  50:  AS:   15.08:  -117.72:    -8.0:  BS7:
+    =BS7H;
+Taiwan:                   24:  44:  AS:   23.72:  -120.88:    -8.0:  BV:
+    BM,BN,BO,BP,BQ,BU,BV,BW,BX;
+Pratas Island:            24:  44:  AS:   20.70:  -116.70:    -8.0:  BV9P:
+    BM9P,BN9P,BO9P,BP9P,BQ9P,BU9P,BV9P,BW9P,BX9P;
+China:                    24:  44:  AS:   36.00:  -102.00:    -8.0:  BY:
+    3H,3H0(23)[42],3H9(23)[43],3I,3I0(23)[42],3I9(23)[43],3J,3J0(23)[42],
+    3J9(23)[43],3K,3K0(23)[42],3K9(23)[43],3L,3L0(23)[42],3L9(23)[43],3M,
+    3M0(23)[42],3M9(23)[43],3N,3N0(23)[42],3N9(23)[43],3O,3O0(23)[42],
+    3O9(23)[43],3P,3P0(23)[42],3P9(23)[43],3Q,3Q0(23)[42],3Q9(23)[43],3R,
+    3R0(23)[42],3R9(23)[43],3S,3S0(23)[42],3S9(23)[43],3T,3T0(23)[42],
+    3T9(23)[43],3U,3U0(23)[42],3U9(23)[43],B0(23)[42],B2,B3,B4,B5,B6,B7,B8,
+    B9(23)[43],BA,BA0(23)[42],BA9(23)[43],BD,BD0(23)[42],BD9(23)[43],BG,
+    BG0(23)[42],BG9(23)[43],BH,BH0(23)[42],BH9(23)[43],BI,BI0(23)[42],
+    BI9(23)[43],BJ,BJ0(23)[42],BJ9(23)[43],BL,BL0(23)[42],BL9(23)[43],BT,
+    BT0(23)[42],BT9(23)[43],BY,BY0(23)[42],BY9(23)[43],BZ,BZ0(23)[42],
+    BZ9(23)[43],XS,XS0(23)[42],XS9(23)[43],B1,B2A[33],B2B[33],B2C[33],B2D[33],
+    B2E[33],B2F[33],B2G[33],B2H[33],B2I[33],B2J[33],B2K[33],B2L[33],B2M[33],
+    B2N[33],B2O[33],B2P[33],B3G(23)[33],B3H(23)[33],B3I(23)[33],B3J(23)[33],
+    B3K(23)[33],B3L(23)[33],B6Q[43],B6R[43],B6S[43],B6T[43],B6U[43],B6V[43],
+    B6W[43],B6X[43],B7A[43],B7B[43],B7C[43],B7D[43],B7E[43],B7F[43],B7G[43],
+    B7H[43],B7Q[43],B7R[43],B7S[43],B7T[43],B7U[43],B7V[43],B7W[43],B7X[43],
+    B8A[43],B8B[43],B8C[43],B8D[43],B8E[43],B8F[43],B8G[43],B8H[43],B8I[43],
+    B8J[43],B8K[43],B8L[43],B8M[43],B8N[43],B8O[43],B8P[43],B8Q[43],B8R[43],
+    B8S[43],B8T[43],B8U[43],B8V[43],B8W[43],B8X[43],B9A(24)[43],B9B(24)[43],
+    B9C(24)[43],B9D(24)[43],B9E(24)[43],B9F(24)[43],B9S(23)[42],B9T(23)[42],
+    B9U(23)[42],B9V(23)[42],B9W(23)[42],B9X(23)[42],BA2A[33],BA2B[33],
+    BA2C[33],BA2D[33],BA2E[33],BA2F[33],BA2G[33],BA2H[33],BA2I[33],BA2J[33],
+    BA2K[33],BA2L[33],BA2M[33],BA2N[33],BA2O[33],BA2P[33],BA3G(23)[33],
+    BA3H(23)[33],BA3I(23)[33],BA3J(23)[33],BA3K(23)[33],BA3L(23)[33],BA6Q[43],
+    BA6R[43],BA6S[43],BA6T[43],BA6U[43],BA6V[43],BA6W[43],BA6X[43],BA7A[43],
+    BA7B[43],BA7C[43],BA7D[43],BA7E[43],BA7F[43],BA7G[43],BA7H[43],BA7Q[43],
+    BA7R[43],BA7S[43],BA7T[43],BA7U[43],BA7V[43],BA7W[43],BA7X[43],BA8A[43],
+    BA8B[43],BA8C[43],BA8D[43],BA8E[43],BA8F[43],BA8G[43],BA8H[43],BA8I[43],
+    BA8J[43],BA8K[43],BA8L[43],BA8M[43],BA8N[43],BA8O[43],BA8P[43],BA8Q[43],
+    BA8R[43],BA8S[43],BA8T[43],BA8U[43],BA8V[43],BA8W[43],BA8X[43],
+    BA9A(24)[43],BA9B(24)[43],BA9C(24)[43],BA9D(24)[43],BA9E(24)[43],
+    BA9F(24)[43],BA9S(23)[42],BA9T(23)[42],BA9U(23)[42],BA9V(23)[42],
+    BA9W(23)[42],BA9X(23)[42],BD2A[33],BD2B[33],BD2C[33],BD2D[33],BD2E[33],
+    BD2F[33],BD2G[33],BD2H[33],BD2I[33],BD2J[33],BD2K[33],BD2L[33],BD2M[33],
+    BD2N[33],BD2O[33],BD2P[33],BD3G(23)[33],BD3H(23)[33],BD3I(23)[33],
+    BD3J(23)[33],BD3K(23)[33],BD3L(23)[33],BD6Q[43],BD6R[43],BD6S[43],
+    BD6T[43],BD6U[43],BD6V[43],BD6W[43],BD6X[43],BD7A[43],BD7B[43],BD7C[43],
+    BD7D[43],BD7E[43],BD7F[43],BD7G[43],BD7H[43],BD7Q[43],BD7R[43],BD7S[43],
+    BD7T[43],BD7U[43],BD7V[43],BD7W[43],BD7X[43],BD8A[43],BD8B[43],BD8C[43],
+    BD8D[43],BD8E[43],BD8F[43],BD8G[43],BD8H[43],BD8I[43],BD8J[43],BD8K[43],
+    BD8L[43],BD8M[43],BD8N[43],BD8O[43],BD8P[43],BD8Q[43],BD8R[43],BD8S[43],
+    BD8T[43],BD8U[43],BD8V[43],BD8W[43],BD8X[43],BD9A(24)[43],BD9B(24)[43],
+    BD9C(24)[43],BD9D(24)[43],BD9E(24)[43],BD9F(24)[43],BD9S(23)[42],
+    BD9T(23)[42],BD9U(23)[42],BD9V(23)[42],BD9W(23)[42],BD9X(23)[42],BG2A[33],
+    BG2B[33],BG2C[33],BG2D[33],BG2E[33],BG2F[33],BG2G[33],BG2H[33],BG2I[33],
+    BG2J[33],BG2K[33],BG2L[33],BG2M[33],BG2N[33],BG2O[33],BG2P[33],
+    BG3G(23)[33],BG3H(23)[33],BG3I(23)[33],BG3J(23)[33],BG3K(23)[33],
+    BG3L(23)[33],BG6Q[43],BG6R[43],BG6S[43],BG6T[43],BG6U[43],BG6V[43],
+    BG6W[43],BG6X[43],BG7A[43],BG7B[43],BG7C[43],BG7D[43],BG7E[43],BG7F[43],
+    BG7G[43],BG7H[43],BG7Q[43],BG7R[43],BG7S[43],BG7T[43],BG7U[43],BG7V[43],
+    BG7W[43],BG7X[43],BG8A[43],BG8B[43],BG8C[43],BG8D[43],BG8E[43],BG8F[43],
+    BG8G[43],BG8H[43],BG8I[43],BG8J[43],BG8K[43],BG8L[43],BG8M[43],BG8N[43],
+    BG8O[43],BG8P[43],BG8Q[43],BG8R[43],BG8S[43],BG8T[43],BG8U[43],BG8V[43],
+    BG8W[43],BG8X[43],BG9A(24)[43],BG9B(24)[43],BG9C(24)[43],BG9D(24)[43],
+    BG9E(24)[43],BG9F(24)[43],BG9S(23)[42],BG9T(23)[42],BG9U(23)[42],
+    BG9V(23)[42],BG9W(23)[42],BG9X(23)[42],BH2A[33],BH2B[33],BH2C[33],
+    BH2D[33],BH2E[33],BH2F[33],BH2G[33],BH2H[33],BH2I[33],BH2J[33],BH2K[33],
+    BH2L[33],BH2M[33],BH2N[33],BH2O[33],BH2P[33],BH3G(23)[33],BH3H(23)[33],
+    BH3I(23)[33],BH3J(23)[33],BH3K(23)[33],BH3L(23)[33],BH6Q[43],BH6R[43],
+    BH6S[43],BH6T[43],BH6U[43],BH6V[43],BH6W[43],BH6X[43],BH7A[43],BH7B[43],
+    BH7C[43],BH7D[43],BH7E[43],BH7F[43],BH7G[43],BH7H[43],BH7Q[43],BH7R[43],
+    BH7S[43],BH7T[43],BH7U[43],BH7V[43],BH7W[43],BH7X[43],BH8A[43],BH8B[43],
+    BH8C[43],BH8D[43],BH8E[43],BH8F[43],BH8G[43],BH8H[43],BH8I[43],BH8J[43],
+    BH8K[43],BH8L[43],BH8M[43],BH8N[43],BH8O[43],BH8P[43],BH8Q[43],BH8R[43],
+    BH8S[43],BH8T[43],BH8U[43],BH8V[43],BH8W[43],BH8X[43],BH9A(24)[43],
+    BH9B(24)[43],BH9C(24)[43],BH9D(24)[43],BH9E(24)[43],BH9F(24)[43],
+    BH9S(23)[42],BH9T(23)[42],BH9U(23)[42],BH9V(23)[42],BH9W(23)[42],
+    BH9X(23)[42],BI2A[33],BI2B[33],BI2C[33],BI2D[33],BI2E[33],BI2F[33],
+    BI2G[33],BI2H[33],BI2I[33],BI2J[33],BI2K[33],BI2L[33],BI2M[33],BI2N[33],
+    BI2O[33],BI2P[33],BI3G(23)[33],BI3H(23)[33],BI3I(23)[33],BI3J(23)[33],
+    BI3K(23)[33],BI3L(23)[33],BI6Q[43],BI6R[43],BI6S[43],BI6T[43],BI6U[43],
+    BI6V[43],BI6W[43],BI6X[43],BI7A[43],BI7B[43],BI7C[43],BI7D[43],BI7E[43],
+    BI7F[43],BI7G[43],BI7H[43],BI7Q[43],BI7R[43],BI7S[43],BI7T[43],BI7U[43],
+    BI7V[43],BI7W[43],BI7X[43],BI8A[43],BI8B[43],BI8C[43],BI8D[43],BI8E[43],
+    BI8F[43],BI8G[43],BI8H[43],BI8I[43],BI8J[43],BI8K[43],BI8L[43],BI8M[43],
+    BI8N[43],BI8O[43],BI8P[43],BI8Q[43],BI8R[43],BI8S[43],BI8T[43],BI8U[43],
+    BI8V[43],BI8W[43],BI8X[43],BI9A(24)[43],BI9B(24)[43],BI9C(24)[43],
+    BI9D(24)[43],BI9E(24)[43],BI9F(24)[43],BI9S(23)[42],BI9T(23)[42],
+    BI9U(23)[42],BI9V(23)[42],BI9W(23)[42],BI9X(23)[42],BJ2A[33],BJ2B[33],
+    BJ2C[33],BJ2D[33],BJ2E[33],BJ2F[33],BJ2G[33],BJ2H[33],BJ2I[33],BJ2J[33],
+    BJ2K[33],BJ2L[33],BJ2M[33],BJ2N[33],BJ2O[33],BJ2P[33],BJ3G(23)[33],
+    BJ3H(23)[33],BJ3I(23)[33],BJ3J(23)[33],BJ3K(23)[33],BJ3L(23)[33],BJ6Q[43],
+    BJ6R[43],BJ6S[43],BJ6T[43],BJ6U[43],BJ6V[43],BJ6W[43],BJ6X[43],BJ7A[43],
+    BJ7B[43],BJ7C[43],BJ7D[43],BJ7E[43],BJ7F[43],BJ7G[43],BJ7H[43],BJ7Q[43],
+    BJ7R[43],BJ7S[43],BJ7T[43],BJ7U[43],BJ7V[43],BJ7W[43],BJ7X[43],BJ8A[43],
+    BJ8B[43],BJ8C[43],BJ8D[43],BJ8E[43],BJ8F[43],BJ8G[43],BJ8H[43],BJ8I[43],
+    BJ8J[43],BJ8K[43],BJ8L[43],BJ8M[43],BJ8N[43],BJ8O[43],BJ8P[43],BJ8Q[43],
+    BJ8R[43],BJ8S[43],BJ8T[43],BJ8U[43],BJ8V[43],BJ8W[43],BJ8X[43],
+    BJ9A(24)[43],BJ9B(24)[43],BJ9C(24)[43],BJ9D(24)[43],BJ9E(24)[43],
+    BJ9F(24)[43],BJ9S(23)[42],BJ9T(23)[42],BJ9U(23)[42],BJ9V(23)[42],
+    BJ9W(23)[42],BJ9X(23)[42],BL2A[33],BL2B[33],BL2C[33],BL2D[33],BL2E[33],
+    BL2F[33],BL2G[33],BL2H[33],BL2I[33],BL2J[33],BL2K[33],BL2L[33],BL2M[33],
+    BL2N[33],BL2O[33],BL2P[33],BL3G(23)[33],BL3H(23)[33],BL3I(23)[33],
+    BL3J(23)[33],BL3K(23)[33],BL3L(23)[33],BL6Q[43],BL6R[43],BL6S[43],
+    BL6T[43],BL6U[43],BL6V[43],BL6W[43],BL6X[43],BL7A[43],BL7B[43],BL7C[43],
+    BL7D[43],BL7E[43],BL7F[43],BL7G[43],BL7H[43],BL7Q[43],BL7R[43],BL7S[43],
+    BL7T[43],BL7U[43],BL7V[43],BL7W[43],BL7X[43],BL8A[43],BL8B[43],BL8C[43],
+    BL8D[43],BL8E[43],BL8F[43],BL8G[43],BL8H[43],BL8I[43],BL8J[43],BL8K[43],
+    BL8L[43],BL8M[43],BL8N[43],BL8O[43],BL8P[43],BL8Q[43],BL8R[43],BL8S[43],
+    BL8T[43],BL8U[43],BL8V[43],BL8W[43],BL8X[43],BL9A(24)[43],BL9B(24)[43],
+    BL9C(24)[43],BL9D(24)[43],BL9E(24)[43],BL9F(24)[43],BL9S(23)[42],
+    BL9T(23)[42],BL9U(23)[42],BL9V(23)[42],BL9W(23)[42],BL9X(23)[42],BT2A[33],
+    BT2B[33],BT2C[33],BT2D[33],BT2E[33],BT2F[33],BT2G[33],BT2H[33],BT2I[33],
+    BT2J[33],BT2K[33],BT2L[33],BT2M[33],BT2N[33],BT2O[33],BT2P[33],
+    BT3G(23)[33],BT3H(23)[33],BT3I(23)[33],BT3J(23)[33],BT3K(23)[33],
+    BT3L(23)[33],BT6Q[43],BT6R[43],BT6S[43],BT6T[43],BT6U[43],BT6V[43],
+    BT6W[43],BT6X[43],BT7A[43],BT7B[43],BT7C[43],BT7D[43],BT7E[43],BT7F[43],
+    BT7G[43],BT7H[43],BT7Q[43],BT7R[43],BT7S[43],BT7T[43],BT7U[43],BT7V[43],
+    BT7W[43],BT7X[43],BT8A[43],BT8B[43],BT8C[43],BT8D[43],BT8E[43],BT8F[43],
+    BT8G[43],BT8H[43],BT8I[43],BT8J[43],BT8K[43],BT8L[43],BT8M[43],BT8N[43],
+    BT8O[43],BT8P[43],BT8Q[43],BT8R[43],BT8S[43],BT8T[43],BT8U[43],BT8V[43],
+    BT8W[43],BT8X[43],BT9A(24)[43],BT9B(24)[43],BT9C(24)[43],BT9D(24)[43],
+    BT9E(24)[43],BT9F(24)[43],BT9S(23)[42],BT9T(23)[42],BT9U(23)[42],
+    BT9V(23)[42],BT9W(23)[42],BT9X(23)[42],BY2A[33],BY2B[33],BY2C[33],
+    BY2D[33],BY2E[33],BY2F[33],BY2G[33],BY2H[33],BY2I[33],BY2J[33],BY2K[33],
+    BY2L[33],BY2M[33],BY2N[33],BY2O[33],BY2P[33],BY3G(23)[33],BY3H(23)[33],
+    BY3I(23)[33],BY3J(23)[33],BY3K(23)[33],BY3L(23)[33],BY6Q[43],BY6R[43],
+    BY6S[43],BY6T[43],BY6U[43],BY6V[43],BY6W[43],BY6X[43],BY7A[43],BY7B[43],
+    BY7C[43],BY7D[43],BY7E[43],BY7F[43],BY7G[43],BY7H[43],BY7Q[43],BY7R[43],
+    BY7S[43],BY7T[43],BY7U[43],BY7V[43],BY7W[43],BY7X[43],BY8A[43],BY8B[43],
+    BY8C[43],BY8D[43],BY8E[43],BY8F[43],BY8G[43],BY8H[43],BY8I[43],BY8J[43],
+    BY8K[43],BY8L[43],BY8M[43],BY8N[43],BY8O[43],BY8P[43],BY8Q[43],BY8R[43],
+    BY8S[43],BY8T[43],BY8U[43],BY8V[43],BY8W[43],BY8X[43],BY9A(24)[43],
+    BY9B(24)[43],BY9C(24)[43],BY9D(24)[43],BY9E(24)[43],BY9F(24)[43],
+    BY9S(23)[42],BY9T(23)[42],BY9U(23)[42],BY9V(23)[42],BY9W(23)[42],
+    BY9X(23)[42],BZ2A[33],BZ2B[33],BZ2C[33],BZ2D[33],BZ2E[33],BZ2F[33],
+    BZ2G[33],BZ2H[33],BZ2I[33],BZ2J[33],BZ2K[33],BZ2L[33],BZ2M[33],BZ2N[33],
+    BZ2O[33],BZ2P[33],BZ3G(23)[33],BZ3H(23)[33],BZ3I(23)[33],BZ3J(23)[33],
+    BZ3K(23)[33],BZ3L(23)[33],BZ6Q[43],BZ6R[43],BZ6S[43],BZ6T[43],BZ6U[43],
+    BZ6V[43],BZ6W[43],BZ6X[43],BZ7A[43],BZ7B[43],BZ7C[43],BZ7D[43],BZ7E[43],
+    BZ7F[43],BZ7G[43],BZ7H[43],BZ7Q[43],BZ7R[43],BZ7S[43],BZ7T[43],BZ7U[43],
+    BZ7V[43],BZ7W[43],BZ7X[43],BZ8A[43],BZ8B[43],BZ8C[43],BZ8D[43],BZ8E[43],
+    BZ8F[43],BZ8G[43],BZ8H[43],BZ8I[43],BZ8J[43],BZ8K[43],BZ8L[43],BZ8M[43],
+    BZ8N[43],BZ8O[43],BZ8P[43],BZ8Q[43],BZ8R[43],BZ8S[43],BZ8T[43],BZ8U[43],
+    BZ8V[43],BZ8W[43],BZ8X[43],BZ9A(24)[43],BZ9B(24)[43],BZ9C(24)[43],
+    BZ9D(24)[43],BZ9E(24)[43],BZ9F(24)[43],BZ9S(23)[42],BZ9T(23)[42],
+    BZ9U(23)[42],BZ9V(23)[42],BZ9W(23)[42],BZ9X(23)[42];
+Nauru:                    31:  65:  OC:   -0.52:  -166.92:   -12.0:  C2:
+    C2;
+Andorra:                  14:  27:  EU:   42.58:    -1.62:    -1.0:  C3:
+    C3;
+The Gambia:               35:  46:  AF:   13.40:    16.38:     0.0:  C5:
+    C5;
+Bahamas:                  08:  11:  NA:   24.25:    76.00:     5.0:  C6:
+    C6;
+Mozambique:               37:  53:  AF:  -18.25:   -35.00:    -2.0:  C9:
+    C8,C9;
+Chile:                    12:  14:  SA:  -30.00:    71.00:     4.0:  CE:
+    3G,CA,CB,CC,CD,CE,XQ,XR,3G7[16],3G8[16],CA7[16],CA8[16],CB7[16],CB8[16],
+    CC7[16],CC8[16],CD7[16],CD8[16],CE7[16],CE8[16],XQ7[16],XQ8[16],XR7[16],
+    XR8[16],=CE6RFP[16],=XQ6CF[16],=XQ6OA[16];
+San Felix & San Ambrosio: 12:  14:  SA:  -26.28:    80.07:     4.0:  CE0X:
+    3G0X,CA0X,CB0X,CC0X,CD0X,CE0X,XQ0X,XR0X;
+Easter Island:            12:  63:  SA:  -27.10:   109.37:     6.0:  CE0Y:
+    3G0,CA0,CB0,CC0,CD0,CE0,XQ0,XR0;
+Juan Fernandez Islands:   12:  14:  SA:  -33.60:    78.85:     4.0:  CE0Z:
+    3G0Z,CA0Z,CB0Z,CC0Z,CD0Z,CE0I,CE0Z,XQ0Z,XR0Z;
+Antarctica:               13:  74:  SA:  -90.00:     0.00:     0.0:  CE9:
+    3Y[73],AX0(39)[69],AY1Z[73],AY2Z[73],AY3Z[73],AY4Z[73],AY5Z[73],AY6Z[73],
+    AY7Z[73],AY8Z[73],AY9Z[73],FT0Y(30)[70],FT1Y(30)[70],FT2Y(30)[70],
+    FT3Y(30)[70],FT4Y(30)[70],FT5Y(30)[70],FT6Y(30)[70],FT7Y(30)[70],
+    FT8Y(30)[70],LU1Z[73],LU2Z[73],LU3Z[73],LU4Z[73],LU5Z[73],LU6Z[73],
+    LU7Z[73],LU8Z[73],LU9Z[73],RI1AN(29)[69],VI0(39)[69],VK0(39)[69],
+    ZL5(30)[71],ZM5(30)[71],ZS7(38)[67],=8J1RL(39)[67],=AT44I(39)[69],
+    =DP0GVN(38)[67],=DP1POL(38)[67],=KC4AAA(39),=RI1ANC(29)[70],
+    =RI1ANI(39)[69],=VK0TBC(29)[70];
+Cuba:                     08:  11:  NA:   21.50:    80.00:     5.0:  CM:
+    CL,CM,CO,T4;
+Morocco:                  33:  37:  AF:   32.00:     5.00:     0.0:  CN:
+    5C,5D,5E,5F,5G,CN;
+Bolivia:                  10:  12:  SA:  -17.00:    65.00:     4.0:  CP:
+    CP,CP2[14],CP3[14],CP4[14],CP5[14],CP6[14],CP7[14];
+Portugal:                 14:  37:  EU:   39.50:     8.00:     0.0:  CT:
+    CQ,CR,CS,CT;
+Madeira Islands:          33:  36:  AF:   32.75:    16.95:     0.0:  CT3:
+    CQ2,CQ3,CQ9,CR3,CR9,CS3,CS9,CT3,CT9;
+Azores:                   14:  36:  EU:   38.70:    27.23:     1.0:  CU:
+    CQ1,CQ8,CR1,CR2,CR8,CS4,CS8,CT8,CU;
+Uruguay:                  13:  14:  SA:  -33.00:    56.00:     3.0:  CX:
+    CV,CW,CX;
+Sable Island:             05:  09:  NA:   43.93:    59.90:     4.0:  CY0:
+    CY0;
+St. Paul Island:          05:  09:  NA:   47.00:    60.00:     4.0:  CY9:
+    CY9;
+Angola:                   36:  52:  AF:  -12.50:   -18.50:    -1.0:  D2:
+    D2,D3;
+Cape Verde:               35:  46:  AF:   16.00:    24.00:     1.0:  D4:
+    D4;
+Comoros:                  39:  53:  AF:  -11.63:   -43.30:    -3.0:  D6:
+    D6;
+Fed. Rep. of Germany:     14:  28:  EU:   51.00:   -10.00:    -1.0:  DL:
+    DA,DB,DC,DD,DE,DF,DG,DH,DI,DJ,DK,DL,DM,DN,DO,DP,DQ,DR,Y2,Y3,Y4,Y5,Y6,Y7,
+    Y8,Y9;
+Philippines:              27:  50:  OC:   13.00:  -122.00:    -8.0:  DU:
+    4D,4E,4F,4G,4H,4I,DU,DV,DW,DX,DY,DZ;
+Eritrea:                  37:  48:  AF:   15.00:   -39.00:    -3.0:  E3:
+    E3;
+Palestine:                20:  39:  AS:   31.28:   -34.27:    -2.0:  E4:
+    E4;
+North Cook Islands:       32:  62:  OC:  -10.02:   161.08:    10.0:  E5/n:
+    =E51PT,=E51WL[63];
+South Cook Islands:       32:  63:  OC:  -21.90:   157.93:    10.0:  E5/s:
+    E5;
+Niue:                     32:  62:  OC:  -19.03:   169.85:    11.0:  E6:
+    E6;
+Bosnia-Herzegovina:       15:  28:  EU:   44.32:   -17.57:    -1.0:  E7:
+    E7;
+Spain:                    14:  37:  EU:   40.32:     3.43:    -1.0:  EA:
+    AM,AN,AO,EA,EB,EC,ED,EE,EF,EG,EH,=EG61GURU,=EA1RCI/P,=EA2EZ/P,=EA5CC/P,
+    =EA5IKT/P,=EA6XQ/P,=EA8JR,=EA9ADD,=EA9HU,=EC5AHA/P,=EH90ALL;
+Balearic Islands:         14:  37:  EU:   39.60:    -2.95:    -1.0:  EA6:
+    AM6,AN6,AO6,EA6,EB6,EC6,ED6,EE6,EF6,EG6,EH6,=EA1EV,=EA5IYX/P;
+Canary Islands:           33:  36:  AF:   28.32:    15.85:     0.0:  EA8:
+    AM8,AN8,AO8,EA8,EB8,EC8,ED8,EE8,EF8,EG8,EH8,=EG2MKO;
+Ceuta & Melilla:          33:  37:  AF:   35.90:     5.27:    -1.0:  EA9:
+    AM9,AN9,AO9,EA9,EB9,EC9,ED9,EE9,EF9,EG9,EH9;
+Ireland:                  14:  27:  EU:   53.13:     8.02:     0.0:  EI:
+    EI,EJ;
+Armenia:                  21:  29:  AS:   40.40:   -44.90:    -4.0:  EK:
+    EK;
+Liberia:                  35:  46:  AF:    6.50:     9.50:     0.0:  EL:
+    5L,5M,6Z,A8,D5,EL;
+Iran:                     21:  40:  AS:   32.00:   -53.00:    -3.5:  EP:
+    9B,9C,9D,EP,EQ;
+Moldova:                  16:  29:  EU:   47.00:   -29.00:    -2.0:  ER:
+    ER;
+Estonia:                  15:  29:  EU:   59.00:   -25.00:    -2.0:  ES:
+    ES;
+Ethiopia:                 37:  48:  AF:    9.00:   -39.00:    -3.0:  ET:
+    9E,9F,ET;
+Belarus:                  16:  29:  EU:   54.00:   -28.00:    -2.0:  EU:
+    EU,EV,EW;
+Kyrgyzstan:               17:  30:  AS:   41.70:   -74.13:    -6.0:  EX:
+    EX,EX0P[31],EX0Q[31],EX2P[31],EX2Q[31],EX6P[31],EX6Q[31],EX7P[31],
+    EX7Q[31],EX8P[31],EX8Q[31];
+Tajikistan:               17:  30:  AS:   38.82:   -71.22:    -5.0:  EY:
+    EY;
+Turkmenistan:             17:  30:  AS:   38.00:   -58.00:    -5.0:  EZ:
+    EZ;
+France:                   14:  27:  EU:   46.00:    -2.00:    -1.0:  F:
+    F,HW,HX,HY,TH,TM,TO,TP,TQ,TV,TX;
+Guadeloupe:               08:  11:  NA:   16.13:    61.67:     4.0:  FG:
+    FG;
+Mayotte:                  39:  53:  AF:  -12.88:   -45.15:    -3.0:  FH:
+    FH;
+St. Barthelemy:           08:  11:  NA:   17.90:    62.83:     4.0:  FJ:
+    FJ;
+New Caledonia:            32:  56:  OC:  -21.50:  -165.50:   -11.0:  FK:
+    FK;
+Chesterfield Islands:     30:  56:  OC:  -19.87:  -158.32:   -11.0:  FK/c:
+    =TX3X;
+Martinique:               08:  11:  NA:   14.70:    61.03:     4.0:  FM:
+    FM,=TO4A,=TO5A,=TO7A,=TO7O;
+French Polynesia:         32:  63:  OC:  -17.65:   149.40:    10.0:  FO:
+    FO;
+Austral Islands:          32:  63:  OC:  -23.37:   149.48:    10.0:  FO/a:
+    =TX5EU;
+Clipperton Island:        07:  10:  NA:   10.28:   109.22:     8.0:  FO/c:
+    =TX5S;
+Marquesas Islands:        31:  63:  OC:   -8.92:   140.07:     9.5:  FO/m:
+    =FO5QS,=TX9W;
+St. Pierre & Miquelon:    05:  09:  NA:   46.77:    56.20:     3.0:  FP:
+    FP;
+Reunion Island:           39:  53:  AF:  -21.12:   -55.48:    -4.0:  FR:
+    FR,=TO7K;
+St. Martin:               08:  11:  NA:   18.08:    63.03:     4.0:  FS:
+    FS,=TO5M,=TO5T;
+Glorioso Islands:         39:  53:  AF:  -11.55:   -47.28:    -4.0:  FT/g:
+    FT0G,FT1G,FT2G,FT3G,FT4G,FT5G,FT6G,FT7G,FT8G,FT9G;
+Juan de Nova, Europa:     39:  53:  AF:  -17.05:   -42.72:    -3.0:  FT/j:
+    FT0E,FT0J,FT1E,FT1J,FT2E,FT2J,FT3E,FT3J,FT4E,FT4J,FT6E,FT6J,FT7E,FT7J,
+    FT8E,FT8J,FT9E,FT9J;
+Tromelin Island:          39:  53:  AF:  -15.88:   -54.50:    -4.0:  FT/t:
+    FT0T,FT1T,FT2T,FT3T,FT4T,FT5T,FT6T,FT7T,FT8T,FT9T;
+Crozet Island:            39:  68:  AF:  -46.42:   -51.75:    -5.0:  FT/w:
+    FT0W,FT4W,FT5W,FT8W;
+Kerguelen Islands:        39:  68:  AF:  -49.00:   -69.27:    -5.0:  FT/x:
+    FT0X,FT2X,FT4X,FT5X,FT8X;
+Amsterdam & St. Paul Is.: 39:  68:  AF:  -37.85:   -77.53:    -5.0:  FT/z:
+    FT0Z,FT1Z,FT2Z,FT3Z,FT4Z,FT5Z,FT6Z,FT7Z,FT8Z;
+Wallis & Futuna Islands:  32:  62:  OC:  -13.30:   176.20:   -12.0:  FW:
+    FW,TW;
+French Guiana:            09:  12:  SA:    4.00:    53.00:     3.0:  FY:
+    FY,=TO1A;
+England:                  14:  27:  EU:   52.77:     1.47:     0.0:  G:
+    2E,G,M;
+Isle of Man:              14:  27:  EU:   54.20:     4.53:     0.0:  GD:
+    2D,GD,GT,MD,MT,=G6ICR;
+Northern Ireland:         14:  27:  EU:   54.73:     6.68:     0.0:  GI:
+    2I,GI,GN,MI,MN,=GB0SPD,=GB4SPD,=GB5PAT,=GB6SPD,=GB9SPD,=M0KXR;
+Jersey:                   14:  27:  EU:   49.22:     2.18:     0.0:  GJ:
+    2J,GH,GJ,MH,MJ;
+Scotland:                 14:  27:  EU:   56.82:     4.18:     0.0:  GM:
+    2A,2M,GM,GS,MA,MM,MS,=G0HCQ,=G0JCE,=G1R,=G1T,=G4WZG,=G4X,=G5RDX,=GB0GGR,
+    =GB0OH,=GB1DAA,=GB26RNLI,=GB2CM,=GB2ELH,=GB2JCM,=GB3ANG,=GB3LER,=GB3LER/B,
+    =GB4LER,=M3I,=M7HPC;
+Shetland Islands:         14:  27:  EU:   60.50:     1.50:     0.0:  *GM/s:
+    =2M0BDR,=2M0BDT,=2M0CPN,=2M0GFC,=2M0SEG,=2M0SPX,=2M0ZET,=GB1DAA,=GB2ELH,
+    =GB3LER,=GB3LER/B,=GB4LER,=GM0AVR,=GM0EKM,=GM0GFL,=GM0ILB,=GM0JDB,=GM1FGN,
+    =GM1KKI,=GM1ZNR,=GM3WHT,=GM3ZET,=GM4IPK,=GM4JPI,=GM4LBE,=GM4LER,=GM4PXG,
+    =GM4SLV,=GM4WXQ,=GM4ZHL,=GM6RQW,=GM6YQA,=GM7AFE,=GM7GWW,=GM8LNH,=GM8MMA,
+    =GM8YEC,=GS3ZET,=MM0LSM,=MM0NQY,=MM0VIK,=MM0XAU,=MM0ZAL,=MM0ZCG,=MM0ZRC,
+    =MM1FEO,=MM1FJM,=MM3VQO,=MM5PSL,=MM5YLO,=MM6BDU,=MM6BZQ,=MM6IKB,=MM6IMB,
+    =MM6MFA,=MM6PTE,=MM6SJK,=MM6YLO,=MM6ZBG,=MM6ZDW,=MM7CGR,=MM7HBQ,=MM8A,
+    =MS0ZCG,=MS0ZET,=MS5B;
+Guernsey:                 14:  27:  EU:   49.45:     2.58:     0.0:  GU:
+    2U,GP,GU,MP,MU,=GB4RS,=GB5CC;
+Wales:                    14:  27:  EU:   52.28:     3.73:     0.0:  GW:
+    2W,GC,GW,MC,MW,=G5DXR,=G5MUT,=GB0MPA,=GB2IMD,=GB2MOP,=GB2TD,=GB2VK,
+    =GB4MDI,=GB4SDD,=M0KWG;
+Solomon Islands:          28:  51:  OC:   -9.00:  -160.00:   -11.0:  H4:
+    H4;
+Temotu Province:          32:  51:  OC:  -10.72:  -165.80:   -11.0:  H40:
+    H40;
+Hungary:                  15:  28:  EU:   47.12:   -19.28:    -1.0:  HA:
+    HA,HG;
+Switzerland:              14:  28:  EU:   46.87:    -8.12:    -1.0:  HB:
+    HB,HE;
+Liechtenstein:            14:  28:  EU:   47.13:    -9.57:    -1.0:  HB0:
+    HB0,HE0;
+Ecuador:                  10:  12:  SA:   -1.40:    78.40:     5.0:  HC:
+    HC,HD,=HC8M/5;
+Galapagos Islands:        10:  12:  SA:   -0.78:    91.03:     6.0:  HC8:
+    HC8,HD8,=HD5MW/8;
+Haiti:                    08:  11:  NA:   19.02:    72.18:     5.0:  HH:
+    4V,HH;
+Dominican Republic:       08:  11:  NA:   19.13:    70.68:     4.0:  HI:
+    HI;
+Colombia:                 09:  12:  SA:    5.00:    74.00:     5.0:  HK:
+    5J,5K,HJ,HK;
+San Andres & Providencia: 07:  11:  NA:   12.55:    81.72:     5.0:  HK0/a:
+    5J0,5K0,HJ0,HK0;
+Malpelo Island:           09:  12:  SA:    3.98:    81.58:     5.0:  HK0/m:
+    HJ0M,HK0M,=HK0TU;
+Republic of Korea:        25:  44:  AS:   36.23:  -127.90:    -9.0:  HL:
+    6K,6L,6M,6N,D7,D8,D9,DS,DT,HL,KL9K;
+Panama:                   07:  11:  NA:    9.00:    80.00:     5.0:  HP:
+    3E,3F,H3,H8,H9,HO,HP;
+Honduras:                 07:  11:  NA:   15.00:    87.00:     6.0:  HR:
+    HQ,HR;
+Thailand:                 26:  49:  AS:   12.60:   -99.70:    -7.0:  HS:
+    E2,HS;
+Vatican City:             15:  28:  EU:   41.90:   -12.47:    -1.0:  HV:
+    HV;
+Saudi Arabia:             21:  39:  AS:   24.20:   -43.83:    -3.0:  HZ:
+    7Z,8Z,HZ;
+Italy:                    15:  28:  EU:   42.82:   -12.58:    -1.0:  I:
+    4U,I,=I2DMK/RM,=IA5KRO/4,=IQ9SZ/0,=IQ9SZ/2,=IQ9SZ/3,=IQ9SZ/4,=IT9CLY/4,
+    =IT9ELM/0;
+African Italy:            33:  37:  AF:   35.67:   -12.67:    -1.0:  *IG9:
+    IG9,IH9;
+Sardinia:                 15:  28:  EU:   40.15:    -9.27:    -1.0:  IS:
+    IM0,IS0,IW0U,IW0V,IW0W,IW0X,IW0Y,IW0Z,=II0D,=II0ICH,=II0ICV,=II0IDP,=II0M,
+    =IP0A,=IP0Y,=IQ0AAI,=IQ0AG,=IQ0AH,=IQ0AI,=IQ0AK,=IQ0AL,=IQ0AM,=IQ0EH,
+    =IQ0HO,=IQ0ID,=IQ0NU,=IQ0OG,=IQ0PM,=IQ0QP,=IQ0SS,=IQ0SS/P,=IR0A,=IR0IDP,
+    =IR0RIVA,=IR0SAR,=IY0GA;
+Sicily:                   15:  28:  EU:   37.50:   -14.00:    -1.0:  *IT9:
+    IB9,ID9,IE9,IF9,II9,IJ9,IO9,IP9,IQ9,IR9,IT9,IU9,IW9,IY9,=II0GDF/9,
+    =IQ0JV/9,=IW0HBY/9;
+Djibouti:                 37:  48:  AF:   11.75:   -42.35:    -3.0:  J2:
+    J2;
+Grenada:                  08:  11:  NA:   12.13:    61.68:     4.0:  J3:
+    J3;
+Guinea-Bissau:            35:  46:  AF:   12.02:    14.80:     0.0:  J5:
+    J5;
+St. Lucia:                08:  11:  NA:   13.87:    61.00:     4.0:  J6:
+    J6;
+Dominica:                 08:  11:  NA:   15.43:    61.35:     4.0:  J7:
+    J7;
+St. Vincent:              08:  11:  NA:   13.23:    61.20:     4.0:  J8:
+    J8;
+Japan:                    25:  45:  AS:   36.40:  -138.38:    -9.0:  JA:
+    7J,7K,7L,7M,7N,8J,8K,8L,8M,8N,JA,JE,JF,JG,JH,JI,JJ,JK,JL,JM,JN,JO,JP,JQ,
+    JR,JS,=JD1BPS/1;
+Minami Torishima:         27:  90:  OC:   24.28:  -153.97:   -10.0:  JD/m:
+    =JD1YAA,=JD1YBJ,=JG8NQJ/JD1;
+Ogasawara:                27:  45:  AS:   27.05:  -142.20:    -9.0:  JD/o:
+    JD1;
+Mongolia:                 23:  32:  AS:   46.77:  -102.17:    -7.0:  JT:
+    JT,JU,JV,JT2[33],JT3[33],JU2[33],JU3[33],JV2[33],JV3[33];
+Svalbard:                 40:  18:  EU:   78.00:   -16.00:    -1.0:  JW:
+    JW;
+Bear Island:              40:  18:  EU:   74.43:   -19.08:    -1.0:  *JW/b:
+    =JW/LB2PG;
+Jan Mayen:                40:  18:  EU:   71.05:     8.28:     1.0:  JX:
+    JX;
+Jordan:                   20:  39:  AS:   31.18:   -36.42:    -2.0:  JY:
+    JY;
+United States:            05:  08:  NA:   37.60:    91.87:     5.0:  K:
+    AA,AB,AC,AD,AE,AF,AG,AI,AJ,AK,K,N,W,=4U1WB(5)[8],=AA0BY(3)[6],=AA0O(5)[8],
+    =AA0Y(3)[6],=AA1AO(3)[6],=AA1JM(4)[8],=AA2F(4)[8],=AA2HJ(3)[6],
+    =AA2IL(3)[6],=AA2MA(4)[8],=AA2Q(4)[8],=AA3C(4)[7],=AA3CS(4)[8],
+    =AA3OO(4)[7],=AA4CS(4)[8],=AA4CW(4)[8],=AA4DD(4)[8],=AA4HV(4)[8],
+    =AA4NU(4)[8],=AA4PA(4)[8],=AA4Q(3)[6],=AA4RY(4)[8],=AA4S(4)[8],
+    =AA4U(4)[8],=AA4WX(4)[8],=AA5JF(5)[8],=AA5NT(5)[8],=AA5TL(3)[6],
+    =AA6DQ(5)[8],=AA6KJ(4)[7],=AA7JV(5)[8],=AA7TJ(4)[7],=AA8R(5)[8],
+    =AA8UL(5)[8],=AA9HQ(5)[8],=AB1MM(4)[7],=AB1U(3)[6],=AB2A(4)[8],
+    =AB3AH(4)[8],=AB3DC(4)[8],=AB3I(4)[8],=AB4B(4)[8],=AB4BA(4)[7],
+    =AB4EJ(4)[8],=AB4IQ(4)[8],=AB4WL(4)[8],=AB4WV(4)[8],=AB5VJ(5)[8],
+    =AB5ZA(4)[6],=AB6GS(4)[7],=AB8RL(5)[8],=AB8YZ(4)[7],=AB9BH(3)[6],
+    =AC0WL(4)[8],=AC1W(4)[8],=AC4G(4)[8],=AC4HI(4)[8],=AC4NK(4)[8],
+    =AC5XK(5)[8],=AC6NT(4)[8],=AC6ZM(4)[8],=AC7AF(4)[7],=AC7GG(5)[8],
+    =AC7P(4)[7],=AC7YT(4)[6],=AC8Y(5)[8],=AC9DX(4)[7],=AC9TO(4)[7],
+    =AD0L(3)[6],=AD1C(4)[7],=AD4DQ(4)[8],=AD4EB(4)[8],=AD4GG(4)[8],
+    =AD4SM(4)[8],=AD4TA(4)[8],=AD5IT(4)[8],=AD6V(5)[8],=AD7CL(4)[7],
+    =AD7JL(5)[8],=AD7KI(4)[7],=AD8J(5)[8],=AE2V(4)[8],=AE4ED(4)[8],
+    =AE4GS(4)[8],=AE4GW(4)[8],=AE4JC(4)[8],=AE4JM(4)[8],=AE4QU(4)[8],
+    =AE5X(5)[8],=AE7AP(4)[6],=AE7EB(5)[8],=AE8K(5)[8],=AF1US(4)[8],
+    =AF4AI(4)[8],=AF4JF(4)[7],=AF4LL(4)[8],=AF4T(4)[8],=AF6G(5)[8],
+    =AF9W(3)[6],=AG4DG(4)[8],=AG4EP(4)[8],=AG4H(4)[8],=AG4P(4)[8],=AG4V(4)[8],
+    =AG4W(4)[8],=AG5B(4)[8],=AG7AE(5)[8],=AG8GT(5)[8],=AG9G(4)[7],=AH0U(3)[6],
+    =AH2O(5)[8],=AH2S(3)[6],=AH6FF(4)[8],=AH6JS(3)[6],=AH6LE(3)[6],
+    =AH6SU(4)[8],=AI4DB(4)[8],=AI4IC(4)[8],=AI5BE(4)[8],=AI5HG(4)[8],
+    =AI6O(4)[7],=AI7FF(4)[7],=AI8L(4)[7],=AI8O(5)[8],=AI8Z(4)[7],=AI9K(4)[7],
+    =AJ0SE(3)[6],=AJ4A(4)[8],=AJ4F(4)[7],=AJ4MP(4)[8],=AJ4SB(4)[8],
+    =AJ6T(4)[8],=AK4NF(4)[8],=AK4QR(4)[8],=AK4R(4)[8],=AK4Z(4)[8],
+    =AK5CT(4)[8],=AK9B(4)[7],=AK9D(3)[6],=AL1VE(3)[6],=AL3X(5)[8],=AL4U(5)[8],
+    =AL5M(4)[7],=AL7CR(3)[6],=AL7RF(3)[6],=AL7RT(4)[6],=AL7T(4)[7],
+    =G8ERJ(5)[8],=K0ACP(4)[8],=K0AU(3)[6],=K0BAK(5)[8],=K0CHA(5)[8],
+    =K0CIE(5)[8],=K0DTJ(3)[6],=K0EJ(4)[8],=K0EMT(4)[8],=K0HNL(5)[8],
+    =K0HT(5)[8],=K0IP(3)[6],=K0KXF(4)[8],=K0LB(5)[8],=K0LUZ(5)[8],=K0NG(4)[8],
+    =K0NW(3)[6],=K0OZ(5)[8],=K0PG(4)[8],=K0PJ(4)[8],=K0PLC(4)[8],=K0RGI(4)[8],
+    =K0RJW(4)[8],=K0RK(5)[8],=K0SM(5)[8],=K0SN(4)[6],=K0TB(5)[8],=K0TF(5)[8],
+    =K0TQ(4)[8],=K0VSH(4)[8],=K0XP(3)[6],=K0ZR(5)[8],=K1AF(4)[7],=K1AUS(4)[7],
+    =K1AY(4)[8],=K1BJC(4)[7],=K1CCN(4)[8],=K1CPT(4)[7],=K1DW(4)[7],
+    =K1EAR(4)[7],=K1GU(4)[8],=K1IEB(4)[7],=K1JD(4)[7],=K1JH(3)[6],=K1KD(4)[7],
+    =K1LEC(4)[7],=K1LT(4)[8],=K1MWH(4)[8],=K1MZ(3)[6],=K1ND(4)[8],=K1RS(3)[6],
+    =K1SP(4)[7],=K1SPD(4)[8],=K1USA(4)[7],=K1VX(4)[8],=K1WTF(4)[7],
+    =K1XT(4)[7],=K2AD(4)[7],=K2BY(4)[7],=K2DP(4)[7],=K2DRH(4)[7],=K2GMY(3)[6],
+    =K2HT(4)[7],=K2KAR(4)[8],=K2KMC(4)[8],=K2KR(4)[7],=K2LLC(4)[8],
+    =K2MMT(3)[6],=K2ORC(4)[7],=K2PM(4)[8],=K2PO(3)[6],=K2RD(3)[6],=K2RP(3)[6],
+    =K2SHN(4)[7],=K2SS(3)[6],=K2SY(4)[8],=K2TKB(4)[7],=K2VL(4)[8],=K2VV(4)[7],
+    =K2YAZ(4)[8],=K3ARC(4)[8],=K3EST(3)[6],=K3FBR(4)[7],=K3GP(4)[8],
+    =K3HTK(4)[8],=K3IE(4)[8],=K3IGA(4)[7],=K3ILC(4)[7],=K3JWI(4)[8],
+    =K3KEK(4)[7],=K3KO(4)[8],=K3NQ(3)[6],=K3PA(4)[7],=K3PS(3)[6],=K3UWY(4)[7],
+    =K3WYC(3)[6],=K3XC(3)[6],=K3YP(4)[8],=K4AB(4)[8],=K4AFE(4)[8],=K4AL(4)[8],
+    =K4AMC(4)[8],=K4AZE(4)[8],=K4BFT(4)[8],=K4BP(4)[8],=K4BTR(4)[8],
+    =K4BWP(4)[8],=K4BX(4)[8],=K4CCT(4)[8],=K4CPO(4)[8],=K4CUP(4)[8],
+    =K4CVD(4)[8],=K4DR(4)[8],=K4DXV(4)[8],=K4DZR(4)[8],=K4EES(4)[8],
+    =K4FN(4)[8],=K4FR(4)[8],=K4FTY(4)[8],=K4FWO(4)[8],=K4HAL(4)[8],
+    =K4HWS(4)[8],=K4HY(4)[8],=K4IDB(4)[8],=K4IDT(4)[8],=K4IE(4)[8],
+    =K4ISV(4)[8],=K4IU(4)[7],=K4JW(4)[8],=K4KCG(4)[8],=K4KO(4)[8],
+    =K4KYN(4)[8],=K4MHR(4)[8],=K4MHW(4)[8],=K4MQM(4)[8],=K4MSU(4)[8],
+    =K4MSW(4)[7],=K4NAX(4)[8],=K4NH(4)[8],=K4OBC(4)[8],=K4OCE(4)[7],
+    =K4PJ(4)[8],=K4RFT(4)[8],=K4RO(4)[8],=K4RST(4)[8],=K4SAF(4)[8],
+    =K4SPO(4)[8],=K4SX(4)[7],=K4TCG(4)[8],=K4TEP(4)[8],=K4TG(4)[8],
+    =K4TIN(4)[8],=K4TMR(4)[8],=K4TO(4)[8],=K4TXJ(4)[8],=K4TZ(4)[8],
+    =K4UI(4)[8],=K4UU(4)[8],=K4UWC(4)[8],=K4VBM(4)[7],=K4VIG(4)[8],
+    =K4WG(4)[8],=K4WI(4)[8],=K4WNY(4)[8],=K4WW(4)[8],=K4XU(3)[6],=K4YJ(4)[8],
+    =K4YUC(4)[8],=K4ZGB(4)[8],=K5ADR(5)[8],=K5AN(3)[6],=K5AUP(5)[8],
+    =K5EEE(5)[8],=K5EK(5)[8],=K5EM(3)[6],=K5FP(4)[8],=K5FZ(4)[8],=K5GDX(4)[8],
+    =K5GM(4)[8],=K5HDU(3)[6],=K5HIP(5)[8],=K5JR(5)[8],=K5JSL(5)[8],
+    =K5KG(5)[8],=K5KIP(5)[8],=K5KMB(3)[6],=K5LD(5)[8],=K5MDX(4)[8],
+    =K5MH(4)[6],=K5ML(3)[6],=K5MO(5)[8],=K5OA(3)[6],=K5OF(5)[8],=K5OLV(4)[8],
+    =K5PN(4)[8],=K5PS(5)[8],=K5RC(3)[6],=K5RR(3)[6],=K5TF(5)[8],=K5TT(3)[6],
+    =K5VG(3)[6],=K5VIP(5)[8],=K5XI(3)[6],=K5XQ(4)[8],=K5YDR(5)[8],=K5YS(4)[8],
+    =K5YVY(4)[8],=K5ZD(4)[8],=K6ACV(4)[7],=K6AER(4)[7],=K6AFW(4)[7],
+    =K6ES(5)[8],=K6FX(4)[7],=K6HLC(5)[8],=K6HU(4)[7],=K6KII(4)[7],
+    =K6LIE(4)[7],=K6LJ(4)[7],=K6LPO(4)[7],=K6RCW(4)[7],=K6RM(5)[8],
+    =K6RSP(4)[7],=K6SK(5)[8],=K6UMO(5)[8],=K6ZB(4)[7],=K6ZZ(4)[8],
+    =K7ABV(4)[6],=K7AP(5)[8],=K7BG(4)[7],=K7CS(4)[8],=K7DWI(4)[7],
+    =K7DZE(4)[8],=K7EFA(4)[7],=K7FB(4)[7],=K7GM(5)[8],=K7IOL(4)[7],
+    =K7JN(5)[8],=K7KAR(4)[7],=K7KMM(3)[7],=K7LU(5)[8],=K7MOA(4)[7],
+    =K7MOE(4)[7],=K7MS(4)[6],=K7MTD(4)[6],=K7NCK(4)[7],=K7OM(5)[8],
+    =K7QA(4)[6],=K7RB(4)[7],=K7SCX(4)[7],=K7SHR(4)[7],=K7SV(5)[8],
+    =K7SWS(4)[6],=K7TD(4)[7],=K7TRT(4)[7],=K7USN(4)[8],=K7UWR(5)[8],
+    =K7VF(4)[7],=K7VU(4)[7],=K7WAX(4)[7],=K7WWR(5)[8],=K7ZKM(4)[7],
+    =K7ZYV(4)[8],=K8AC(5)[8],=K8ARY(5)[8],=K8BVY(3)[6],=K8CN(5)[8],
+    =K8DF(5)[8],=K8FB(3)[6],=K8FC(5)[8],=K8GP(5)[8],=K8HC(5)[8],=K8IA(3)[6],
+    =K8II(5)[8],=K8IY(5)[8],=K8LBQ(5)[8],=K8LF(5)[8],=K8LSB(5)[8],=K8LT(5)[8],
+    =K8MV(5)[8],=K8NS(5)[8],=K8NYG(5)[8],=K8OM(4)[7],=K8OS(4)[7],=K8OZ(4)[7],
+    =K8PT(5)[8],=K8RAR(5)[8],=K8SYH(5)[8],=K8TE(4)[7],=K8TR(3)[6],
+    =K8UGG(5)[8],=K8VAN(5)[8],=K8YC(5)[8],=K8YFM(5)[8],=K9AJC(4)[7],
+    =K9AXT(5)[8],=K9CHP(5)[8],=K9DR(4)[7],=K9DU(4)[7],=K9DY(5)[8],=K9EE(5)[8],
+    =K9EX(3)[6],=K9EZ(5)[8],=K9GMM(5)[8],=K9GWH(5)[8],=K9GWS(5)[8],
+    =K9ILS(4)[7],=K9IVN(4)[7],=K9JF(3)[6],=K9JHQ(4)[7],=K9JM(3)[6],
+    =K9JX(4)[7],=K9JY(5)[8],=K9KA(5)[8],=K9LRD(4)[7],=K9LTX(4)[7],
+    =K9MBQ(5)[8],=K9MK(4)[7],=K9MU(4)[7],=K9MWM(4)[7],=K9NS(4)[7],=K9OM(5)[8],
+    =K9OQ(5)[8],=K9OZ(4)[7],=K9PSM(3)[6],=K9PY(3)[6],=K9QC(4)[7],=K9RG(3)[6],
+    =K9RQ(5)[8],=K9RS(5)[8],=K9RZ(3)[6],=K9SAT(3)[6],=K9TAD(3)[6],=K9VB(5)[8],
+    =K9VIT(3)[6],=K9WA(4)[7],=K9WDW(4)[7],=K9WFX(4)[7],=K9WWW(3)[6],
+    =K9YC(3)[6],=K9ZA(4)[7],=K9ZU(5)[8],=KA0AZS(4)[8],=KA0KVW(5)[8],
+    =KA0S(4)[8],=KA0WAS(4)[8],=KA0WWT(3)[6],=KA1RUE(4)[8],=KA1VRY(4)[8],
+    =KA2MLH(4)[8],=KA3DRR(3)[6],=KA3MTT(4)[8],=KA3NAM(4)[7],=KA4BVG(4)[8],
+    =KA4J(4)[8],=KA4OTB(4)[7],=KA5NDH(4)[8],=KA5USN(5)[8],=KA5VZG(4)[8],
+    =KA5WSS(3)[6],=KA6Y(5)[8],=KA7PNH(4)[7],=KA7Y(4)[7],=KA8HDE(4)[7],
+    =KA8JIL(5)[8],=KA8P(5)[8],=KA8Q(5)[8],=KA8VHF(4)[7],=KA9FOX(4)[7],
+    =KA9MDP(3)[6],=KA9OZP(4)[7],=KA9VVQ(4)[7],=KB0NVR(5)[8],=KB0TTL(4)[8],
+    =KB1V(4)[8],=KB2BRD(4)[7],=KB2FSK(4)[7],=KB3A(4)[8],=KB3HF(4)[7],
+    =KB3KYH(4)[8],=KB4EKK(4)[7],=KB4GRD(4)[8],=KB4IRR(4)[7],=KB4TLH(4)[8],
+    =KB5ZYC(3)[6],=KB6B(4)[7],=KB6NU(4)[8],=KB6OJE(4)[7],=KB6QPI(5)[8],
+    =KB7MLK(4)[7],=KB7PF(4)[8],=KB8DX(5)[8],=KB8ERA(5)[8],=KB8NUF(5)[8],
+    =KB8NXH(5)[8],=KB8PKC(5)[8],=KB8TNU(5)[8],=KB8TRH(5)[8],=KB8UFP(5)[8],
+    =KB8UPO(5)[8],=KB9DFE(4)[7],=KB9ELS(4)[7],=KB9LHT(3)[6],=KB9RUG(4)[7],
+    =KB9S(4)[7],=KB9SJD(4)[7],=KB9TBB(4)[7],=KB9TYC(4)[7],=KC0VKN(4)[8],
+    =KC1BB(3)[6],=KC1EO(3)[6],=KC1NY(4)[7],=KC2LM(4)[7],=KC2RT(3)[6],
+    =KC3MAL(4)[7],=KC3OL(4)[7],=KC3QND(4)[8],=KC3SJ(4)[8],=KC4BB(4)[8],
+    =KC4CR(3)[6],=KC4HW(4)[8],=KC4IR(4)[8],=KC4NJX(4)[8],=KC4RNF(4)[8],
+    =KC4TEO(4)[8],=KC4WQ(4)[8],=KC4ZMB(4)[8],=KC5AAV(4)[8],=KC5RFU(5)[8],
+    =KC5ZAP(5)[8],=KC6ZBE(4)[7],=KC7MDT(4)[7],=KC7QY(4)[7],=KC7TY(4)[7],
+    =KC8J(3)[6],=KC8NFN(4)[7],=KC8OPV(5)[8],=KC9BEX(5)[8],=KC9C(3)[6],
+    =KC9CRM(4)[7],=KC9DGP(4)[7],=KC9EI(3)[6],=KC9GNK(4)[7],=KC9JIK(4)[7],
+    =KC9K(4)[7],=KC9LBO(4)[7],=KC9LC(5)[8],=KC9YTT(4)[7],=KD0EE(4)[8],
+    =KD0LHI(3)[6],=KD2CFD(4)[7],=KD2FSH(3)[6],=KD2KW(4)[7],=KD2RPX(4)[7],
+    =KD4ADC(4)[8],=KD4BLK(4)[8],=KD4BWM(4)[8],=KD4CXE(4)[8],=KD4EE(4)[8],
+    =KD4LT(4)[8],=KD4ULD(4)[8],=KD4ULW(4)[8],=KD5AJC(3)[6],=KD5EJG(4)[8],
+    =KD5UVV(4)[8],=KD5YBE(4)[8],=KD6AF(4)[7],=KD6MCX(5)[8],=KD7MT(4)[7],
+    =KD8HE(5)[8],=KD8TF(5)[8],=KD8YWF(5)[8],=KD9ERP(4)[7],=KD9LTN(4)[7],
+    =KD9MLG(4)[7],=KD9QS(5)[8],=KD9S(4)[7],=KD9ZUN(4)[7],=KE0L(4)[8],
+    =KE0YI(4)[8],=KE1B(3)[6],=KE2VB(3)[6],=KE3K(4)[8],=KE4EW(3)[6],
+    =KE4GOI(4)[8],=KE4KY(4)[8],=KE4MRX(4)[8],=KE4VAM(4)[8],=KE4VQM(4)[8],
+    =KE4WKH(4)[8],=KE4XT(4)[7],=KE5ABB(5)[8],=KE5GY(4)[8],=KE5HDE(5)[8],
+    =KE5NJ(5)[8],=KE6GAE(4)[7],=KE6QEY(5)[8],=KE7HK(4)[7],=KE7LBB(4)[7],
+    =KE7NO(4)[6],=KE7RTB(4)[7],=KE8FT(3)[6],=KE8KMX(5)[8],=KE8NN(3)[6],
+    =KE8WIC(5)[8],=KE8ZZH(5)[8],=KF0CT(4)[8],=KF0IWN(4)[8],=KF4AV(4)[8],
+    =KF4FMQ(4)[8],=KF4L(4)[8],=KF4TY(4)[8],=KF5MU(4)[8],=KF6D(5)[8],
+    =KF6HDJ(5)[8],=KF6HI(4)[8],=KF7EB(4)[7],=KF7MD(4)[7],=KF7YED(4)[6],
+    =KF7Z(4)[7],=KF8EYE(5)[8],=KF8N(5)[8],=KF9LI(4)[7],=KF9MT(4)[7],
+    =KG0AF(5)[8],=KG2MD(4)[8],=KG4BIG(4)[8],=KG4C(4)[8],=KG4STL(4)[8],
+    =KG5EG(4)[8],=KG5SSB(4)[8],=KG5TA(5)[8],=KG7SPL(4)[6],=KG7VQ(4)[6],
+    =KG8AI(5)[8],=KG9JF(4)[7],=KH2AR(4)[7],=KH2BR(3)[6],=KH2GM(4)[8],
+    =KH2PM(5)[8],=KH2SR(3)[6],=KH2TJ(3)[6],=KH6CT(5)[8],=KH6GK(3)[6],
+    =KH6M(5)[8],=KH6ND(3)[6],=KH6VM(3)[6],=KH7DA/4(5)[8],=KH7X(3)[6],
+    =KI0EB(4)[8],=KI4EZC(4)[8],=KI4JFX(4)[7],=KI4KWR(4)[8],=KI4PHE(4)[8],
+    =KI4RKM(4)[8],=KI5HVD(4)[8],=KI5VNB(4)[8],=KI6DY(4)[8],=KI6KGC(4)[7],
+    =KI6QDH(4)[7],=KI7ID(4)[7],=KI7WX(5)[8],=KI8GM(5)[8],=KJ4AOM(4)[8],
+    =KJ4DVR(4)[8],=KJ4JPV(4)[8],=KJ4KVC(4)[8],=KJ4M(4)[8],=KJ4ND(4)[8],
+    =KJ4QIS(4)[7],=KJ4UGO(4)[8],=KJ4YLR(4)[8],=KJ6DQ(4)[7],=KJ6SVE(4)[8],
+    =KJ6XC(4)[8],=KJ6YXI(4)[8],=KJ9C(4)[6],=KK0L(4)[8],=KK1J(3)[6],
+    =KK2A(4)[8],=KK2TT(4)[7],=KK4ADQ(3)[6],=KK4EM(4)[8],=KK4NAW(4)[7],
+    =KK4OVW(4)[8],=KK4PC(4)[8],=KK4XA(4)[8],=KK5OQ(4)[8],=KK6MC(4)[7],
+    =KK6OKU(4)[8],=KK7BWQ(5)[8],=KK7TZP(4)[7],=KK7VXK(4)[7],=KK8C(4)[7],
+    =KK9A(5)[8],=KK9N(4)[7],=KL0S(5)[8],=KL0SS(5)[8],=KL2YE(4)[8],
+    =KL3KZ(4)[7],=KL4QZ(4)[7],=KL7DJ(3)[6],=KL7FDQ(3)[6],=KL7HQR(3)[6],
+    =KL7IKV(3)[6],=KL7KWA(3)[6],=KL7NL(5)[8],=KL7NW(4)[7],=KL7OF(3)[6],
+    =KL7QW(4)[7],=KL7Y(5)[8],=KL7YK(4)[7],=KM1Z(4)[8],=KM4CH(4)[8],
+    =KM4CRB(4)[8],=KM4DR(4)[7],=KM4ECH(4)[8],=KM4FO(4)[8],=KM4FOC(4)[8],
+    =KM4HQE(4)[8],=KM4IYW(4)[8],=KM4JAD(4)[8],=KM4RO(4)[8],=KM4VI(4)[8],
+    =KM5AT(5)[8],=KM5E(5)[8],=KM5WX(4)[8],=KM6UH(5)[8],=KM6VRX(5)[8],
+    =KM7AFF(5)[8],=KM7CT(5)[8],=KM7SAD(5)[8],=KM7W(4)[6],=KM8L(5)[8],
+    =KM9R(3)[6],=KN0A(5)[8],=KN0S(5)[8],=KN1MT(4)[8],=KN4A(4)[8],=KN4AL(4)[8],
+    =KN4DUA(4)[8],=KN4JGH(4)[8],=KN4LIU(4)[8],=KN4OK(4)[8],=KN4PHS(4)[8],
+    =KN4RD(4)[7],=KN4ULT(4)[7],=KN4WPR(4)[8],=KN6BU(5)[8],=KN9K(3)[6],
+    =KO1H(3)[6],=KO1Z(4)[7],=KO4DDG(4)[8],=KO4DWB(4)[8],=KO4EVC(4)[8],
+    =KO4FX(4)[8],=KO4IDC(4)[8],=KO4LFZ(4)[8],=KO4O(4)[8],=KO4OL(4)[8],
+    =KO4OSL(4)[8],=KO4PZX(4)[8],=KO4TFE(4)[8],=KO4TNK(4)[8],=KO4TUP(4)[8],
+    =KO4UFD(4)[8],=KO4UOJ(4)[8],=KO4VJN(4)[8],=KO4VPW(4)[8],=KO4XJ(4)[8],
+    =KO4Z(4)[8],=KO7G(5)[8],=KO8SCA(5)[8],=KO8V(5)[8],=KO9V(4)[7],
+    =KP2BH(5)[8],=KP2X(4)[7],=KP3U(5)[8],=KP4CTO(4)[8],=KP4EOP(4)[7],
+    =KP4PW(5)[8],=KP4WW(5)[8],=KQ0J(5)[8],=KQ2X(3)[6],=KQ4AHO(4)[8],
+    =KQ4E(4)[8],=KQ4FBF(4)[8],=KQ4FIP(4)[8],=KQ4GAH(4)[8],=KQ4HZK(4)[8],
+    =KQ4JEQ(4)[8],=KQ4MYC(4)[8],=KQ4NOM(4)[8],=KQ4RLN(4)[8],=KQ4SMI(4)[8],
+    =KQ4SRE(4)[8],=KQ4TPD(4)[8],=KQ4UJG(4)[8],=KQ4VET(4)[8],=KQ4VPZ(4)[8],
+    =KQ4YEX(4)[8],=KQ6KC(4)[8],=KQ6NT(5)[8],=KQ9J(4)[7],=KR4AUX(4)[8],
+    =KR4EE(4)[8],=KR4F(4)[8],=KR4FQG(4)[8],=KR5X(5)[8],=KS4L(4)[8],
+    =KS4NL(4)[8],=KS4V(4)[8],=KS4X(4)[8],=KS4XU(4)[7],=KS4YT(4)[8],
+    =KS7T(4)[6],=KS7X(5)[8],=KS9A(4)[7],=KT0P(4)[6],=KT0V(4)[8],=KT3M(4)[7],
+    =KT3R(4)[7],=KT3X(4)[7],=KT4AC(4)[8],=KT4E(4)[8],=KT4O(4)[8],=KT4RH(4)[8],
+    =KT4XA(4)[8],=KT4XL(4)[8],=KT5LA(3)[6],=KT6D(5)[8],=KT9T(4)[7],
+    =KU4A(4)[8],=KU4UK(4)[8],=KU8E(5)[8],=KU8V(5)[8],=KV1I(4)[7],=KV3T(4)[8],
+    =KV4AC(4)[8],=KV4E(4)[8],=KV4T(4)[8],=KW0A(5)[8],=KW0V(4)[8],=KW4J(4)[8],
+    =KW4LU(4)[8],=KW4OV(4)[8],=KW4YA(4)[8],=KW7EET(4)[7],=KW7Q(4)[7],
+    =KW9A(4)[7],=KX2P(4)[7],=KX3H(4)[8],=KX3Y(4)[8],=KX4AV(4)[8],=KX4X(4)[8],
+    =KY0Q(4)[8],=KY0W(3)[6],=KY3G(4)[8],=KY4AR(4)[8],=KY4BG(4)[8],
+    =KY4BP(4)[8],=KY4DMD(4)[8],=KY4G(4)[8],=KY4HS(4)[8],=KY4HV(4)[8],
+    =KY4KY(4)[8],=KY4NA(4)[8],=KY4REX(4)[8],=KY4X(4)[8],=KY6AA(4)[8],
+    =KZ1W(3)[6],=KZ2T(4)[7],=KZ2V(3)[6],=KZ4BE(4)[8],=KZ4IT(4)[8],
+    =KZ4KG(4)[8],=KZ5DX(4)[8],=KZ5ED(5)[8],=KZ7Y(5)[8],=KZ9V(4)[7],
+    =N0CK(5)[8],=N0DQD(5)[8],=N0FUC(4)[8],=N0FW(4)[8],=N0IMJ(4)[8],
+    =N0KRE(3)[6],=N0KWA(4)[8],=N0MNY(5)[8],=N0OEP(5)[8],=N0OJ(5)[8],
+    =N0QQ(5)[8],=N0RR(3)[6],=N0SMX(5)[8],=N0VQE(5)[8],=N0VRS(4)[8],
+    =N0WOP(4)[8],=N0XMD(4)[8],=N0YFI(5)[8],=N0YY(5)[8],=N1CCC(4)[7],
+    =N1CFO(4)[7],=N1CLC(3)[6],=N1JM(3)[6],=N1KW(4)[8],=N1OG(4)[7],
+    =N1OKL(4)[8],=N1RIP(4)[8],=N1RKB(4)[8],=N1ROE(3)[6],=N1SLO(3)[6],
+    =N1SMB(4)[7],=N1XK(4)[7],=N2BJ(4)[8],=N2CB(4)[8],=N2FSH(4)[7],=N2GG(4)[7],
+    =N2GJ(4)[7],=N2GSB(4)[8],=N2HC(3)[6],=N2HTE(4)[8],=N2IC(4)[7],=N2JF(4)[8],
+    =N2JNR(3)[6],=N2UR(4)[7],=N3AIU(3)[6],=N3AWS(4)[8],=N3BB(4)[7],
+    =N3BEN(3)[6],=N3CI(4)[7],=N3CMI(4)[7],=N3CO(4)[8],=N3DEB(3)[6],
+    =N3EG(3)[6],=N3JJT(4)[8],=N3MC(4)[8],=N3MRA(4)[7],=N3QQ(3)[6],=N3RA(4)[8],
+    =N3RC(3)[6],=N3UUS(4)[8],=N3WVB(4)[8],=N3ZZ(4)[7],=N4ARO(4)[8],
+    =N4AU(4)[8],=N4BAA(4)[8],=N4BCD(4)[8],=N4BCT(4)[8],=N4CVG(4)[8],
+    =N4DBR(4)[8],=N4DD(4)[8],=N4DEX(4)[8],=N4DLA(3)[6],=N4DW(4)[8],
+    =N4DXN(4)[8],=N4EJW(4)[8],=N4EL(4)[8],=N4EMP(4)[8],=N4FOC(4)[8],
+    =N4FR(4)[8],=N4FUR(4)[7],=N4GO(4)[8],=N4HAI(4)[8],=N4IAM(4)[8],
+    =N4IDH(4)[8],=N4IN(4)[8],=N4IY(4)[8],=N4JEH(4)[8],=N4JN(4)[8],=N4JR(4)[8],
+    =N4JRG(4)[8],=N4KC(4)[8],=N4KGL(4)[8],=N4KGY(3)[6],=N4KH(4)[8],
+    =N4KWX(4)[8],=N4KZ(4)[8],=N4KZS(4)[8],=N4LCA(4)[8],=N4LJT(4)[8],
+    =N4LR(4)[8],=N4LS(4)[8],=N4LSJ(4)[8],=N4LT(4)[8],=N4MCC(4)[8],=N4MJ(4)[8],
+    =N4MRM(4)[8],=N4MZ(4)[8],=N4NA(4)[8],=N4NJJ(3)[6],=N4NM(4)[8],=N4NP(4)[8],
+    =N4NT(4)[8],=N4NVG(4)[7],=N4OGW(4)[8],=N4PV(4)[8],=N4PWG(4)[8],
+    =N4PX(4)[8],=N4QS(4)[8],=N4QWZ(4)[8],=N4QYO(4)[8],=N4ROA(4)[8],
+    =N4RRR(4)[8],=N4RS(4)[7],=N4RZ(4)[8],=N4SB(4)[8],=N4SCP(4)[8],=N4SS(4)[8],
+    =N4SV(4)[8],=N4TY(4)[8],=N4TZ(4)[8],=N4UC(4)[8],=N4UL(4)[8],=N4UN(4)[8],
+    =N4UW(4)[8],=N4VC(4)[8],=N4VI(4)[7],=N4VN(4)[8],=N4VV(3)[6],=N4WE(4)[8],
+    =N4XFF(4)[8],=N4XTT(4)[8],=N4ZZ(4)[8],=N5BF(3)[6],=N5BLM(4)[8],
+    =N5BLY(4)[8],=N5BO(5)[8],=N5CW(4)[8],=N5DEX(5)[8],=N5DF(4)[8],=N5DX(5)[8],
+    =N5EP(4)[8],=N5FTY(4)[8],=N5GI(5)[8],=N5HC(5)[8],=N5HF(5)[8],=N5HOT(4)[8],
+    =N5JED(4)[8],=N5JEY(5)[8],=N5KO(3)[6],=N5LR(3)[6],=N5LZ(3)[6],
+    =N5NPD(3)[6],=N5RP(4)[8],=N5RTG(5)[8],=N5SA(4)[8],=N5SMQ(5)[8],
+    =N5TB(5)[8],=N5TOO(5)[8],=N5UE(4)[8],=N5VJX(4)[8],=N5VX(5)[8],
+    =N5WCS(4)[8],=N5YJZ(3)[6],=N5YT(4)[8],=N5ZO(3)[6],=N6AR(5)[8],=N6CA(4)[7],
+    =N6DW(5)[8],=N6EV(4)[7],=N6FS(4)[8],=N6GQ(4)[7],=N6GR(4)[7],=N6HEW(4)[7],
+    =N6IGA(4)[6],=N6JRL(4)[8],=N6LEE(4)[7],=N6MA(4)[8],=N6NT(5)[8],
+    =N6QLS(4)[7],=N6RAM(4)[7],=N6RSH(4)[7],=N6TCO(4)[7],=N6US(4)[7],
+    =N6YMM(5)[8],=N6ZFO(5)[8],=N7AGP(4)[6],=N7DED(4)[8],=N7DR(4)[7],
+    =N7EMG(4)[7],=N7FUL(4)[7],=N7GFB(5)[8],=N7HG(3)[7],=N7IV(4)[7],
+    =N7KA(4)[7],=N7ML(4)[6],=N7MM(4)[7],=N7MZW(4)[7],=N7PMS(4)[6],
+    =N7PVW(4)[8],=N7QAX(4)[7],=N7QPP(5)[8],=N7QS(4)[6],=N7SE(4)[7],
+    =N7TJB(4)[8],=N7US(4)[8],=N7UW(4)[7],=N7WY(4)[7],=N7YA(5)[8],=N7YDH(4)[7],
+    =N7ZZ(4)[8],=N8AAY(5)[8],=N8CL(5)[8],=N8CQD(5)[8],=N8DWB(5)[8],
+    =N8ELA(3)[6],=N8GB(5)[8],=N8GU(5)[8],=N8HM(5)[8],=N8II(5)[8],=N8IK(5)[8],
+    =N8IVN(5)[8],=N8JAA(5)[8],=N8KH(5)[8],=N8MD(4)[7],=N8MXL(4)[7],
+    =N8NA(5)[8],=N8NN(5)[8],=N8OO(4)[7],=N8OYY(5)[8],=N8PFK(5)[8],
+    =N8QOT(5)[8],=N8RA(5)[8],=N8RV(5)[8],=N8SLT(5)[8],=N8TP(5)[8],=N8UM(3)[6],
+    =N8UOA(5)[8],=N8URE(5)[8],=N8VCL(4)[7],=N8VU(5)[8],=N8WXQ(5)[8],
+    =N8WXZ(5)[8],=N8XHF(5)[8],=N8XX(5)[8],=N8ZR(5)[8],=N9ARX(4)[7],
+    =N9ATF(4)[7],=N9BD(3)[6],=N9BSO(4)[7],=N9CD(4)[7],=N9CHA(4)[7],
+    =N9CI(4)[7],=N9CIQ(4)[7],=N9CNF(4)[7],=N9DK(3)[6],=N9EA(4)[7],
+    =N9EAT(4)[7],=N9FZ(5)[8],=N9GB(4)[7],=N9HDE(4)[7],=N9JNQ(4)[7],
+    =N9JYJ(4)[7],=N9MM(4)[7],=N9MS(5)[8],=N9NA(3)[6],=N9NB(5)[8],=N9NC(5)[8],
+    =N9NFT(5)[8],=N9NM(4)[7],=N9OF(4)[7],=N9OH(5)[8],=N9OHW(3)[6],=N9PC(4)[7],
+    =N9PGG(5)[8],=N9QY(4)[7],=N9RV(4)[6],=N9SB(4)[7],=N9SEO(4)[7],=N9SM(5)[8],
+    =N9SV(4)[7],=N9TTX(4)[7],=N9VAO(4)[7],=N9VPV(4)[7],=N9ZW(4)[7],
+    =NA1KW(4)[7],=NA2U(3)[6],=NA4A(4)[8],=NA4C(4)[8],=NA4DX(4)[7],=NA4M(4)[7],
+    =NA4MM(4)[8],=NA5DX(4)[8],=NA5NN(4)[8],=NA5Y(5)[8],=NA7L(5)[8],
+    =NA7XX(4)[7],=NA9J(5)[8],=NB3C(4)[7],=NB4A(4)[8],=NB5E(5)[8],=NC6K(4)[7],
+    =ND0L(4)[8],=ND2T(3)[6],=ND3N(4)[8],=ND4U(4)[8],=ND4X(4)[8],=ND4Y(4)[8],
+    =ND8L(5)[8],=ND8N(3)[6],=ND9M(5)[8],=NE1LA(3)[6],=NE2I(4)[7],=NE5W(4)[8],
+    =NE7DX(3)[7],=NE7R(4)[6],=NE7WY(4)[7],=NE8P(5)[8],=NE9U(4)[7],=NF1R(3)[6],
+    =NF6P(5)[8],=NF7D(4)[8],=NF8H(4)[7],=NG2G(3)[6],=NG2S(4)[8],=NG3Q(4)[8],
+    =NG6X(4)[6],=NG7A(4)[7],=NG7IL(4)[7],=NG9B(4)[7],=NH6HE(3)[6],=NH6L(4)[7],
+    =NH6PK(4)[8],=NH6T(4)[8],=NH8S(4)[8],=NI2M(4)[7],=NI5L(3)[7],=NI7R(5)[8],
+    =NJ4P(4)[8],=NJ7T(5)[8],=NJ8J(5)[8],=NJ8M(4)[7],=NJ9L(5)[8],=NK3V(4)[8],
+    =NK4I(4)[8],=NK7U(5)[8],=NL7CQ(4)[7],=NL7WA(5)[8],=NL7XM(5)[8],
+    =NL7XT(4)[8],=NN4NT(4)[8],=NN4SA(4)[8],=NN6TT(4)[8],=NN7A(4)[7],
+    =NN7CW(5)[8],=NN7V(4)[7],=NN9DD(5)[8],=NO2D(4)[7],=NO3OO(4)[7],
+    =NO5O(3)[6],=NO9E(5)[8],=NP2GG(5)[8],=NP3FB(4)[8],=NP3K(5)[8],
+    =NP3XP(4)[7],=NQ4U(4)[8],=NQ4Y(4)[8],=NQ8C(5)[8],=NR3S(3)[6],=NR4L(4)[8],
+    =NR5N(5)[8],=NR5NN(3)[6],=NR7DX(4)[6],=NR7K(4)[8],=NR8Z(5)[8],=NS2X(4)[8],
+    =NS4E(4)[8],=NS4X(4)[8],=NT0K(5)[8],=NT0Y(4)[8],=NT4A(4)[8],=NT4J(4)[8],
+    =NT4M(4)[8],=NT4W(4)[8],=NU4B(4)[8],=NU4N(4)[8],=NU4X(4)[8],=NU7M(4)[7],
+    =NV4B(4)[8],=NV4G(4)[8],=NV9L(5)[8],=NW8U(5)[8],=NX5DX(5)[8],=NX7W(4)[6],
+    =NX9T(5)[8],=NY1V(4)[8],=NY4JB(4)[8],=NY5E(5)[8],=NY6DX(5)[8],=NY9P(4)[7],
+    =NZ2S(3)[6],=NZ6O(5)[8],=W0AG(4)[8],=W0AO(3)[6],=W0BF(3)[6],=W0CGC(4)[8],
+    =W0EBN(4)[8],=W0HJW(3)[6],=W0JX(4)[8],=W0LL(5)[8],=W0LV(3)[6],
+    =W0OIT(3)[6],=W0PV(5)[8],=W0PZ(3)[6],=W0RIC(3)[6],=W0RMX(5)[8],
+    =W0RXC(4)[8],=W0SK(4)[8],=W0YK(3)[6],=W0ZP(4)[8],=W1CAM(4)[7],
+    =W1CHL(4)[8],=W1CR(4)[7],=W1DGL(3)[6],=W1ESE(3)[6],=W1GKT(4)[8],
+    =W1GUU(4)[7],=W1HRB(4)[8],=W1JCW(4)[7],=W1LTC(4)[8],=W1MJC(4)[8],
+    =W1NN(4)[8],=W1NV(4)[7],=W1PD(4)[8],=W1PR(3)[6],=W1RH(3)[6],=W1RO(3)[6],
+    =W1SAV(3)[6],=W1SRD(3)[6],=W1UL(4)[7],=W1WSF(4)[8],=W1YY(3)[6],
+    =W2ACY(4)[7],=W2BJN(4)[8],=W2CO(4)[7],=W2DB(4)[7],=W2DON(3)[6],
+    =W2EH(4)[7],=W2FV(3)[6],=W2GS(4)[7],=W2HZ(3)[6],=W2IJ(4)[7],=W2IY(4)[7],
+    =W2KF(4)[7],=W2KGO(4)[7],=W2NC(3)[6],=W2NQ(3)[6],=W2SKI(4)[7],
+    =W2STE(4)[7],=W2UP(4)[7],=W2VJN(3)[6],=W2XX(3)[6],=W3ACO(4)[7],
+    =W3ACR(4)[8],=W3AW(4)[8],=W3CB(4)[8],=W3CRZ(4)[8],=W3DEV(4)[8],
+    =W3FF(3)[6],=W3GW(4)[7],=W3HDH(4)[8],=W3HKK(4)[8],=W3LS(3)[6],=W3LZ(4)[8],
+    =W3PWF(4)[7],=W3TB(4)[8],=W3USA(4)[8],=W3WCT(4)[8],=W3XO(4)[7],
+    =W4AM(4)[8],=W4ATD(4)[8],=W4AUB(4)[8],=W4BAX(4)[8],=W4BBB(4)[8],
+    =W4BLT(4)[8],=W4BQK(4)[8],=W4BQN(4)[8],=W4BS(4)[8],=W4CDA(4)[8],
+    =W4CK(4)[8],=W4CMG(4)[8],=W4CN(4)[8],=W4CQE(4)[8],=W4CRV(4)[8],
+    =W4DAN(4)[8],=W4EF(3)[6],=W4ER(4)[8],=W4ETA(4)[8],=W4FCL(4)[8],
+    =W4GB(4)[8],=W4GGM(4)[8],=W4GHD(4)[8],=W4GKM(4)[8],=W4IAX(4)[8],
+    =W4IDX(3)[6],=W4IFI(4)[7],=W4IOD(4)[8],=W4IX(3)[6],=W4JDM(4)[8],
+    =W4JHV(4)[8],=W4JNB(4)[8],=W4JUU(4)[8],=W4KAM(4)[8],=W4KRC(4)[8],
+    =W4KW(4)[8],=W4LB(4)[7],=W4LC(4)[8],=W4LOO(3)[6],=W4MF(4)[8],=W4MTO(4)[8],
+    =W4NBS(4)[8],=W4NEU(4)[8],=W4NHO(4)[8],=W4NI(4)[8],=W4NJA(4)[8],
+    =W4NNF(4)[8],=W4NZ(4)[8],=W4OLB(4)[8],=W4ORS(4)[8],=W4PA(4)[8],
+    =W4PF(4)[8],=W4PGM(4)[8],=W4PUD(4)[8],=W4PV(4)[8],=W4PW(4)[8],
+    =W4RLB(4)[8],=W4RYW(4)[8],=W4SDX(4)[8],=W4SHL(4)[8],=W4SIG(3)[6],
+    =W4SK(4)[8],=W4SSF(4)[8],=W4SV(4)[8],=W4TLK(4)[8],=W4TRC(4)[8],
+    =W4TTA(4)[8],=W4UAL(4)[8],=W4UT(4)[8],=W4UWC(4)[8],=W4WC(4)[8],
+    =W4WKN(4)[8],=W4WKU(4)[8],=W4WTS(4)[8],=W4WWV(4)[8],=W4XK(4)[8],
+    =W4XTT(4)[8],=W4YEM(4)[8],=W4YPW(4)[8],=W5ACQ(4)[8],=W5BMO(3)[6],
+    =W5DT(4)[8],=W5DX(5)[8],=W5FB(5)[8],=W5GAI(4)[8],=W5KBW(4)[8],
+    =W5LNX(4)[8],=W5MPB(5)[8],=W5MX(4)[8],=W5NZ(4)[8],=W5OBM(4)[8],
+    =W5ORC(4)[8],=W5OT(3)[6],=W5PET(4)[8],=W5RCG(4)[8],=W5SGL(4)[8],
+    =W5SPH(4)[8],=W5THT(4)[8],=W5UE(4)[8],=W5UHQ(4)[8],=W5UJ(3)[6],
+    =W5VS(5)[8],=W5WTX(4)[8],=W5XB(5)[8],=W5YD(4)[8],=W6ALG(5)[8],=W6AQ(4)[7],
+    =W6BIV(4)[7],=W6BSD(4)[7],=W6DVS(5)[8],=W6EHY(4)[7],=W6EMM(4)[8],
+    =W6FB(4)[7],=W6GOK(5)[8],=W6GRE(4)[7],=W6HDG(5)[8],=W6HN(4)[8],
+    =W6JSL(4)[8],=W6JTB(5)[8],=W6KGP(4)[7],=W6KW(5)[8],=W6LFB(4)[7],
+    =W6LX(4)[8],=W6NJB(4)[7],=W6NWS(5)[8],=W6QUV(4)[7],=W6RIF(5)[8],
+    =W6SFG(5)[8],=W6UB(4)[8],=W6WU(5)[8],=W6WWW(5)[8],=W6ZD(5)[8],
+    =W7DGR(4)[7],=W7EE(4)[6],=W7EY(4)[6],=W7FW(4)[8],=W7HU(5)[8],=W7II(4)[7],
+    =W7IMP(5)[8],=W7IY(5)[8],=W7JR(4)[7],=W7KF(4)[6],=W7KK(4)[6],=W7LG(5)[8],
+    =W7MSL(4)[7],=W7NX(4)[7],=W7PX(4)[6],=W7RF(4)[7],=W7RIP(4)[6],=W7RY(4)[7],
+    =W7TVS(4)[6],=W7UM(4)[7],=W7UT(4)[7],=W7VHW(4)[7],=W7VNE(4)[6],
+    =W7VOA(4)[8],=W7WXR(4)[7],=W7WZ(5)[8],=W7XB(4)[8],=W7XT(4)[6],
+    =W8AKS(5)[8],=W8ANT(5)[8],=W8BFX(3)[6],=W8BLA(5)[8],=W8BRY(5)[8],
+    =W8BT(5)[8],=W8CMK(5)[8],=W8CS(5)[8],=W8CUL(5)[8],=W8DDS(5)[8],
+    =W8DMB(5)[8],=W8DOF(5)[8],=W8ES(5)[8],=W8FJ(5)[8],=W8FN(5)[8],=W8GK(5)[8],
+    =W8GV(5)[8],=W8HAP(5)[8],=W8IX(5)[8],=W8JMV(5)[8],=W8KA(3)[6],=W8KR(4)[7],
+    =W8KRZ(5)[8],=W8KXW(5)[8],=W8LYJ(4)[7],=W8MOX(5)[8],=W8MYL(4)[7],
+    =W8NOR(3)[6],=W8OP(5)[8],=W8OV(4)[7],=W8PAR(5)[8],=W8QI(5)[8],
+    =W8RKW(5)[8],=W8SA(3)[6],=W8SP(5)[8],=W8TJM(3)[6],=W8TK(3)[6],=W8VZ(5)[8],
+    =W8WVA(5)[8],=W8WZ(4)[7],=W8XAL(4)[7],=W8ZN(5)[8],=W9ARO(5)[8],
+    =W9AT(5)[8],=W9AVM(4)[7],=W9AWE(4)[7],=W9BLP(4)[7],=W9CF(3)[6],
+    =W9CPD(3)[6],=W9CTY(3)[6],=W9DC(5)[8],=W9DKB(4)[7],=W9DP(4)[7],
+    =W9EN(3)[6],=W9ERE(4)[7],=W9ET(4)[7],=W9FZ(4)[7],=W9GOL(5)[8],=W9JA(4)[7],
+    =W9JAB(4)[7],=W9JH(3)[6],=W9JJ(5)[8],=W9JXT(3)[6],=W9KB(5)[8],
+    =W9KNI(3)[6],=W9KXI(5)[8],=W9LCQ(4)[7],=W9LG(4)[7],=W9LWO(4)[7],
+    =W9MAF(4)[7],=W9MAK(3)[6],=W9MC(4)[7],=W9MET(5)[8],=W9MIC(5)[8],
+    =W9MVA(4)[7],=W9PR(5)[8],=W9RM(4)[7],=W9RNY(4)[7],=W9TCV(5)[8],
+    =W9TR(4)[7],=W9UP(4)[7],=W9WE(4)[7],=W9XG(4)[7],=W9YV(4)[7],=W9YZR(4)[7],
+    =WA0PFC(3)[6],=WA0RMW(3)[6],=WA0WWW(3)[6],=WA0YPC(5)[8],=WA1FCN(4)[8],
+    =WA1FMM(4)[7],=WA1UJU(4)[8],=WA1X(4)[8],=WA2DFI(3)[6],=WA2DHG(4)[8],
+    =WA2DLN(4)[8],=WA2EDJ(3)[6],=WA2JQZ(4)[7],=WA2PCN(4)[7],=WA2QWP(3)[6],
+    =WA2USA(4)[8],=WA2VAM(4)[8],=WA2VYA(4)[7],=WA3C(4)[8],=WA3IHV(3)[6],
+    =WA3JAT(4)[8],=WA4CAX(4)[8],=WA4CB(4)[8],=WA4CDP(4)[8],=WA4FAT(4)[8],
+    =WA4FXT(4)[8],=WA4GGK(4)[8],=WA4GNL(4)[8],=WA4JA(4)[8],=WA4JQS(4)[8],
+    =WA4TTP(4)[8],=WA4USA(4)[8],=WA4VEK(4)[8],=WA4WZR(4)[8],=WA4YJB(4)[8],
+    =WA5POK(4)[8],=WA5T(5)[8],=WA5ZQO(4)[8],=WA6CW(4)[8],=WA6VZN(5)[8],
+    =WA7AFV(4)[7],=WA7DIA(5)[8],=WA7EM(4)[7],=WA7NPX(4)[7],=WA8AHZ(5)[8],
+    =WA8KAN(5)[8],=WA8NLX(5)[8],=WA8OJR(5)[8],=WA8PAG(5)[8],=WA8YVF(5)[8],
+    =WA8ZBT(4)[7],=WA9AFM(4)[7],=WA9ETL(4)[7],=WA9JBR(4)[7],=WA9JIB(3)[6],
+    =WA9KIA(4)[7],=WA9LT(4)[7],=WA9Z(4)[7],=WB0CJB(4)[8],=WB0NPR(4)[8],
+    =WB0POH(5)[8],=WB2AWQ(3)[6],=WB2GDD(4)[7],=WB2MFU(4)[7],=WB3JFS(3)[6],
+    =WB3JKQ(4)[8],=WB4BMQ(4)[8],=WB4CS(4)[8],=WB4E(4)[8],=WB4HMA(4)[8],
+    =WB4IT(4)[8],=WB4MSN(4)[8],=WB4NCT(4)[8],=WB4SPB(3)[6],=WB4VAM(3)[6],
+    =WB4WXE(4)[8],=WB4YDL(4)[8],=WB4YDY(4)[8],=WB4ZBI(4)[8],=WB5DXG(4)[8],
+    =WB5EVF(5)[8],=WB5RYB(5)[8],=WB5SKM(4)[8],=WB5WAJ(4)[8],=WB6ARO(4)[8],
+    =WB6BEE(5)[8],=WB6RAB(5)[8],=WB6UIA(4)[7],=WB7BNE(4)[7],=WB7BWZ(4)[7],
+    =WB7PMP(5)[8],=WB7RAV(5)[8],=WB7S(4)[7],=WB7UOF(3)[7],=WB8BEL(5)[8],
+    =WB8BPU(5)[8],=WB8EKG(5)[8],=WB8IMY(5)[8],=WB8LZR(5)[8],=WB8QZM(4)[7],
+    =WB8WUP(5)[8],=WB8YQJ(3)[6],=WB8YYY(5)[8],=WB9COY(3)[6],=WB9DBD(5)[8],
+    =WB9G(5)[8],=WB9JTK(5)[8],=WB9PRG(4)[7],=WB9RRU(5)[8],=WB9WKT(4)[7],
+    =WB9YLZ(4)[7],=WB9Z(5)[8],=WC0W(5)[8],=WC4D(4)[8],=WC4DC(4)[8],
+    =WC7S(4)[7],=WC8L(4)[7],=WC9D(5)[8],=WD0ETG(5)[8],=WD4CFN(4)[8],
+    =WD4IXD(4)[7],=WD4KTF(4)[8],=WD4NYL(4)[8],=WD4OHD(4)[8],=WD4PTJ(4)[8],
+    =WD4XA(4)[8],=WD5CCA(4)[8],=WD5FCA(4)[8],=WD6BNY(4)[8],=WD6V(4)[7],
+    =WD7CW(4)[7],=WD8DII(3)[6],=WD8DSV(5)[8],=WD8RYV(5)[8],=WD9IGL(4)[7],
+    =WE2DX(4)[8],=WE4DX(3)[6],=WE5E(4)[8],=WE5P(4)[8],=WE6EZ(4)[7],
+    =WE8R(5)[8],=WE8RV(3)[6],=WE8USN(5)[8],=WE9N(4)[7],=WF1A(3)[6],
+    =WF3H(4)[7],=WF3T(4)[8],=WF4U(3)[6],=WF7I(5)[8],=WF7T(4)[8],=WF8E(5)[8],
+    =WF9A(5)[8],=WG4M(4)[7],=WG5D(5)[8],=WG8Y(5)[8],=WG9X(5)[8],=WH0AI(4)[7],
+    =WH2T(3)[6],=WH6AQ(5)[8],=WH6LE(5)[8],=WH6VL(4)[7],=WH7R(4)[7],
+    =WI9P(4)[7],=WJ4I(4)[8],=WJ8L(5)[8],=WJ9B(3)[6],=WJ9H(4)[7],=WJ9O(4)[7],
+    =WJ9T(3)[6],=WL7OU(4)[7],=WM0G(5)[8],=WM4Q(4)[8],=WM5DX(4)[8],=WN1R(4)[8],
+    =WN4AAA(3)[6],=WN4AT(4)[8],=WN7S(5)[8],=WN7Y(4)[7],=WN8KXY(5)[8],
+    =WO3X(4)[8],=WO7U(4)[7],=WO8L(5)[8],=WP3ME(5)[8],=WQ0X(5)[8],=WQ5L(4)[8],
+    =WQ5O(4)[8],=WQ9T(4)[7],=WR3O(4)[8],=WR4T(4)[8],=WS6K(4)[8],=WS6X(5)[8],
+    =WS7X(5)[8],=WS9M(5)[8],=WT2P(4)[8],=WT4DX(4)[7],=WT4R(4)[8],=WT4U(4)[8],
+    =WT4W(4)[8],=WT5A(4)[8],=WT5L(5)[8],=WT7TT(4)[7],=WT8P(3)[6],=WT9Q(4)[7],
+    =WT9Y(5)[8],=WU5E(5)[8],=WU5X(4)[8],=WU8T(3)[6],=WV0T(3)[6],=WV4E(4)[8],
+    =WV4P(4)[8],=WV7MS(5)[8],=WV8AR(5)[8],=WV8HAT(5)[8],=WV8HC(5)[8],
+    =WV8TG(5)[8],=WW3K(4)[7],=WW4N(4)[8],=WW4R(4)[8],=WW5M(4)[8],=WW5X(4)[8],
+    =WW6W(4)[7],=WW8L(4)[7],=WX4W(4)[8],=WX5S(3)[6],=WX7AA(4)[8],=WX7T(5)[8],
+    =WX7V(4)[7],=WX8C(5)[8],=WY7AA(4)[7],=WY7FD(4)[7],=WY7KY(4)[7],
+    =WY7M(4)[7],=WY7QP(4)[7],=WZ4F(4)[8],=WZ6P(4)[7],=WZ7I(5)[8],=WZ8T(3)[6],
+    =WZ8X(5)[8];
+Guantanamo Bay:           08:  11:  NA:   20.00:    75.00:     5.0:  KG4:
+    KG4,=KG4NE;
+Mariana Islands:          27:  64:  OC:   15.18:  -145.72:   -10.0:  KH0:
+    AH0,KH0,NH0,WH0,=AH2U,=KO6JPQ,=NA1M,=NB9G,=NH2B,=NO3V;
+Baker & Howland Islands:  31:  61:  OC:    0.00:   176.00:    12.0:  KH1:
+    AH1,KH1,NH1,WH1;
+Guam:                     27:  64:  OC:   13.37:  -144.70:   -10.0:  KH2:
+    AH2,KH2,NH2,WH2,=KG6DX,=KG6JDX,=KH6KK,=KK7FAU;
+Johnston Island:          31:  61:  OC:   16.72:   169.53:    10.0:  KH3:
+    AH3,KH3,NH3,WH3;
+Midway Island:            31:  61:  OC:   28.20:   177.37:    11.0:  KH4:
+    AH4,KH4,NH4,WH4;
+Palmyra & Jarvis Islands: 31:  61:  OC:    5.87:   162.07:    11.0:  KH5:
+    AH5,KH5,NH5,WH5;
+Hawaii:                   31:  61:  OC:   21.12:   157.48:    10.0:  KH6:
+    AH6,AH7,KH6,KH7,NH6,NH7,WH6,WH7,=AG7XY,=K2GT,=K4RPB,=K4XV,=K6KO,=KA0RGT,
+    =KB0TBA,=KB0VKF,=KB2DJE,=KB6EGA,=KC0QZS,=KC1EGP,=KC1EGQ,=KE6FZD,=KF6AST,
+    =KG5DVX,=KG7WCF,=KH0WJ,=KH3AE,=KH8DN,=KI6AMI,=KI6AMJ,=KK4PEQ,=KK6MZE,
+    =KK6PSW,=KK6VYF,=KM4HKQ,=KN3VER,=KN4FTF,=KN4MTF,=KN6KCA,=KT4GL,=N2HNQ,
+    =N4ZSU,=N6AZU,=N6KB,=N9PK,=ND1A,=NV2T,=W6TDX,=WB4JTT,=WB7N,=WF6K,=WV6K;
+Kure Island:              31:  61:  OC:   29.00:   178.00:    10.0:  KH7K:
+    AH7K,KH7K,NH7K,WH7K;
+American Samoa:           32:  62:  OC:  -14.32:   170.78:    11.0:  KH8:
+    AH8,KH8,NH8,WH8;
+Swains Island:            32:  62:  OC:  -11.05:   171.25:    11.0:  KH8/s:
+    =K9CS/KH8S;
+Wake Island:              31:  65:  OC:   19.28:  -166.63:   -12.0:  KH9:
+    AH9,KH9,NH9,WH9;
+Alaska:                   01:  01:  NA:   61.40:   148.87:     8.0:  KL:
+    AL,KL,NL,WL,=AD4BL,=AI7YJ,=K1LH,=K1TAQ,=K2CRA,=K6JPB,=K7HFU,=K7ZVZ,
+    =KA1NCN,=KA2ZSD,=KB1OHI,=KB6KSD,=KC5SGK,=KC7CRS,=KC9GMO,=KD7CYC,=KD9FBI,
+    =KE0GUV,=KE0HMK,=KF7HGP,=KF7HGR,=KF8ENL,=KG4HZF,=KG7TLW,=KH6RF,=KI7KPB,
+    =KJ7IEZ,=KK6WJY,=KK7GYU,=KK7TSX,=KM4UMZ,=KN4ICW,=KN6NFQ,=KN6PHX,=KO4BJA,
+    =KR4CNM,=KT5Z,=KZ7MFL,=N1TX,=N5UC,=N6MHR,=N7DKL,=N7RNG,=NN7C,=W1TJW,
+    =W3ALF,=W5MFH,=WA6TUX,=WB1BR,=WX4ICE;
+Navassa Island:           08:  11:  NA:   18.40:    75.00:     5.0:  KP1:
+    KP1,NP1,WP1;
+US Virgin Islands:        08:  11:  NA:   17.73:    64.80:     4.0:  KP2:
+    KP2,NP2,WP2,=K4JWO,=K9VV,=KC2LMZ,=KD4CDL,=KF9EM,=N4KK,=W4LIS;
+Puerto Rico:              08:  11:  NA:   18.18:    66.55:     4.0:  KP4:
+    KP3,KP4,NP3,NP4,WP3,WP4,=K2IDA,=K4VIC,=K4Z,=KD2BK,=KD2VAF,=KK6USA,=KM4DNE,
+    =KP2Z,=N4UXG,=N7BPT,=NP2R/4;
+Desecheo Island:          08:  11:  NA:   18.08:    67.88:     4.0:  KP5:
+    KP5,NP5,WP5,=KP5/NP3VI;
+Norway:                   14:  18:  EU:   61.00:    -9.00:    -1.0:  LA:
+    LA,LB,LC,LD,LE,LF,LG,LH,LI,LJ,LK,LL,LM,LN;
+Argentina:                13:  14:  SA:  -32.50:    62.13:     3.0:  LU:
+    AY,AZ,L1,L2,L3,L4,L5,L6,L7,L8,L9,LO,LP,LQ,LR,LS,LT,LU,LV,LW,AY0V[16],
+    AY0W[16],AY0X[16],AY0Y[16],AY1V[16],AY1W[16],AY1X[16],AY1Y[16],AY2V[16],
+    AY2W[16],AY2X[16],AY2Y[16],AY3V[16],AY3W[16],AY3X[16],AY3Y[16],AY4V[16],
+    AY4W[16],AY4X[16],AY4Y[16],AY5V[16],AY5W[16],AY5X[16],AY5Y[16],AY6V[16],
+    AY6W[16],AY6X[16],AY6Y[16],AY7V[16],AY7W[16],AY7X[16],AY7Y[16],AY8V[16],
+    AY8W[16],AY8X[16],AY8Y[16],AY9V[16],AY9W[16],AY9X[16],AY9Y[16],AZ0V[16],
+    AZ0W[16],AZ0X[16],AZ0Y[16],AZ1V[16],AZ1W[16],AZ1X[16],AZ1Y[16],AZ2V[16],
+    AZ2W[16],AZ2X[16],AZ2Y[16],AZ3V[16],AZ3W[16],AZ3X[16],AZ3Y[16],AZ4V[16],
+    AZ4W[16],AZ4X[16],AZ4Y[16],AZ5V[16],AZ5W[16],AZ5X[16],AZ5Y[16],AZ6V[16],
+    AZ6W[16],AZ6X[16],AZ6Y[16],AZ7V[16],AZ7W[16],AZ7X[16],AZ7Y[16],AZ8V[16],
+    AZ8W[16],AZ8X[16],AZ8Y[16],AZ9V[16],AZ9W[16],AZ9X[16],AZ9Y[16],L20V[16],
+    L20W[16],L20X[16],L20Y[16],L21V[16],L21W[16],L21X[16],L21Y[16],L22V[16],
+    L22W[16],L22X[16],L22Y[16],L23V[16],L23W[16],L23X[16],L23Y[16],L24V[16],
+    L24W[16],L24X[16],L24Y[16],L25V[16],L25W[16],L25X[16],L25Y[16],L26V[16],
+    L26W[16],L26X[16],L26Y[16],L27V[16],L27W[16],L27X[16],L27Y[16],L28V[16],
+    L28W[16],L28X[16],L28Y[16],L29V[16],L29W[16],L29X[16],L29Y[16],L30V[16],
+    L30W[16],L30X[16],L30Y[16],L31V[16],L31W[16],L31X[16],L31Y[16],L32V[16],
+    L32W[16],L32X[16],L32Y[16],L33V[16],L33W[16],L33X[16],L33Y[16],L34V[16],
+    L34W[16],L34X[16],L34Y[16],L35V[16],L35W[16],L35X[16],L35Y[16],L36V[16],
+    L36W[16],L36X[16],L36Y[16],L37V[16],L37W[16],L37X[16],L37Y[16],L38V[16],
+    L38W[16],L38X[16],L38Y[16],L39V[16],L39W[16],L39X[16],L39Y[16],L40V[16],
+    L40W[16],L40X[16],L40Y[16],L41V[16],L41W[16],L41X[16],L41Y[16],L42V[16],
+    L42W[16],L42X[16],L42Y[16],L43V[16],L43W[16],L43X[16],L43Y[16],L44V[16],
+    L44W[16],L44X[16],L44Y[16],L45V[16],L45W[16],L45X[16],L45Y[16],L46V[16],
+    L46W[16],L46X[16],L46Y[16],L47V[16],L47W[16],L47X[16],L47Y[16],L48V[16],
+    L48W[16],L48X[16],L48Y[16],L49V[16],L49W[16],L49X[16],L49Y[16],L50V[16],
+    L50W[16],L50X[16],L50Y[16],L51V[16],L51W[16],L51X[16],L51Y[16],L52V[16],
+    L52W[16],L52X[16],L52Y[16],L53V[16],L53W[16],L53X[16],L53Y[16],L54V[16],
+    L54W[16],L54X[16],L54Y[16],L55V[16],L55W[16],L55X[16],L55Y[16],L56V[16],
+    L56W[16],L56X[16],L56Y[16],L57V[16],L57W[16],L57X[16],L57Y[16],L58V[16],
+    L58W[16],L58X[16],L58Y[16],L59V[16],L59W[16],L59X[16],L59Y[16],L60V[16],
+    L60W[16],L60X[16],L60Y[16],L61V[16],L61W[16],L61X[16],L61Y[16],L62V[16],
+    L62W[16],L62X[16],L62Y[16],L63V[16],L63W[16],L63X[16],L63Y[16],L64V[16],
+    L64W[16],L64X[16],L64Y[16],L65V[16],L65W[16],L65X[16],L65Y[16],L66V[16],
+    L66W[16],L66X[16],L66Y[16],L67V[16],L67W[16],L67X[16],L67Y[16],L68V[16],
+    L68W[16],L68X[16],L68Y[16],L69V[16],L69W[16],L69X[16],L69Y[16],L70V[16],
+    L70W[16],L70X[16],L70Y[16],L71V[16],L71W[16],L71X[16],L71Y[16],L72V[16],
+    L72W[16],L72X[16],L72Y[16],L73V[16],L73W[16],L73X[16],L73Y[16],L74V[16],
+    L74W[16],L74X[16],L74Y[16],L75V[16],L75W[16],L75X[16],L75Y[16],L76V[16],
+    L76W[16],L76X[16],L76Y[16],L77V[16],L77W[16],L77X[16],L77Y[16],L78V[16],
+    L78W[16],L78X[16],L78Y[16],L79V[16],L79W[16],L79X[16],L79Y[16],L80V[16],
+    L80W[16],L80X[16],L80Y[16],L81V[16],L81W[16],L81X[16],L81Y[16],L82V[16],
+    L82W[16],L82X[16],L82Y[16],L83V[16],L83W[16],L83X[16],L83Y[16],L84V[16],
+    L84W[16],L84X[16],L84Y[16],L85V[16],L85W[16],L85X[16],L85Y[16],L86V[16],
+    L86W[16],L86X[16],L86Y[16],L87V[16],L87W[16],L87X[16],L87Y[16],L88V[16],
+    L88W[16],L88X[16],L88Y[16],L89V[16],L89W[16],L89X[16],L89Y[16],L90V[16],
+    L90W[16],L90X[16],L90Y[16],L91V[16],L91W[16],L91X[16],L91Y[16],L92V[16],
+    L92W[16],L92X[16],L92Y[16],L93V[16],L93W[16],L93X[16],L93Y[16],L94V[16],
+    L94W[16],L94X[16],L94Y[16],L95V[16],L95W[16],L95X[16],L95Y[16],L96V[16],
+    L96W[16],L96X[16],L96Y[16],L97V[16],L97W[16],L97X[16],L97Y[16],L98V[16],
+    L98W[16],L98X[16],L98Y[16],L99V[16],L99W[16],L99X[16],L99Y[16],LO0V[16],
+    LO0W[16],LO0X[16],LO0Y[16],LO1V[16],LO1W[16],LO1X[16],LO1Y[16],LO2V[16],
+    LO2W[16],LO2X[16],LO2Y[16],LO3V[16],LO3W[16],LO3X[16],LO3Y[16],LO4V[16],
+    LO4W[16],LO4X[16],LO4Y[16],LO5V[16],LO5W[16],LO5X[16],LO5Y[16],LO6V[16],
+    LO6W[16],LO6X[16],LO6Y[16],LO7V[16],LO7W[16],LO7X[16],LO7Y[16],LO8V[16],
+    LO8W[16],LO8X[16],LO8Y[16],LO9V[16],LO9W[16],LO9X[16],LO9Y[16],LP0V[16],
+    LP0W[16],LP0X[16],LP0Y[16],LP1V[16],LP1W[16],LP1X[16],LP1Y[16],LP2V[16],
+    LP2W[16],LP2X[16],LP2Y[16],LP3V[16],LP3W[16],LP3X[16],LP3Y[16],LP4V[16],
+    LP4W[16],LP4X[16],LP4Y[16],LP5V[16],LP5W[16],LP5X[16],LP5Y[16],LP6V[16],
+    LP6W[16],LP6X[16],LP6Y[16],LP7V[16],LP7W[16],LP7X[16],LP7Y[16],LP8V[16],
+    LP8W[16],LP8X[16],LP8Y[16],LP9V[16],LP9W[16],LP9X[16],LP9Y[16],LQ0V[16],
+    LQ0W[16],LQ0X[16],LQ0Y[16],LQ1V[16],LQ1W[16],LQ1X[16],LQ1Y[16],LQ2V[16],
+    LQ2W[16],LQ2X[16],LQ2Y[16],LQ3V[16],LQ3W[16],LQ3X[16],LQ3Y[16],LQ4V[16],
+    LQ4W[16],LQ4X[16],LQ4Y[16],LQ5V[16],LQ5W[16],LQ5X[16],LQ5Y[16],LQ6V[16],
+    LQ6W[16],LQ6X[16],LQ6Y[16],LQ7V[16],LQ7W[16],LQ7X[16],LQ7Y[16],LQ8V[16],
+    LQ8W[16],LQ8X[16],LQ8Y[16],LQ9V[16],LQ9W[16],LQ9X[16],LQ9Y[16],LR0V[16],
+    LR0W[16],LR0X[16],LR0Y[16],LR1V[16],LR1W[16],LR1X[16],LR1Y[16],LR2V[16],
+    LR2W[16],LR2X[16],LR2Y[16],LR3V[16],LR3W[16],LR3X[16],LR3Y[16],LR4V[16],
+    LR4W[16],LR4X[16],LR4Y[16],LR5V[16],LR5W[16],LR5X[16],LR5Y[16],LR6V[16],
+    LR6W[16],LR6X[16],LR6Y[16],LR7V[16],LR7W[16],LR7X[16],LR7Y[16],LR8V[16],
+    LR8W[16],LR8X[16],LR8Y[16],LR9V[16],LR9W[16],LR9X[16],LR9Y[16],LS0V[16],
+    LS0W[16],LS0X[16],LS0Y[16],LS1V[16],LS1W[16],LS1X[16],LS1Y[16],LS2V[16],
+    LS2W[16],LS2X[16],LS2Y[16],LS3V[16],LS3W[16],LS3X[16],LS3Y[16],LS4V[16],
+    LS4W[16],LS4X[16],LS4Y[16],LS5V[16],LS5W[16],LS5X[16],LS5Y[16],LS6V[16],
+    LS6W[16],LS6X[16],LS6Y[16],LS7V[16],LS7W[16],LS7X[16],LS7Y[16],LS8V[16],
+    LS8W[16],LS8X[16],LS8Y[16],LS9V[16],LS9W[16],LS9X[16],LS9Y[16],LT0V[16],
+    LT0W[16],LT0X[16],LT0Y[16],LT1V[16],LT1W[16],LT1X[16],LT1Y[16],LT2V[16],
+    LT2W[16],LT2X[16],LT2Y[16],LT3V[16],LT3W[16],LT3X[16],LT3Y[16],LT4V[16],
+    LT4W[16],LT4X[16],LT4Y[16],LT5V[16],LT5W[16],LT5X[16],LT5Y[16],LT6V[16],
+    LT6W[16],LT6X[16],LT6Y[16],LT7V[16],LT7W[16],LT7X[16],LT7Y[16],LT8V[16],
+    LT8W[16],LT8X[16],LT8Y[16],LT9V[16],LT9W[16],LT9X[16],LT9Y[16],LU0V[16],
+    LU0W[16],LU0X[16],LU0Y[16],LU1V[16],LU1W[16],LU1X[16],LU1Y[16],LU2V[16],
+    LU2W[16],LU2X[16],LU2Y[16],LU3V[16],LU3W[16],LU3X[16],LU3Y[16],LU4V[16],
+    LU4W[16],LU4X[16],LU4Y[16],LU5V[16],LU5W[16],LU5X[16],LU5Y[16],LU6V[16],
+    LU6W[16],LU6X[16],LU6Y[16],LU7V[16],LU7W[16],LU7X[16],LU7Y[16],LU8V[16],
+    LU8W[16],LU8X[16],LU8Y[16],LU9V[16],LU9W[16],LU9X[16],LU9Y[16],LV0V[16],
+    LV0W[16],LV0X[16],LV0Y[16],LV1V[16],LV1W[16],LV1X[16],LV1Y[16],LV2V[16],
+    LV2W[16],LV2X[16],LV2Y[16],LV3V[16],LV3W[16],LV3X[16],LV3Y[16],LV4V[16],
+    LV4W[16],LV4X[16],LV4Y[16],LV5V[16],LV5W[16],LV5X[16],LV5Y[16],LV6V[16],
+    LV6W[16],LV6X[16],LV6Y[16],LV7V[16],LV7W[16],LV7X[16],LV7Y[16],LV8V[16],
+    LV8W[16],LV8X[16],LV8Y[16],LV9V[16],LV9W[16],LV9X[16],LV9Y[16],LW0V[16],
+    LW0W[16],LW0X[16],LW0Y[16],LW1V[16],LW1W[16],LW1X[16],LW1Y[16],LW2V[16],
+    LW2W[16],LW2X[16],LW2Y[16],LW3V[16],LW3W[16],LW3X[16],LW3Y[16],LW4V[16],
+    LW4W[16],LW4X[16],LW4Y[16],LW5V[16],LW5W[16],LW5X[16],LW5Y[16],LW6V[16],
+    LW6W[16],LW6X[16],LW6Y[16],LW7V[16],LW7W[16],LW7X[16],LW7Y[16],LW8V[16],
+    LW8W[16],LW8X[16],LW8Y[16],LW9V[16],LW9W[16],LW9X[16],LW9Y[16],=LO7E/D,
+    =LU1AAS/XP[16],=LU1AM/D,=LU1ANG/D,=LU1ANG/S,=LU1APS/H,=LU1AW/D,=LU1DHL/D,
+    =LU1DHL/W[16],=LU1DNQ/D,=LU1DUA/D,=LU1DXG/D,=LU1EAF/D,=LU1EJK/K,=LU1EVW/D,
+    =LU1JCE/O,=LU1MAW/D,=LU1UG/U,=LU1VZ/V[16],=LU1WF/W[16],=LU2DGI/D,=LU2DT/D,
+    =LU2HDM/H,=LU2IKP/I,=LU2WA/W[16],=LU3AJL/D,=LU3DVN/X[16],=LU3DXG/D,
+    =LU3EMN/W[16],=LU3EMN/XA[16],=LU3EU/D,=LU3EU/E,=LU3HBC/U,=LU3HGB/H,
+    =LU3HGB/V[16],=LU3HT/H,=LU4ARU/D,=LU4DPL/H,=LU4HDE/H,=LU4HK/H,=LU4SCM/S,
+    =LU5JU/L,=LU5OIJ/O,=LU5VGP/V[16],=LU5VNL/V[16],=LU6DO/V[16],=LU6HL/H,
+    =LU6HPA/H,=LU6UVI/D,=LU7AA/G,=LU7AA/Y[16],=LU7CC/E,=LU7DZV/D,=LU7EYX/D,
+    =LU7HKH/H,=LU7VRC/V[16],=LU7YG/Y[16],=LU8DAL/D,=LU8DCH/D,=LU8EHV/D,
+    =LU8EMD/D,=LU8SAM/S,=LU8YE/Y[16],=LU9CNS/D,=LU9CNS/S,=LU9DCA/D,=LU9EHB/D,
+    =LU9IMM/L,=LU9WT/W[16],=LW2DMD/D,=LW2DO/D,=LW3DMV/D,=LW3EMP/I,=LW4DAF/D,
+    =LW4EIN/D,=LW5ECI/D,=LW6DGA/D,=LW6DGI/D,=LW6DNF/D,=LW8HBE/H,=LW9EVV/D;
+Luxembourg:               14:  27:  EU:   50.00:    -6.00:    -1.0:  LX:
+    LX;
+Lithuania:                15:  29:  EU:   55.45:   -23.63:    -2.0:  LY:
+    LY;
+Bulgaria:                 20:  28:  EU:   42.83:   -25.08:    -2.0:  LZ:
+    LZ;
+Peru:                     10:  12:  SA:  -10.00:    76.00:     5.0:  OA:
+    4T,OA,OB,OC;
+Lebanon:                  20:  39:  AS:   33.83:   -35.83:    -2.0:  OD:
+    OD;
+Austria:                  15:  28:  EU:   47.33:   -13.33:    -1.0:  OE:
+    OE,=4U0IARU,=4U0R,=4U1A,=4U1VIC,=4U2U,=4UNR,=4Y1A,=C7A;
+Finland:                  15:  18:  EU:   61.38:   -24.82:    -2.0:  OH:
+    OF,OG,OH,OI,OJ;
+Aland Islands:            15:  18:  EU:   60.13:   -20.37:    -2.0:  OH0:
+    OF0,OG0,OH0,OI0;
+Market Reef:              15:  18:  EU:   60.00:   -19.00:    -2.0:  OJ0:
+    OJ0;
+Czech Republic:           15:  28:  EU:   50.00:   -16.00:    -1.0:  OK:
+    OK,OL;
+Slovak Republic:          15:  28:  EU:   49.00:   -20.00:    -1.0:  OM:
+    OM;
+Belgium:                  14:  27:  EU:   50.70:    -4.85:    -1.0:  ON:
+    ON,OO,OP,OQ,OR,OS,OT;
+Greenland:                40:  05:  NA:   74.00:    42.78:     3.0:  OX:
+    OX,XP;
+Faroe Islands:            14:  18:  EU:   62.07:     6.93:     0.0:  OY:
+    OW,OY;
+Denmark:                  14:  18:  EU:   56.00:   -10.00:    -1.0:  OZ:
+    5P,5Q,OU,OV,OZ;
+Papua New Guinea:         28:  51:  OC:   -9.50:  -147.12:   -10.0:  P2:
+    P2;
+Aruba:                    09:  11:  SA:   12.53:    69.98:     4.0:  P4:
+    P4;
+DPR of Korea:             25:  44:  AS:   39.78:  -126.30:    -9.0:  P5:
+    P5,P6,P7,P8,P9;
+Netherlands:              14:  27:  EU:   52.28:    -5.47:    -1.0:  PA:
+    PA,PB,PC,PD,PE,PF,PG,PH,PI,=PI4ZWN/MILL;
+Curacao:                  09:  11:  SA:   12.17:    69.00:     4.0:  PJ2:
+    PJ2;
+Bonaire:                  09:  11:  SA:   12.20:    68.25:     4.0:  PJ4:
+    PJ4;
+Saba & St. Eustatius:     08:  11:  NA:   17.57:    63.10:     4.0:  PJ5:
+    PJ5,PJ6;
+Sint Maarten:             08:  11:  NA:   18.07:    63.07:     4.0:  PJ7:
+    PJ0,PJ7,PJ8;
+Brazil:                   11:  15:  SA:  -10.00:    53.00:     3.0:  PY:
+    PP,PQ,PR,PS,PT,PU,PV,PW,PX,PY,ZV,ZW,ZX,ZY,ZZ,PP6[13],PP7[13],PP8[12],
+    PP9[13],PQ2[13],PQ6[13],PQ7[13],PQ8[13],PQ9[13],PR6[13],PR7[13],PR8[13],
+    PR9[13],PS6[13],PS7[13],PS8[13],PS9[13],PT2[13],PT6[13],PT7[13],PT8[12],
+    PU6[13],PU7[13],PU8[13],PU9[13],PV6[13],PV7[13],PV8[12],PV9[13],PW6[13],
+    PW7[13],PW8[12],PW9[13],PX6[13],PX7[13],PX8[13],PX9[13],PY6[13],PY7[13],
+    PY8[13],PY9[13],ZV6[13],ZV7[13],ZV8[13],ZV9[13],ZW6[13],ZW7[13],ZW8[13],
+    ZW9[13],ZX6[13],ZX7[13],ZX8[13],ZX9[13],ZY6[13],ZY7[13],ZY8[13],ZY9[13],
+    ZZ6[13],ZZ7[13],ZZ8[13],ZZ9[13],=ZV2DF[13],=ZV2TO[13],=ZV8AC[12],
+    =ZV8AM[12],=ZV8RO[12],=ZV8RR[12],=ZV9MS;
+Fernando de Noronha:      11:  13:  SA:   -3.85:    32.43:     2.0:  PY0F:
+    PP0F,PP0ZF,PQ0F,PQ0ZF,PR0F,PR0ZF,PS0F,PS0ZF,PT0F,PT0ZF,PU0F,PU0ZF,PV0F,
+    PV0ZF,PW0F,PW0ZF,PX0F,PX0ZF,PY0F,PY0Z,ZV0F,ZV0ZF,ZW0F,ZW0ZF,ZX0F,ZX0ZF,
+    ZY0F,ZY0Z,ZZ0F,ZZ0ZF,PP0R,PP0ZR,PQ0R,PQ0ZR,PR0R,PR0ZR,PS0R,PS0ZR,PT0R,
+    PT0ZR,PU0R,PU0ZR,PV0R,PV0ZR,PW0R,PW0ZR,PX0R,PX0ZR,PY0R,ZV0R,ZV0ZR,ZW0R,
+    ZW0ZR,ZX0R,ZX0ZR,ZY0R,ZZ0R,ZZ0ZR;
+St. Peter & St. Paul:     11:  13:  SA:    0.00:    29.00:     2.0:  PY0S:
+    PP0S,PP0ZS,PQ0S,PQ0ZS,PR0S,PR0ZS,PS0S,PS0ZS,PT0S,PT0ZS,PU0S,PU0ZS,PV0S,
+    PV0ZS,PW0S,PW0ZS,PX0S,PX0ZS,PY0S,PY0ZS,ZV0S,ZV0ZS,ZW0S,ZW0ZS,ZX0S,ZX0ZS,
+    ZY0S,ZY0ZS,ZZ0S,ZZ0ZS;
+Trindade & Martim Vaz:    11:  15:  SA:  -20.50:    29.32:     2.0:  PY0T:
+    PP0T,PP0ZT,PQ0T,PQ0ZT,PR0T,PR0ZT,PS0T,PS0ZT,PT0T,PT0ZT,PU0T,PU0ZT,PV0T,
+    PV0ZT,PW0T,PW0ZT,PX0T,PX0ZT,PY0T,PY0ZT,ZV0T,ZV0ZT,ZW0T,ZW0ZT,ZX0T,ZX0ZT,
+    ZY0T,ZY0ZT,ZZ0T,ZZ0ZT;
+Suriname:                 09:  12:  SA:    4.00:    56.00:     3.0:  PZ:
+    PZ;
+Franz Josef Land:         40:  75:  EU:   80.68:   -49.92:    -3.0:  R1FJ:
+    RI1F;
+Western Sahara:           33:  46:  AF:   24.82:    13.85:     0.0:  S0:
+    S0;
+Bangladesh:               22:  41:  AS:   24.12:   -89.65:    -6.0:  S2:
+    S2,S3;
+Slovenia:                 15:  28:  EU:   46.00:   -14.00:    -1.0:  S5:
+    S5;
+Seychelles:               39:  53:  AF:   -4.67:   -55.47:    -4.0:  S7:
+    S7;
+Sao Tome & Principe:      36:  47:  AF:    0.22:    -6.57:     0.0:  S9:
+    S9;
+Sweden:                   14:  18:  EU:   58.90:   -15.33:    -1.0:  SM:
+    7S,8S,SA,SB,SC,SD,SE,SF,SG,SH,SI,SJ,SK,SL,SM;
+Poland:                   15:  28:  EU:   52.28:   -18.67:    -1.0:  SP:
+    3Z,HF,SN,SO,SP,SQ,SR;
+Sudan:                    34:  48:  AF:   14.47:   -28.62:    -3.0:  ST:
+    6T,6U,ST;
+Egypt:                    34:  38:  AF:   26.28:   -28.60:    -2.0:  SU:
+    6A,6B,SS,SU;
+Greece:                   20:  28:  EU:   39.78:   -21.78:    -2.0:  SV:
+    J4,SV,SW,SX,SY,SZ;
+Mount Athos:              20:  28:  EU:   40.00:   -24.00:    -2.0:  SV/a:
+    =SV2RSG/A;
+Dodecanese:               20:  28:  EU:   36.17:   -27.93:    -2.0:  SV5:
+    J45,SV5,SW5,SX5,SY5,SZ5;
+Crete:                    20:  28:  EU:   35.23:   -24.78:    -2.0:  SV9:
+    J49,SV9,SW9,SX9,SY9,SZ9,=SV0XAZ;
+Tuvalu:                   31:  65:  OC:   -8.50:  -179.20:   -12.0:  T2:
+    T2;
+Western Kiribati:         31:  65:  OC:    1.42:  -173.00:   -12.0:  T30:
+    T30;
+Central Kiribati:         31:  62:  OC:   -2.83:   171.72:   -13.0:  T31:
+    T31;
+Eastern Kiribati:         31:  61:  OC:    1.80:   157.35:   -14.0:  T32:
+    T32;
+Banaba Island:            31:  65:  OC:   -0.88:  -169.53:   -12.0:  T33:
+    T33;
+Somalia:                  37:  48:  AF:    2.03:   -45.35:    -3.0:  T5:
+    6O,T5;
+San Marino:               15:  28:  EU:   43.95:   -12.45:    -1.0:  T7:
+    T7;
+Palau:                    27:  64:  OC:    7.45:  -134.53:    -9.0:  T8:
+    T8;
+Asiatic Turkey:           20:  39:  AS:   39.18:   -35.65:    -2.0:  TA:
+    TA,TB,TC,YM,=TA1AO/4;
+European Turkey:          20:  39:  EU:   41.02:   -28.97:    -2.0:  *TA1:
+    TA1,TB1,TC1,YM1,=TA3AC/1,=TA6CQ/1,=TA7H/1;
+Iceland:                  40:  17:  EU:   64.80:    18.73:     0.0:  TF:
+    TF;
+Guatemala:                07:  11:  NA:   15.50:    90.30:     6.0:  TG:
+    TD,TG;
+Costa Rica:               07:  11:  NA:   10.00:    84.00:     6.0:  TI:
+    TE,TI;
+Cocos Island:             07:  11:  NA:    5.52:    87.05:     6.0:  TI9:
+    TE9,TI9;
+Cameroon:                 36:  47:  AF:    5.38:   -11.87:    -1.0:  TJ:
+    TJ;
+Corsica:                  15:  28:  EU:   42.00:    -9.00:    -1.0:  TK:
+    TK;
+Central African Republic: 36:  47:  AF:    6.75:   -20.33:    -1.0:  TL:
+    TL;
+Republic of the Congo:    36:  52:  AF:   -1.02:   -15.37:    -1.0:  TN:
+    TN;
+Gabon:                    36:  52:  AF:   -0.37:   -11.73:    -1.0:  TR:
+    TR;
+Chad:                     36:  47:  AF:   15.80:   -18.17:    -1.0:  TT:
+    TT;
+Cote d'Ivoire:            35:  46:  AF:    7.58:     5.80:     0.0:  TU:
+    TU;
+Benin:                    35:  46:  AF:    9.87:    -2.25:    -1.0:  TY:
+    TY;
+Mali:                     35:  46:  AF:   18.00:     2.58:     0.0:  TZ:
+    TZ;
+European Russia:          16:  29:  EU:   53.65:   -41.37:    -4.0:  UA:
+    R,U,R1I(17)[20],R1N[19],R1O[19],R1P[20],R1Z[19],R4H[30],R4I[30],R4W[30],
+    R8F(17)[30],R8G(17)[30],R8X(17)[20],R9F(17)[30],R9G(17)[30],R9X(17)[20],
+    RA1I(17)[20],RA1N[19],RA1O[19],RA1P[20],RA1Z[19],RA4H[30],RA4I[30],
+    RA4W[30],RA8F(17)[30],RA8G(17)[30],RA8X(17)[20],RA9F(17)[30],RA9G(17)[30],
+    RA9X(17)[20],RC1I(17)[20],RC1N[19],RC1O[19],RC1P[20],RC1Z[19],RC4H[30],
+    RC4I[30],RC4W[30],RC8F(17)[30],RC8G(17)[30],RC8X(17)[20],RC9F(17)[30],
+    RC9G(17)[30],RC9X(17)[20],RD1I(17)[20],RD1N[19],RD1O[19],RD1P[20],
+    RD1Z[19],RD4H[30],RD4I[30],RD4W[30],RD8F(17)[30],RD8G(17)[30],
+    RD8X(17)[20],RD9F(17)[30],RD9G(17)[30],RD9X(17)[20],RE1I(17)[20],RE1N[19],
+    RE1O[19],RE1P[20],RE1Z[19],RE4H[30],RE4I[30],RE4W[30],RE8F(17)[30],
+    RE8G(17)[30],RE8X(17)[20],RE9F(17)[30],RE9G(17)[30],RE9X(17)[20],
+    RF1I(17)[20],RF1N[19],RF1O[19],RF1P[20],RF1Z[19],RF4H[30],RF4I[30],
+    RF4W[30],RF8F(17)[30],RF8G(17)[30],RF8X(17)[20],RF9F(17)[30],RF9G(17)[30],
+    RF9X(17)[20],RG1I(17)[20],RG1N[19],RG1O[19],RG1P[20],RG1Z[19],RG4H[30],
+    RG4I[30],RG4W[30],RG8F(17)[30],RG8G(17)[30],RG8X(17)[20],RG9F(17)[30],
+    RG9G(17)[30],RG9X(17)[20],RI8X(17)[20],RI9X(17)[20],RJ1I(17)[20],RJ1N[19],
+    RJ1O[19],RJ1P[20],RJ1Z[19],RJ4H[30],RJ4I[30],RJ4W[30],RJ8F(17)[30],
+    RJ8G(17)[30],RJ8X(17)[20],RJ9F(17)[30],RJ9G(17)[30],RJ9X(17)[20],
+    RK1I(17)[20],RK1N[19],RK1O[19],RK1P[20],RK1Z[19],RK4H[30],RK4I[30],
+    RK4W[30],RK8F(17)[30],RK8G(17)[30],RK8X(17)[20],RK9F(17)[30],RK9G(17)[30],
+    RK9X(17)[20],RL1I(17)[20],RL1N[19],RL1O[19],RL1P[20],RL1Z[19],RL4H[30],
+    RL4I[30],RL4W[30],RL8F(17)[30],RL8G(17)[30],RL8X(17)[20],RL9F(17)[30],
+    RL9G(17)[30],RL9X(17)[20],RM1I(17)[20],RM1N[19],RM1O[19],RM1P[20],
+    RM1Z[19],RM4H[30],RM4I[30],RM4W[30],RM8F(17)[30],RM8G(17)[30],
+    RM8X(17)[20],RM9F(17)[30],RM9G(17)[30],RM9X(17)[20],RN1I(17)[20],RN1N[19],
+    RN1O[19],RN1P[20],RN1Z[19],RN4H[30],RN4I[30],RN4W[30],RN8F(17)[30],
+    RN8G(17)[30],RN8X(17)[20],RN9F(17)[30],RN9G(17)[30],RN9X(17)[20],
+    RO1I(17)[20],RO1N[19],RO1O[19],RO1P[20],RO1Z[19],RO4H[30],RO4I[30],
+    RO4W[30],RO8F(17)[30],RO8G(17)[30],RO8X(17)[20],RO9F(17)[30],RO9G(17)[30],
+    RO9X(17)[20],RQ1I(17)[20],RQ1N[19],RQ1O[19],RQ1P[20],RQ1Z[19],RQ4H[30],
+    RQ4I[30],RQ4W[30],RQ8F(17)[30],RQ8G(17)[30],RQ8X(17)[20],RQ9F(17)[30],
+    RQ9G(17)[30],RQ9X(17)[20],RT1I(17)[20],RT1N[19],RT1O[19],RT1P[20],
+    RT1Z[19],RT4H[30],RT4I[30],RT4W[30],RT8F(17)[30],RT8G(17)[30],
+    RT8X(17)[20],RT9F(17)[30],RT9G(17)[30],RT9X(17)[20],RU1I(17)[20],RU1N[19],
+    RU1O[19],RU1P[20],RU1Z[19],RU4H[30],RU4I[30],RU4W[30],RU8F(17)[30],
+    RU8G(17)[30],RU8X(17)[20],RU9F(17)[30],RU9G(17)[30],RU9X(17)[20],
+    RV1I(17)[20],RV1N[19],RV1O[19],RV1P[20],RV1Z[19],RV4H[30],RV4I[30],
+    RV4W[30],RV8F(17)[30],RV8G(17)[30],RV8X(17)[20],RV9F(17)[30],RV9G(17)[30],
+    RV9X(17)[20],RW1I(17)[20],RW1N[19],RW1O[19],RW1P[20],RW1Z[19],RW4H[30],
+    RW4I[30],RW4W[30],RW8F(17)[30],RW8G(17)[30],RW8X(17)[20],RW9F(17)[30],
+    RW9G(17)[30],RW9X(17)[20],RX1I(17)[20],RX1N[19],RX1O[19],RX1P[20],
+    RX1Z[19],RX4H[30],RX4I[30],RX4W[30],RX8F(17)[30],RX8G(17)[30],
+    RX8X(17)[20],RX9F(17)[30],RX9G(17)[30],RX9X(17)[20],RY1I(17)[20],RY1N[19],
+    RY1O[19],RY1P[20],RY1Z[19],RY4H[30],RY4I[30],RY4W[30],RY8F(17)[30],
+    RY8G(17)[30],RY8X(17)[20],RY9F(17)[30],RY9G(17)[30],RY9X(17)[20],
+    RZ1I(17)[20],RZ1N[19],RZ1O[19],RZ1P[20],RZ1Z[19],RZ4H[30],RZ4I[30],
+    RZ4W[30],RZ8F(17)[30],RZ8G(17)[30],RZ8X(17)[20],RZ9F(17)[30],RZ9G(17)[30],
+    RZ9X(17)[20],U1I(17)[20],U1N[19],U1O[19],U1P[20],U1Z[19],U4H[30],U4I[30],
+    U4W[30],U8F(17)[30],U8G(17)[30],U8X(17)[20],U9F(17)[30],U9G(17)[30],
+    U9X(17)[20],UA1I(17)[20],UA1N[19],UA1O[19],UA1P[20],UA1Z[19],UA4H[30],
+    UA4I[30],UA4W[30],UA8F(17)[30],UA8G(17)[30],UA8X(17)[20],UA9F(17)[30],
+    UA9G(17)[30],UA9X(17)[20],UB1I(17)[20],UB1N[19],UB1O[19],UB1P[20],
+    UB1Z[19],UB4H[30],UB4I[30],UB4W[30],UB8F(17)[30],UB8G(17)[30],
+    UB8X(17)[20],UB9F(17)[30],UB9G(17)[30],UB9X(17)[20],UC1I(17)[20],UC1N[19],
+    UC1O[19],UC1P[20],UC1Z[19],UC4H[30],UC4I[30],UC4W[30],UC8F(17)[30],
+    UC8G(17)[30],UC8X(17)[20],UC9F(17)[30],UC9G(17)[30],UC9X(17)[20],
+    UD1I(17)[20],UD1N[19],UD1O[19],UD1P[20],UD1Z[19],UD4H[30],UD4I[30],
+    UD4W[30],UD8F(17)[30],UD8G(17)[30],UD8X(17)[20],UD9F(17)[30],UD9G(17)[30],
+    UD9X(17)[20],UE1I(17)[20],UE1N[19],UE1O[19],UE1P[20],UE1Z[19],UE4H[30],
+    UE4I[30],UE4W[30],UE8F(17)[30],UE8G(17)[30],UE8X(17)[20],UE9F(17)[30],
+    UE9G(17)[30],UE9X(17)[20],UF1I(17)[20],UF1N[19],UF1O[19],UF1P[20],
+    UF1Z[19],UF4H[30],UF4I[30],UF4W[30],UF8F(17)[30],UF8G(17)[30],
+    UF8X(17)[20],UF9F(17)[30],UF9G(17)[30],UF9X(17)[20],UG1I(17)[20],UG1N[19],
+    UG1O[19],UG1P[20],UG1Z[19],UG4H[30],UG4I[30],UG4W[30],UG8F(17)[30],
+    UG8G(17)[30],UG8X(17)[20],UG9F(17)[30],UG9G(17)[30],UG9X(17)[20],
+    UH1I(17)[20],UH1N[19],UH1O[19],UH1P[20],UH1Z[19],UH4H[30],UH4I[30],
+    UH4W[30],UH8F(17)[30],UH8G(17)[30],UH8X(17)[20],UH9F(17)[30],UH9G(17)[30],
+    UH9X(17)[20],UI1I(17)[20],UI1N[19],UI1O[19],UI1P[20],UI1Z[19],UI4H[30],
+    UI4I[30],UI4W[30],UI8F(17)[30],UI8G(17)[30],UI8X(17)[20],UI9F(17)[30],
+    UI9G(17)[30],UI9X(17)[20],=RA0ANB/3,=RA9M/6,=RI0SP(40),=R065A,=R065C,
+    =R065L,=R065N,=R065O,=R065S,=R065YG,=R1AT[19],=R1CAA[19],=R4HAT[29],
+    =R4HC[29],=R4HCE[29],=R4HCZ[29],=R4HD[29],=R4HDC[29],=R4HDR[29],=R4HL[29],
+    =R4IC[29],=R4ID[29],=R4II[29],=R4IK[29],=R4IM[29],=R4IN[29],=R4IO[29],
+    =R4IT[29],=R4PH[30],=R4RB[30],=R4RM[30],=R8FF/3,=R8MB/1(17)[20],=R9GM/6,
+    =R9JQ/6,=R9KC/6,=R9OM/6,=RA3X/1(17)[20],=RA4HL[29],=RA4NCC[30],=RC4HT[29],
+    =RC4I[29],=RJ4I[29],=RK4HM[29],=RL1I/P(17)[20],=RM4I[29],=RN4HFJ[29],
+    =RN4HIF[29],=RT4Q[30],=RU1AC[19],=RU4HD[29],=RU4HP[29],=RU4I[29],
+    =RW4HM[29],=RW4HTK[29],=RW4HW[29],=RW4HZ[29],=RW8T/1,=RZ4PXP[30],
+    =UA1A[19],=UA1F[19],=UA4H[29],=UA4HBM[29],=UA4HGL[29],=UA4HIP[29],
+    =UA4HRZ[29],=UA4HY[29],=UA4NF[30],=UA4PN[30],=UA4PRU[30],=UA4Q[30],
+    =UA4RX/1[19],=UC4I[29],=UG4I[29],=UG4P[30],=UI4I[29];
+Kaliningrad:              15:  29:  EU:   54.72:   -20.52:    -3.0:  UA2:
+    R2F,R2K,RA2,RC2F,RC2K,RD2F,RD2K,RE2F,RE2K,RF2F,RF2K,RG2F,RG2K,RJ2F,RJ2K,
+    RK2F,RK2K,RL2F,RL2K,RM2F,RM2K,RN2F,RN2K,RO2F,RO2K,RQ2F,RQ2K,RT2F,RT2K,
+    RU2F,RU2K,RV2F,RV2K,RW2F,RW2K,RX2F,RX2K,RY2F,RY2K,RZ2F,RZ2K,U2F,U2K,UA2,
+    UB2,UC2,UD2,UE2,UF2,UG2,UH2,UI2,=R2MWO;
+Asiatic Russia:           17:  30:  AS:   55.88:   -84.08:    -7.0:  UA9:
+    R0,R8(17)[30],R9,RA0,RA8(17)[30],RA9,RC0,RC8(17)[30],RC9,RD0,RD8(17)[30],
+    RD9,RE0,RE8(17)[30],RE9,RF0,RF8(17)[30],RF9,RG0,RG8(17)[30],RG9,RI0,
+    RI8(17)[30],RI9,RJ0,RJ8(17)[30],RJ9,RK0,RK8(17)[30],RK9,RL0,RL8(17)[30],
+    RL9,RM0,RM8(17)[30],RM9,RN0,RN8(17)[30],RN9,RO0,RO8(17)[30],RO9,RQ0,
+    RQ8(17)[30],RQ9,RT0,RT8(17)[30],RT9,RU0,RU8(17)[30],RU9,RV0,RV8(17)[30],
+    RV9,RW0,RW8(17)[30],RW9,RX0,RX8(17)[30],RX9,RY0,RY8(17)[30],RY9,RZ0,
+    RZ8(17)[30],RZ9,U0,U8(17)[30],U9,UA0,UA8(17)[30],UA9,UB0,UB8(17)[30],UB9,
+    UC0,UC8(17)[30],UC9,UD0,UD8(17)[30],UD9,UE0,UE8(17)[30],UE9,UF0,
+    UF8(17)[30],UF9,UG0,UG8(17)[30],UG9,UH0,UH8(17)[30],UH9,UI0,UI8(17)[30],
+    UI9,R0T(18)[32],R8H(18)[31],R8I(18)[31],R8O(18)[31],R8P(18)[31],
+    R8S(16)[30],R8T(16)[30],R8U(18)[31],R8V(18)[31],R8W(16)[30],R8Y(18)[31],
+    R8Z(18)[31],R9I(18)[31],R9M(17)[30],R9P(18)[31],R9S(16),R9T(16),
+    R9V(18)[31],R9W(16),RA0T(18)[32],RA8H(18)[31],RA8I(18)[31],RA8O(18)[31],
+    RA8P(18)[31],RA8S(16)[30],RA8T(16)[30],RA8U(18)[31],RA8V(18)[31],
+    RA8W(16)[30],RA8Y(18)[31],RA8Z(18)[31],RA9I(18)[31],RA9M(17)[30],
+    RA9P(18)[31],RA9S(16),RA9T(16),RA9V(18)[31],RA9W(16),RC0T(18)[32],
+    RC8H(18)[31],RC8I(18)[31],RC8O(18)[31],RC8P(18)[31],RC8S(16)[30],
+    RC8T(16)[30],RC8U(18)[31],RC8V(18)[31],RC8W(16)[30],RC8Y(18)[31],
+    RC8Z(18)[31],RC9I(18)[31],RC9M(17)[30],RC9P(18)[31],RC9S(16),RC9T(16),
+    RC9V(18)[31],RC9W(16),RD0T(18)[32],RD8H(18)[31],RD8I(18)[31],RD8O(18)[31],
+    RD8P(18)[31],RD8S(16)[30],RD8T(16)[30],RD8U(18)[31],RD8V(18)[31],
+    RD8W(16)[30],RD8Y(18)[31],RD8Z(18)[31],RD9I(18)[31],RD9M(17)[30],
+    RD9P(18)[31],RD9S(16),RD9T(16),RD9V(18)[31],RD9W(16),RE0T(18)[32],
+    RE8H(18)[31],RE8I(18)[31],RE8O(18)[31],RE8P(18)[31],RE8S(16)[30],
+    RE8T(16)[30],RE8U(18)[31],RE8V(18)[31],RE8W(16)[30],RE8Y(18)[31],
+    RE8Z(18)[31],RE9I(18)[31],RE9M(17)[30],RE9P(18)[31],RE9S(16),RE9T(16),
+    RE9V(18)[31],RE9W(16),RF0T(18)[32],RF8H(18)[31],RF8I(18)[31],RF8O(18)[31],
+    RF8P(18)[31],RF8S(16)[30],RF8T(16)[30],RF8U(18)[31],RF8V(18)[31],
+    RF8W(16)[30],RF8Y(18)[31],RF8Z(18)[31],RF9I(18)[31],RF9M(17)[30],
+    RF9P(18)[31],RF9S(16),RF9T(16),RF9V(18)[31],RF9W(16),RG0T(18)[32],
+    RG8H(18)[31],RG8I(18)[31],RG8O(18)[31],RG8P(18)[31],RG8S(16)[30],
+    RG8T(16)[30],RG8U(18)[31],RG8V(18)[31],RG8W(16)[30],RG8Y(18)[31],
+    RG8Z(18)[31],RG9I(18)[31],RG9M(17)[30],RG9P(18)[31],RG9S(16),RG9T(16),
+    RG9V(18)[31],RG9W(16),RJ0T(18)[32],RJ8H(18)[31],RJ8I(18)[31],RJ8O(18)[31],
+    RJ8P(18)[31],RJ8S(16)[30],RJ8T(16)[30],RJ8U(18)[31],RJ8V(18)[31],
+    RJ8W(16)[30],RJ8Y(18)[31],RJ8Z(18)[31],RJ9I(18)[31],RJ9M(17)[30],
+    RJ9P(18)[31],RJ9S(16),RJ9T(16),RJ9V(18)[31],RJ9W(16),RK0T(18)[32],
+    RK8H(18)[31],RK8I(18)[31],RK8O(18)[31],RK8P(18)[31],RK8S(16)[30],
+    RK8T(16)[30],RK8U(18)[31],RK8V(18)[31],RK8W(16)[30],RK8Y(18)[31],
+    RK8Z(18)[31],RK9I(18)[31],RK9M(17)[30],RK9P(18)[31],RK9S(16),RK9T(16),
+    RK9V(18)[31],RK9W(16),RL0T(18)[32],RL8H(18)[31],RL8I(18)[31],RL8O(18)[31],
+    RL8P(18)[31],RL8S(16)[30],RL8T(16)[30],RL8U(18)[31],RL8V(18)[31],
+    RL8W(16)[30],RL8Y(18)[31],RL8Z(18)[31],RL9I(18)[31],RL9M(17)[30],
+    RL9P(18)[31],RL9S(16),RL9T(16),RL9V(18)[31],RL9W(16),RM0T(18)[32],
+    RM8H(18)[31],RM8I(18)[31],RM8O(18)[31],RM8P(18)[31],RM8S(16)[30],
+    RM8T(16)[30],RM8U(18)[31],RM8V(18)[31],RM8W(16)[30],RM8Y(18)[31],
+    RM8Z(18)[31],RM9I(18)[31],RM9M(17)[30],RM9P(18)[31],RM9S(16),RM9T(16),
+    RM9V(18)[31],RM9W(16),RN0T(18)[32],RN8H(18)[31],RN8I(18)[31],RN8O(18)[31],
+    RN8P(18)[31],RN8S(16)[30],RN8T(16)[30],RN8U(18)[31],RN8V(18)[31],
+    RN8W(16)[30],RN8Y(18)[31],RN8Z(18)[31],RN9I(18)[31],RN9M(17)[30],
+    RN9P(18)[31],RN9S(16),RN9T(16),RN9V(18)[31],RN9W(16),RO0T(18)[32],
+    RO8H(18)[31],RO8I(18)[31],RO8O(18)[31],RO8P(18)[31],RO8S(16)[30],
+    RO8T(16)[30],RO8U(18)[31],RO8V(18)[31],RO8W(16)[30],RO8Y(18)[31],
+    RO8Z(18)[31],RO9I(18)[31],RO9M(17)[30],RO9P(18)[31],RO9S(16),RO9T(16),
+    RO9V(18)[31],RO9W(16),RQ0T(18)[32],RQ8H(18)[31],RQ8I(18)[31],RQ8O(18)[31],
+    RQ8P(18)[31],RQ8S(16)[30],RQ8T(16)[30],RQ8U(18)[31],RQ8V(18)[31],
+    RQ8W(16)[30],RQ8Y(18)[31],RQ8Z(18)[31],RQ9I(18)[31],RQ9M(17)[30],
+    RQ9P(18)[31],RQ9S(16),RQ9T(16),RQ9V(18)[31],RQ9W(16),RT0T(18)[32],
+    RT8H(18)[31],RT8I(18)[31],RT8O(18)[31],RT8P(18)[31],RT8S(16)[30],
+    RT8T(16)[30],RT8U(18)[31],RT8V(18)[31],RT8W(16)[30],RT8Y(18)[31],
+    RT8Z(18)[31],RT9I(18)[31],RT9M(17)[30],RT9P(18)[31],RT9S(16),RT9T(16),
+    RT9V(18)[31],RT9W(16),RU0T(18)[32],RU8H(18)[31],RU8I(18)[31],RU8O(18)[31],
+    RU8P(18)[31],RU8S(16)[30],RU8T(16)[30],RU8U(18)[31],RU8V(18)[31],
+    RU8W(16)[30],RU8Y(18)[31],RU8Z(18)[31],RU9I(18)[31],RU9M(17)[30],
+    RU9P(18)[31],RU9S(16),RU9T(16),RU9V(18)[31],RU9W(16),RV0T(18)[32],
+    RV8H(18)[31],RV8I(18)[31],RV8O(18)[31],RV8P(18)[31],RV8S(16)[30],
+    RV8T(16)[30],RV8U(18)[31],RV8V(18)[31],RV8W(16)[30],RV8Y(18)[31],
+    RV8Z(18)[31],RV9I(18)[31],RV9M(17)[30],RV9P(18)[31],RV9S(16),RV9T(16),
+    RV9V(18)[31],RV9W(16),RW0T(18)[32],RW8H(18)[31],RW8I(18)[31],RW8O(18)[31],
+    RW8P(18)[31],RW8S(16)[30],RW8T(16)[30],RW8U(18)[31],RW8V(18)[31],
+    RW8W(16)[30],RW8Y(18)[31],RW8Z(18)[31],RW9I(18)[31],RW9M(17)[30],
+    RW9P(18)[31],RW9S(16),RW9T(16),RW9V(18)[31],RW9W(16),RX0T(18)[32],
+    RX8H(18)[31],RX8I(18)[31],RX8O(18)[31],RX8P(18)[31],RX8S(16)[30],
+    RX8T(16)[30],RX8U(18)[31],RX8V(18)[31],RX8W(16)[30],RX8Y(18)[31],
+    RX8Z(18)[31],RX9I(18)[31],RX9M(17)[30],RX9P(18)[31],RX9S(16),RX9T(16),
+    RX9V(18)[31],RX9W(16),RY0T(18)[32],RY8H(18)[31],RY8I(18)[31],RY8O(18)[31],
+    RY8P(18)[31],RY8S(16)[30],RY8T(16)[30],RY8U(18)[31],RY8V(18)[31],
+    RY8W(16)[30],RY8Y(18)[31],RY8Z(18)[31],RY9I(18)[31],RY9M(17)[30],
+    RY9P(18)[31],RY9S(16),RY9T(16),RY9V(18)[31],RY9W(16),RZ0T(18)[32],
+    RZ8H(18)[31],RZ8I(18)[31],RZ8O(18)[31],RZ8P(18)[31],RZ8S(16)[30],
+    RZ8T(16)[30],RZ8U(18)[31],RZ8V(18)[31],RZ8W(16)[30],RZ8Y(18)[31],
+    RZ8Z(18)[31],RZ9I(18)[31],RZ9M(17)[30],RZ9P(18)[31],RZ9S(16),RZ9T(16),
+    RZ9V(18)[31],RZ9W(16),U0T(18)[32],U8H(18)[31],U8I(18)[31],U8O(18)[31],
+    U8P(18)[31],U8S(16)[30],U8T(16)[30],U8U(18)[31],U8V(18)[31],U8W(16)[30],
+    U8Y(18)[31],U8Z(18)[31],U9I(18)[31],U9M(17)[30],U9P(18)[31],U9S(16),
+    U9T(16),U9V(18)[31],U9W(16),UA0T(18)[32],UA8H(18)[31],UA8I(18)[31],
+    UA8O(18)[31],UA8P(18)[31],UA8S(16)[30],UA8T(16)[30],UA8U(18)[31],
+    UA8V(18)[31],UA8W(16)[30],UA8Y(18)[31],UA8Z(18)[31],UA9I(18)[31],
+    UA9M(17)[30],UA9P(18)[31],UA9S(16),UA9T(16),UA9V(18)[31],UA9W(16),
+    UB0T(18)[32],UB8H(18)[31],UB8I(18)[31],UB8O(18)[31],UB8P(18)[31],
+    UB8S(16)[30],UB8T(16)[30],UB8U(18)[31],UB8V(18)[31],UB8W(16)[30],
+    UB8Y(18)[31],UB8Z(18)[31],UB9I(18)[31],UB9M(17)[30],UB9P(18)[31],UB9S(16),
+    UB9T(16),UB9V(18)[31],UB9W(16),UC0T(18)[32],UC8H(18)[31],UC8I(18)[31],
+    UC8O(18)[31],UC8P(18)[31],UC8S(16)[30],UC8T(16)[30],UC8U(18)[31],
+    UC8V(18)[31],UC8W(16)[30],UC8Y(18)[31],UC8Z(18)[31],UC9I(18)[31],
+    UC9M(17)[30],UC9P(18)[31],UC9S(16),UC9T(16),UC9V(18)[31],UC9W(16),
+    UD0T(18)[32],UD8H(18)[31],UD8I(18)[31],UD8O(18)[31],UD8P(18)[31],
+    UD8S(16)[30],UD8T(16)[30],UD8U(18)[31],UD8V(18)[31],UD8W(16)[30],
+    UD8Y(18)[31],UD8Z(18)[31],UD9I(18)[31],UD9M(17)[30],UD9P(18)[31],UD9S(16),
+    UD9T(16),UD9V(18)[31],UD9W(16),UE0T(18)[32],UE8H(18)[31],UE8I(18)[31],
+    UE8O(18)[31],UE8P(18)[31],UE8S(16)[30],UE8T(16)[30],UE8U(18)[31],
+    UE8V(18)[31],UE8W(16)[30],UE8Y(18)[31],UE8Z(18)[31],UE9I(18)[31],
+    UE9M(17)[30],UE9P(18)[31],UE9S(16),UE9T(16),UE9V(18)[31],UE9W(16),
+    UF0T(18)[32],UF8H(18)[31],UF8I(18)[31],UF8O(18)[31],UF8P(18)[31],
+    UF8S(16)[30],UF8T(16)[30],UF8U(18)[31],UF8V(18)[31],UF8W(16)[30],
+    UF8Y(18)[31],UF8Z(18)[31],UF9I(18)[31],UF9M(17)[30],UF9P(18)[31],UF9S(16),
+    UF9T(16),UF9V(18)[31],UF9W(16),UG0T(18)[32],UG8H(18)[31],UG8I(18)[31],
+    UG8O(18)[31],UG8P(18)[31],UG8S(16)[30],UG8T(16)[30],UG8U(18)[31],
+    UG8V(18)[31],UG8W(16)[30],UG8Y(18)[31],UG8Z(18)[31],UG9I(18)[31],
+    UG9M(17)[30],UG9P(18)[31],UG9S(16),UG9T(16),UG9V(18)[31],UG9W(16),
+    UH0T(18)[32],UH8H(18)[31],UH8I(18)[31],UH8O(18)[31],UH8P(18)[31],
+    UH8S(16)[30],UH8T(16)[30],UH8U(18)[31],UH8V(18)[31],UH8W(16)[30],
+    UH8Y(18)[31],UH8Z(18)[31],UH9I(18)[31],UH9M(17)[30],UH9P(18)[31],UH9S(16),
+    UH9T(16),UH9V(18)[31],UH9W(16),UI0T(18)[32],UI8H(18)[31],UI8I(18)[31],
+    UI8O(18)[31],UI8P(18)[31],UI8S(16)[30],UI8T(16)[30],UI8U(18)[31],
+    UI8V(18)[31],UI8W(16)[30],UI8Y(18)[31],UI8Z(18)[31],UI9I(18)[31],
+    UI9M(17)[30],UI9P(18)[31],UI9S(16),UI9T(16),UI9V(18)[31],UI9W(16),
+    =R1BJA/0,=UB9MCW/0,=R065X(19)[34],=R065Z(19)[34],=R0KA/9(18)[31],
+    =R0YAC/9(18)[31],=R130EK,=R2FDP/0(19)[35],=R4HMS/0(19)[23],
+    =R5AF/0(19)[34],=R9MA(17)[31],=R9PS/0(18)[33],=RA2FA/0(19)[34],=RA9J[21],
+    =RA9JM[21],=RC9J[21],=RG0C/P(19)[34],=RN1B/0(19)[34],=RT25BU(18)[32],
+    =RT9J[21],=RU4B/4(16),=RV3DSA/0(19)[34],=RW9AV[21],=RW9C[20],
+    =RX0TX/P(18)[32],=RX9CC[20],=RY0AAN/P(18)[32],=UA0KBG(19)[26],=UA9JNT[21],
+    =UA9MW(17)[31],=UD6AOP/0(19)[35];
+Uzbekistan:               17:  30:  AS:   41.40:   -63.97:    -5.0:  UK:
+    UJ,UK,UL,UM;
+Kazakhstan:               17:  30:  AS:   48.17:   -65.18:    -5.0:  UN:
+    UN,UO,UP,UQ,UN0F[31],UN0G[31],UN0J[31],UN0Q[31],UN1F[31],UN1G[31],
+    UN1J[31],UN1Q[31],UN2F[31],UN2G[31],UN2J[31],UN2Q[31],UN3F[31],UN3G[31],
+    UN3J[31],UN3Q[31],UN4F[31],UN4G[31],UN4J[31],UN4Q[31],UN5F[31],UN5G[31],
+    UN5J[31],UN5Q[31],UN6F[31],UN6G[31],UN6J[31],UN6Q[31],UN7F[31],UN7G[31],
+    UN7J[31],UN7Q[31],UN8F[31],UN8G[31],UN8J[31],UN8Q[31],UN9F[31],UN9G[31],
+    UN9J[31],UN9Q[31],UO0F[31],UO0G[31],UO0J[31],UO0Q[31],UO1F[31],UO1G[31],
+    UO1J[31],UO1Q[31],UO2F[31],UO2G[31],UO2J[31],UO2Q[31],UO3F[31],UO3G[31],
+    UO3J[31],UO3Q[31],UO4F[31],UO4G[31],UO4J[31],UO4Q[31],UO5F[31],UO5G[31],
+    UO5J[31],UO5Q[31],UO6F[31],UO6G[31],UO6J[31],UO6Q[31],UO7F[31],UO7G[31],
+    UO7J[31],UO7Q[31],UO8F[31],UO8G[31],UO8J[31],UO8Q[31],UO9F[31],UO9G[31],
+    UO9J[31],UO9Q[31],UP0F[31],UP0G[31],UP0J[31],UP0Q[31],UP1F[31],UP1G[31],
+    UP1J[31],UP1Q[31],UP2F[31],UP2G[31],UP2J[31],UP2Q[31],UP3F[31],UP3G[31],
+    UP3J[31],UP3Q[31],UP4F[31],UP4G[31],UP4J[31],UP4Q[31],UP5F[31],UP5G[31],
+    UP5J[31],UP5Q[31],UP6F[31],UP6G[31],UP6J[31],UP6Q[31],UP7F[31],UP7G[31],
+    UP7J[31],UP7Q[31],UP8F[31],UP8G[31],UP8J[31],UP8Q[31],UP9F[31],UP9G[31],
+    UP9J[31],UP9Q[31],UQ0F[31],UQ0G[31],UQ0J[31],UQ0Q[31],UQ1F[31],UQ1G[31],
+    UQ1J[31],UQ1Q[31],UQ2F[31],UQ2G[31],UQ2J[31],UQ2Q[31],UQ3F[31],UQ3G[31],
+    UQ3J[31],UQ3Q[31],UQ4F[31],UQ4G[31],UQ4J[31],UQ4Q[31],UQ5F[31],UQ5G[31],
+    UQ5J[31],UQ5Q[31],UQ6F[31],UQ6G[31],UQ6J[31],UQ6Q[31],UQ7F[31],UQ7G[31],
+    UQ7J[31],UQ7Q[31],UQ8F[31],UQ8G[31],UQ8J[31],UQ8Q[31],UQ9F[31],UQ9G[31],
+    UQ9J[31],UQ9Q[31];
+Ukraine:                  16:  29:  EU:   50.00:   -30.00:    -2.0:  UR:
+    EM,EN,EO,U5,UR,US,UT,UU,UV,UW,UX,UY,UZ;
+Antigua & Barbuda:        08:  11:  NA:   17.07:    61.80:     4.0:  V2:
+    V2;
+Belize:                   07:  11:  NA:   16.97:    88.67:     6.0:  V3:
+    V3;
+St. Kitts & Nevis:        08:  11:  NA:   17.37:    62.78:     4.0:  V4:
+    V4;
+Namibia:                  38:  57:  AF:  -22.00:   -17.00:    -1.0:  V5:
+    V5;
+Micronesia:               27:  65:  OC:    6.88:  -158.20:   -10.0:  V6:
+    V6;
+Marshall Islands:         31:  65:  OC:    9.08:  -167.33:   -12.0:  V7:
+    V7;
+Brunei Darussalam:        28:  54:  OC:    4.50:  -114.60:    -8.0:  V8:
+    V8;
+Canada:                   05:  09:  NA:   44.35:    78.75:     5.0:  VE:
+    CF,CG,CJ,CK,VA,VB,VC,VE,VG,VX,VY9,XL,XM,CF2[4],CG2[4],CH1,CH2(2),
+    CI0(2)[4],CI1(1)[2],CI2,CJ2[4],CK2[4],CY1,CY2(2),CZ0(2)[4],CZ1(1)[2],CZ2,
+    VA2[4],VB2[4],VC2[4],VD1,VD2(2),VE2[4],VF1(1)[2],VF2,VG2[4],VO1,VO2(2),
+    VX2[4],VY0(2)[4],VY1(1)[2],VY2,XJ1,XJ2(2),XK0(2)[4],XK1(1)[2],XK2,XL2[4],
+    XM2[4],XN1,XN2(2),XO0(2)[4],XO1(1)[2],XO2,=VER20260325,=VA2VVV(2)[4],
+    =VA2WMA(2)[4],=VE2CSI(2)[4],=VE2EKA(2)[4],=VE2FK[9],=VE2IDX(2)[4],
+    =VE2IM(2)[4],=VE2PID/3(4)[4],=VE2TKH(2)[4],=VY0PW(4)[3],=VY0ZOO/VE2(2)[4];
+Australia:                30:  59:  OC:  -23.70:  -132.33:   -10.0:  VK:
+    AX,VI,VJ,VK,VL,AX4[55],VI4[55],VJ4[55],VK4[55],VL4[55],=VK6TX[55],
+    =VK70VHF(29)[58];
+Heard Island:             39:  68:  AF:  -53.08:   -73.50:    -5.0:  VK0H:
+    =VK0EK;
+Macquarie Island:         30:  60:  OC:  -54.60:  -158.88:   -10.0:  VK0M:
+    =VK0MQ;
+Cocos (Keeling) Islands:  29:  54:  OC:  -12.15:   -96.82:    -6.5:  VK9C:
+    AX9C,AX9Y,VI9C,VI9Y,VK9C,VK9FC,VK9KC,VK9Y,VK9ZY,VZ9Y,=VK9BSA,=VK9DEE,
+    =VK9FISH;
+Lord Howe Island:         30:  60:  OC:  -31.55:  -159.08:   -10.5:  VK9L:
+    VK9FL,=VK4YQS;
+Mellish Reef:             30:  56:  OC:  -17.40:  -155.85:   -10.0:  VK9M:
+    AX9M,VI9M,VK9M,VZ9M;
+Norfolk Island:           32:  60:  OC:  -29.03:  -167.93:   -11.5:  VK9N:
+    AX9,VI9,VK9;
+Willis Island:            30:  55:  OC:  -16.22:  -150.02:   -10.0:  VK9W:
+    AX9W,AX9Z,VI9W,VI9Z,VK9FW,VK9W,VK9Z,VZ9W;
+Christmas Island:         29:  54:  OC:  -10.48:  -105.63:    -7.0:  VK9X:
+    AX9X,VI9X,VK9FX,VK9KX,VK9X,VZ9X,=VK9AFP;
+Anguilla:                 08:  11:  NA:   18.23:    63.00:     4.0:  VP2E:
+    VP2E;
+Montserrat:               08:  11:  NA:   16.75:    62.18:     4.0:  VP2M:
+    VP2M;
+British Virgin Islands:   08:  11:  NA:   18.33:    64.75:     4.0:  VP2V:
+    VP2V;
+Turks & Caicos Islands:   08:  11:  NA:   21.77:    71.75:     5.0:  VP5:
+    VP5,VQ5;
+Pitcairn Island:          32:  63:  OC:  -25.07:   130.10:     8.0:  VP6:
+    VP6;
+Ducie Island:             32:  63:  OC:  -24.70:   124.80:     8.0:  VP6/d:
+    =VP6A;
+Falkland Islands:         13:  16:  SA:  -51.63:    58.72:     4.0:  VP8:
+    VP8;
+South Georgia Island:     13:  73:  SA:  -54.48:    37.08:     2.0:  VP8/g:
+    VP0G;
+South Shetland Islands:   13:  73:  SA:  -62.08:    58.67:     4.0:  VP8/h:
+    CE9,XR9,=HF0PAS,=LZ0A;
+South Orkney Islands:     13:  73:  SA:  -60.60:    45.55:     3.0:  VP8/o:
+    =LU1DMZ/Z,=LU1ZA;
+South Sandwich Islands:   13:  73:  SA:  -58.43:    26.33:     2.0:  VP8/s:
+    VP0S;
+Bermuda:                  05:  11:  NA:   32.32:    64.73:     4.0:  VP9:
+    VP9;
+Chagos Islands:           39:  41:  AF:   -7.32:   -72.42:    -6.0:  VQ9:
+    VQ9;
+Hong Kong:                24:  44:  AS:   22.28:  -114.18:    -8.0:  VR:
+    VR;
+India:                    22:  41:  AS:   22.50:   -77.58:    -5.5:  VU:
+    8T,8U,8V,8W,8X,8Y,AT,AU,AV,AW,VT,VU,VV,VW;
+Andaman & Nicobar Is.:    26:  49:  AS:   12.37:   -92.78:    -5.5:  VU4:
+    VU4;
+Lakshadweep Islands:      22:  41:  AS:   11.23:   -72.78:    -5.5:  VU7:
+    VU7,=AU7RS;
+Mexico:                   06:  10:  NA:   21.32:   100.23:     6.0:  XE:
+    4A,4B,4C,6D,6E,6F,6G,6H,6I,6J,XA,XB,XC,XD,XE,XF,XG,XH,XI;
+Revillagigedo:            06:  10:  NA:   18.77:   110.97:     7.0:  XF4:
+    4A4,4B4,4C4,6D4,6E4,6F4,6G4,6H4,6I4,6J4,XA4,XB4,XC4,XD4,XE4,XF4,XG4,XH4,
+    XI4;
+Burkina Faso:             35:  46:  AF:   12.00:     2.00:     0.0:  XT:
+    XT;
+Cambodia:                 26:  49:  AS:   12.93:  -105.13:    -7.0:  XU:
+    XU;
+Laos:                     26:  49:  AS:   18.20:  -104.55:    -7.0:  XW:
+    XW;
+Macao:                    24:  44:  AS:   22.10:  -113.50:    -8.0:  XX9:
+    XX9;
+Myanmar:                  26:  49:  AS:   20.00:   -96.37:    -6.5:  XZ:
+    XY,XZ;
+Afghanistan:              21:  40:  AS:   34.70:   -65.80:    -4.5:  YA:
+    T6,YA;
+Indonesia:                28:  54:  OC:   -7.30:  -109.88:    -7.0:  YB:
+    7A,7B,7C,7D,7E,7F,7G,7H,7I,8A,8B,8C,8D,8E,8F,8G,8H,8I,PK,PL,PM,PN,PO,YB,
+    YC,YD,YE,YF,YG,YH,7A9[51],7B9[51],7C9[51],7D9[51],7E9[51],7F9[51],7G9[51],
+    7H9[51],7I9[51],8A9[51],8B9[51],8C9[51],8D9[51],8E9[51],8F9[51],8G9[51],
+    8H9[51],8I9[51],YB9[51],YC9[51],YD9[51],YE9[51],YF9[51],YG9[51],YH9[51];
+Iraq:                     21:  39:  AS:   33.92:   -42.78:    -3.0:  YI:
+    HN,YI;
+Vanuatu:                  32:  56:  OC:  -17.67:  -168.38:   -11.0:  YJ:
+    YJ;
+Syria:                    20:  39:  AS:   35.38:   -38.20:    -2.0:  YK:
+    6C,YK;
+Latvia:                   15:  29:  EU:   57.03:   -24.65:    -2.0:  YL:
+    YL;
+Nicaragua:                07:  11:  NA:   12.88:    85.05:     6.0:  YN:
+    H6,H7,HT,YN;
+Romania:                  20:  28:  EU:   45.78:   -24.70:    -2.0:  YO:
+    YO,YP,YQ,YR,=YO8DMA/IC;
+El Salvador:              07:  11:  NA:   14.00:    89.00:     6.0:  YS:
+    HU,YS;
+Serbia:                   15:  28:  EU:   44.00:   -21.00:    -1.0:  YU:
+    YT,YU;
+Venezuela:                09:  12:  SA:    8.00:    66.00:     4.5:  YV:
+    4M,YV,YW,YX,YY;
+Aves Island:              08:  11:  NA:   15.67:    63.60:     4.0:  YV0:
+    4M0,YV0,YW0,YX0,YY0;
+Zimbabwe:                 38:  53:  AF:  -18.00:   -31.00:    -2.0:  Z2:
+    Z2;
+North Macedonia:          15:  28:  EU:   41.60:   -21.65:    -1.0:  Z3:
+    Z3;
+Republic of Kosovo:       15:  28:  EU:   42.67:   -21.17:    -1.0:  Z6:
+    Z6;
+Republic of South Sudan:  34:  48:  AF:    4.85:   -31.60:    -3.0:  Z8:
+    Z8;
+Albania:                  15:  28:  EU:   41.00:   -20.00:    -1.0:  ZA:
+    ZA;
+Gibraltar:                14:  37:  EU:   36.15:     5.37:    -1.0:  ZB:
+    ZB,ZG;
+UK Base Areas on Cyprus:  20:  39:  AS:   35.32:   -33.57:    -2.0:  ZC4:
+    ZC4;
+St. Helena:               36:  66:  AF:  -15.97:     5.72:     0.0:  ZD7:
+    ZD7;
+Ascension Island:         36:  66:  AF:   -7.93:    14.37:     0.0:  ZD8:
+    ZD8;
+Tristan da Cunha & Gough: 38:  66:  AF:  -37.13:    12.30:     0.0:  ZD9:
+    ZD9;
+Cayman Islands:           08:  11:  NA:   19.32:    81.22:     5.0:  ZF:
+    ZF;
+Tokelau Islands:          31:  62:  OC:   -9.40:   171.20:   -13.0:  ZK3:
+    ZK3;
+New Zealand:              32:  60:  OC:  -39.03:  -174.47:   -12.0:  ZL:
+    ZK,ZL,ZL50,ZM;
+Chatham Islands:          32:  60:  OC:  -43.85:   176.48:  -12.75:  ZL7:
+    ZL7,ZM7;
+Kermadec Islands:         32:  60:  OC:  -29.25:   177.92:   -12.0:  ZL8:
+    ZL8,ZM8;
+N.Z. Subantarctic Is.:    32:  60:  OC:  -51.62:  -167.62:   -12.0:  ZL9:
+    ZL9;
+Paraguay:                 11:  14:  SA:  -25.27:    57.67:     4.0:  ZP:
+    ZP;
+South Africa:             38:  57:  AF:  -29.07:   -22.63:    -2.0:  ZS:
+    H5,S4,S8,V9,ZR,ZS,ZT,ZU;
+Pr. Edward & Marion Is.:  38:  57:  AF:  -46.88:   -37.72:    -3.0:  ZS8:
+    ZR8,ZS8,ZT8,ZU8;

--- a/resources.qrc
+++ b/resources.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/">
         <file alias="icon.png">docs/logo-circle.png</file>
+        <file alias="cty.dat">cty.dat</file>
     </qresource>
     <qresource prefix="/bandplans">
         <file alias="arrl-us.json">resources/bandplans/arrl-us.json</file>

--- a/src/core/AdifParser.cpp
+++ b/src/core/AdifParser.cpp
@@ -1,0 +1,143 @@
+#include "AdifParser.h"
+
+#include <QFile>
+#include <QRegularExpression>
+#include <QtAlgorithms>
+
+namespace AetherSDR {
+
+// ---------------------------------------------------------------------------
+// Static helpers
+// ---------------------------------------------------------------------------
+
+// Extract the value of a named ADIF field from a block of text.
+// ADIF field format: <FIELDNAME:length>value  (case insensitive)
+static QString extractField(const QString& block, const QString& fieldName)
+{
+    // e.g. <CALL:6>G3ABC  or <CALL:6:S>G3ABC
+    static const QRegularExpression re(
+        R"(<)" + QRegularExpression::escape(fieldName) + R"((?::\d+(?::[A-Z])?)?:(\d+)>)",
+        QRegularExpression::CaseInsensitiveOption);
+    auto m = re.match(block);
+    if (!m.hasMatch()) return {};
+    int len = m.captured(1).toInt();
+    int start = m.capturedEnd(0);
+    if (start + len > block.length()) return {};
+    return block.mid(start, len);
+}
+
+QString AdifParser::normaliseMode(const QString& mode, const QString& submode)
+{
+    // Check submode first (handles MFSK/FT8, MFSK/FT4, etc.)
+    const QString sub = submode.toUpper();
+    if (!sub.isEmpty()) {
+        if (sub == "FT8" || sub == "FT4" || sub == "JS8" ||
+            sub == "JT65" || sub == "JT9" || sub == "WSPR" ||
+            sub == "PSK31" || sub == "PSK63" || sub == "RTTY")
+            return "DATA";
+    }
+
+    const QString m = mode.toUpper();
+    if (m == "CW")   return "CW";
+    if (m == "SSB" || m == "USB" || m == "LSB" || m == "AM" || m == "FM")
+        return "PHONE";
+    if (m == "FT8"  || m == "FT4"  || m == "RTTY" || m == "PSK31" ||
+        m == "PSK63" || m == "WSPR" || m == "JT65" || m == "JT9"  ||
+        m == "JS8"   || m == "MFSK" || m == "OLIVIA" || m == "CONTESTIA" ||
+        m == "SSTV"  || m == "PACKET" || m == "HELL"  || m == "ATV")
+        return "DATA";
+    // Unknown — treat as DATA
+    if (!m.isEmpty()) return "DATA";
+    return "PHONE";  // default
+}
+
+QString AdifParser::freqToBand(double mhz)
+{
+    if (mhz >= 1.8   && mhz < 2.0)   return "160m";
+    if (mhz >= 3.5   && mhz < 4.0)   return "80m";
+    if (mhz >= 5.0   && mhz < 5.6)   return "60m";
+    if (mhz >= 7.0   && mhz < 7.3)   return "40m";
+    if (mhz >= 10.1  && mhz < 10.15) return "30m";
+    if (mhz >= 14.0  && mhz < 14.35) return "20m";
+    if (mhz >= 18.068&& mhz < 18.168)return "17m";
+    if (mhz >= 21.0  && mhz < 21.45) return "15m";
+    if (mhz >= 24.89 && mhz < 24.99) return "12m";
+    if (mhz >= 28.0  && mhz < 29.7)  return "10m";
+    if (mhz >= 50.0  && mhz < 54.0)  return "6m";
+    if (mhz >= 70.0  && mhz < 70.5)  return "4m";
+    if (mhz >= 144.0 && mhz < 148.0) return "2m";
+    if (mhz >= 430.0 && mhz < 440.0) return "70cm";
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// Core parser
+// ---------------------------------------------------------------------------
+
+QVector<QsoRecord> AdifParser::parse(const QByteArray& data)
+{
+    QVector<QsoRecord> records;
+    const QString text = QString::fromUtf8(data);
+
+    // Skip ADIF header section (everything before <EOH>)
+    int bodyStart = 0;
+    int eoh = text.indexOf("<EOH>", 0, Qt::CaseInsensitive);
+    if (eoh != -1)
+        bodyStart = eoh + 5;
+
+    // Split on <EOR> record separators
+    static const QRegularExpression eorRe("<EOR>", QRegularExpression::CaseInsensitiveOption);
+    int pos = bodyStart;
+    QRegularExpressionMatchIterator it = eorRe.globalMatch(text, bodyStart);
+
+    while (it.hasNext()) {
+        auto eorMatch = it.next();
+        const QString block = text.mid(pos, eorMatch.capturedStart() - pos);
+        pos = eorMatch.capturedEnd();
+
+        if (block.trimmed().isEmpty()) continue;
+
+        QsoRecord rec;
+        rec.callsign = extractField(block, "CALL").trimmed().toUpper();
+        if (rec.callsign.isEmpty()) continue;
+
+        // Band: prefer explicit <BAND> field, fall back to <FREQ> → freqToBand
+        rec.band = extractField(block, "BAND").trimmed().toLower();
+        if (rec.band.isEmpty()) {
+            const QString freqStr = extractField(block, "FREQ").trimmed();
+            if (!freqStr.isEmpty()) {
+                bool ok = false;
+                double mhz = freqStr.toDouble(&ok);
+                if (ok) rec.band = freqToBand(mhz);
+            }
+        }
+
+        // Mode
+        const QString mode    = extractField(block, "MODE").trimmed();
+        const QString submode = extractField(block, "SUBMODE").trimmed();
+        rec.modeGroup = normaliseMode(mode, submode);
+
+        records.append(rec);
+    }
+
+    return records;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+QVector<QsoRecord> AdifParser::parseFile(const QString& path)
+{
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly))
+        return {};
+    return parse(f.readAll());
+}
+
+void AdifParser::parseFileAsync(const QString& path)
+{
+    emit finished(parseFile(path));
+}
+
+} // namespace AetherSDR

--- a/src/core/AdifParser.h
+++ b/src/core/AdifParser.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QString>
+#include <QVector>
+#include <QObject>
+
+namespace AetherSDR {
+
+struct QsoRecord {
+    QString callsign;
+    QString band;       // "80m", "40m", etc. (normalised)
+    QString modeGroup;  // "CW", "PHONE", "DATA"
+    QString dxccPrefix; // filled by DxccColorProvider after callsign resolution
+};
+
+// ---------------------------------------------------------------------------
+// AdifParser
+//
+// Parses .adi / .adif log files into QsoRecord vectors.
+// Can be used synchronously (parseFile) or from a worker thread.
+// ---------------------------------------------------------------------------
+class AdifParser : public QObject {
+    Q_OBJECT
+
+public:
+    explicit AdifParser(QObject* parent = nullptr) : QObject(parent) {}
+
+    // Synchronous — returns records directly.
+    static QVector<QsoRecord> parseFile(const QString& path);
+
+    // Async — call this slot (e.g. via QMetaObject::invokeMethod on a worker
+    // thread).  Emits finished() when done.
+    Q_INVOKABLE void parseFileAsync(const QString& path);
+
+signals:
+    void finished(QVector<QsoRecord> records);
+
+private:
+    static QVector<QsoRecord> parse(const QByteArray& data);
+    static QString normaliseMode(const QString& mode, const QString& submode);
+    static QString freqToBand(double mhz);
+};
+
+} // namespace AetherSDR

--- a/src/core/CtyDatParser.cpp
+++ b/src/core/CtyDatParser.cpp
@@ -1,0 +1,204 @@
+#include "CtyDatParser.h"
+
+#include <QFile>
+#include <QTextStream>
+#include <QRegularExpression>
+#include <algorithm>
+
+namespace AetherSDR {
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Strip zone overrides "(xx)" and "[xx]" and leading "=" from a prefix token.
+static QString cleanPrefix(const QString& raw)
+{
+    QString s = raw.trimmed();
+    // remove zone overrides like (14) and [14]
+    static const QRegularExpression zoneRe(R"(\([^)]*\)|\[[^\]]*\])");
+    s.remove(zoneRe);
+    s = s.trimmed();
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+bool CtyDatParser::loadFromFile(const QString& path)
+{
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
+        return false;
+    QTextStream ts(&f);
+    QStringList lines;
+    while (!ts.atEnd())
+        lines.append(ts.readLine());
+    parse(lines);
+    return isLoaded();
+}
+
+bool CtyDatParser::loadFromResource(const QString& resourcePath)
+{
+    QFile f(resourcePath);
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
+        return false;
+    QTextStream ts(&f);
+    QStringList lines;
+    while (!ts.atEnd())
+        lines.append(ts.readLine());
+    parse(lines);
+    return isLoaded();
+}
+
+// ---------------------------------------------------------------------------
+// cty.dat parser
+//
+// Format:
+//   Entity Name:  CQ:  ITU:  Continent:  lat:  lon:  tz:  PrimaryPrefix:
+//       alias1,alias2,=EXACT1,=EXACT2;
+//
+// Alias tokens may have zone overrides in () or [] which we strip.
+// Tokens starting with '=' are exact callsign matches.
+// ---------------------------------------------------------------------------
+void CtyDatParser::parse(const QStringList& lines)
+{
+    m_exactMatch.clear();
+    m_prefixTable.clear();
+    m_entityByPrefix.clear();
+    m_maxPrefixLen = 0;
+
+    // We accumulate alias lines until we hit a new entity header.
+    DxccEntity current;
+    bool inEntity = false;
+    QString aliasBuffer;
+
+    auto commitEntity = [&]() {
+        if (!inEntity || current.primaryPrefix.isEmpty())
+            return;
+
+        m_entityByPrefix.insert(current.primaryPrefix, current);
+
+        // Register primary prefix itself
+        m_prefixTable.insert(current.primaryPrefix, current.primaryPrefix);
+        m_maxPrefixLen = std::max(m_maxPrefixLen, (int)current.primaryPrefix.length());
+
+        // Parse accumulated alias buffer
+        QString buf = aliasBuffer;
+        buf.remove('\n');
+        buf.remove('\r');
+        // Remove trailing semicolon
+        buf = buf.trimmed();
+        if (buf.endsWith(';')) buf.chop(1);
+
+        const QStringList tokens = buf.split(',', Qt::SkipEmptyParts);
+        for (const QString& raw : tokens) {
+            const QString tok = raw.trimmed();
+            if (tok.isEmpty()) continue;
+
+            if (tok.startsWith('=')) {
+                // Exact match
+                const QString exact = cleanPrefix(tok.mid(1)).toUpper();
+                if (!exact.isEmpty())
+                    m_exactMatch.insert(exact, current.primaryPrefix);
+            } else {
+                // Prefix
+                const QString pfx = cleanPrefix(tok).toUpper();
+                if (!pfx.isEmpty()) {
+                    m_prefixTable.insert(pfx, current.primaryPrefix);
+                    m_maxPrefixLen = std::max(m_maxPrefixLen, (int)pfx.length());
+                }
+            }
+        }
+    };
+
+    // Regex for header line: "Entity Name:  CQ:  ITU:  Cont:  lat:  lon:  tz:  Prefix:"
+    // Fields are colon-separated on the first line.
+    static const QRegularExpression headerRe(
+        R"(^([^:]+):\s*(\d+):\s*(\d+):\s*(\w+):\s*[\d\.\-]+:\s*[\d\.\-]+:\s*[\d\.\-]+:\s*([^:]+):)");
+
+    for (const QString& line : lines) {
+        // Header line — doesn't start with whitespace
+        if (!line.isEmpty() && line[0] != ' ' && line[0] != '\t') {
+            // Commit previous entity
+            commitEntity();
+
+            auto m = headerRe.match(line);
+            if (!m.hasMatch()) {
+                inEntity = false;
+                continue;
+            }
+
+            current = DxccEntity{};
+            current.name         = m.captured(1).trimmed();
+            current.cqZone       = m.captured(2).toInt();
+            current.ituZone      = m.captured(3).toInt();
+            current.continent    = m.captured(4).trimmed();
+            current.primaryPrefix = m.captured(5).trimmed().toUpper();
+            // Remove trailing slash variants like "3D2/c" -> use as-is (sub-entities get own primary prefix)
+            inEntity = true;
+            aliasBuffer.clear();
+        } else if (inEntity) {
+            // Continuation line with aliases
+            aliasBuffer += line;
+        }
+    }
+    // Commit the last entity
+    commitEntity();
+}
+
+// ---------------------------------------------------------------------------
+// Callsign resolution
+// ---------------------------------------------------------------------------
+
+QString CtyDatParser::resolvePrimaryPrefix(const QString& callsign) const
+{
+    if (callsign.isEmpty()) return {};
+    const QString cs = callsign.toUpper();
+
+    // 1. Exact match first
+    if (m_exactMatch.contains(cs))
+        return m_exactMatch.value(cs);
+
+    // Strip /P /M /MM /AM portable suffixes — use base call for prefix lookup.
+    // But keep /country suffixes (e.g. G3ABC/VK4) — the part after the last /
+    // is tried as a prefix override if it's 1-3 chars.
+    QString base = cs;
+    if (cs.contains('/')) {
+        const QStringList parts = cs.split('/');
+        if (parts.size() == 2) {
+            const QString& suffix = parts[1];
+            // If suffix looks like a DXCC prefix (not P/M/MM/AM/QRP)
+            if (suffix != "P" && suffix != "M" && suffix != "MM" &&
+                suffix != "AM" && suffix != "QRP" && suffix.length() <= 4) {
+                // Try the suffix as a prefix
+                QString r = resolvePrimaryPrefix(suffix);
+                if (!r.isEmpty()) return r;
+            }
+            base = parts[0];
+        } else {
+            base = parts[0];
+        }
+    }
+
+    // 2. Longest-prefix match (try from longest to shortest)
+    const int maxLen = std::min(m_maxPrefixLen, (int)base.length());
+    for (int len = maxLen; len >= 1; --len) {
+        const QString pfx = base.left(len);
+        auto it = m_prefixTable.find(pfx);
+        if (it != m_prefixTable.end())
+            return it.value();
+    }
+
+    return {};
+}
+
+const DxccEntity* CtyDatParser::entityByPrefix(const QString& primaryPrefix) const
+{
+    auto it = m_entityByPrefix.find(primaryPrefix.toUpper());
+    if (it == m_entityByPrefix.end()) return nullptr;
+    return &it.value();
+}
+
+} // namespace AetherSDR

--- a/src/core/CtyDatParser.h
+++ b/src/core/CtyDatParser.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <QString>
+#include <QHash>
+#include <QSet>
+
+namespace AetherSDR {
+
+struct DxccEntity {
+    QString primaryPrefix;   // e.g. "G"
+    QString name;            // e.g. "England"
+    QString continent;       // e.g. "EU"
+    int     cqZone{0};
+    int     ituZone{0};
+};
+
+// ---------------------------------------------------------------------------
+// CtyDatParser
+//
+// Parses the AD1C cty.dat file and resolves callsigns to DXCC entities via
+// longest-prefix matching.  Load once at startup; queries are O(prefix_len).
+// ---------------------------------------------------------------------------
+class CtyDatParser {
+public:
+    // Returns true on success.
+    bool loadFromFile(const QString& path);
+    bool loadFromResource(const QString& resourcePath);   // e.g. ":/cty.dat"
+
+    // Resolve callsign -> primary prefix of matched entity ("G", "VK", …)
+    // Returns empty string if no match.
+    QString resolvePrimaryPrefix(const QString& callsign) const;
+
+    // Look up entity details by primary prefix.
+    const DxccEntity* entityByPrefix(const QString& primaryPrefix) const;
+
+    int entityCount() const { return m_entityByPrefix.size(); }
+    bool isLoaded()   const { return !m_entityByPrefix.isEmpty(); }
+
+private:
+    void parse(const QStringList& lines);
+
+    // exact-match table:  "=VK9XX"  -> primaryPrefix
+    QHash<QString, QString> m_exactMatch;
+    // prefix table: "VK9X" -> primaryPrefix
+    QHash<QString, QString> m_prefixTable;
+    // entity details keyed by primaryPrefix
+    QHash<QString, DxccEntity> m_entityByPrefix;
+    int m_maxPrefixLen{0};
+};
+
+} // namespace AetherSDR

--- a/src/core/DxccColorProvider.cpp
+++ b/src/core/DxccColorProvider.cpp
@@ -1,0 +1,139 @@
+#include "DxccColorProvider.h"
+#include "AdifParser.h"
+
+#include <QMetaObject>
+
+namespace AetherSDR {
+
+DxccColorProvider::DxccColorProvider(QObject* parent)
+    : QObject(parent)
+{
+    m_parser = new AdifParser;
+    m_parser->moveToThread(&m_parseThread);
+    connect(m_parser, &AdifParser::finished,
+            this,     &DxccColorProvider::onParseFinished,
+            Qt::QueuedConnection);
+    m_parseThread.start();
+
+    // Debounce timer: fires 2 seconds after the last file-changed notification
+    m_debounceTimer.setSingleShot(true);
+    m_debounceTimer.setInterval(2000);
+    connect(&m_debounceTimer, &QTimer::timeout, this, [this]() {
+        if (!m_watchedPath.isEmpty())
+            importAdifFile(m_watchedPath);
+    });
+
+    connect(&m_fileWatcher, &QFileSystemWatcher::fileChanged,
+            this, [this](const QString&) {
+        // Re-add the path: some editors replace the file (inode changes)
+        if (!m_watchedPath.isEmpty() && !m_fileWatcher.files().contains(m_watchedPath))
+            m_fileWatcher.addPath(m_watchedPath);
+        m_debounceTimer.start();  // restart the 2-second window
+    });
+}
+
+DxccColorProvider::~DxccColorProvider()
+{
+    m_parseThread.quit();
+    m_parseThread.wait();
+    delete m_parser;
+}
+
+bool DxccColorProvider::loadCtyDat(const QString& resourcePath)
+{
+    return m_ctyParser.loadFromResource(resourcePath);
+}
+
+void DxccColorProvider::importAdifFile(const QString& path)
+{
+    QMetaObject::invokeMethod(m_parser, "parseFileAsync",
+                              Qt::QueuedConnection,
+                              Q_ARG(QString, path));
+}
+
+void DxccColorProvider::setAutoReload(bool on, const QString& path)
+{
+    // Remove any existing watched paths
+    if (!m_fileWatcher.files().isEmpty())
+        m_fileWatcher.removePaths(m_fileWatcher.files());
+    m_debounceTimer.stop();
+
+    if (on && !path.isEmpty()) {
+        m_watchedPath = path;
+        m_fileWatcher.addPath(path);
+    } else {
+        m_watchedPath.clear();
+    }
+}
+
+void DxccColorProvider::onParseFinished(QVector<QsoRecord> records)
+{
+    // Resolve DXCC prefix for every record (runs on GUI thread after queued signal)
+    for (auto& r : records)
+        r.dxccPrefix = m_ctyParser.resolvePrimaryPrefix(r.callsign);
+
+    m_workedStatus.load(records);
+    emit importFinished(m_workedStatus.totalQsos(), m_workedStatus.entityCount());
+}
+
+// ---------------------------------------------------------------------------
+// Spot queries
+// ---------------------------------------------------------------------------
+
+QString DxccColorProvider::freqToBand(double mhz)
+{
+    if (mhz >= 1.8   && mhz < 2.0)   return "160m";
+    if (mhz >= 3.5   && mhz < 4.0)   return "80m";
+    if (mhz >= 5.0   && mhz < 5.6)   return "60m";
+    if (mhz >= 7.0   && mhz < 7.3)   return "40m";
+    if (mhz >= 10.1  && mhz < 10.15) return "30m";
+    if (mhz >= 14.0  && mhz < 14.35) return "20m";
+    if (mhz >= 18.068&& mhz < 18.168)return "17m";
+    if (mhz >= 21.0  && mhz < 21.45) return "15m";
+    if (mhz >= 24.89 && mhz < 24.99) return "12m";
+    if (mhz >= 28.0  && mhz < 29.7)  return "10m";
+    if (mhz >= 50.0  && mhz < 54.0)  return "6m";
+    if (mhz >= 70.0  && mhz < 70.5)  return "4m";
+    if (mhz >= 144.0 && mhz < 148.0) return "2m";
+    if (mhz >= 430.0 && mhz < 440.0) return "70cm";
+    return {};
+}
+
+QString DxccColorProvider::normaliseMode(const QString& mode)
+{
+    const QString m = mode.toUpper();
+    if (m == "CW")   return "CW";
+    if (m == "USB" || m == "LSB" || m == "AM" || m == "FM" || m == "PHONE")
+        return "PHONE";
+    // FT8, RTTY, PSK, etc. -> DATA
+    return "DATA";
+}
+
+DxccStatus DxccColorProvider::statusForSpot(const QString& callsign,
+                                            double freqMhz,
+                                            const QString& mode) const
+{
+    const QString prefix = m_ctyParser.resolvePrimaryPrefix(callsign);
+    if (prefix.isEmpty()) return DxccStatus::Unknown;
+
+    const QString band = freqToBand(freqMhz);
+    if (band.isEmpty()) return DxccStatus::Unknown;
+
+    const QString mg = normaliseMode(mode);
+    return m_workedStatus.query(prefix, band, mg);
+}
+
+QColor DxccColorProvider::colorForSpot(const QString& callsign,
+                                       double freqMhz,
+                                       const QString& mode) const
+{
+    switch (statusForSpot(callsign, freqMhz, mode)) {
+        case DxccStatus::NewDxcc:  return colorNewDxcc;
+        case DxccStatus::NewBand:  return colorNewBand;
+        case DxccStatus::NewMode:  return colorNewMode;
+        case DxccStatus::Worked:   return colorWorked;
+        default:                   return {};  // Unknown — use default spot colour
+    }
+}
+
+} // namespace AetherSDR

--- a/src/core/DxccColorProvider.h
+++ b/src/core/DxccColorProvider.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "CtyDatParser.h"
+#include "DxccWorkedStatus.h"
+
+#include <QObject>
+#include <QColor>
+#include <QString>
+#include <QThread>
+#include <QTimer>
+#include <QFileSystemWatcher>
+
+namespace AetherSDR {
+
+struct QsoRecord;
+class AdifParser;
+
+// ---------------------------------------------------------------------------
+// DxccColorProvider
+//
+// Owns the CtyDatParser + DxccWorkedStatus.  The single public entry point is
+// colorForSpot() — call it from the GUI thread; it's lock-free read-only after
+// importAdifFile() completes.
+// ---------------------------------------------------------------------------
+class DxccColorProvider : public QObject {
+    Q_OBJECT
+
+public:
+    explicit DxccColorProvider(QObject* parent = nullptr);
+    ~DxccColorProvider() override;
+
+    // Load cty.dat from Qt resource (call once at startup).
+    bool loadCtyDat(const QString& resourcePath = ":/cty.dat");
+
+    // Asynchronously parse an ADIF file; emits importFinished() when done.
+    void importAdifFile(const QString& path);
+
+    // Enable/disable auto-reload when the ADIF file changes on disk.
+    // Pass the same path as importAdifFile(); call with on=false to stop watching.
+    void setAutoReload(bool on, const QString& path = {});
+
+    // Synchronous query — safe to call from GUI thread after importFinished().
+    QColor colorForSpot(const QString& callsign,
+                        double freqMhz,
+                        const QString& mode) const;
+
+    DxccStatus statusForSpot(const QString& callsign,
+                             double freqMhz,
+                             const QString& mode) const;
+
+    bool isEnabled()    const { return m_enabled; }
+    void setEnabled(bool on) { m_enabled = on; }
+
+    int  qsoCount()    const { return m_workedStatus.totalQsos(); }
+    int  entityCount() const { return m_workedStatus.entityCount(); }
+
+    // Configurable colors (loaded/saved via AppSettings externally)
+    QColor colorNewDxcc{0xFF, 0x30, 0x30};   // bright red
+    QColor colorNewBand{0xFF, 0x8C, 0x00};   // orange
+    QColor colorNewMode{0xFF, 0xD7, 0x00};   // gold
+    QColor colorWorked {0x60, 0x60, 0x60};   // dim grey
+
+signals:
+    void importFinished(int qsoCount, int entityCount);
+
+private slots:
+    void onParseFinished(QVector<QsoRecord> records);
+
+private:
+    // Band/mode helpers (same logic as AdifParser, but for live spot data)
+    static QString freqToBand(double mhz);
+    static QString normaliseMode(const QString& mode);
+
+    CtyDatParser    m_ctyParser;
+    DxccWorkedStatus m_workedStatus;
+    bool             m_enabled{false};
+
+    // Worker thread for async ADIF parsing
+    QThread     m_parseThread;
+    AdifParser* m_parser{nullptr};
+
+    // Auto-reload on file change (2-second debounce)
+    QFileSystemWatcher m_fileWatcher;
+    QTimer             m_debounceTimer;
+    QString            m_watchedPath;
+};
+
+} // namespace AetherSDR

--- a/src/core/DxccWorkedStatus.cpp
+++ b/src/core/DxccWorkedStatus.cpp
@@ -1,0 +1,44 @@
+#include "DxccWorkedStatus.h"
+#include "AdifParser.h"
+
+namespace AetherSDR {
+
+void DxccWorkedStatus::load(const QVector<QsoRecord>& records)
+{
+    m_worked.clear();
+    m_totalQsos = 0;
+    for (const auto& r : records) {
+        if (r.dxccPrefix.isEmpty() || r.band.isEmpty() || r.modeGroup.isEmpty())
+            continue;
+        m_worked[r.dxccPrefix][r.band].insert(r.modeGroup);
+        ++m_totalQsos;
+    }
+}
+
+void DxccWorkedStatus::clear()
+{
+    m_worked.clear();
+    m_totalQsos = 0;
+}
+
+DxccStatus DxccWorkedStatus::query(const QString& primaryPrefix,
+                                   const QString& band,
+                                   const QString& modeGroup) const
+{
+    if (primaryPrefix.isEmpty()) return DxccStatus::Unknown;
+
+    auto entityIt = m_worked.find(primaryPrefix);
+    if (entityIt == m_worked.end())
+        return DxccStatus::NewDxcc;
+
+    auto bandIt = entityIt->find(band);
+    if (bandIt == entityIt->end())
+        return DxccStatus::NewBand;
+
+    if (!bandIt->contains(modeGroup))
+        return DxccStatus::NewMode;
+
+    return DxccStatus::Worked;
+}
+
+} // namespace AetherSDR

--- a/src/core/DxccWorkedStatus.h
+++ b/src/core/DxccWorkedStatus.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QString>
+#include <QHash>
+#include <QSet>
+#include <QVector>
+
+namespace AetherSDR {
+
+struct QsoRecord;
+
+enum class DxccStatus {
+    NewDxcc,   // entity never worked
+    NewBand,   // entity worked but not on this band
+    NewMode,   // entity worked on this band but not this mode group
+    Worked,    // already worked on this band + mode group
+    Unknown,   // DXCC not resolved (no cty.dat match)
+};
+
+// ---------------------------------------------------------------------------
+// DxccWorkedStatus
+//
+// Fast O(1) lookup of worked status from a loaded ADIF log.
+// Data: QHash<primaryPrefix, QHash<band, QSet<modeGroup>>>
+// ---------------------------------------------------------------------------
+class DxccWorkedStatus {
+public:
+    void load(const QVector<QsoRecord>& records);
+    void clear();
+
+    // Query worked status given the resolved DXCC primary prefix, band, and
+    // normalised mode group (CW / PHONE / DATA).
+    DxccStatus query(const QString& primaryPrefix,
+                     const QString& band,
+                     const QString& modeGroup) const;
+
+    int entityCount() const { return m_worked.size(); }
+    int totalQsos()   const { return m_totalQsos; }
+
+private:
+    // primaryPrefix -> band -> set<modeGroup>
+    QHash<QString, QHash<QString, QSet<QString>>> m_worked;
+    int m_totalQsos{0};
+};
+
+} // namespace AetherSDR

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -21,6 +21,8 @@
 #include <QSlider>
 #include <QColorDialog>
 #include <QFile>
+#include <QFileDialog>
+#include <QFileInfo>
 #include <QRegularExpression>
 
 namespace AetherSDR {
@@ -170,13 +172,15 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
 #ifdef HAVE_WEBSOCKETS
                                    FreeDvClient* freedvClient,
 #endif
-                                   RadioModel* radioModel, QWidget* parent)
+                                   RadioModel* radioModel,
+                                   DxccColorProvider* dxccProvider,
+                                   QWidget* parent)
     : QDialog(parent), m_client(clusterClient), m_rbnClient(rbnClient),
       m_wsjtxClient(wsjtxClient), m_potaClient(potaClient),
 #ifdef HAVE_WEBSOCKETS
       m_freedvClient(freedvClient),
 #endif
-      m_radioModel(radioModel)
+      m_radioModel(radioModel), m_dxccProvider(dxccProvider)
 {
     setWindowTitle("SpotHub");
     setMinimumSize(620, 500);
@@ -1741,6 +1745,142 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     grid->addWidget(m_totalSpotsLabel, row++, 1);
 
     layout->addLayout(grid);
+
+    // ── DXCC Coloring section (#330) ────────────────────────────────────
+    {
+        auto* dxccTitle = new QLabel("DXCC Coloring");
+        dxccTitle->setAlignment(Qt::AlignCenter);
+        dxccTitle->setStyleSheet(
+            "QLabel { font-size: 13px; font-weight: bold; color: #80b0d0; "
+            "border-top: 1px solid #304050; padding-top: 8px; margin-top: 6px; }");
+        layout->addWidget(dxccTitle);
+
+        auto* dxccGrid = new QGridLayout;
+        dxccGrid->setColumnStretch(1, 1);
+        int drow = 0;
+
+        bool dxccEnabled = m_dxccProvider ? m_dxccProvider->isEnabled() : false;
+        auto* dxccToggle = new QPushButton(dxccEnabled ? "Enabled" : "Disabled");
+        dxccToggle->setCheckable(true);
+        dxccToggle->setChecked(dxccEnabled);
+        dxccToggle->setFixedWidth(80);
+        dxccToggle->setStyleSheet(
+            "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
+            "QPushButton:!checked { background: #603020; }");
+        connect(dxccToggle, &QPushButton::toggled, this, [this, dxccToggle, save](bool on) {
+            dxccToggle->setText(on ? "Enabled" : "Disabled");
+            save("IsDxccColoringEnabled", on ? "True" : "False");
+            if (m_dxccProvider) m_dxccProvider->setEnabled(on);
+        });
+        dxccGrid->addWidget(new QLabel("DXCC Colors:"), drow, 0);
+        dxccGrid->addWidget(dxccToggle, drow++, 1, Qt::AlignLeft);
+
+        // ADIF file picker
+        const QString savedAdif = AppSettings::instance().value("DxccAdifFilePath", "").toString();
+        auto* adifPathLabel = new QLabel(savedAdif.isEmpty() ? "(none)" : QFileInfo(savedAdif).fileName());
+        adifPathLabel->setStyleSheet("QLabel { color: #90a8b8; font-size: 11px; }");
+        adifPathLabel->setMaximumWidth(200);
+        auto* browseBtn = new QPushButton("Browse\xe2\x80\xa6");
+        browseBtn->setFixedWidth(80);
+        auto* adifRow = new QHBoxLayout;
+        adifRow->addWidget(adifPathLabel);
+        adifRow->addWidget(browseBtn);
+        adifRow->addStretch();
+        dxccGrid->addWidget(new QLabel("Log File (ADIF):"), drow, 0);
+        dxccGrid->addLayout(adifRow, drow++, 1);
+
+        // Stats label
+        m_dxccStatsLabel = new QLabel(m_dxccProvider && m_dxccProvider->qsoCount() > 0
+            ? QString("%1 QSOs / %2 entities").arg(m_dxccProvider->qsoCount()).arg(m_dxccProvider->entityCount())
+            : "(no log loaded)");
+        m_dxccStatsLabel->setStyleSheet("QLabel { color: #90c890; font-size: 11px; }");
+        dxccGrid->addWidget(new QLabel("Imported:"), drow, 0);
+        dxccGrid->addWidget(m_dxccStatsLabel, drow++, 1);
+
+        // Colour swatches
+        auto* swatchRow = new QHBoxLayout;
+        struct SwatchDef { const char* tip; QColor* colPtr; const char* key; };
+        SwatchDef swatches[] = {
+            { "New DXCC", m_dxccProvider ? &m_dxccProvider->colorNewDxcc : nullptr, "DxccColorNewEntity" },
+            { "New Band",  m_dxccProvider ? &m_dxccProvider->colorNewBand  : nullptr, "DxccColorNewBand"   },
+            { "New Mode",  m_dxccProvider ? &m_dxccProvider->colorNewMode  : nullptr, "DxccColorNewMode"   },
+            { "Worked",    m_dxccProvider ? &m_dxccProvider->colorWorked   : nullptr, "DxccColorWorked"    },
+        };
+        for (const auto& sw : swatches) {
+            auto* col = new QVBoxLayout;
+            auto* lbl = new QLabel(sw.tip);
+            lbl->setAlignment(Qt::AlignCenter);
+            lbl->setStyleSheet("QLabel { color: #809090; font-size: 10px; }");
+            auto* btn = new QPushButton;
+            btn->setFixedSize(28, 22);
+            const QColor initCol = sw.colPtr ? *sw.colPtr : QColor(Qt::gray);
+            updateSwatch(btn, initCol);
+            const QString key = sw.key;
+            QColor* colPtr = sw.colPtr;
+            connect(btn, &QPushButton::clicked, this, [this, btn, key, colPtr, updateSwatch, save]() {
+                const QColor cur = colPtr ? *colPtr : QColor(Qt::gray);
+                QColor c = QColorDialog::getColor(cur, this, "Pick Colour");
+                if (!c.isValid()) return;
+                if (colPtr) *colPtr = c;
+                updateSwatch(btn, c);
+                save(key, c.name());
+            });
+            col->addWidget(lbl);
+            col->addWidget(btn, 0, Qt::AlignCenter);
+            swatchRow->addLayout(col);
+        }
+        swatchRow->addStretch();
+        dxccGrid->addWidget(new QLabel("Colors:"), drow, 0);
+        dxccGrid->addLayout(swatchRow, drow++, 1);
+
+        layout->addLayout(dxccGrid);
+
+        // Auto-reload toggle
+        bool autoReloadEnabled = AppSettings::instance().value("DxccAutoReloadAdif", "False").toString() == "True";
+        auto* autoReloadToggle = new QPushButton(autoReloadEnabled ? "Enabled" : "Disabled");
+        autoReloadToggle->setCheckable(true);
+        autoReloadToggle->setChecked(autoReloadEnabled);
+        autoReloadToggle->setFixedWidth(80);
+        autoReloadToggle->setStyleSheet(
+            "QPushButton:checked { background: #2a6a2a; } QPushButton:!checked { background: #5a2a2a; }");
+        connect(autoReloadToggle, &QPushButton::toggled, this, [this, autoReloadToggle, save](bool on) {
+            autoReloadToggle->setText(on ? "Enabled" : "Disabled");
+            save("DxccAutoReloadAdif", on ? "True" : "False");
+            if (m_dxccProvider) {
+                const QString path = AppSettings::instance().value("DxccAdifFilePath", "").toString();
+                m_dxccProvider->setAutoReload(on, path);
+            }
+        });
+        dxccGrid->addWidget(new QLabel("Auto-Reload Log:"), drow, 0);
+        dxccGrid->addWidget(autoReloadToggle, drow++, 1, Qt::AlignLeft);
+
+        // Wire browse button
+        connect(browseBtn, &QPushButton::clicked, this, [this, adifPathLabel, save](bool) {
+            const QString path = QFileDialog::getOpenFileName(
+                this, "Select ADIF Log File", QDir::homePath(),
+                "ADIF Log Files (*.adi *.adif);;All Files (*)");
+            if (path.isEmpty()) return;
+            adifPathLabel->setText(QFileInfo(path).fileName());
+            save("DxccAdifFilePath", path);
+            if (m_dxccProvider) {
+                if (m_dxccStatsLabel) m_dxccStatsLabel->setText("Importing\xe2\x80\xa6");
+                m_dxccProvider->importAdifFile(path);
+                const bool autoReload = AppSettings::instance().value("DxccAutoReloadAdif","False").toString() == "True";
+                m_dxccProvider->setAutoReload(autoReload, path);
+            }
+        });
+
+        // Update stats when import finishes
+        if (m_dxccProvider) {
+            connect(m_dxccProvider, &DxccColorProvider::importFinished,
+                    this, [this](int qsos, int entities) {
+                if (m_dxccStatsLabel)
+                    m_dxccStatsLabel->setText(
+                        QString("%1 QSOs / %2 entities").arg(qsos).arg(entities));
+            });
+        }
+    }
+
     layout->addStretch();
 
     // ── Clear All Spots button ──────────────────────────────────────────

--- a/src/gui/DxClusterDialog.h
+++ b/src/gui/DxClusterDialog.h
@@ -6,6 +6,7 @@
 #include <QSet>
 #include <QVector>
 #include "core/DxClusterClient.h"
+#include "core/DxccColorProvider.h"
 #include "core/WsjtxClient.h"
 #include "core/PotaClient.h"
 #ifdef HAVE_WEBSOCKETS
@@ -82,7 +83,9 @@ public:
 #ifdef HAVE_WEBSOCKETS
                              FreeDvClient* freedvClient,
 #endif
-                             RadioModel* radioModel, QWidget* parent = nullptr);
+                             RadioModel* radioModel,
+                             DxccColorProvider* dxccProvider,
+                             QWidget* parent = nullptr);
 
     void updateStatus();
     void setTotalSpots(int count);
@@ -189,7 +192,9 @@ private:
     BandFilterProxy*       m_proxyModel;
 
     // Display tab
-    QLabel*         m_totalSpotsLabel{nullptr};
+    QLabel*            m_totalSpotsLabel{nullptr};
+    QLabel*            m_dxccStatsLabel{nullptr};
+    DxccColorProvider* m_dxccProvider{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -126,6 +126,25 @@ MainWindow::MainWindow(QWidget* parent)
     buildUI();
     registerShortcutActions();
 
+    // DXCC spot coloring (#330)
+    m_dxccProvider.loadCtyDat(":/cty.dat");
+    {
+        auto& s = AppSettings::instance();
+        m_dxccProvider.setEnabled(s.value("IsDxccColoringEnabled", "False").toString() == "True");
+        m_dxccProvider.colorNewDxcc = QColor(s.value("DxccColorNewEntity", "#FF3030").toString());
+        m_dxccProvider.colorNewBand = QColor(s.value("DxccColorNewBand", "#FF8C00").toString());
+        m_dxccProvider.colorNewMode = QColor(s.value("DxccColorNewMode", "#FFD700").toString());
+        m_dxccProvider.colorWorked  = QColor(s.value("DxccColorWorked", "#606060").toString());
+        const QString adifPath = s.value("DxccAdifFilePath", "").toString();
+        if (!adifPath.isEmpty()) {
+            m_dxccProvider.importAdifFile(adifPath);
+            if (s.value("DxccAutoReloadAdif", "False").toString() == "True")
+                m_dxccProvider.setAutoReload(true, adifPath);
+        }
+    }
+    connect(&m_dxccProvider, &DxccColorProvider::importFinished,
+            this, [this](int, int) { emit m_radioModel.spotModel()->spotsCleared(); });
+
     // Install event filter on the application to intercept Space PTT
     // before child widgets (buttons, combos) consume the key event.
     qApp->installEventFilter(this);
@@ -1788,7 +1807,7 @@ void MainWindow::buildMenuBar()
 #ifdef HAVE_WEBSOCKETS
                             m_freedvClient,
 #endif
-                            &m_radioModel, this);
+                            &m_radioModel, &m_dxccProvider, this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
         m_spotHubDialog = dlg;
         dlg->setTotalSpots(m_radioModel.spotModel()->spots().size());
@@ -3592,11 +3611,14 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         auto* s = m_radioModel.spotModel();
         QVector<SpectrumWidget::SpotMarker> markers;
         for (const auto& spot : s->spots()) {
-            QDateTime ts = spot.timestamp;
-            if (!ts.isValid() || ts.toMSecsSinceEpoch() <= 0)
-                ts = QDateTime::fromMSecsSinceEpoch(spot.addedMs, Qt::UTC);
+            qint64 tsMs = (spot.timestamp.isValid() && spot.timestamp.toMSecsSinceEpoch() > 0)
+                ? spot.timestamp.toMSecsSinceEpoch()
+                : spot.addedMs;
+            QColor dxccCol;
+            if (m_dxccProvider.isEnabled())
+                dxccCol = m_dxccProvider.colorForSpot(spot.callsign, spot.rxFreqMhz, spot.mode);
             markers.append({spot.index, spot.callsign, spot.rxFreqMhz, spot.color, spot.mode,
-                            spot.source, spot.spotterCallsign, spot.comment, ts});
+                            dxccCol, spot.source, spot.spotterCallsign, spot.comment, tsMs});
         }
         swGuard->setSpotMarkers(markers);
     };

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -26,6 +26,7 @@
 #endif
 #include "core/ShortcutManager.h"
 #include "core/TgxlConnection.h"
+#include "core/DxccColorProvider.h"
 
 #include <QMainWindow>
 #include <QSplitter>
@@ -110,6 +111,7 @@ private:
     // Core objects
     RadioDiscovery    m_discovery;
     RadioModel        m_radioModel;
+    DxccColorProvider m_dxccProvider;
     AudioEngine       m_audio;
     BandSettings      m_bandSettings;
     // 4-channel CAT: each channel (A-D) binds to a slice index (0-3)

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -25,6 +25,7 @@
 #include "models/BandPlanManager.h"
 #include "models/BandDefs.h"
 #include <QDateTime>
+#include <QTimeZone>
 #include <cmath>
 #include <cstring>
 
@@ -1060,9 +1061,9 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
                                     tip += QString("<br>Spotter: %1").arg(sm.spotterCallsign);
                                 if (!sm.comment.isEmpty())
                                     tip += QString("<br>%1").arg(sm.comment);
-                                if (sm.timestamp.isValid() && sm.timestamp.toMSecsSinceEpoch() > 0)
+                                if (sm.timestampMs > 0)
                                     tip += QString("<br>Spotted: %1 UTC").arg(
-                                        sm.timestamp.toUTC().toString("yyyy-MM-dd HH:mm:ss"));
+                                        QDateTime::fromMSecsSinceEpoch(sm.timestampMs, QTimeZone::utc()).toString("yyyy-MM-dd HH:mm:ss"));
                                 QToolTip::showText(ev->globalPosition().toPoint(), tip, this);
                             }
                             spotHover = true;
@@ -1931,10 +1932,12 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
         const int x = mhzToX(spot.freqMhz);
         if (x < 0 || x > width()) continue;
 
-        // Color: override uses m_spotColor, otherwise use spot-provided or default cyan
+        // Color priority: override → DXCC → spot-provided → default cyan
         QColor col(0x00, 0xb4, 0xd8);  // default cyan
         if (m_spotOverrideColors) {
             col = m_spotColor;
+        } else if (spot.dxccColor.isValid()) {
+            col = spot.dxccColor;
         } else if (!spot.color.isEmpty() && spot.color.startsWith('#')) {
             QColor parsed(spot.color);
             if (parsed.isValid()) col = parsed;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -185,10 +185,11 @@ public:
         double freqMhz;
         QString color;       // #AARRGGBB or empty for default
         QString mode;
+        QColor  dxccColor;   // DXCC-aware color from DxccColorProvider (#330)
         QString source;
         QString spotterCallsign;
         QString comment;
-        QDateTime timestamp;
+        qint64  timestampMs{0};
     };
     void setSpotMarkers(const QVector<SpotMarker>& markers);
 


### PR DESCRIPTION
Color-code DX spots on the panadapter by DXCC worked status:
- New DXCC (red) — entity never worked
- New Band (orange) — entity worked, not on this band
- New Mode (gold) — entity/band worked, different mode group
- Worked (grey) — already worked on this band + mode

Features:
- CtyDatParser: AD1C cty.dat prefix database (bundled as Qt resource)
- AdifParser: async ADIF .adi/.adif parser on worker thread
- DxccWorkedStatus: O(1) lookup by prefix/band/mode
- DxccColorProvider: integration layer with colorForSpot()
- SpotHub Display tab: enable toggle, ADIF file picker, color swatches,
  auto-reload with QFileSystemWatcher (2s debounce)
- Color priority: override → DXCC → spot-provided → default cyan

Based on PR #476 by @Chaosuk97, rebased onto current main.

Co-Authored-By: Chaosuk97 <chaosuk97@users.noreply.github.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
