### PR TITLE
Add Windows/MinGW build support for RADE and Opus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,13 @@ if(ENABLE_RADE AND EXISTS "${RADE_DIR}/src/rade_api.h")
         ${RADE_DIR}/src/kiss_fft.c
         ${RADE_DIR}/src/kiss_fftr.c
     )
+    if(MSVC)
+        set(RADE_WARN_FLAG "/w")
+    else()
+        set(RADE_WARN_FLAG "-w")
+    endif()
     set_source_files_properties(${RADE_SOURCES} PROPERTIES
-        COMPILE_FLAGS "-w -DIS_BUILDING_RADE_API=1 -DRADE_PYTHON_FREE=1"
+        COMPILE_FLAGS "${RADE_WARN_FLAG} -DIS_BUILDING_RADE_API=1 -DRADE_PYTHON_FREE=1"
         INCLUDE_DIRECTORIES "${RADE_DIR}/src"
     )
     set(RADE_FOUND TRUE)
@@ -479,9 +484,13 @@ if(FFTW3_FOUND)
 endif()
 
 if(RADE_FOUND)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_RADE HAVE_OPUS)
+    target_compile_definitions(AetherSDR PRIVATE HAVE_RADE HAVE_OPUS IS_BUILDING_RADE_API=1)
     target_include_directories(AetherSDR PRIVATE ${RADE_DIR}/src)
-    target_link_libraries(AetherSDR PRIVATE opus m)
+    if(WIN32)
+        target_link_libraries(AetherSDR PRIVATE opus)
+    else()
+        target_link_libraries(AetherSDR PRIVATE opus m)
+    endif()
 elseif(OPUS_FOUND)
     target_compile_definitions(AetherSDR PRIVATE HAVE_OPUS)
     target_include_directories(AetherSDR PRIVATE ${OPUS_INCLUDE_DIRS})

--- a/third_party/radae/cmake/BuildOpus.cmake
+++ b/third_party/radae/cmake/BuildOpus.cmake
@@ -11,7 +11,52 @@ set(OPUS_URL https://github.com/xiph/opus/archive/940d4e5af64351ca8ba8390df3f555
 endif (NOT DEFINED OPUS_URL)
 
 include(ExternalProject)
-if(APPLE AND BUILD_OSX_UNIVERSAL)
+
+# ── Windows: build Opus via CMake (no autotools) ─────────────────────────
+if(WIN32)
+    ExternalProject_Add(build_opus
+        DOWNLOAD_EXTRACT_TIMESTAMP NO
+        URL ${OPUS_URL}
+        PATCH_COMMAND ${CMAKE_COMMAND}
+            -DSOURCE_DIR=<SOURCE_DIR>
+            -DRADE_DIR=${RADE_DIR}
+            -P ${RADE_DIR}/cmake/PatchOpusNnet.cmake
+        CMAKE_ARGS
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+            -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+            -DBUILD_SHARED_LIBS=OFF
+            -DOPUS_BUILD_TESTING=OFF
+            -DOPUS_BUILD_PROGRAMS=OFF
+            -DOPUS_INSTALL_PKG_CONFIG_MODULE=OFF
+            -DOPUS_INSTALL_CMAKE_CONFIG_MODULE=OFF
+            -DOPUS_DRED=ON
+            -DOPUS_OSCE=ON
+        BUILD_BYPRODUCTS <BINARY_DIR>/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
+                         <BINARY_DIR>/libopus${CMAKE_STATIC_LIBRARY_SUFFIX}
+        INSTALL_COMMAND ""
+    )
+
+    ExternalProject_Get_Property(build_opus BINARY_DIR)
+    ExternalProject_Get_Property(build_opus SOURCE_DIR)
+    add_library(opus STATIC IMPORTED)
+    add_dependencies(opus build_opus)
+
+    # CMake produces opus.lib (MSVC) or libopus.a (MinGW)
+    if(MSVC)
+        set(_opus_lib "${BINARY_DIR}/opus${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    else()
+        set(_opus_lib "${BINARY_DIR}/libopus${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    endif()
+    set_target_properties(opus PROPERTIES
+        IMPORTED_LOCATION "${_opus_lib}"
+        IMPORTED_IMPLIB   "${_opus_lib}"
+    )
+
+    include_directories(${SOURCE_DIR}/dnn ${SOURCE_DIR}/celt ${SOURCE_DIR}/include ${SOURCE_DIR})
+
+# ── macOS universal: build twice and lipo ────────────────────────────────
+elseif(APPLE AND BUILD_OSX_UNIVERSAL)
 # Opus ./configure doesn't behave properly when built as a universal binary;
 # build it twice and use lipo to create a universal libopus.a instead.
 ExternalProject_Add(build_opus_x86
@@ -56,7 +101,8 @@ set_target_properties(opus PROPERTIES
     IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/libopus${CMAKE_STATIC_LIBRARY_SUFFIX}"
 )
 
-else(APPLE AND BUILD_OSX_UNIVERSAL)
+# ── Unix/Linux: autotools ────────────────────────────────────────────────
+else()
 ExternalProject_Add(build_opus
     DOWNLOAD_EXTRACT_TIMESTAMP NO
     BUILD_IN_SOURCE 1
@@ -79,4 +125,4 @@ set_target_properties(opus PROPERTIES
 )
 
 include_directories(${SOURCE_DIR}/dnn ${SOURCE_DIR}/celt ${SOURCE_DIR}/include ${SOURCE_DIR})
-endif(APPLE AND BUILD_OSX_UNIVERSAL)
+endif()

--- a/third_party/radae/cmake/PatchOpusNnet.cmake
+++ b/third_party/radae/cmake/PatchOpusNnet.cmake
@@ -1,0 +1,96 @@
+# PatchOpusNnet.cmake — Apply the RADE_EXPORT patch to Opus dnn/nnet.h
+# This replaces `patch dnn/nnet.h < opus-nnet.h.diff` for platforms without patch(1).
+# Invoked as: cmake -DSOURCE_DIR=<opus_src> -DRADE_DIR=<radae_dir> -P PatchOpusNnet.cmake
+
+set(NNET_H "${SOURCE_DIR}/dnn/nnet.h")
+file(READ "${NNET_H}" content)
+
+# 1. Add RADE_EXPORT fallback definition after #define NNET_H_
+string(REPLACE
+    "#define NNET_H_\n"
+    "#define NNET_H_\n\n#ifndef RADE_EXPORT\n#define RADE_EXPORT __attribute__((visibility(\"default\")))\n#endif /* RADE_EXPORT */\n"
+    content "${content}")
+
+# 2. Add RADE_EXPORT to function declarations
+string(REPLACE
+    "void compute_generic_dense("
+    "void RADE_EXPORT compute_generic_dense("
+    content "${content}")
+string(REPLACE
+    "void compute_generic_gru("
+    "void RADE_EXPORT compute_generic_gru("
+    content "${content}")
+string(REPLACE
+    "void compute_generic_conv1d("
+    "void RADE_EXPORT compute_generic_conv1d("
+    content "${content}")
+string(REPLACE
+    "void compute_generic_conv1d_dilation("
+    "void RADE_EXPORT compute_generic_conv1d_dilation("
+    content "${content}")
+string(REPLACE
+    "void compute_glu("
+    "void RADE_EXPORT compute_glu("
+    content "${content}")
+string(REPLACE
+    "void compute_gated_activation("
+    "void RADE_EXPORT compute_gated_activation("
+    content "${content}")
+string(REPLACE
+    "int parse_weights("
+    "int RADE_EXPORT parse_weights("
+    content "${content}")
+string(REPLACE
+    "int linear_init("
+    "int RADE_EXPORT linear_init("
+    content "${content}")
+string(REPLACE
+    "int conv2d_init("
+    "int RADE_EXPORT conv2d_init("
+    content "${content}")
+
+file(WRITE "${NNET_H}" "${content}")
+message(STATUS "Patched ${NNET_H} with RADE_EXPORT attributes")
+
+# ── Download and extract neural network model data ───────────────────────
+# The autotools build does this via autogen.sh; the CMake build needs it
+# done explicitly.  The tarball contains generated *_data.h / *_data.c files
+# (fargan_data.h, plc_data.h, lace_data.h, etc.) that carry the trained
+# neural network weights.
+set(MODEL_HASH "4ed9445b96698bad25d852e912b41495ddfa30c8dbc8a55f9cde5826ed793453")
+set(MODEL_TAR  "opus_data-${MODEL_HASH}.tar.gz")
+set(MODEL_PATH "${SOURCE_DIR}/${MODEL_TAR}")
+
+if(NOT EXISTS "${SOURCE_DIR}/dnn/fargan_data.h")
+    if(NOT EXISTS "${MODEL_PATH}")
+        message(STATUS "Downloading Opus neural network model data...")
+        file(DOWNLOAD
+            "https://media.xiph.org/opus/models/${MODEL_TAR}"
+            "${MODEL_PATH}"
+            SHOW_PROGRESS
+            STATUS download_status)
+        list(GET download_status 0 download_code)
+        if(NOT download_code EQUAL 0)
+            # Fallback: try the AetherSDR release mirror
+            message(STATUS "Primary download failed, trying mirror...")
+            file(DOWNLOAD
+                "https://github.com/ten9876/AetherSDR/releases/download/v0.7.16/${MODEL_TAR}"
+                "${MODEL_PATH}"
+                SHOW_PROGRESS
+                STATUS download_status2)
+            list(GET download_status2 0 download_code2)
+            if(NOT download_code2 EQUAL 0)
+                message(FATAL_ERROR "Failed to download Opus model data")
+            endif()
+        endif()
+    endif()
+    message(STATUS "Extracting Opus model data...")
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E tar xzf "${MODEL_PATH}"
+        WORKING_DIRECTORY "${SOURCE_DIR}"
+        RESULT_VARIABLE extract_result)
+    if(NOT extract_result EQUAL 0)
+        message(FATAL_ERROR "Failed to extract Opus model data")
+    endif()
+    message(STATUS "Opus model data extracted")
+endif()

--- a/third_party/radae/src/kiss_fft.h
+++ b/third_party/radae/src/kiss_fft.h
@@ -34,7 +34,11 @@ extern "C" {
 #endif
 
 #ifdef FIXED_POINT
+#ifdef _WIN32
+#include <stddef.h>
+#else
 #include <sys/types.h>
+#endif
 #if (FIXED_POINT == 32)
 #define kiss_fft_scalar int32_t
 #else

--- a/third_party/radae/src/rade_api.h
+++ b/third_party/radae/src/rade_api.h
@@ -37,7 +37,11 @@
 #ifndef __RADE_API__
 #define __RADE_API__
 
+#ifdef _WIN32
+#include <stddef.h>
+#else
 #include <sys/types.h>
+#endif
 
 #if IS_BUILDING_RADE_API
 #if _WIN32


### PR DESCRIPTION
## Summary

The RADE/Opus integration assumed a POSIX build environment (autotools, `<sys/types.h>`, `libm`). This PR adds full Windows build support so AetherSDR can be compiled with MinGW or MSVC toolchains while retaining the existing Linux/macOS build path.

### Changes

**`CMakeLists.txt`**
- Use `/w` (MSVC) or `-w` (GCC/MinGW) for RADE source warning suppression — the previous hardcoded `-w` flag is not valid for MSVC
- Add `IS_BUILDING_RADE_API=1` to the main target's compile definitions (was only set on the RADE sources, causing missing symbol errors when the main target includes RADE headers)
- Conditionally link `libm` only on non-Windows — MSVC provides math functions in the CRT; linking `-lm` on MSVC produces linker errors

**`third_party/radae/cmake/BuildOpus.cmake`**
- Add a Windows-specific `ExternalProject` path that builds Opus via its **native CMake build system** instead of autotools. The autotools path (`./configure && make`) requires MSYS2/Cygwin on Windows and fails under MinGW-w64
- Handles both MSVC (`opus.lib`) and MinGW (`libopus.a`) library naming conventions
- Enables `OPUS_DRED` and `OPUS_OSCE` for the neural codec features used by RADE

**`third_party/radae/cmake/PatchOpusNnet.cmake`** (new file)
- Pure-CMake replacement for the Unix `patch` command used by the autotools build to apply `RADE_EXPORT` attributes to Opus `dnn/nnet.h`
- Downloads and extracts the Opus neural network model data (`fargan_data.h`, `plc_data.h`, `lace_data.h` etc.) with a fallback mirror URL — the autotools build does this via `autogen.sh`, which doesn't run under the CMake path
- Works on all platforms without requiring `patch(1)`

**`third_party/radae/src/kiss_fft.h` / `rade_api.h`**
- Replace `#include <sys/types.h>` with `#include <stddef.h>` on Windows — `sys/types.h` is a POSIX header not available in the MSVC standard library. `stddef.h` provides the needed `size_t` type portably.

## Test Plan

- [ ] Build on Windows with MinGW-w64 (GCC 14+) — verify RADE/Opus compiles and links
- [ ] Build on Windows with MSVC (Visual Studio 2022) — verify `/w` flag and `opus.lib` naming
- [ ] Build on Linux (existing CI) — verify no regression in autotools Opus path
- [ ] Build on macOS — verify no regression in universal binary path
- [ ] Run AetherSDR on Windows — verify RADE digital voice encode/decode works
- [ ] Verify Opus neural network model data downloads and extracts correctly on first build

🤖 Generated with [Claude Code](https://claude.com/claude-code)