### PR TITLE
Remove redundant push-to-main CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,6 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   schedule:


### PR DESCRIPTION
All changes go through PRs via git ship. The push trigger duplicated
every CI + CodeQL run after merge. Cuts CI usage in half.

CodeQL keeps its weekly schedule trigger for proactive scanning.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
