### PR TITLE
Add RX filter Low/High cut controls to RxApplet

### DIFF
--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -491,6 +491,98 @@ void RxApplet::buildUI()
         leftCol->addWidget(m_filterContainer);
     }
 
+    // Filter Lo/Hi cut controls (arbitrary bandwidth entry)
+    {
+        m_filterCutContainer = new QWidget;
+        auto* grid = new QHBoxLayout(m_filterCutContainer);
+        grid->setContentsMargins(0, 0, 0, 0);
+        grid->setSpacing(0);
+
+        // ── Left column: Low Cut ─────────────────────────────────────
+        auto* lowCol = new QVBoxLayout;
+        lowCol->setSpacing(1);
+
+        auto* lowLbl = new QLabel("Low Cut");
+        lowLbl->setAlignment(Qt::AlignCenter);
+        lowLbl->setStyleSheet("QLabel { color: #8090a0; font-size: 10px; }");
+        lowCol->addWidget(lowLbl);
+
+        auto* lowRow = new QHBoxLayout;
+        lowRow->setSpacing(2);
+
+        m_filterLoDown = mkLeft();
+        connect(m_filterLoDown, &QPushButton::clicked, this, [this] {
+            if (!m_slice) return;
+            m_slice->setFilterWidth(m_slice->filterLow() - FILTER_STEP_HZ,
+                                    m_slice->filterHigh());
+        });
+        lowRow->addWidget(m_filterLoDown);
+
+        m_filterLoLabel = new QLabel("0");
+        m_filterLoLabel->setFixedWidth(46);
+        m_filterLoLabel->setAlignment(Qt::AlignCenter);
+        m_filterLoLabel->setStyleSheet(
+            "QLabel { font-size: 10px; color: #c8d8e8; background: #0a0a18; "
+            "border: 1px solid #1e2e3e; border-radius: 3px; padding: 1px 3px; }");
+        lowRow->addWidget(m_filterLoLabel);
+
+        m_filterLoUp = mkRight();
+        connect(m_filterLoUp, &QPushButton::clicked, this, [this] {
+            if (!m_slice) return;
+            int newLo = qMin(m_slice->filterHigh() - FILTER_STEP_HZ,
+                             m_slice->filterLow() + FILTER_STEP_HZ);
+            m_slice->setFilterWidth(newLo, m_slice->filterHigh());
+        });
+        lowRow->addWidget(m_filterLoUp);
+
+        lowCol->addLayout(lowRow);
+        grid->addLayout(lowCol);
+
+        grid->addStretch();
+
+        // ── Right column: High Cut ───────────────────────────────────
+        auto* highCol = new QVBoxLayout;
+        highCol->setSpacing(1);
+
+        auto* highLbl = new QLabel("High Cut");
+        highLbl->setAlignment(Qt::AlignCenter);
+        highLbl->setStyleSheet("QLabel { color: #8090a0; font-size: 10px; }");
+        highCol->addWidget(highLbl);
+
+        auto* highRow = new QHBoxLayout;
+        highRow->setSpacing(2);
+
+        m_filterHiDown = mkLeft();
+        connect(m_filterHiDown, &QPushButton::clicked, this, [this] {
+            if (!m_slice) return;
+            int newHi = qMax(m_slice->filterLow() + FILTER_STEP_HZ,
+                             m_slice->filterHigh() - FILTER_STEP_HZ);
+            m_slice->setFilterWidth(m_slice->filterLow(), newHi);
+        });
+        highRow->addWidget(m_filterHiDown);
+
+        m_filterHiLabel = new QLabel("2700");
+        m_filterHiLabel->setFixedWidth(46);
+        m_filterHiLabel->setAlignment(Qt::AlignCenter);
+        m_filterHiLabel->setStyleSheet(
+            "QLabel { font-size: 10px; color: #c8d8e8; background: #0a0a18; "
+            "border: 1px solid #1e2e3e; border-radius: 3px; padding: 1px 3px; }");
+        highRow->addWidget(m_filterHiLabel);
+
+        m_filterHiUp = mkRight();
+        connect(m_filterHiUp, &QPushButton::clicked, this, [this] {
+            if (!m_slice) return;
+            m_slice->setFilterWidth(m_slice->filterLow(),
+                                    m_slice->filterHigh() + FILTER_STEP_HZ);
+        });
+        highRow->addWidget(m_filterHiUp);
+
+        highCol->addLayout(highRow);
+        grid->addLayout(highCol);
+
+        leftCol->addWidget(m_filterCutContainer);
+    }
+
     // FM duplex/repeater controls (hidden by default, shown for FM modes)
     {
         m_fmContainer = new QWidget;
@@ -1250,9 +1342,13 @@ void RxApplet::connectSlice(SliceModel* s)
 
     // ── Filter ─────────────────────────────────────────────────────────────
     updateFilterButtons();
+    m_filterLoLabel->setText(QString::number(s->filterLow()));
+    m_filterHiLabel->setText(QString::number(s->filterHigh()));
     connect(s, &SliceModel::filterChanged, this, [this](int lo, int hi) {
         updateFilterButtons();
         m_filterWidthLbl->setText(formatFilterWidth(lo, hi));
+        m_filterLoLabel->setText(QString::number(lo));
+        m_filterHiLabel->setText(QString::number(hi));
     });
 
     // AGC mode
@@ -1546,6 +1642,7 @@ void RxApplet::updateModeSettings(const QString& mode)
     m_filterWidths = settings.filterWidths;
     rebuildFilterButtons();
     m_filterContainer->setVisible(!m_filterWidths.isEmpty() && !isFM);
+    m_filterCutContainer->setVisible(!isFM);
 
     // Show/hide FM vs SSB/CW controls
     m_fmContainer->setVisible(isFM);

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -117,6 +117,16 @@ private:
     QGridLayout*            m_filterGrid{nullptr};
     QWidget*                m_filterContainer{nullptr};
 
+    // Filter Lo/Hi cut controls (arbitrary bandwidth entry)
+    QWidget*     m_filterCutContainer{nullptr};
+    QPushButton* m_filterLoDown{nullptr};
+    QLabel*      m_filterLoLabel{nullptr};
+    QPushButton* m_filterLoUp{nullptr};
+    QPushButton* m_filterHiDown{nullptr};
+    QLabel*      m_filterHiLabel{nullptr};
+    QPushButton* m_filterHiUp{nullptr};
+    static constexpr int FILTER_STEP_HZ = 50;
+
     // FM duplex/repeater controls (shown only in FM/NFM/DFM modes)
     QWidget*        m_fmContainer{nullptr};
     QComboBox*      m_toneModeCmb{nullptr};


### PR DESCRIPTION
## Summary

Adds direct numeric **Low Cut / High Cut** filter edge controls to the RX applet panel, giving users the ability to set arbitrary RX bandwidth and shape asymmetric filters without dragging edges on the spectrum display.

### Problem

The RX applet currently only offers fixed filter width presets (e.g. 1.8K, 2.1K, 2.7K). While filter edges can be dragged on the spectrum widget, there is no way to enter precise filter values numerically. Users need fine control over individual filter edges for:
- Rejecting hum by raising the low cut (e.g. USB with 200 Hz low cut)
- Narrowing bandwidth for weak signal work with non-standard widths
- Matching filter settings from other clients or station logs

### Solution

Two-column control matching the existing PhoneApplet TX filter pattern:

```
  Low Cut          High Cut
  [<] [  0 ] [>]   [<] [2700] [>]
```

- **50 Hz step** per button click (same granularity as PhoneApplet TX filter)
- **Bounds enforcement**: minimum 50 Hz gap between low and high edges
- **Real-time sync**: labels update from radio via existing `SliceModel::filterChanged` signal — changes from spectrum drag, filter presets, or other clients are reflected immediately
- **Mode-aware visibility**: hidden in FM modes (same as filter preset buttons)
- **No model changes**: uses existing `SliceModel::setFilterWidth(lo, hi)` which sends the standard `filt <id> <lo> <hi>` FlexAPI command

### Files Changed

| File | Change |
|------|--------|
| `src/gui/RxApplet.h` | Add 7 member variables + `FILTER_STEP_HZ` constant |
| `src/gui/RxApplet.cpp` | Add filter cut UI in `buildUI()`, sync in `connectSlice()`, hide in `updateModeSettings()` |

### Design Decisions

- **Placed below filter presets**: presets remain as quick-select shortcuts; Lo/Hi controls give fine-grained override
- **Reuses existing `TriBtn`**: same `< >` arrow button widget used by step size, RIT/XIT
- **No new model API**: the combined `setFilterWidth(lo, hi)` is correct per FlexAPI (`filt` command always sets both edges)

## Test Plan

- [ ] Connect to radio — verify Lo/Hi labels show actual filter values from radio
- [ ] Click `>` on High Cut — verify filter widens by 50 Hz, spectrum passband updates
- [ ] Click `>` on Low Cut — verify low edge moves up, passband narrows from the left
- [ ] Verify 50 Hz minimum gap: clicking Low Cut `>` when lo is near hi should stop
- [ ] Switch to LSB — verify labels show negative values (e.g. -2700, 0)
- [ ] Switch to FM — verify Lo/Hi controls are hidden
- [ ] Use a filter preset button — verify Lo/Hi labels update to match
- [ ] Drag filter edge on spectrum — verify Lo/Hi labels update in real time
- [ ] Change filter from Maestro/SmartSDR — verify AetherSDR labels sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)