### PR TITLE
Fix VITA-49 not resuming after reconnect (#561)

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -693,17 +693,16 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
             }
         });
 
-        if (!m_panStream->isRunning()) {
-            // Start on network thread (socket must be created there) (#502)
-            if (m_wanConn) {
-                QMetaObject::invokeMethod(m_panStream, [this]() {
-                    m_panStream->startWan(QHostAddress(m_wanPublicIp), m_wanUdpPort);
-                }, Qt::BlockingQueuedConnection);
-            } else {
-                QMetaObject::invokeMethod(m_panStream, [this]() {
-                    m_panStream->start(m_connection);
-                }, Qt::BlockingQueuedConnection);
-            }
+        // Always (re)start on connect — re-binds socket and re-registers
+        // UDP port with the radio. start() calls stop() internally if needed. (#561)
+        if (m_wanConn) {
+            QMetaObject::invokeMethod(m_panStream, [this]() {
+                m_panStream->startWan(QHostAddress(m_wanPublicIp), m_wanUdpPort);
+            }, Qt::BlockingQueuedConnection);
+        } else {
+            QMetaObject::invokeMethod(m_panStream, [this]() {
+                m_panStream->start(m_connection);
+            }, Qt::BlockingQueuedConnection);
         }
 
         // On WAN: use "client udp_register" via UDP (not TCP "client udpport").


### PR DESCRIPTION
On reconnect, start() was skipped because isRunning() returned true
(socket still bound from previous session). The radio had dropped our
UDP registration but we never re-registered. Always call start() on
connect — it calls stop() internally to close and rebind the socket.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
