### PR TITLE
Fix disconnect crash: PanadapterStream::stop() from wrong thread (#561)

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1039,7 +1039,9 @@ void RadioModel::onDisconnected()
     m_headphoneGain = 50;
 
     stopNetworkMonitor();
-    m_panStream->stop();
+    // stop() must run on the network thread (socket lives there). (#561)
+    QMetaObject::invokeMethod(m_panStream, &PanadapterStream::stop,
+                              Qt::BlockingQueuedConnection);
     m_panStream->clearRegisteredStreams();
     // Clean up panadapter models
     qDeleteAll(m_panadapters);


### PR DESCRIPTION
onDisconnected() called m_panStream->stop() directly from the main
thread, but the socket lives on the network thread. On macOS this
corrupts the socket notifier and crashes. Use BlockingQueuedConnection
to ensure stop() runs on the network thread.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
