### PR TITLE
Fix CodeQL Opus model cache — split configure/build steps

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,16 +28,24 @@ jobs:
         with:
           languages: ${{ matrix.language }}
 
-      - name: Build
+      - name: Configure
+        run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+      - name: Pre-cache Opus neural net model
         run: |
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          # Pre-cache Opus model from Docker image
+          # Copy cached model from Docker image so Opus autogen.sh skips
+          # the media.xiph.org download. Falls back to network if not cached.
           MODEL="opus_data-4ed9445b96698bad25d852e912b41495ddfa30c8dbc8a55f9cde5826ed793453.tar.gz"
           OPUS_SRC=$(find build -path "*/build_opus-prefix/src/build_opus" -type d 2>/dev/null | head -1)
           if [ -f "/opt/opus-model/$MODEL" ] && [ -n "$OPUS_SRC" ]; then
             cp "/opt/opus-model/$MODEL" "$OPUS_SRC/"
+            echo "Copied cached Opus model to $OPUS_SRC"
+          else
+            echo "No cached model or Opus source not yet extracted — will download during build"
           fi
-          cmake --build build -j$(nproc)
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
The pre-cache step needs the Opus source dir to exist, which only
happens after cmake configure. CodeQL had configure+build in one
step so the model copy ran before ExternalProject extracted the
source. Split into separate steps to match CI workflow.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
