### PR TITLE
Split Dockerfile Opus build into separate steps for error isolation (#473)

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -32,12 +32,21 @@ RUN apt-get update && apt-get install -y \
 # at CI time. The neural net model is pre-downloaded from our GitHub release
 # (mirrored from xiph.org) and placed where autogen.sh expects it, so it
 # skips the network download entirely. (#473)
+
+# Step 1: Download and extract Opus source
 RUN mkdir -p /tmp/opus-build && cd /tmp/opus-build \
     && curl -L -o opus.zip https://github.com/xiph/opus/archive/940d4e5af64351ca8ba8390df3f555484c567fbb.zip \
     && mkdir src && cd src && python3 -c "import zipfile; zipfile.ZipFile('/tmp/opus-build/opus.zip').extractall()" \
-    && mv opus-*/* . && rmdir opus-* \
+    && mv opus-*/* . && rmdir opus-*
+
+# Step 2: Pre-download neural net model from our GitHub mirror
+RUN cd /tmp/opus-build/src \
     && curl -L -o opus_data-4ed9445b96698bad25d852e912b41495ddfa30c8dbc8a55f9cde5826ed793453.tar.gz \
        https://github.com/ten9876/AetherSDR/releases/download/v0.7.16/opus_data-4ed9445b96698bad25d852e912b41495ddfa30c8dbc8a55f9cde5826ed793453.tar.gz \
+    && ls -lh opus_data-*.tar.gz
+
+# Step 3: autogen + configure + build
+RUN cd /tmp/opus-build/src \
     && ./autogen.sh \
     && ./configure --with-pic --enable-osce --enable-dred --disable-shared --disable-doc --disable-extra-programs \
     && make -j$(nproc) \


### PR DESCRIPTION
Docker buildx truncates logs for monolithic RUN commands, making it
impossible to identify which step fails. Split into 3 steps:
download source, download model, build.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
