### PR TITLE
Add TGXL 3x1 antenna switch controls to Tuner Applet (#573)

### DIFF
--- a/src/core/TgxlConnection.h
+++ b/src/core/TgxlConnection.h
@@ -34,6 +34,9 @@ public:
     // Manual relay adjustment: relay 0=C1, 1=L, 2=C2; direction +1 or -1
     void adjustRelay(int relay, int direction);
 
+    // Send an arbitrary command to the TGXL (e.g. "activate ant=2")
+    quint32 sendCommand(const QString& cmd);
+
 signals:
     void connected();
     void disconnected();
@@ -49,7 +52,6 @@ private slots:
 
 private:
     void processLine(const QString& line);
-    quint32 sendCommand(const QString& cmd);
 
     QTcpSocket m_socket;
     QTimer     m_pollTimer;       // 1/sec status poll

--- a/src/gui/TunerApplet.cpp
+++ b/src/gui/TunerApplet.cpp
@@ -109,6 +109,46 @@ void TunerApplet::buildUI()
     bottomRow->addLayout(btnCol, 3);  // stretch 3 (30%)
 
     vbox->addLayout(bottomRow);
+
+    // Antenna switch row (TGXL 3x1) — hidden until direct connection active
+    {
+        m_antContainer = new QWidget;
+        m_antContainer->setVisible(false);
+        auto* antRow = new QHBoxLayout(m_antContainer);
+        antRow->setContentsMargins(0, 0, 0, 0);
+        antRow->setSpacing(2);
+
+        auto makeAntBtn = [](const QString& text) {
+            auto* btn = new QPushButton(text);
+            btn->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+            btn->setFixedHeight(22);
+            btn->setStyleSheet(
+                "QPushButton { background: #1a2a3a; border: 1px solid #205070; "
+                "border-radius: 3px; color: #c8d8e8; font-size: 10px; font-weight: bold; }"
+                "QPushButton:hover { background: #204060; }");
+            return btn;
+        };
+
+        m_ant1Btn = makeAntBtn("ANT 1");
+        m_ant2Btn = makeAntBtn("ANT 2");
+        m_ant3Btn = makeAntBtn("ANT 3");
+        antRow->addWidget(m_ant1Btn);
+        antRow->addWidget(m_ant2Btn);
+        antRow->addWidget(m_ant3Btn);
+
+        connect(m_ant1Btn, &QPushButton::clicked, this, [this]() {
+            if (m_model) m_model->setAntennaA(1);
+        });
+        connect(m_ant2Btn, &QPushButton::clicked, this, [this]() {
+            if (m_model) m_model->setAntennaA(2);
+        });
+        connect(m_ant3Btn, &QPushButton::clicked, this, [this]() {
+            if (m_model) m_model->setAntennaA(3);
+        });
+
+        vbox->addWidget(m_antContainer);
+    }
+
     outer->addWidget(body);
 
     // TUNE button: send autotune command
@@ -147,6 +187,20 @@ void TunerApplet::setTunerModel(TunerModel* model)
     };
     connect(m_model, &TunerModel::directConnectionChanged, this, updateScrollEnabled);
     updateScrollEnabled();
+
+    // Antenna switch: show buttons only when direct connection is active AND
+    // the TGXL reports antA (models without a switch never send antA).
+    auto updateAntVisible = [this]() {
+        m_antContainer->setVisible(m_model->hasDirectConnection()
+                                   && m_model->hasAntennaSwitch());
+    };
+    connect(m_model, &TunerModel::directConnectionChanged, this, updateAntVisible);
+    connect(m_model, &TunerModel::antennaAChanged, this, [this, updateAntVisible](int antA) {
+        updateAntVisible();
+        updateAntennaButtons(antA);
+    });
+    updateAntVisible();
+    updateAntennaButtons(m_model->antennaA());
 
     // Tuning state changes → red button + SWR result flash
     connect(m_model, &TunerModel::tuningChanged, this, [this](bool tuning) {
@@ -251,6 +305,22 @@ void TunerApplet::updateMeters(float fwdPower, float swr)
             m_tuneSwr = swr;
         m_tuneBtn->setText(QString("SWR %1").arg(swr, 0, 'f', 2));
     }
+}
+
+void TunerApplet::updateAntennaButtons(int antA)
+{
+    // antA is 0-indexed: 0=ANT1, 1=ANT2, 2=ANT3
+    static constexpr const char* kDefault =
+        "QPushButton { background: #1a2a3a; border: 1px solid #205070; "
+        "border-radius: 3px; color: #c8d8e8; font-size: 10px; font-weight: bold; }"
+        "QPushButton:hover { background: #204060; }";
+    static constexpr const char* kActive =
+        "QPushButton { background: #006030; border: 1px solid #008040; "
+        "border-radius: 3px; color: #ffffff; font-size: 10px; font-weight: bold; }";
+
+    m_ant1Btn->setStyleSheet(antA == 0 ? kActive : kDefault);
+    m_ant2Btn->setStyleSheet(antA == 1 ? kActive : kDefault);
+    m_ant3Btn->setStyleSheet(antA == 2 ? kActive : kDefault);
 }
 
 } // namespace AetherSDR

--- a/src/gui/TunerApplet.h
+++ b/src/gui/TunerApplet.h
@@ -43,6 +43,7 @@ private:
     void buildUI();
     void syncFromModel();
     void cycleOperateState();
+    void updateAntennaButtons(int antA);
 
     TunerModel* m_model{nullptr};
     MeterModel* m_meter{nullptr};
@@ -59,6 +60,12 @@ private:
     // Buttons
     QPushButton* m_tuneBtn{nullptr};
     QPushButton* m_operateBtn{nullptr};
+
+    // Antenna switch buttons (TGXL 3x1)
+    QPushButton* m_ant1Btn{nullptr};
+    QPushButton* m_ant2Btn{nullptr};
+    QPushButton* m_ant3Btn{nullptr};
+    QWidget*     m_antContainer{nullptr};
 
     // Meter values (updated by updateMeters)
     float m_fwdPower{0.0f};

--- a/src/models/TunerModel.cpp
+++ b/src/models/TunerModel.cpp
@@ -60,7 +60,13 @@ void TunerModel::applyStatus(const QMap<QString, QString>& kvs)
             int v = val.toInt();
             if (m_relayL != v) { m_relayL = v; changed = true; }
         }
-        else if (key == "ip") {
+        else if (key == "antA") {
+            int v = val.toInt();
+            if (m_antennaA != v) { m_antennaA = v; changed = true; emit antennaAChanged(v); }
+        } else if (key == "one_by_three") {
+            bool v = val == "1";
+            if (m_oneByThree != v) { m_oneByThree = v; changed = true; }
+        } else if (key == "ip") {
             if (m_tgxlIp != val) { m_tgxlIp = val; changed = true; }
         }
         // nickname, version, ant, dhcp, netmask, gateway, ptta, pttb
@@ -106,6 +112,17 @@ void TunerModel::autoTune()
     emit commandReady(cmd);
 }
 
+void TunerModel::setAntennaA(int ant)
+{
+    if (!m_directConn || !m_directConn->isConnected()) {
+        qCDebug(lcTuner) << "TunerModel::setAntennaA: no direct connection";
+        return;
+    }
+    if (ant < 1 || ant > 3) return;
+    qCDebug(lcTuner) << "TunerModel: activate ant=" << ant;
+    m_directConn->sendCommand(QString("activate ant=%1").arg(ant));
+}
+
 // ── Direct TGXL connection (port 9010) ──────────────────────────────────────
 
 void TunerModel::setDirectConnection(TgxlConnection* conn)
@@ -140,7 +157,23 @@ void TunerModel::setDirectConnection(TgxlConnection* conn)
                 int v = kvs.value("relayC2").toInt();
                 if (m_relayC2 != v) { m_relayC2 = v; changed = true; }
             }
+            if (kvs.contains("antA")) {
+                int v = kvs.value("antA").toInt();
+                if (m_antennaA != v) { m_antennaA = v; changed = true; emit antennaAChanged(v); }
+            }
             if (changed) emit stateChanged();
+        });
+        // Also parse antA from 1/sec status poll responses (pre-load on connect)
+        connect(m_directConn, &TgxlConnection::statusUpdated, this,
+                [this](const QMap<QString, QString>& kvs) {
+            if (kvs.contains("antA")) {
+                int v = kvs.value("antA").toInt();
+                if (m_antennaA != v) {
+                    m_antennaA = v;
+                    emit antennaAChanged(v);
+                    emit stateChanged();
+                }
+            }
         });
     }
 }

--- a/src/models/TunerModel.h
+++ b/src/models/TunerModel.h
@@ -35,6 +35,8 @@ public:
     int     relayC1()   const { return m_relayC1; }
     int     relayL()    const { return m_relayL; }
     int     relayC2()   const { return m_relayC2; }
+    int     antennaA()  const { return m_antennaA; }  // 0-indexed: 0=ANT1, 1=ANT2, 2=ANT3, -1=unknown
+    bool    hasAntennaSwitch() const { return m_oneByThree; }  // true for TGXL 3x1 model (one_by_three=1)
     bool    isPresent() const { return !m_handle.isEmpty(); }
     bool    hasDirectConnection() const;
 
@@ -55,9 +57,13 @@ public:
     void setBypass(bool on);
     void autoTune();
 
+    // Antenna switch (TGXL 3x1): ant = 1, 2, or 3 (1-indexed for command)
+    void setAntennaA(int ant);
+
 signals:
     void stateChanged();               // any property changed
     void tuningChanged(bool tuning);   // tuning started/stopped
+    void antennaAChanged(int antA);    // antenna port changed (0-indexed)
     void presenceChanged(bool present); // tuner detected / lost
     void directConnectionChanged(bool connected);
     void commandReady(const QString& cmd);
@@ -73,6 +79,8 @@ private:
     int     m_relayC1{0};
     int     m_relayL{0};
     int     m_relayC2{0};
+    int     m_antennaA{-1};   // 0-indexed antenna port (-1 = unknown)
+    bool    m_oneByThree{false}; // true for TGXL 3x1 model (from one_by_three=1)
 
     TgxlConnection* m_directConn{nullptr};
 };


### PR DESCRIPTION
Based on PR #573 by @boydsoftprez with one modification:
antenna switch visibility uses the declarative one_by_three=1
field from amplifier status instead of inferring from antA
presence. SO2R models (one_by_three=0) never show the buttons.

- ANT 1/2/3 buttons in Tuner Applet for TGXL 3x1 models
- Protocol: 'activate ant=N' via direct TGXL TCP port 9010
- Status: antA field (0-indexed) from state push and status poll
- Buttons visible only with direct connection + one_by_three=1

Co-Authored-By: boydsoftprez <boydsoftprez@users.noreply.github.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
