### PR TITLE
Move external controllers to dedicated worker thread (#502)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,17 +162,19 @@ src/
 
 ### Data Pipelines
 
-Three-thread architecture after Phase 1+2 migration (#502):
-- **Main thread**: GUI rendering (paintEvent), TCP command/status, user input
+Five-thread architecture after #502 migration:
+- **Main thread**: GUI rendering (paintEvent), RadioModel + all sub-models, user input
+- **Connection thread**: RadioConnection (TCP 4992 I/O, ping RTT measurement)
 - **Audio thread**: AudioEngine (RX/TX audio, NR2/RN2/BNR DSP, QAudioSink/Source)
 - **Network thread**: PanadapterStream (VITA-49 UDP parsing, FFT/waterfall/meter demux)
+- **ExtControllers thread**: FlexControl, MIDI, SerialPort (USB/serial I/O, RtMidi callbacks)
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
 │                      NETWORK LAYER                                  │
 │                                                                     │
 │  Radio UDP 4992 ──→ RadioDiscovery ──→ ConnectionPanel    [MAIN]    │
-│  Radio TCP 4992 ──→ RadioConnection ──→ RadioModel        [MAIN]    │
+│  Radio TCP 4992 ──→ RadioConnection ──→ RadioModel        [CONN]→[MAIN] │
 │  Radio UDP 4991 ──→ PanadapterStream (VITA-49 demux)      [NETWORK] │
 │  TGXL  TCP 9010 ──→ TgxlConnection ──→ TunerModel        [MAIN]    │
 │  WAN   TLS 4992 ──→ WanConnection ──→ RadioModel          [MAIN]    │
@@ -199,7 +201,7 @@ SpectrumWidget   SpectrumWidget  MeterModel     AudioEngine
     │ + NB blanker     │     │    ├─→ TxApplet        ├─→ RN2 (RNNoiseFilter)
     ▼                  ▼     │    ├─→ TunerApplet     ├─→ BNR (NvidiaBnrFilter)
   paintEvent()    paintEvent │    └─→ StatusBar       ├─→ CwDecoder [MAIN]
-  (~99% CPU)                 │                        ▼
+  (~98% CPU)                 │                        ▼
                              │                   QAudioSink
                              │                   (speakers)
                              │
@@ -232,32 +234,40 @@ TX AUDIO PIPELINE:                          ◄── AUDIO THREAD
                       ▼                       ▼
                  Radio UDP 4991          Radio UDP 4991
 
-TCP COMMAND PIPELINE (bidirectional):       ◄── MAIN THREAD
-  GUI widget ──→ SliceModel.setXxx() ──→ emit commandReady("slice ...")
+TCP COMMAND PIPELINE (bidirectional):
+  GUI widget ──→ SliceModel.setXxx() ──→ emit commandReady("slice ...")  [MAIN]
                  TransmitModel          ──→ emit commandReady("xmit ...")
                  TunerModel             ──→ emit commandReady("tgxl ...")
                  EqualizerModel         ──→ emit commandReady("eq ...")
                  TnfModel               ──→ emit commandReady("tnf ...")
                         │
                         ▼
-                 RadioModel.sendCmd(cmd)
-                        │
-              ┌─────────┴─────────┐
-              ▼                   ▼
-        RadioConnection     WanConnection
-        (TCP 4992)          (TLS 4992)
-              │                   │
-              ▼                   ▼
-        QTcpSocket          QSslSocket
-              │                   │
-              └─────────┬─────────┘
-                        ▼
-                      Radio
+                 RadioModel.sendCmd(cmd)                                  [MAIN]
+                   │ stores callback in m_pendingCallbacks
+                   │ allocates sequence number
+                   ▼ [QMetaObject::invokeMethod → queued to CONN thread]
+              ┌─────────────────┐
+              │ RadioConnection  │  ◄── CONNECTION THREAD
+              │ writeCommand()   │      heap-allocated, moveToThread
+              │ QTcpSocket       │      init() creates socket on thread
+              │ ping RTT timer   │      measures RTT at socket read time
+              └────────┬────────┘
+                       │
+              ┌────────┴────────┐
+              ▼                 ▼
+         QTcpSocket       WanConnection    ◄── WAN stays on MAIN (TLS)
+              │                 │
+              └────────┬────────┘
+                       ▼
+                     Radio
 
   Radio ──→ "S<handle>|<object> key=val ..."
               │
-              ▼
-        RadioModel.onStatusReceived()       ◄── MAIN THREAD
+              ▼ CONNECTION THREAD
+        RadioConnection.processLine()
+              │ emits statusReceived, commandResponse
+              ▼ [auto-queued signal to MAIN]
+        RadioModel.onStatusReceived()                                    [MAIN]
               │
               ├─→ SliceModel.applyStatus()      ──→ GUI signals
               ├─→ PanadapterModel.applyStatus()  ──→ SpectrumWidget
@@ -267,11 +277,20 @@ TCP COMMAND PIPELINE (bidirectional):       ◄── MAIN THREAD
               ├─→ MeterModel.registerMeter()     ──→ meter definitions
               └─→ Multi-Flex client tracking     ──→ TitleBar badge
 
-EXTERNAL CONTROL PIPELINES:                 ◄── MAIN THREAD
-  FlexControl (USB serial) ──→ FlexControlManager ──→ MainWindow ──→ slice tune
-  MIDI (RtMidi)            ──→ MidiControlManager  ──→ parameter setters
-  SerialPort (PTT/CW)     ──→ SerialPortController ──→ RadioModel TX/CW
-  TGXL (TCP 9010)          ──→ TgxlConnection      ──→ TunerModel relay adjust
+        RadioModel.onCommandResponse()                                   [MAIN]
+              │ looks up callback by sequence number
+              └─→ invokes callback on main thread (safe model access)
+
+EXTERNAL CONTROL PIPELINES:                 ◄── EXTCONTROLLERS THREAD
+  FlexControl (USB serial) ──→ FlexControlManager ──┐
+  MIDI (RtMidi)            ──→ MidiControlManager  ──┼─→ [auto-queued signals]
+  SerialPort (PTT/CW)     ──→ SerialPortController ──┘       │
+                                                              ▼ MAIN THREAD
+                                                     MainWindow dispatches:
+                                                       ├─→ RadioModel (tune, TX, CW)
+                                                       ├─→ SliceModel (freq, gain, DSP)
+                                                       └─→ AudioEngine (mute, mic gain)
+  TGXL (TCP 9010)          ──→ TgxlConnection      ──→ TunerModel relay adjust [MAIN]
 
 SPOT PIPELINES:                             ◄── SPOT WORKER THREAD
   DX Cluster (telnet)  ─┐
@@ -285,15 +304,19 @@ SPOT PIPELINES:                             ◄── SPOT WORKER THREAD
 
 | Thread | Components | CPU | Notes |
 |--------|-----------|-----|-------|
-| **Main** | paintEvent, RadioConnection, RadioModel, all GUI widgets, CwDecoder | ~99% | Dominated by QPainter waterfall blit |
-| **Audio** | AudioEngine, NR2/RN2/BNR DSP, QAudioSink/Source, TX encoding | ~1% | std::atomic flags, recursive_mutex for DSP lifecycle |
-| **Network** | PanadapterStream, QUdpSocket, VITA-49 parsing, FFT/WF assembly | ~0.5% | QMutex guards stream ID sets |
+| **Main** | paintEvent, RadioModel, all sub-models, all GUI widgets, CwDecoder | ~97% | Dominated by QPainter waterfall blit |
+| **Connection** | RadioConnection, QTcpSocket, ping RTT | ~0% | Heap-allocated, init() slot pattern |
+| **Audio** | AudioEngine, NR2/RN2/BNR DSP, QAudioSink/Source, TX encoding | ~1.5% | std::atomic flags, recursive_mutex for DSP lifecycle |
+| **Network** | PanadapterStream, QUdpSocket, VITA-49 parsing, FFT/WF assembly | ~0.3% | QMutex guards stream ID sets |
+| **ExtControllers** | FlexControlManager, MidiControlManager, SerialPortController | ~0% | USB serial I/O, RtMidi, poll timers |
 | **Spot** | DxCluster, RBN, WSJT-X, POTA, FreeDV clients | ~0% | Batched 1/sec forwarding |
 | **DAX IQ** | DaxIqModel worker | ~0% | Byte-swap + pipe I/O |
 | **RADE** | RADEEngine | ~0% | Neural encoder/decoder |
 | **BNR gRPC** | NvidiaBnrFilter async I/O | ~0% | GPU container communication |
 
 **Cross-thread signals (auto-queued):**
+- Connection → Main: statusReceived, messageReceived, commandResponse, pingRttMeasured
+- Main → Connection: writeCommand (via QMetaObject::invokeMethod), connectToRadio, disconnectFromRadio
 - Network → Main: spectrumReady, waterfallRowReady, meterDataReady, daxAudioReady
 - Network → Audio: audioDataReady
 - Audio → Network: txPacketReady (→ sendToRadio)
@@ -301,8 +324,16 @@ SPOT PIPELINES:                             ◄── SPOT WORKER THREAD
 - Main → Audio: setNr2/Rn2/BnrEnabled (via QMetaObject::invokeMethod)
 - Main → Audio: startRxStream/stopRxStream (via helper methods)
 - Main → Network: registerPanStream, setDbmRange (QMutex-protected setters)
+- ExtControllers → Main: tuneSteps, buttonPressed, externalPttChanged, cwKeyChanged, paramAction
+- Main → ExtControllers: setTransmitting, loadSettings, open/close (via QMetaObject::invokeMethod)
 
-**Remaining bottleneck:** Main thread at ~99% is entirely QPainter waterfall
+**Design principle:** Everything except GUI rendering and model dispatch runs
+on a dedicated worker thread. RadioModel owns all sub-models as value members
+on the main thread — GUI accesses models directly with no pointer indirection.
+Each worker thread has a single responsibility and communicates exclusively via
+auto-queued signals. The main thread handles only paintEvent + model updates.
+
+**Remaining bottleneck:** Main thread at ~98% is entirely QPainter waterfall
 rendering (`p.drawImage()` blit). With waterfall closed, main thread drops to
 2-3%. GPU offload (Phase 3, #502) is the path to resolving this.
 

--- a/src/core/MidiControlManager.cpp
+++ b/src/core/MidiControlManager.cpp
@@ -282,11 +282,10 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2)
 
         // For toggles: use > 0.5 threshold; for triggers: only fire on > 0.5
         if (param->type == MidiParamType::Toggle) {
-            // Toggle on each NoteOn, or CC > 63
+            // NoteOn = toggle (sentinel -1 tells MainWindow to flip current state)
+            // CC = direct threshold
             if (msgType == MidiBinding::NoteOn) {
-                // Get current value and toggle
-                float cur = param->getter ? param->getter() : 0.0f;
-                scaled = (cur > 0.5f) ? 0.0f : 1.0f;
+                scaled = -1.0f;  // sentinel: MainWindow reads getter and toggles (#502)
             } else {
                 scaled = (value > 0.5f) ? 1.0f : 0.0f;
             }
@@ -299,8 +298,9 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2)
             scaled = normValue > 0.0f ? 1.0f : 0.0f;
         }
 
-        if (param->setter)
-            param->setter(scaled);
+        // Don't call setter directly — may be on a worker thread while
+        // setters access main-thread objects. Emit signal instead. (#502)
+        emit paramAction(binding.paramId, scaled);
     }
 
     emit paramValueChanged(binding.paramId, value);

--- a/src/core/MidiControlManager.h
+++ b/src/core/MidiControlManager.h
@@ -94,6 +94,9 @@ signals:
     void portError(const QString& error);
     void midiActivity(int channel, int msgType, int number, int value);
     void paramValueChanged(const QString& paramId, float normalizedValue);
+    // Emitted with the final scaled value for MainWindow to dispatch
+    // the setter on the main thread. (#502)
+    void paramAction(const QString& paramId, float scaledValue);
     void learnCompleted(const QString& paramId, const MidiBinding& binding);
     void learnCancelled();
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -601,7 +601,7 @@ MainWindow::MainWindow(QWidget* parent)
         }
 #endif
 #ifdef HAVE_SERIALPORT
-        m_serialPort.setTransmitting(tx);
+        QMetaObject::invokeMethod(m_serialPort, [this, tx] { m_serialPort->setTransmitting(tx); });
 #endif
     });
 
@@ -1129,26 +1129,34 @@ MainWindow::MainWindow(QWidget* parent)
             m_radioModel.transmitModel().apdConfigurable());
     });
 
-    // ── Serial port PTT/CW keying ───────────────────────────────────────
+    // ── External controllers run on a dedicated worker thread (#502) ────
+    // FlexControl, SerialPort, and MIDI controllers are created on the
+    // worker thread so their I/O (serial port, RtMidi callbacks, poll timers)
+    // never competes with paintEvent. Signals auto-queue to main thread.
+    m_extCtrlThread = new QThread(this);
+    m_extCtrlThread->setObjectName("ExtControllers");
+
 #ifdef HAVE_SERIALPORT
-    m_serialPort.loadSettings();
-    connect(&m_serialPort, &SerialPortController::externalPttChanged,
+    m_serialPort = new SerialPortController;  // no parent — moved to thread
+    m_serialPort->moveToThread(m_extCtrlThread);
+    m_flexControl = new FlexControlManager;
+    m_flexControl->moveToThread(m_extCtrlThread);
+
+    // Serial port signals (auto-queued from worker → main)
+    connect(m_serialPort, &SerialPortController::externalPttChanged,
             this, [this](bool active) {
         m_radioModel.setTransmit(active);
     });
-    connect(&m_serialPort, &SerialPortController::cwKeyChanged,
+    connect(m_serialPort, &SerialPortController::cwKeyChanged,
             this, [this](bool down) {
         m_radioModel.sendCwKey(down);
     });
-    connect(&m_serialPort, &SerialPortController::cwPaddleChanged,
+    connect(m_serialPort, &SerialPortController::cwPaddleChanged,
             this, [this](bool dit, bool dah) {
         m_radioModel.sendCwPaddle(dit, dah);
     });
 
-    // ── FlexControl tuning knob ─────────────────────────────────────────
-    // Coalesce rapid encoder steps into a single command every 20ms.
-    // Without this, each step sends a separate TCP command, flooding the
-    // radio and causing the UI to lag behind the knob.
+    // FlexControl coalesce timer stays on main thread (accesses activeSlice)
     m_flexCoalesceTimer.setSingleShot(true);
     m_flexCoalesceTimer.setInterval(20);
     connect(&m_flexCoalesceTimer, &QTimer::timeout, this, [this]() {
@@ -1164,20 +1172,18 @@ MainWindow::MainWindow(QWidget* parent)
                 QString("slice m %1 pan=%2").arg(newMhz, 0, 'f', 6).arg(panId));
         if (spectrum()) spectrum()->setVfoFrequency(newMhz);
     });
-    connect(&m_flexControl, &FlexControlManager::tuneSteps,
+    // FlexControl signals (auto-queued from worker → main)
+    connect(m_flexControl, &FlexControlManager::tuneSteps,
             this, [this](int steps) {
         m_flexPendingSteps += steps;
         if (!m_flexCoalesceTimer.isActive())
             m_flexCoalesceTimer.start();
     });
 
-    connect(&m_flexControl, &FlexControlManager::buttonPressed,
+    connect(m_flexControl, &FlexControlManager::buttonPressed,
             this, [this](int button, int action) {
-        // Look up configurable action from AppSettings
         QString key = QString("FlexControlBtn%1Action%2").arg(button).arg(action);
         auto& settings = AppSettings::instance();
-
-        // Defaults: Btn1=StepUp/StepDown, Btn2=ToggleMox/ToggleTune, Btn3=ToggleMute/ToggleLock
         static const char* defaults[3][3] = {
             {"StepUp",     "StepDown",     "None"},
             {"ToggleMox",  "ToggleTune",   "None"},
@@ -1187,7 +1193,6 @@ MainWindow::MainWindow(QWidget* parent)
                           ? defaults[button-1][action] : "None";
         QString actionName = settings.value(key, def).toString();
 
-        // Dispatch action
         if (actionName == "StepUp") {
             if (auto* rx = m_appletPanel->rxApplet()) rx->cycleStepUp();
         } else if (actionName == "StepDown") {
@@ -1208,8 +1213,7 @@ MainWindow::MainWindow(QWidget* parent)
                 for (int i = 0; i < slices.size(); ++i) {
                     if (slices[i]->sliceId() == m_activeSliceId) { idx = i; break; }
                 }
-                int next = (idx + 1) % slices.size();
-                setActiveSlice(slices[next]->sliceId());
+                setActiveSlice(slices[(idx + 1) % slices.size()]->sliceId());
             }
         } else if (actionName == "PrevSlice") {
             const auto& slices = m_radioModel.slices();
@@ -1218,36 +1222,68 @@ MainWindow::MainWindow(QWidget* parent)
                 for (int i = 0; i < slices.size(); ++i) {
                     if (slices[i]->sliceId() == m_activeSliceId) { idx = i; break; }
                 }
-                int prev = (idx - 1 + slices.size()) % slices.size();
-                setActiveSlice(slices[prev]->sliceId());
+                setActiveSlice(slices[(idx - 1 + slices.size()) % slices.size()]->sliceId());
             }
         }
     });
+#endif
 
-    // Auto-detect FlexControl on startup
-    m_flexControl.setInvertDirection(
+#ifdef HAVE_MIDI
+    m_midiControl = new MidiControlManager;
+    m_midiControl->moveToThread(m_extCtrlThread);
+
+    // Register MIDI params — setters/getters stored on MainWindow for
+    // main-thread dispatch. Param metadata still registered on the manager.
+    registerMidiParams();
+
+    // MIDI paramAction signal: dispatches setter on main thread (#502)
+    connect(m_midiControl, &MidiControlManager::paramAction,
+            this, [this](const QString& paramId, float scaledValue) {
+        auto it = m_midiSetters.find(paramId);
+        if (it == m_midiSetters.end()) return;
+        if (scaledValue == -1.0f) {
+            // Toggle sentinel: read getter, flip, call setter
+            auto git = m_midiGetters.find(paramId);
+            float cur = (git != m_midiGetters.end() && *git) ? (*git)() : 0.0f;
+            it.value()(cur > 0.5f ? 0.0f : 1.0f);
+        } else {
+            it.value()(scaledValue);
+        }
+    });
+
+    MidiSettings::instance().load();
+    auto savedBindings = MidiSettings::instance().loadBindings();
+    for (const auto& b : savedBindings)
+        m_midiControl->addBinding(b);
+#endif
+
+    // Start the external controller thread — objects are already moved
+    m_extCtrlThread->start();
+
+    // Init that must happen on the worker thread (serial port open, etc.)
+#ifdef HAVE_SERIALPORT
+    QMetaObject::invokeMethod(m_serialPort, [this] {
+        m_serialPort->loadSettings();
+    });
+    m_flexControl->setInvertDirection(
         AppSettings::instance().value("FlexControlInvertDir", "False").toString() == "True");
     if (AppSettings::instance().value("FlexControlAutoDetect", "True").toString() == "True") {
         QString fcPort = FlexControlManager::detectPort();
         if (!fcPort.isEmpty()) {
-            m_flexControl.open(fcPort);
+            QMetaObject::invokeMethod(m_flexControl, [this, fcPort] {
+                m_flexControl->open(fcPort);
+            });
         }
     }
 #endif
-
 #ifdef HAVE_MIDI
-    // ── MIDI controller ─────────────────────────────────────────────────
-    registerMidiParams();
-    MidiSettings::instance().load();
-    // Load saved bindings
-    auto savedBindings = MidiSettings::instance().loadBindings();
-    for (const auto& b : savedBindings)
-        m_midiControl.addBinding(b);
-    // Auto-connect to last device
     if (MidiSettings::instance().autoConnect()) {
         QString dev = MidiSettings::instance().lastDevice();
-        if (!dev.isEmpty())
-            m_midiControl.openPortByName(dev);
+        if (!dev.isEmpty()) {
+            QMetaObject::invokeMethod(m_midiControl, [this, dev] {
+                m_midiControl->openPortByName(dev);
+            });
+        }
     }
 #endif
 
@@ -1474,6 +1510,19 @@ MainWindow::~MainWindow()
     m_audioThread->quit();
     m_audioThread->wait();
     delete m_audio;
+
+    // Stop external controller thread (#502)
+    if (m_extCtrlThread && m_extCtrlThread->isRunning()) {
+        m_extCtrlThread->quit();
+        m_extCtrlThread->wait();
+    }
+#ifdef HAVE_SERIALPORT
+    delete m_serialPort;
+    delete m_flexControl;
+#endif
+#ifdef HAVE_MIDI
+    delete m_midiControl;
+#endif
 }
 
 void MainWindow::closeEvent(QCloseEvent* event)
@@ -1731,20 +1780,22 @@ void MainWindow::buildMenuBar()
         m_radioSetupDialog = dlg;
         connect(dlg, &QDialog::finished, this, [this, prevComp]() {
 #ifdef HAVE_SERIALPORT
-            // Re-load serial port settings if changed
-            m_serialPort.loadSettings();
+            // Re-load serial port settings if changed (on worker thread)
+            QMetaObject::invokeMethod(m_serialPort, [this] { m_serialPort->loadSettings(); });
             // Re-check FlexControl open/close state
             auto& fcs = AppSettings::instance();
-            if (fcs.value("FlexControlOpen", "False").toString() == "True") {
-                if (!m_flexControl.isOpen()) {
-                    QString port = fcs.value("FlexControlPort").toString();
-                    if (!port.isEmpty()) m_flexControl.open(port);
+            bool fcOpen = fcs.value("FlexControlOpen", "False").toString() == "True";
+            QString fcPort = fcs.value("FlexControlPort").toString();
+            bool fcInvert = fcs.value("FlexControlInvertDir", "False").toString() == "True";
+            QMetaObject::invokeMethod(m_flexControl, [this, fcOpen, fcPort, fcInvert] {
+                if (fcOpen) {
+                    if (!m_flexControl->isOpen() && !fcPort.isEmpty())
+                        m_flexControl->open(fcPort);
+                } else {
+                    if (m_flexControl->isOpen()) m_flexControl->close();
                 }
-            } else {
-                if (m_flexControl.isOpen()) m_flexControl.close();
-            }
-            m_flexControl.setInvertDirection(
-                fcs.value("FlexControlInvertDir", "False").toString() == "True");
+                m_flexControl->setInvertDirection(fcInvert);
+            });
 #endif
             // Re-evaluate CW decode overlay visibility
             bool decodeOn = AppSettings::instance().value("CwDecodeOverlay", "True").toString() == "True";
@@ -1824,7 +1875,7 @@ void MainWindow::buildMenuBar()
             m_midiDialog->activateWindow();
             return;
         }
-        auto* dlg = new MidiMappingDialog(&m_midiControl, this);
+        auto* dlg = new MidiMappingDialog(m_midiControl, this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
         m_midiDialog = dlg;
         dlg->show();
@@ -5197,11 +5248,15 @@ void MainWindow::stopDax()
 void MainWindow::registerMidiParams()
 {
     using P = MidiParamType;
+    // Setters/getters stored on MainWindow for main-thread dispatch (#502).
+    // MidiControlManager gets metadata only (no lambdas that capture main-thread objects).
     auto reg = [this](const char* id, const char* name, const char* cat,
                       MidiParamType type, float lo, float hi,
                       std::function<void(float)> setter,
                       std::function<float()> getter = {}) {
-        m_midiControl.registerParam({id, name, cat, type, lo, hi, std::move(setter), std::move(getter)});
+        m_midiSetters[id] = setter;
+        if (getter) m_midiGetters[id] = getter;
+        m_midiControl->registerParam({id, name, cat, type, lo, hi, std::move(setter), std::move(getter)});
     };
 
     // ── RX ──────────────────────────────────────────────────────────────

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -149,15 +149,21 @@ private:
 
     // Batched spot add commands (flushed 1/sec)
     QStringList m_spotCmdBatch;
+    // External controllers run on a dedicated worker thread (#502)
+    QThread*             m_extCtrlThread{nullptr};
 #ifdef HAVE_SERIALPORT
-    SerialPortController m_serialPort;
-    FlexControlManager   m_flexControl;
+    SerialPortController* m_serialPort{nullptr};
+    FlexControlManager*   m_flexControl{nullptr};
     QTimer               m_flexCoalesceTimer;
     int                  m_flexPendingSteps{0};
 #endif
 #ifdef HAVE_MIDI
-    MidiControlManager   m_midiControl;
+    MidiControlManager*  m_midiControl{nullptr};
     void registerMidiParams();
+    // MIDI param setters indexed by ID — called on main thread from
+    // paramAction signal (worker thread cannot call them directly). (#502)
+    QHash<QString, std::function<void(float)>> m_midiSetters;
+    QHash<QString, std::function<float()>>     m_midiGetters;
 #endif
 
     // GUI — left sidebar


### PR DESCRIPTION
FlexControl, MidiControlManager, and SerialPortController now run on a
shared ExtControllers worker thread. USB serial I/O, RtMidi callbacks,
and poll timers no longer compete with paintEvent on the main thread.

- Controllers heap-allocated and moveToThread before start
- Signals auto-queue to MainWindow for model dispatch
- MIDI param setters stored on MainWindow, invoked via paramAction signal
  (worker thread cannot call lambdas that capture main-thread objects)
- Settings changes and serial port open/close use invokeMethod
- Toggle sentinel (-1) for NoteOn toggle avoids cross-thread getter call

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
