### PR TITLE
Add NB waterfall blanker — impulse row suppression (#277)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3741,6 +3741,11 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             m_radioModel.sendCommand(
                 QString("display panafall set %1 line_duration=%2").arg(pan->waterfallId()).arg(ms));
     });
+    // NB Waterfall Blanker (#277)
+    connect(menu, &SpectrumOverlayMenu::wfBlankerEnabledChanged,
+            sw, &SpectrumWidget::setWfBlankerEnabled);
+    connect(menu, &SpectrumOverlayMenu::wfBlankerThresholdChanged,
+            sw, &SpectrumWidget::setWfBlankerThreshold);
 
     // ── Click-to-tune ────────────────────────────────────────────────────
     // Uses "slice m <freq> pan=<panId>" (matches SmartSDR protocol).

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -968,6 +968,27 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         emit wfLineDurationChanged(v + 70);  // map 1-30 → 71-100
     });
 
+    // NB Waterfall Blanker (#277) — uses same grid layout as other controls
+    makeRow("NB Blank:", 5, 95, 15, m_wfBlankerThreshSlider, m_wfBlankerThreshLabel);
+    m_wfBlankerBtn = new QPushButton("Off");
+    m_wfBlankerBtn->setCheckable(true);
+    m_wfBlankerBtn->setChecked(false);
+    m_wfBlankerBtn->setFixedSize(36, 18);
+    m_wfBlankerBtn->setStyleSheet(btnStyle);
+    m_wfBlankerBtn->setToolTip("Suppress impulse noise stripes in waterfall");
+    // Replace the label cell with the toggle button
+    grid->addWidget(m_wfBlankerBtn, row - 1, 1);
+
+    connect(m_wfBlankerBtn, &QPushButton::toggled, this, [this](bool on) {
+        m_wfBlankerBtn->setText(on ? "On" : "Off");
+        emit wfBlankerEnabledChanged(on);
+    });
+    connect(m_wfBlankerThreshSlider, &QSlider::valueChanged, this, [this](int v) {
+        float t = 1.0f + v / 100.0f;
+        m_wfBlankerThreshLabel->setText(QString::number(t, 'f', 2));
+        emit wfBlankerThresholdChanged(t);
+    });
+
     m_displayPanel->adjustSize();
 }
 

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -88,6 +88,9 @@ signals:
     void wnbLevelChanged(int level);
     // Emitted when RF gain slider changes (panadapter-level).
     void rfGainChanged(int gain);
+    // NB Waterfall Blanker (#277)
+    void wfBlankerEnabledChanged(bool on);
+    void wfBlankerThresholdChanged(float threshold);
 
 private:
     QString m_panId;
@@ -163,6 +166,10 @@ private:
     QPushButton* m_autoBlackBtn{nullptr};
     QSlider*     m_rateSlider{nullptr};
     QLabel*      m_rateLabel{nullptr};
+    // NB Waterfall Blanker (#277)
+    QPushButton* m_wfBlankerBtn{nullptr};
+    QSlider*     m_wfBlankerThreshSlider{nullptr};
+    QLabel*      m_wfBlankerThreshLabel{nullptr};
     QSlider*     m_floorSlider{nullptr};
     QLabel*      m_floorLabel{nullptr};
     QPushButton* m_floorEnableBtn{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -117,6 +117,11 @@ void SpectrumWidget::loadSettings()
     m_wfBlackLevel   = s.value(settingsKey("DisplayWfBlackLevel"), "15").toInt();
     m_wfAutoBlack    = s.value(settingsKey("DisplayWfAutoBlack"), "True").toString() == "True";
     m_wfLineDuration = s.value(settingsKey("DisplayWfLineDuration"), "100").toInt();
+    // NB Waterfall Blanker (#277)
+    m_wfBlankerEnabled   = s.value(settingsKey("WaterfallBlankingEnabled"), "False").toString() == "True";
+    m_wfBlankerMode      = s.value(settingsKey("WaterfallBlankingMode"), "0").toInt();
+    m_wfBlankerThreshold = std::clamp(
+        s.value(settingsKey("WaterfallBlankingThreshold"), "1.15").toFloat(), 1.05f, 2.0f);
     // Migrate old ShowBandPlan bool → BandPlanFontSize int
     if (s.value("BandPlanFontSize").toString().isEmpty()) {
         m_bandPlanFontSize = s.value("ShowBandPlan", "True").toString() == "True" ? 6 : 0;
@@ -230,6 +235,37 @@ void SpectrumWidget::setWfLineDuration(int ms) {
     s.save();
     // Re-calibrate the time scale for the new rate
     resetWfTimeScale();
+}
+
+// ── NB Waterfall Blanker setters (#277) ──────────────────────────────────────
+
+void SpectrumWidget::setWfBlankerEnabled(bool on)
+{
+    m_wfBlankerEnabled = on;
+    auto& s = AppSettings::instance();
+    s.setValue(settingsKey("WaterfallBlankingEnabled"), on ? "True" : "False");
+    s.save();
+    if (!on) {
+        m_wfBlankerRingCount = 0;
+        m_wfBlankerRingIdx = 0;
+    }
+}
+
+void SpectrumWidget::setWfBlankerThreshold(float t)
+{
+    m_wfBlankerThreshold = std::clamp(t, 1.05f, 2.0f);
+    auto& s = AppSettings::instance();
+    s.setValue(settingsKey("WaterfallBlankingThreshold"),
+              QString::number(m_wfBlankerThreshold, 'f', 2));
+    s.save();
+}
+
+void SpectrumWidget::setWfBlankerMode(int mode)
+{
+    m_wfBlankerMode = qBound(0, mode, 1);
+    auto& s = AppSettings::instance();
+    s.setValue(settingsKey("WaterfallBlankingMode"), QString::number(m_wfBlankerMode));
+    s.save();
 }
 
 void SpectrumWidget::resetWfTimeScale() {
@@ -557,6 +593,42 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
                 scanline[x] = intensityToRgb(i0 + frac * (i1 - i0));
             }
         }
+    }
+
+    // NB Waterfall Blanker (#277) — suppress impulse rows
+    if (m_wfBlankerEnabled) {
+        float rowSum = 0.0f;
+        const int binCount = binsIntensity.size();
+        for (int i = 0; i < binCount; ++i)
+            rowSum += binsIntensity[i];
+        const float rowMean = (binCount > 0) ? (rowSum / binCount) : 0.0f;
+
+        // Compute rolling baseline
+        float baseline = 0.0f;
+        for (int i = 0; i < m_wfBlankerRingCount; ++i)
+            baseline += m_wfBlankerRing[i];
+        if (m_wfBlankerRingCount > 0)
+            baseline /= m_wfBlankerRingCount;
+
+        // Detect impulse (need ≥8 rows of history)
+        if (m_wfBlankerRingCount >= 8 && baseline > 0.0f
+                && rowMean > baseline * m_wfBlankerThreshold) {
+            // Impulse detected — replace with last good row (interpolate)
+            if (m_wfLastGoodRow.size() == destWidth) {
+                scanline = m_wfLastGoodRow;
+            } else {
+                // No previous good row yet — fill with noise floor color
+                const QRgb floorColor = intensityToRgb(baseline);
+                std::fill(scanline.begin(), scanline.end(), floorColor);
+            }
+            m_wfBlankerRing[m_wfBlankerRingIdx] = std::min(rowMean, baseline * 1.05f);
+        } else {
+            m_wfLastGoodRow = scanline;
+            m_wfBlankerRing[m_wfBlankerRingIdx] = rowMean;
+        }
+        m_wfBlankerRingIdx = (m_wfBlankerRingIdx + 1) % WF_BLANKER_N;
+        if (m_wfBlankerRingCount < WF_BLANKER_N)
+            ++m_wfBlankerRingCount;
     }
 
     // Write rows into ring buffer (no memmove)

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -107,6 +107,14 @@ public:
     int  rfGainValue() const { return m_rfGainValue; }
     void setWnbActive(bool on) { m_wnbActive = on; update(); }
     void setRfGain(int gain) { m_rfGainValue = gain; update(); }
+
+    // NB Waterfall Blanker (#277) — client-side impulse suppression
+    void setWfBlankerEnabled(bool on);
+    void setWfBlankerThreshold(float t);
+    void setWfBlankerMode(int mode);  // 0=Fill, 1=Interpolate
+    bool  wfBlankerEnabled()   const { return m_wfBlankerEnabled; }
+    float wfBlankerThreshold() const { return m_wfBlankerThreshold; }
+    int   wfBlankerMode()      const { return m_wfBlankerMode; }
     void setShowBandPlan(bool on) { m_bandPlanFontSize = on ? 6 : 0; update(); }
     void setBandPlanFontSize(int pt) { m_bandPlanFontSize = pt; update(); }
     void setBandPlanManager(class BandPlanManager* mgr);
@@ -386,6 +394,16 @@ private:
     // On-screen indicators (WNB, RF Gain)
     bool m_wnbActive{false};
     int  m_rfGainValue{0};
+
+    // NB Waterfall Blanker (#277)
+    bool  m_wfBlankerEnabled{false};
+    int   m_wfBlankerMode{0};            // 0=Fill, 1=Interpolate
+    float m_wfBlankerThreshold{1.15f};   // impulse multiplier vs rolling baseline
+    static constexpr int WF_BLANKER_N = 32;
+    float m_wfBlankerRing[WF_BLANKER_N]{};
+    int   m_wfBlankerRingIdx{0};
+    int   m_wfBlankerRingCount{0};
+    QVector<QRgb> m_wfLastGoodRow;
     int  m_bandPlanFontSize{6};  // 0 = off
     BandPlanManager* m_bandPlanMgr{nullptr};
 #if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)


### PR DESCRIPTION
Client-side impulse suppression in the waterfall. When enabled,
rows with mean intensity exceeding the rolling baseline by the
threshold multiplier are replaced with the previous good row.

- Toggle + threshold slider in Display overlay panel
- 32-row rolling baseline with ≥8 row warmup
- Interpolation mode (previous good row) to avoid visible gaps
- Per-pan persistence in AppSettings
- No auto-linking to NB/WNB — fully manual opt-in

Based on PR #508 by @boydsoftprez, simplified and rebased.

Co-Authored-By: boydsoftprez <boydsoftprez@users.noreply.github.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
