### PR TITLE
Add TGXL 3x1 antenna switch controls to Tuner Applet

### DIFF
--- a/src/core/TgxlConnection.h
+++ b/src/core/TgxlConnection.h
@@ -34,6 +34,9 @@ public:
     // Manual relay adjustment: relay 0=C1, 1=L, 2=C2; direction +1 or -1
     void adjustRelay(int relay, int direction);
 
+    // Send an arbitrary command to the TGXL (e.g. "activate ant=2")
+    quint32 sendCommand(const QString& cmd);
+
 signals:
     void connected();
     void disconnected();
@@ -49,7 +52,6 @@ private slots:
 
 private:
     void processLine(const QString& line);
-    quint32 sendCommand(const QString& cmd);
 
     QTcpSocket m_socket;
     QTimer     m_pollTimer;       // 1/sec status poll

--- a/src/gui/TunerApplet.cpp
+++ b/src/gui/TunerApplet.cpp
@@ -109,6 +109,46 @@ void TunerApplet::buildUI()
     bottomRow->addLayout(btnCol, 3);  // stretch 3 (30%)
 
     vbox->addLayout(bottomRow);
+
+    // Antenna switch row (TGXL 3x1) — hidden until direct connection active
+    {
+        m_antContainer = new QWidget;
+        m_antContainer->setVisible(false);
+        auto* antRow = new QHBoxLayout(m_antContainer);
+        antRow->setContentsMargins(0, 0, 0, 0);
+        antRow->setSpacing(2);
+
+        auto makeAntBtn = [](const QString& text) {
+            auto* btn = new QPushButton(text);
+            btn->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+            btn->setFixedHeight(22);
+            btn->setStyleSheet(
+                "QPushButton { background: #1a2a3a; border: 1px solid #205070; "
+                "border-radius: 3px; color: #c8d8e8; font-size: 10px; font-weight: bold; }"
+                "QPushButton:hover { background: #204060; }");
+            return btn;
+        };
+
+        m_ant1Btn = makeAntBtn("ANT 1");
+        m_ant2Btn = makeAntBtn("ANT 2");
+        m_ant3Btn = makeAntBtn("ANT 3");
+        antRow->addWidget(m_ant1Btn);
+        antRow->addWidget(m_ant2Btn);
+        antRow->addWidget(m_ant3Btn);
+
+        connect(m_ant1Btn, &QPushButton::clicked, this, [this]() {
+            if (m_model) m_model->setAntennaA(1);
+        });
+        connect(m_ant2Btn, &QPushButton::clicked, this, [this]() {
+            if (m_model) m_model->setAntennaA(2);
+        });
+        connect(m_ant3Btn, &QPushButton::clicked, this, [this]() {
+            if (m_model) m_model->setAntennaA(3);
+        });
+
+        vbox->addWidget(m_antContainer);
+    }
+
     outer->addWidget(body);
 
     // TUNE button: send autotune command
@@ -147,6 +187,20 @@ void TunerApplet::setTunerModel(TunerModel* model)
     };
     connect(m_model, &TunerModel::directConnectionChanged, this, updateScrollEnabled);
     updateScrollEnabled();
+
+    // Antenna switch: show buttons only when direct connection is active AND
+    // the TGXL reports antA (models without a switch never send antA).
+    auto updateAntVisible = [this]() {
+        m_antContainer->setVisible(m_model->hasDirectConnection()
+                                   && m_model->hasAntennaSwitch());
+    };
+    connect(m_model, &TunerModel::directConnectionChanged, this, updateAntVisible);
+    connect(m_model, &TunerModel::antennaAChanged, this, [this, updateAntVisible](int antA) {
+        updateAntVisible();
+        updateAntennaButtons(antA);
+    });
+    updateAntVisible();
+    updateAntennaButtons(m_model->antennaA());
 
     // Tuning state changes → red button + SWR result flash
     connect(m_model, &TunerModel::tuningChanged, this, [this](bool tuning) {
@@ -251,6 +305,22 @@ void TunerApplet::updateMeters(float fwdPower, float swr)
             m_tuneSwr = swr;
         m_tuneBtn->setText(QString("SWR %1").arg(swr, 0, 'f', 2));
     }
+}
+
+void TunerApplet::updateAntennaButtons(int antA)
+{
+    // antA is 0-indexed: 0=ANT1, 1=ANT2, 2=ANT3
+    static constexpr const char* kDefault =
+        "QPushButton { background: #1a2a3a; border: 1px solid #205070; "
+        "border-radius: 3px; color: #c8d8e8; font-size: 10px; font-weight: bold; }"
+        "QPushButton:hover { background: #204060; }";
+    static constexpr const char* kActive =
+        "QPushButton { background: #006030; border: 1px solid #008040; "
+        "border-radius: 3px; color: #ffffff; font-size: 10px; font-weight: bold; }";
+
+    m_ant1Btn->setStyleSheet(antA == 0 ? kActive : kDefault);
+    m_ant2Btn->setStyleSheet(antA == 1 ? kActive : kDefault);
+    m_ant3Btn->setStyleSheet(antA == 2 ? kActive : kDefault);
 }
 
 } // namespace AetherSDR

--- a/src/gui/TunerApplet.h
+++ b/src/gui/TunerApplet.h
@@ -43,6 +43,7 @@ private:
     void buildUI();
     void syncFromModel();
     void cycleOperateState();
+    void updateAntennaButtons(int antA);
 
     TunerModel* m_model{nullptr};
     MeterModel* m_meter{nullptr};
@@ -59,6 +60,12 @@ private:
     // Buttons
     QPushButton* m_tuneBtn{nullptr};
     QPushButton* m_operateBtn{nullptr};
+
+    // Antenna switch buttons (TGXL 3x1)
+    QPushButton* m_ant1Btn{nullptr};
+    QPushButton* m_ant2Btn{nullptr};
+    QPushButton* m_ant3Btn{nullptr};
+    QWidget*     m_antContainer{nullptr};
 
     // Meter values (updated by updateMeters)
     float m_fwdPower{0.0f};

--- a/src/models/TunerModel.cpp
+++ b/src/models/TunerModel.cpp
@@ -60,7 +60,10 @@ void TunerModel::applyStatus(const QMap<QString, QString>& kvs)
             int v = val.toInt();
             if (m_relayL != v) { m_relayL = v; changed = true; }
         }
-        else if (key == "ip") {
+        else if (key == "antA") {
+            int v = val.toInt();
+            if (m_antennaA != v) { m_antennaA = v; changed = true; emit antennaAChanged(v); }
+        } else if (key == "ip") {
             if (m_tgxlIp != val) { m_tgxlIp = val; changed = true; }
         }
         // nickname, version, ant, dhcp, netmask, gateway, ptta, pttb
@@ -106,6 +109,17 @@ void TunerModel::autoTune()
     emit commandReady(cmd);
 }
 
+void TunerModel::setAntennaA(int ant)
+{
+    if (!m_directConn || !m_directConn->isConnected()) {
+        qCDebug(lcTuner) << "TunerModel::setAntennaA: no direct connection";
+        return;
+    }
+    if (ant < 1 || ant > 3) return;
+    qCDebug(lcTuner) << "TunerModel: activate ant=" << ant;
+    m_directConn->sendCommand(QString("activate ant=%1").arg(ant));
+}
+
 // ── Direct TGXL connection (port 9010) ──────────────────────────────────────
 
 void TunerModel::setDirectConnection(TgxlConnection* conn)
@@ -140,7 +154,23 @@ void TunerModel::setDirectConnection(TgxlConnection* conn)
                 int v = kvs.value("relayC2").toInt();
                 if (m_relayC2 != v) { m_relayC2 = v; changed = true; }
             }
+            if (kvs.contains("antA")) {
+                int v = kvs.value("antA").toInt();
+                if (m_antennaA != v) { m_antennaA = v; changed = true; emit antennaAChanged(v); }
+            }
             if (changed) emit stateChanged();
+        });
+        // Also parse antA from 1/sec status poll responses (pre-load on connect)
+        connect(m_directConn, &TgxlConnection::statusUpdated, this,
+                [this](const QMap<QString, QString>& kvs) {
+            if (kvs.contains("antA")) {
+                int v = kvs.value("antA").toInt();
+                if (m_antennaA != v) {
+                    m_antennaA = v;
+                    emit antennaAChanged(v);
+                    emit stateChanged();
+                }
+            }
         });
     }
 }

--- a/src/models/TunerModel.h
+++ b/src/models/TunerModel.h
@@ -35,6 +35,8 @@ public:
     int     relayC1()   const { return m_relayC1; }
     int     relayL()    const { return m_relayL; }
     int     relayC2()   const { return m_relayC2; }
+    int     antennaA()  const { return m_antennaA; }  // 0-indexed: 0=ANT1, 1=ANT2, 2=ANT3, -1=unknown
+    bool    hasAntennaSwitch() const { return m_antennaA >= 0; }  // true once antA reported by TGXL
     bool    isPresent() const { return !m_handle.isEmpty(); }
     bool    hasDirectConnection() const;
 
@@ -55,9 +57,13 @@ public:
     void setBypass(bool on);
     void autoTune();
 
+    // Antenna switch (TGXL 3x1): ant = 1, 2, or 3 (1-indexed for command)
+    void setAntennaA(int ant);
+
 signals:
     void stateChanged();               // any property changed
     void tuningChanged(bool tuning);   // tuning started/stopped
+    void antennaAChanged(int antA);    // antenna port changed (0-indexed)
     void presenceChanged(bool present); // tuner detected / lost
     void directConnectionChanged(bool connected);
     void commandReady(const QString& cmd);
@@ -73,6 +79,7 @@ private:
     int     m_relayC1{0};
     int     m_relayL{0};
     int     m_relayC2{0};
+    int     m_antennaA{-1};   // 0-indexed antenna port (-1 = unknown)
 
     TgxlConnection* m_directConn{nullptr};
 };


### PR DESCRIPTION
## Summary

Adds ANT 1 / ANT 2 / ANT 3 antenna switch buttons to the Tuner Genius XL applet for TGXL models with a built-in 3-position antenna switch (e.g. TGXL 3x1).

- **Protocol**: reverse-engineered from 4O3A Tuner Genius XL management app via Wireshark capture (fw 1.2.17). Command `activate ant=N` (N=1,2,3) sent over direct TGXL TCP port 9010. Status reported as `antA=N` (0-indexed) in both `S0|state` pushes and `S<seq>|status` poll responses.
- **Model detection**: buttons only appear when the TGXL reports `antA` in its status — models without an antenna switch never send this field, so buttons stay hidden automatically.
- **Pre-load**: active antenna is read from the first status poll response on connect, so the correct button illuminates green immediately.

### Files Changed

| File | Change |
|------|--------|
| `src/models/TunerModel.h` | Add `m_antennaA` member, `antennaA()` getter, `hasAntennaSwitch()`, `setAntennaA()`, `antennaAChanged` signal |
| `src/models/TunerModel.cpp` | Parse `antA` from FlexRadio status (`applyStatus`) and direct TGXL (`stateUpdated` + `statusUpdated`). Add `setAntennaA()` command via direct connection |
| `src/core/TgxlConnection.h` | Make `sendCommand()` public for `activate ant=N` command |
| `src/gui/TunerApplet.h` | Add antenna button member pointers, `updateAntennaButtons()` helper |
| `src/gui/TunerApplet.cpp` | Add 3 ANT buttons in `buildUI()`, wire `antennaAChanged` + `directConnectionChanged` signals, green highlight for active antenna matching OPERATE button style |

### TGXL Antenna Switch Protocol (fw 1.2.17)

| | Detail |
|---|---|
| **Command** | `activate ant=N` via direct TCP 9010 (N = 1, 2, 3) |
| **Response** | `R<seq>\|0\|` (success) |
| **Status key** | `antA=N` (0-indexed: 0=ANT1, 1=ANT2, 2=ANT3) |
| **Transition** | `antA` briefly passes through intermediate values during relay switching |

## Test Plan

- [x] Connect to radio with TGXL 3x1 attached — verify ANT buttons appear after direct connection established
- [x] Verify active antenna button illuminates green on connect (pre-load)
- [x] Click ANT 2 → verify antenna switches (relay click audible), button turns green
- [x] Click ANT 3 → verify switch, green highlight moves
- [x] Click ANT 1 → verify switch back
- [x] Switch antenna from 4O3A app → verify AetherSDR button highlight updates in real time
- [ ] Connect with a TGXL model WITHOUT antenna switch → verify ANT buttons do NOT appear
- [x] Disconnect/reconnect → verify buttons reappear with correct antenna pre-loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)