### PR TITLE
Add visual filter passband widget, remove RxApplet DSP buttons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,7 @@ set(GUI_SOURCES
     src/gui/PanLayoutDialog.cpp
     src/gui/AppletPanel.cpp
     src/gui/RxApplet.cpp
+    src/gui/FilterPassbandWidget.cpp
     src/gui/SMeterWidget.cpp
     src/gui/TunerApplet.cpp
     src/gui/TxApplet.cpp

--- a/src/gui/FilterPassbandWidget.cpp
+++ b/src/gui/FilterPassbandWidget.cpp
@@ -1,0 +1,162 @@
+#include "FilterPassbandWidget.h"
+
+#include <QPainterPath>
+#include <QFontMetrics>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+FilterPassbandWidget::FilterPassbandWidget(QWidget* parent)
+    : QWidget(parent)
+{
+    setMinimumSize(minimumSizeHint());
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    setMouseTracking(true);
+    setCursor(Qt::SizeAllCursor);
+}
+
+void FilterPassbandWidget::setFilter(int lo, int hi)
+{
+    if (lo == m_lo && hi == m_hi) return;
+    m_lo = lo;
+    m_hi = hi;
+    update();
+}
+
+void FilterPassbandWidget::setMode(const QString& mode)
+{
+    if (mode == m_mode) return;
+    m_mode = mode;
+    update();
+}
+
+// ─── Paint ──────────────────────────────────────────────────────────────────
+
+void FilterPassbandWidget::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+
+    const int w = width();
+    const int h = height();
+
+    // Background
+    p.fillRect(rect(), QColor(0x0a, 0x0a, 0x18));
+
+    // Border
+    p.setPen(QColor(0x20, 0x30, 0x40));
+    p.drawRect(0, 0, w - 1, h - 1);
+
+    // ── Static trapezoid shape ──────────────────────────────────────────
+    // Fixed geometry — shape doesn't change with filter width
+    const int margin = 16;
+    const int topY = 14;
+    const int botY = h - 16;  // room for labels
+    const int loX = margin;
+    const int hiX = w - margin;
+    constexpr int SKIRT = 16;
+
+    // Filter shape: left skirt, flat top, right skirt (no bottom, no fill)
+    p.setPen(QPen(QColor(0x00, 0xb4, 0xd8), 1.5));
+    p.drawLine(loX, botY, loX + SKIRT, topY);          // left skirt
+    p.drawLine(loX + SKIRT, topY, hiX - SKIRT, topY);  // flat top
+    p.drawLine(hiX - SKIRT, topY, hiX, botY);           // right skirt
+
+    // Dashed vertical lines at filter edges (8px inside the skirt vertices)
+    p.setPen(QPen(QColor(0x00, 0xb4, 0xd8, 120), 1, Qt::DashLine));
+    p.drawLine(loX + SKIRT + 8, 2, loX + SKIRT + 8, h - 2);
+    p.drawLine(hiX - SKIRT - 8, 2, hiX - SKIRT - 8, h - 2);
+
+    // ── Labels ──────────────────────────────────────────────────────────
+    QFont font = p.font();
+    font.setPixelSize(10);
+    p.setFont(font);
+    const QFontMetrics fm(font);
+
+    // Bandwidth label (centered at bottom)
+    int bw = std::abs(m_hi - m_lo);
+    QString bwText = bw >= 1000 ? QString("%1.%2K").arg(bw / 1000).arg((bw % 1000) / 100)
+                                : QString::number(bw);
+    p.setPen(QColor(0xc8, 0xd8, 0xe8));
+    p.drawText((loX + hiX) / 2 - fm.horizontalAdvance(bwText) / 2, botY + 12, bwText);
+
+    // Passband center offset (distance from carrier to filter center, below top line)
+    int center = (m_lo + m_hi) / 2;
+    QString centerText = std::abs(center) >= 1000
+        ? QString("%1.%2K").arg(std::abs(center) / 1000).arg((std::abs(center) % 1000) / 100)
+        : QString::number(std::abs(center));
+    p.setPen(QColor(0x90, 0xa0, 0xb0));
+    p.drawText((loX + hiX) / 2 - fm.horizontalAdvance(centerText) / 2, topY + 12, centerText);
+
+    // Lo label (centered on left slant bottom point)
+    QString loText = QString::number(std::abs(m_lo));
+    p.setPen(QColor(0x80, 0x90, 0xa0));
+    p.drawText(loX - fm.horizontalAdvance(loText) / 2, botY + 12, loText);
+
+    // Hi label (centered on right slant bottom point)
+    QString hiText = QString::number(std::abs(m_hi));
+    p.drawText(hiX - fm.horizontalAdvance(hiText) / 2, botY + 12, hiText);
+}
+
+// ─── Mouse interaction ──────────────────────────────────────────────────────
+
+void FilterPassbandWidget::mousePressEvent(QMouseEvent* ev)
+{
+    if (ev->button() != Qt::LeftButton) return;
+    m_dragging = true;
+    m_dragStartPos = ev->pos();
+    m_dragStartLo = m_lo;
+    m_dragStartHi = m_hi;
+}
+
+void FilterPassbandWidget::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (!m_dragging) return;
+
+    const int dx = ev->pos().x() - m_dragStartPos.x();
+    const int dy = ev->pos().y() - m_dragStartPos.y();
+
+    // Horizontal drag: move both filter edges (shift passband)
+    // Vertical drag: expand/contract bandwidth symmetrically
+    // Scale: full widget width = ~6000 Hz shift, full height = ~4000 Hz BW change
+    const int usableW = width() - 32;
+    const int usableH = height();
+    const double hzPerPxH = 6000.0 / std::max(usableW, 1);
+    const double hzPerPxV = 4000.0 / std::max(usableH, 1);
+
+    int shiftHz = static_cast<int>(dx * hzPerPxH);
+    int bwChange = static_cast<int>(-dy * hzPerPxV);  // drag up = wider
+
+    // Snap to 50 Hz
+    shiftHz = (shiftHz / 50) * 50;
+    bwChange = (bwChange / 50) * 50;
+
+    int newLo = m_dragStartLo + shiftHz - bwChange / 2;
+    int newHi = m_dragStartHi + shiftHz + bwChange / 2;
+
+    // Enforce minimum bandwidth
+    if (newHi - newLo < MIN_BW) {
+        int center = (newLo + newHi) / 2;
+        newLo = center - MIN_BW / 2;
+        newHi = center + MIN_BW / 2;
+    }
+
+    // Snap to 50 Hz grid
+    newLo = (newLo / 50) * 50;
+    newHi = (newHi / 50) * 50;
+
+    if (newLo != m_lo || newHi != m_hi) {
+        m_lo = newLo;
+        m_hi = newHi;
+        update();
+        emit filterChanged(m_lo, m_hi);
+    }
+}
+
+void FilterPassbandWidget::mouseReleaseEvent(QMouseEvent*)
+{
+    m_dragging = false;
+}
+
+} // namespace AetherSDR

--- a/src/gui/FilterPassbandWidget.h
+++ b/src/gui/FilterPassbandWidget.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <QWidget>
+#include <QPainter>
+#include <QMouseEvent>
+
+namespace AetherSDR {
+
+// Visual filter passband display with drag-to-adjust interaction.
+// Static trapezoid shape with numeric lo/hi/bandwidth labels.
+// Horizontal drag shifts the passband, vertical drag adjusts width.
+// Matches SmartSDR's RX panel filter widget behavior.
+class FilterPassbandWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit FilterPassbandWidget(QWidget* parent = nullptr);
+
+    void setFilter(int lo, int hi);
+    void setMode(const QString& mode);
+
+    int filterLo() const { return m_lo; }
+    int filterHi() const { return m_hi; }
+
+    QSize minimumSizeHint() const override { return {120, 36}; }
+    QSize sizeHint() const override { return {200, 60}; }
+
+signals:
+    void filterChanged(int lo, int hi);
+
+protected:
+    void paintEvent(QPaintEvent*) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseMoveEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
+
+private:
+    int m_lo{100};
+    int m_hi{2800};
+    QString m_mode{"USB"};
+
+    bool m_dragging{false};
+    QPoint m_dragStartPos;
+    int m_dragStartLo{0};
+    int m_dragStartHi{0};
+
+    static constexpr int MIN_BW = 50;
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -934,43 +934,8 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_audio, &AudioEngine::nr2EnabledChanged, this, syncNr2);
     connect(m_audio, &AudioEngine::rn2EnabledChanged, this, syncRn2);
     connect(m_audio, &AudioEngine::bnrEnabledChanged, this, syncBnr);
-    // NR2/RN2 overlay sync is wired in wirePanadapter()
-    // RxApplet NR button 3-state cycle → NR2 enable/disable (#329)
-    connect(m_appletPanel->rxApplet(), &RxApplet::nr2CycleToggled,
-            this, [this](bool on) {
-        if (on)
-            enableNr2WithWisdom();
-        else
-            QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setNr2Enabled(false); });
-    });
-    // Sync RxApplet NR button visual when NR2 state changes
-    connect(m_audio, &AudioEngine::nr2EnabledChanged,
-            this, [this](bool on) {
-        auto* rx = m_appletPanel->rxApplet();
-        if (on) {
-            if (auto* s = activeSlice(); s && s->nrOn())
-                s->setNr(false);
-            rx->setNrState(2);
-        } else if (rx->nrState() == 2) {
-            rx->setNrState(0);
-        }
-    });
-
-    // ── RxApplet RNN 3-state cycle → RN2 enable/disable ────────────────────
-    connect(m_appletPanel->rxApplet(), &RxApplet::rn2CycleToggled,
-            this, [this](bool on) {
-        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setRn2Enabled(on); });
-    });
-    // Sync RxApplet RNN button visual when RN2 state changes
-    connect(m_audio, &AudioEngine::rn2EnabledChanged,
-            this, [this](bool on) {
-        auto* rx = m_appletPanel->rxApplet();
-        if (on) {
-            rx->setRnnState(2);
-        } else if (rx->rnnState() == 2) {
-            rx->setRnnState(0);
-        }
-    });
+    // NR2/RN2/BNR DSP controls now only in VFO DSP tab and spectrum overlay.
+    // RxApplet DSP buttons removed — no sync wiring needed.
 
 #ifdef HAVE_RADE
     connect(m_appletPanel->rxApplet(), &RxApplet::radeActivated,

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1,4 +1,5 @@
 #include "RxApplet.h"
+#include "FilterPassbandWidget.h"
 #include "ComboStyle.h"
 #include "SliceColors.h"
 #include "models/SliceModel.h"
@@ -491,6 +492,18 @@ void RxApplet::buildUI()
         leftCol->addWidget(m_filterContainer);
     }
 
+    // Visual filter passband widget (draggable lo/hi edges)
+    {
+        m_filterPassband = new AetherSDR::FilterPassbandWidget;
+        m_filterPassband->setMinimumHeight(40);
+        m_filterPassband->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        connect(m_filterPassband, &AetherSDR::FilterPassbandWidget::filterChanged,
+                this, [this](int lo, int hi) {
+            if (m_slice) m_slice->setFilterWidth(lo, hi);
+        });
+        leftCol->addWidget(m_filterPassband);
+    }
+
     // FM duplex/repeater controls (hidden by default, shown for FM modes)
     {
         m_fmContainer = new QWidget;
@@ -621,153 +634,8 @@ void RxApplet::buildUI()
         leftCol->addWidget(m_fmContainer);
     }
 
-    // DSP toggles (wrapped in container for FM hide)
-    {
-        m_dspContainer = new QWidget;
-        auto* dspLayout = new QVBoxLayout(m_dspContainer);
-        dspLayout->setContentsMargins(0, 0, 0, 0);
-        dspLayout->setSpacing(2);
+    // DSP toggles removed — use VFO DSP tab or spectrum overlay instead
 
-        // NB / NR / ANF
-        {
-            auto* row = new QHBoxLayout;
-            row->setSpacing(2);
-
-            m_nbBtn  = mkToggle("NB");
-            m_nrBtn  = mkToggle("NR");
-            m_anfBtn = mkToggle("ANF");
-
-            for (auto* b : {m_nbBtn, m_nrBtn, m_anfBtn})
-                b->setStyleSheet(QString(kButtonBase) + kGreenActive);
-
-            // NR button: 3-state cycle (Off → NR → NR2 → Off)
-            // Make it non-checkable so we control the visual state manually
-            m_nrBtn->setCheckable(false);
-            connect(m_nrBtn, &QPushButton::clicked, this, [this]() {
-                if (!m_slice) return;
-                if (m_nrState == 0) {
-                    // Off → NR on
-                    m_nrState = 1;
-                    m_slice->setNr(true);
-                    m_nrBtn->setText("NR");
-                    m_nrBtn->setStyleSheet(QString(kButtonBase) + kGreenActive
-                        + "QPushButton { background: #1a6030; color: #ffffff;"
-                        " border: 1px solid #20a040; }");
-                } else if (m_nrState == 1) {
-                    // NR on → disable NR, enable NR2
-                    m_nrState = 2;
-                    m_slice->setNr(false);
-                    m_nrBtn->setText("NR2");
-                    emit nr2CycleToggled(true);
-                } else {
-                    // NR2 on → Off
-                    m_nrState = 0;
-                    m_nrBtn->setText("NR");
-                    m_nrBtn->setStyleSheet(QString(kButtonBase) + kGreenActive);
-                    emit nr2CycleToggled(false);
-                }
-            });
-
-            connect(m_nbBtn,  &QPushButton::toggled, this, [this](bool on) {
-                if (m_slice) m_slice->setNb(on);
-            });
-            connect(m_anfBtn, &QPushButton::toggled, this, [this](bool on) {
-                if (m_slice) m_slice->setAnf(on);
-            });
-
-            row->addWidget(m_nbBtn);
-            row->addWidget(m_nrBtn);
-            row->addWidget(m_anfBtn);
-            dspLayout->addLayout(row);
-        }
-
-        // NRL / NRS / RNN
-        {
-            auto* row = new QHBoxLayout;
-            row->setSpacing(2);
-
-            m_nrlBtn = mkToggle("NRL");
-            m_nrsBtn = mkToggle("NRS");
-            m_rnnBtn = mkToggle("RNN");
-
-            for (auto* b : {m_nrlBtn, m_nrsBtn, m_rnnBtn})
-                b->setStyleSheet(QString(kButtonBase) + kGreenActive);
-
-            connect(m_nrlBtn, &QPushButton::toggled, this, [this](bool on) {
-                if (m_slice) m_slice->setNrl(on);
-            });
-            connect(m_nrsBtn, &QPushButton::toggled, this, [this](bool on) {
-                if (m_slice) m_slice->setNrs(on);
-            });
-
-            // RNN button: 3-state cycle (Off → RNN radio → RN2 client → Off)
-            m_rnnBtn->setCheckable(false);
-            connect(m_rnnBtn, &QPushButton::clicked, this, [this]() {
-                if (!m_slice) return;
-                if (m_rnnState == 0) {
-                    // Off → RNN on (radio-side)
-                    m_rnnState = 1;
-                    m_slice->setRnn(true);
-                    m_rnnBtn->setText("RNN");
-                    m_rnnBtn->setStyleSheet(QString(kButtonBase) + kGreenActive
-                        + "QPushButton { background: #1a6030; color: #ffffff;"
-                        " border: 1px solid #20a040; }");
-                } else if (m_rnnState == 1) {
-                    // RNN on → disable RNN, enable RN2
-                    m_rnnState = 2;
-                    m_slice->setRnn(false);
-                    m_rnnBtn->setText("RN2");
-                    m_rnnBtn->setStyleSheet(QString(kButtonBase) + kGreenActive
-                        + "QPushButton { background: #1a6030; color: #ffffff;"
-                        " border: 1px solid #20a040; }");
-                    emit rn2CycleToggled(true);
-                } else {
-                    // RN2 on → Off
-                    m_rnnState = 0;
-                    m_rnnBtn->setText("RNN");
-                    m_rnnBtn->setStyleSheet(QString(kButtonBase) + kGreenActive);
-                    emit rn2CycleToggled(false);
-                }
-            });
-
-            row->addWidget(m_nrlBtn);
-            row->addWidget(m_nrsBtn);
-            row->addWidget(m_rnnBtn);
-            dspLayout->addLayout(row);
-        }
-
-        // NRF / ANFL / ANFT
-        {
-            auto* row = new QHBoxLayout;
-            row->setSpacing(2);
-
-            m_nrfBtn  = mkToggle("NRF");
-            m_anflBtn = mkToggle("ANFL");
-            m_anftBtn = mkToggle("ANFT");
-
-            for (auto* b : {m_nrfBtn, m_anflBtn, m_anftBtn})
-                b->setStyleSheet(QString(kButtonBase) + kGreenActive);
-
-            connect(m_nrfBtn, &QPushButton::toggled, this, [this](bool on) {
-                if (m_slice) m_slice->setNrf(on);
-            });
-            connect(m_anflBtn, &QPushButton::toggled, this, [this](bool on) {
-                if (m_slice) m_slice->setAnfl(on);
-            });
-            connect(m_anftBtn, &QPushButton::toggled, this, [this](bool on) {
-                if (m_slice) m_slice->setAnft(on);
-            });
-
-            row->addWidget(m_nrfBtn);
-            row->addWidget(m_anflBtn);
-            row->addWidget(m_anftBtn);
-            dspLayout->addLayout(row);
-        }
-
-        leftCol->addWidget(m_dspContainer);
-    }
-
-    leftCol->addStretch(1);
     columns->addLayout(leftCol, 2);  // 40%
 
     // ── Right column (40%) ───────────────────────────────────────────────
@@ -998,91 +866,7 @@ void RxApplet::buildUI()
 
 // ─── NR button 3-state sync ──────────────────────────────────────────────────
 
-void RxApplet::syncNrButton(bool nrOn)
-{
-    static const QString kOn =
-        "QPushButton { background: #1a6030; color: #ffffff;"
-        " border: 1px solid #20a040; border-radius: 2px;"
-        " font-size: 10px; font-weight: bold; padding: 1px 4px; }";
-    static const QString kOff = QString(kButtonBase) + kGreenActive;
-
-    if (nrOn) {
-        m_nrState = 1;
-        m_nrBtn->setText("NR");
-        m_nrBtn->setStyleSheet(kOn);
-    } else if (m_nrState == 1) {
-        // NR turned off externally (not via our cycle) — go to off
-        m_nrState = 0;
-        m_nrBtn->setText("NR");
-        m_nrBtn->setStyleSheet(kOff);
-    }
-    // If m_nrState == 2 (NR2), don't change — NR2 is client-side
-}
-
-// ─── RNN button 3-state sync ─────────────────────────────────────────────────
-
-void RxApplet::syncRnnButton(bool rnnOn)
-{
-    static const QString kOn =
-        "QPushButton { background: #1a6030; color: #ffffff;"
-        " border: 1px solid #20a040; border-radius: 2px;"
-        " font-size: 10px; font-weight: bold; padding: 1px 4px; }";
-    static const QString kOff = QString(kButtonBase) + kGreenActive;
-
-    if (rnnOn) {
-        m_rnnState = 1;
-        m_rnnBtn->setText("RNN");
-        m_rnnBtn->setStyleSheet(kOn);
-    } else if (m_rnnState == 1) {
-        // RNN turned off externally — go to off
-        m_rnnState = 0;
-        m_rnnBtn->setText("RNN");
-        m_rnnBtn->setStyleSheet(kOff);
-    }
-    // If m_rnnState == 2 (RN2), don't change — RN2 is client-side
-}
-
-void RxApplet::setNrState(int state)
-{
-    static const QString kOn =
-        "QPushButton { background: #1a6030; color: #ffffff;"
-        " border: 1px solid #20a040; border-radius: 2px;"
-        " font-size: 10px; font-weight: bold; padding: 1px 4px; }";
-    static const QString kOff = QString(kButtonBase) + kGreenActive;
-
-    m_nrState = state;
-    if (state == 0) {
-        m_nrBtn->setText("NR");
-        m_nrBtn->setStyleSheet(kOff);
-    } else if (state == 1) {
-        m_nrBtn->setText("NR");
-        m_nrBtn->setStyleSheet(kOn);
-    } else {
-        m_nrBtn->setText("NR2");
-        m_nrBtn->setStyleSheet(kOn);
-    }
-}
-
-void RxApplet::setRnnState(int state)
-{
-    static const QString kOn =
-        "QPushButton { background: #1a6030; color: #ffffff;"
-        " border: 1px solid #20a040; border-radius: 2px;"
-        " font-size: 10px; font-weight: bold; padding: 1px 4px; }";
-    static const QString kOff = QString(kButtonBase) + kGreenActive;
-
-    m_rnnState = state;
-    if (state == 0) {
-        m_rnnBtn->setText("RNN");
-        m_rnnBtn->setStyleSheet(kOff);
-    } else if (state == 1) {
-        m_rnnBtn->setText("RNN");
-        m_rnnBtn->setStyleSheet(kOn);
-    } else {
-        m_rnnBtn->setText("RN2");
-        m_rnnBtn->setStyleSheet(kOn);
-    }
-}
+// DSP sync functions removed — VFO DSP tab and spectrum overlay handle all DSP state
 
 void RxApplet::setAfGain(int pct)
 {
@@ -1250,9 +1034,15 @@ void RxApplet::connectSlice(SliceModel* s)
 
     // ── Filter ─────────────────────────────────────────────────────────────
     updateFilterButtons();
+    m_filterPassband->setFilter(s->filterLow(), s->filterHigh());
+    m_filterPassband->setMode(s->mode());
     connect(s, &SliceModel::filterChanged, this, [this](int lo, int hi) {
         updateFilterButtons();
         m_filterWidthLbl->setText(formatFilterWidth(lo, hi));
+        m_filterPassband->setFilter(lo, hi);
+    });
+    connect(s, &SliceModel::modeChanged, this, [this](const QString& mode) {
+        m_filterPassband->setMode(mode);
     });
 
     // AGC mode
@@ -1320,54 +1110,7 @@ void RxApplet::connectSlice(SliceModel* s)
         m_sqlSlider->setValue(level);
     });
 
-    // DSP toggles
-    {
-        QSignalBlocker b1(m_nbBtn), b3(m_anfBtn);
-        m_nbBtn->setChecked(s->nbOn());
-        m_anfBtn->setChecked(s->anfOn());
-        // Sync NR button visual state
-        syncNrButton(s->nrOn());
-    }
-    connect(s, &SliceModel::nbChanged,  this, [this](bool on) {
-        QSignalBlocker b(m_nbBtn);  m_nbBtn->setChecked(on);
-    });
-    connect(s, &SliceModel::nrChanged,  this, [this](bool on) {
-        syncNrButton(on);
-    });
-    connect(s, &SliceModel::anfChanged, this, [this](bool on) {
-        QSignalBlocker b(m_anfBtn); m_anfBtn->setChecked(on);
-    });
-
-    // DSP toggles row 2 & 3
-    {
-        QSignalBlocker b1(m_nrlBtn), b2(m_nrsBtn),
-                       b4(m_nrfBtn), b5(m_anflBtn), b6(m_anftBtn);
-        m_nrlBtn->setChecked(s->nrlOn());
-        m_nrsBtn->setChecked(s->nrsOn());
-        m_nrfBtn->setChecked(s->nrfOn());
-        m_anflBtn->setChecked(s->anflOn());
-        m_anftBtn->setChecked(s->anftOn());
-        // Sync RNN visual state (non-checkable 3-state button)
-        syncRnnButton(s->rnnOn());
-    }
-    connect(s, &SliceModel::nrlChanged, this, [this](bool on) {
-        QSignalBlocker b(m_nrlBtn); m_nrlBtn->setChecked(on);
-    });
-    connect(s, &SliceModel::nrsChanged, this, [this](bool on) {
-        QSignalBlocker b(m_nrsBtn); m_nrsBtn->setChecked(on);
-    });
-    connect(s, &SliceModel::rnnChanged, this, [this](bool on) {
-        syncRnnButton(on);
-    });
-    connect(s, &SliceModel::nrfChanged, this, [this](bool on) {
-        QSignalBlocker b(m_nrfBtn); m_nrfBtn->setChecked(on);
-    });
-    connect(s, &SliceModel::anflChanged, this, [this](bool on) {
-        QSignalBlocker b(m_anflBtn); m_anflBtn->setChecked(on);
-    });
-    connect(s, &SliceModel::anftChanged, this, [this](bool on) {
-        QSignalBlocker b(m_anftBtn); m_anftBtn->setChecked(on);
-    });
+    // DSP toggles removed — use VFO DSP tab or spectrum overlay
 
     // RIT
     {
@@ -1549,7 +1292,6 @@ void RxApplet::updateModeSettings(const QString& mode)
 
     // Show/hide FM vs SSB/CW controls
     m_fmContainer->setVisible(isFM);
-    m_dspContainer->setVisible(!isFM);
     m_agcContainer->setVisible(!isFM);
     m_ritContainer->setVisible(!isFM);
     m_xitContainer->setVisible(!isFM);

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -3,6 +3,8 @@
 #include <QWidget>
 #include <QVector>
 
+namespace AetherSDR { class FilterPassbandWidget; }
+
 class QHBoxLayout;
 class QGridLayout;
 class QPushButton;
@@ -53,10 +55,6 @@ signals:
     void afGainChanged(int value);
     // Emitted when the user changes the tuning step size (Hz).
     void stepSizeChanged(int hz);
-    // Emitted when NR button cycles to/from NR2 state
-    void nr2CycleToggled(bool on);
-    // Emitted when RNN button cycles to/from RN2 (client RNNoise) state
-    void rn2CycleToggled(bool on);
 
 #ifdef HAVE_RADE
     // Emitted when user selects/deselects RADE digital voice mode
@@ -116,6 +114,7 @@ private:
     QVector<QPushButton*>   m_filterBtns;
     QGridLayout*            m_filterGrid{nullptr};
     QWidget*                m_filterContainer{nullptr};
+    AetherSDR::FilterPassbandWidget* m_filterPassband{nullptr};
 
     // FM duplex/repeater controls (shown only in FM/NFM/DFM modes)
     QWidget*        m_fmContainer{nullptr};
@@ -128,7 +127,6 @@ private:
     QPushButton*    m_revBtn{nullptr};
 
     // Containers for show/hide on mode change
-    QWidget*     m_dspContainer{nullptr};
     QWidget*     m_agcContainer{nullptr};
     QWidget*     m_ritContainer{nullptr};
     QWidget*     m_xitContainer{nullptr};
@@ -148,26 +146,6 @@ private:
     QSlider*     m_sqlSlider{nullptr};
     bool         m_savedSquelchOn{false};
 
-    // DSP
-    QPushButton* m_nbBtn{nullptr};
-    QPushButton* m_nrBtn{nullptr};
-    int m_nrState{0};   // 0=off, 1=NR, 2=NR2
-    void syncNrButton(bool nrOn);
-    void syncRnnButton(bool rnnOn);
-public:
-    int nrState() const { return m_nrState; }
-    void setNrState(int state);
-    void setRnnState(int state);
-    int  rnnState() const { return m_rnnState; }
-private:
-    QPushButton* m_anfBtn{nullptr};
-    QPushButton* m_nrlBtn{nullptr};
-    QPushButton* m_nrsBtn{nullptr};
-    QPushButton* m_rnnBtn{nullptr};
-    int m_rnnState{0};   // 0=off, 1=RNN(radio), 2=RN2(client)
-    QPushButton* m_nrfBtn{nullptr};
-    QPushButton* m_anflBtn{nullptr};
-    QPushButton* m_anftBtn{nullptr};
 
     // RIT
     QPushButton* m_ritOnBtn{nullptr};


### PR DESCRIPTION
FilterPassbandWidget: SmartSDR-style filter control in RX applet
- Static trapezoid shape with draggable interaction
- Horizontal drag shifts passband, vertical adjusts width
- 4 numeric labels: lo, hi, bandwidth, center offset from carrier
- 50 Hz snap grid, minimum 50 Hz bandwidth

Remove DSP toggles from RxApplet:
- 9 buttons removed (NB/NR/ANF/NRL/NRS/RNN/NRF/ANFL/ANFT)
- 27 sync points eliminated between RxApplet ↔ VfoWidget ↔ overlay
- DSP controls remain in VFO DSP tab and spectrum overlay menu
- Eliminates triple-state tracking bugs (NR/NR2, RNN/RN2)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
