### PR TITLE
Add PC Audio hint to CW decode panel (#392)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2915,16 +2915,20 @@ void MainWindow::onConnectionStateChanged(bool connected)
             if (m_appletPanel && m_appletPanel->catApplet())
                 m_appletPanel->catApplet()->setPtyEnabled(true);
         }
-        // Populate XVTR bands after radio status settles
-        QTimer::singleShot(2000, this, [this] {
+        // Populate XVTR bands after radio status settles, and refresh
+        // whenever XVTR config changes (add/remove/rename). (#571)
+        auto refreshXvtr = [this]() {
             if (!m_radioModel.isConnected()) return;
             QVector<SpectrumOverlayMenu::XvtrBand> xvtrBands;
             for (const auto& x : m_radioModel.xvtrList()) {
                 if (x.isValid)
                     xvtrBands.append({x.name, x.rfFreq});
             }
-            spectrum()->overlayMenu()->setXvtrBands(xvtrBands);
-        });
+            for (auto* applet : m_panStack->allApplets())
+                applet->spectrumWidget()->overlayMenu()->setXvtrBands(xvtrBands);
+        };
+        QTimer::singleShot(2000, this, refreshXvtr);
+        connect(&m_radioModel, &RadioModel::infoChanged, this, refreshXvtr);
 
         // Apply saved display settings after panadapter is created
         m_displaySettingsPushed = false;
@@ -4151,6 +4155,15 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             }
             qDebug() << "BandStack: first visit to" << bandName << "using defaults";
         }
+    });
+
+    // XVTR button → open Radio Setup XVTR tab (#571)
+    disconnect(menu, &SpectrumOverlayMenu::xvtrSetupRequested, this, nullptr);
+    connect(menu, &SpectrumOverlayMenu::xvtrSetupRequested,
+            this, [this]() {
+        auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, this);
+        dlg->selectTab("XVTR");
+        dlg->show();
     });
 
     // ── WNB / RF Gain ────────────────────────────────────────────────────

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -72,6 +72,9 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     auto* cwTitle = new QLabel("CW");
     cwTitle->setStyleSheet("QLabel { color: #00b4d8; font-size: 10px; font-weight: bold; background: transparent; }");
     cwBar->addWidget(cwTitle);
+    auto* cwHint = new QLabel("(requires PC Audio)");
+    cwHint->setStyleSheet("QLabel { color: #405060; font-size: 9px; background: transparent; }");
+    cwBar->addWidget(cwHint);
 
     m_cwStatsLabel = new QLabel;
     m_cwStatsLabel->setStyleSheet("QLabel { color: #6a8090; font-size: 10px; background: transparent; }");

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -65,6 +65,7 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio, QWidge
     auto* layout = new QVBoxLayout(this);
 
     auto* tabs = new QTabWidget;
+    m_tabs = tabs;
     tabs->setStyleSheet(
         "QTabWidget::pane { border: 1px solid #304050; background: #0f0f1a; }"
         "QTabBar::tab { background: #1a2a3a; color: #8aa8c0; "
@@ -2880,5 +2881,16 @@ QWidget* RadioSetupDialog::buildSerialTab()
     return page;
 }
 #endif
+
+void RadioSetupDialog::selectTab(const QString& tabName)
+{
+    if (!m_tabs) return;
+    for (int i = 0; i < m_tabs->count(); ++i) {
+        if (m_tabs->tabText(i) == tabName) {
+            m_tabs->setCurrentIndex(i);
+            return;
+        }
+    }
+}
 
 } // namespace AetherSDR

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -24,6 +24,7 @@ class RadioSetupDialog : public QDialog {
 public:
     explicit RadioSetupDialog(RadioModel* model, AudioEngine* audio = nullptr,
                               QWidget* parent = nullptr);
+    void selectTab(const QString& tabName);
 
 private:
     QWidget* buildRadioTab();
@@ -43,6 +44,7 @@ private:
 
     RadioModel*  m_model;
     AudioEngine* m_audio{nullptr};
+    QTabWidget*  m_tabs{nullptr};
 
     // Radio tab fields
     QLabel* m_serialLabel{nullptr};

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -201,16 +201,11 @@ void SpectrumOverlayMenu::buildBandPanel()
             double freq = BAND_GRID[idx].freqMhz;
             QString mode = QString::fromLatin1(BAND_GRID[idx].mode);
             if (idx == 15) {
-                // XVTR button → show XVTR sub-panel
+                // XVTR button → open Radio Setup XVTR tab (#571)
                 connect(btn, &QPushButton::clicked, this, [this]() {
-                    if (m_xvtrPanel) {
-                        m_bandPanel->hide();
-                        m_bandPanelVisible = false;
-                        m_xvtrPanel->move(m_bandPanel->pos());
-                        m_xvtrPanel->show();
-                        m_xvtrPanel->raise();
-                        m_xvtrPanelVisible = true;
-                    }
+                    m_bandPanel->hide();
+                    m_bandPanelVisible = false;
+                    emit xvtrSetupRequested();
                 });
             } else if (bandName.isEmpty()) {
                 btn->setEnabled(false);
@@ -1066,7 +1061,124 @@ void SpectrumOverlayMenu::setRfGain(int gain)
 
 void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
 {
-    // Rebuild the XVTR sub-panel
+    // Remove old XVTR band buttons from main band panel
+    for (auto* btn : m_xvtrBandBtns)
+        btn->deleteLater();
+    m_xvtrBandBtns.clear();
+
+    // Rebuild the main band panel to insert XVTR bands between
+    // HF bands and utility buttons (WWV/GEN/2200/630/XVTR). (#571)
+    if (m_bandPanel) {
+        // Delete existing band panel and rebuild
+        m_bandPanel->deleteLater();
+        m_bandPanel = nullptr;
+    }
+
+    m_bandPanel = new QWidget(parentWidget());
+    m_bandPanel->setStyleSheet("QWidget { background: rgba(15, 15, 26, 220); "
+                                "border: 1px solid #304050; border-radius: 3px; }");
+    m_bandPanel->hide();
+
+    auto* grid = new QGridLayout(m_bandPanel);
+    grid->setContentsMargins(2, 2, 2, 2);
+    grid->setSpacing(2);
+
+    const QString bandBtnStyle =
+        "QPushButton { background: rgba(30, 40, 55, 220); "
+        "border: 1px solid #304050; border-radius: 3px; "
+        "color: #c8d8e8; font-size: 11px; font-weight: bold; }"
+        "QPushButton:hover { background: rgba(0, 112, 192, 180); "
+        "border: 1px solid #0090e0; }";
+
+    const QString xvtrBtnStyle =
+        "QPushButton { background: rgba(30, 40, 55, 220); "
+        "border: 1px solid #304050; border-radius: 3px; "
+        "color: #00d0ff; font-size: 11px; font-weight: bold; }"
+        "QPushButton:hover { background: rgba(0, 112, 192, 180); "
+        "border: 1px solid #0090e0; }";
+
+    // HF bands (indices 0-10)
+    constexpr int hfLayout[][3] = {
+        {0, 1, 2},      // 160, 80, 60
+        {3, 4, 5},      // 40, 30, 20
+        {6, 7, 8},      // 17, 15, 12
+        {9, 10, -1},    // 10, 6
+    };
+
+    int row = 0;
+    for (int r = 0; r < 4; ++r) {
+        for (int col = 0; col < 3; ++col) {
+            int idx = hfLayout[r][col];
+            if (idx < 0) continue;
+            auto* btn = new QPushButton(BAND_GRID[idx].label, m_bandPanel);
+            btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
+            btn->setStyleSheet(bandBtnStyle);
+            QString bandName = QString::fromLatin1(BAND_GRID[idx].bandName);
+            double freq = BAND_GRID[idx].freqMhz;
+            QString mode = QString::fromLatin1(BAND_GRID[idx].mode);
+            connect(btn, &QPushButton::clicked, this, [this, bandName, freq, mode]() {
+                emit bandSelected(bandName, freq, mode);
+            });
+            grid->addWidget(btn, row, col);
+        }
+        ++row;
+    }
+
+    // XVTR bands (inserted between HF and utility)
+    m_xvtrBandBtns.clear();
+    for (int i = 0; i < bands.size(); ++i) {
+        auto* btn = new QPushButton(bands[i].name, m_bandPanel);
+        btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
+        btn->setStyleSheet(xvtrBtnStyle);
+        const double freq = bands[i].rfFreqMhz;
+        const QString name = bands[i].name;
+        connect(btn, &QPushButton::clicked, this, [this, name, freq]() {
+            emit bandSelected(name, freq, "USB");
+            m_bandPanel->hide();
+            m_bandPanelVisible = false;
+        });
+        grid->addWidget(btn, row + i / 3, i % 3);
+        m_xvtrBandBtns.append(btn);
+    }
+    if (!bands.isEmpty())
+        row += (bands.size() + 2) / 3;  // advance past XVTR rows
+
+    // Utility buttons: WWV, GEN, 2200, 630, XVTR config
+    constexpr int utilLayout[][3] = {
+        {11, 12, -1},   // WWV, GEN
+        {13, 14, 15},   // 2200, 630, XVTR
+    };
+    for (int r = 0; r < 2; ++r) {
+        for (int col = 0; col < 3; ++col) {
+            int idx = utilLayout[r][col];
+            if (idx < 0) continue;
+            auto* btn = new QPushButton(BAND_GRID[idx].label, m_bandPanel);
+            btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
+            btn->setStyleSheet(bandBtnStyle);
+            QString bandName = QString::fromLatin1(BAND_GRID[idx].bandName);
+            double freq = BAND_GRID[idx].freqMhz;
+            QString mode = QString::fromLatin1(BAND_GRID[idx].mode);
+            if (idx == 15) {
+                connect(btn, &QPushButton::clicked, this, [this]() {
+                    m_bandPanel->hide();
+                    m_bandPanelVisible = false;
+                    emit xvtrSetupRequested();
+                });
+            } else if (bandName.isEmpty()) {
+                btn->setEnabled(false);
+            } else {
+                connect(btn, &QPushButton::clicked, this, [this, bandName, freq, mode]() {
+                    emit bandSelected(bandName, freq, mode);
+                });
+            }
+            grid->addWidget(btn, row, col);
+        }
+        ++row;
+    }
+
+    m_bandPanel->adjustSize();
+
+    // Rebuild the XVTR sub-panel (kept as fallback)
     if (m_xvtrPanel) {
         m_xvtrPanel->deleteLater();
         m_xvtrPanel = nullptr;
@@ -1078,9 +1190,9 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     m_xvtrPanel->hide();
     m_xvtrPanel->installEventFilter(this);
 
-    auto* grid = new QGridLayout(m_xvtrPanel);
-    grid->setContentsMargins(2, 2, 2, 2);
-    grid->setSpacing(2);
+    auto* xvGrid = new QGridLayout(m_xvtrPanel);
+    xvGrid->setContentsMargins(2, 2, 2, 2);
+    xvGrid->setSpacing(2);
 
     const QString btnStyle =
         "QPushButton { background: rgba(30, 40, 55, 220); "
@@ -1113,7 +1225,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
             m_xvtrPanelVisible = false;
         });
 
-        grid->addWidget(btn, slot / XVTR_COLS, slot % XVTR_COLS);
+        xvGrid->addWidget(btn, slot / XVTR_COLS, slot % XVTR_COLS);
         ++slot;
     }
 
@@ -1123,7 +1235,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
         blank->setFixedSize(BAND_BTN_W, BAND_BTN_H);
         blank->setStyleSheet(disabledStyle);
         blank->setEnabled(false);
-        grid->addWidget(blank, slot / XVTR_COLS, slot % XVTR_COLS);
+        xvGrid->addWidget(blank, slot / XVTR_COLS, slot % XVTR_COLS);
         ++slot;
     }
 
@@ -1139,7 +1251,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
         m_bandPanel->raise();
         m_bandPanelVisible = true;
     });
-    grid->addWidget(hfBtn, slot / XVTR_COLS, slot % XVTR_COLS);
+    xvGrid->addWidget(hfBtn, slot / XVTR_COLS, slot % XVTR_COLS);
 
     m_xvtrPanel->adjustSize();
 }

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -82,6 +82,8 @@ signals:
     void noiseFloorEnableChanged(bool on);
     // Emitted when user selects a band from the sub-panel.
     void bandSelected(const QString& bandName, double freqMhz, const QString& mode);
+    // Emitted when user clicks XVTR button to open Radio Setup XVTR tab.
+    void xvtrSetupRequested();
     // Emitted when WNB toggle changes.
     void wnbToggled(bool on);
     // Emitted when WNB level slider changes (0–100).
@@ -120,6 +122,7 @@ private:
     bool m_bandPanelVisible{false};
     QWidget* m_xvtrPanel{nullptr};
     bool m_xvtrPanelVisible{false};
+    QVector<QPushButton*> m_xvtrBandBtns;
 
     // ANT sub-panel
     QWidget*     m_antPanel{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -699,6 +699,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
                 // Notify the radio that a spot was clicked (#341)
                 if (hr.markerIndex >= 0 && hr.markerIndex < m_spotMarkers.size())
                     emit spotTriggered(m_spotMarkers[hr.markerIndex].index);
+                m_spotClickConsumed = true;  // suppress release-to-tune (#530)
                 ev->accept();
                 return;
             }
@@ -1257,7 +1258,7 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
 
         // Single-click-to-tune: if the mouse didn't move during the
         // "pan drag", treat it as a click-to-tune instead
-        if (m_singleClickTune && ev->button() == Qt::LeftButton) {
+        if (m_singleClickTune && ev->button() == Qt::LeftButton && !m_spotClickConsumed) {
             QPoint delta = ev->position().toPoint() - m_clickPressPos;
             if (delta.manhattanLength() <= 4) {
                 const int mx = static_cast<int>(ev->position().x());
@@ -1267,12 +1268,13 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
                 }
             }
         }
+        m_spotClickConsumed = false;
         ev->accept();
         return;
     }
 
     // Single-click-to-tune in FFT area (not consumed by pan drag)
-    if (m_singleClickTune && ev->button() == Qt::LeftButton) {
+    if (m_singleClickTune && ev->button() == Qt::LeftButton && !m_spotClickConsumed) {
         QPoint delta = ev->position().toPoint() - m_clickPressPos;
         if (delta.manhattanLength() <= 4) {
             const int mx = static_cast<int>(ev->position().x());
@@ -1280,10 +1282,12 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
                 double rawMhz = xToMhz(mx);
                 emit frequencyClicked(snapToStep(rawMhz, m_stepHz));
                 ev->accept();
+                m_spotClickConsumed = false;
                 return;
             }
         }
     }
+    m_spotClickConsumed = false;
 }
 
 void SpectrumWidget::showAddSpotDialog(double freqMhz)

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -405,6 +405,7 @@ private:
     BandPlanManager* m_bandPlanMgr{nullptr};
     bool m_singleClickTune{false};
     QPoint m_clickPressPos;        // for single-click-to-tune drag threshold
+    bool   m_spotClickConsumed{false}; // suppress release-to-tune after spot click (#530)
     bool m_showTxInWaterfall{false};  // default matches radio default (off)
     bool m_hasTxSlice{false};  // true if this pan contains the TX slice
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2089,6 +2089,16 @@ void RadioModel::handleSliceStatus(int id,
 
     s->applyStatus(kvs);
 
+    // Aurora/AU-520: max_internal_pa_power in slice status reports the true
+    // system power capability (e.g. 500W) while transmit status max_power_level
+    // only reports the exciter limit (100W). Use the higher value. (#484)
+    if (kvs.contains("max_internal_pa_power")) {
+        int internalMax = kvs["max_internal_pa_power"].toInt();
+        if (internalMax > m_transmitModel.maxPowerLevel()) {
+            m_transmitModel.setMaxPowerLevel(internalMax);
+        }
+    }
+
     // Send any queued commands (e.g. if GUI changed freq before status arrived)
     if (isConnected()) {
         for (const QString& cmd : s->drainPendingCommands())

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -90,6 +90,7 @@ public:
     int     accTxReqPolarity() const { return m_accTxReqPolarity; }
     int     rcaTxReqPolarity() const { return m_rcaTxReqPolarity; }
     int     maxPowerLevel()  const { return m_maxPowerLevel; }
+    void    setMaxPowerLevel(int w) { if (m_maxPowerLevel != w) { m_maxPowerLevel = w; emit maxPowerLevelChanged(w); } }
     QString tuneMode()       const { return m_tuneMode; }
     bool    showTxInWaterfall() const { return m_showTxInWaterfall; }
 


### PR DESCRIPTION
- Show XVTR bands in main Band panel, XVTR button opens config (#571)
- Fix spot click tuning to mouse position instead of spot frequency (#530)
- Fix Aurora/AU-520 power meter scaling to 600W (#484, #501)
- Add PC Audio hint to CW decode panel (#392)
