### PR TITLE
Add clickable AMP/TUN status bar indicators with state display (#479, #573)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1065,9 +1065,40 @@ MainWindow::MainWindow(QWidget* parent)
         m_appletPanel->sMeterWidget()->setPowerScale(maxW, hasAmp);
     };
     connect(&m_radioModel, &RadioModel::amplifierChanged, this, updatePowerScale);
-    connect(&m_radioModel, &RadioModel::amplifierChanged, this, [this](bool present) {
+
+    // TGXL indicator: two-line rich text — label on top, state smaller below.
+    // Green = OPERATE, amber = BYPASS, grey = STANDBY (matches SmartSDR)
+    auto setIndicatorHtml = [](QLabel* lbl, const QString& name,
+                               const QString& state, const QString& color) {
+        lbl->setText(QString("<span style='color:%1; font-size:18px; font-weight:bold;'>%2</span><br>"
+                             "<span style='color:%1; font-size:11px;'>%3</span>")
+                     .arg(color, name, state));
+    };
+
+    auto updateTgxlStyle = [this, setIndicatorHtml]() {
+        auto& t = m_radioModel.tunerModel();
+        if (t.isOperate() && !t.isBypass())
+            setIndicatorHtml(m_tgxlIndicator, "TUN", "OPERATE", "#00e060");
+        else if (t.isOperate() && t.isBypass())
+            setIndicatorHtml(m_tgxlIndicator, "TUN", "BYPASS", "#e0a000");
+        else
+            setIndicatorHtml(m_tgxlIndicator, "TUN", "STANDBY", "#404858");
+    };
+    connect(&m_radioModel.tunerModel(), &TunerModel::stateChanged, this, updateTgxlStyle);
+
+    // PGXL indicator: OPERATE (green) or STANDBY (grey) — no bypass for PGXL
+    auto updatePgxlStyle = [this, setIndicatorHtml]() {
+        if (m_radioModel.ampOperate())
+            setIndicatorHtml(m_pgxlIndicator, "AMP", "OPERATE", "#00e060");
+        else
+            setIndicatorHtml(m_pgxlIndicator, "AMP", "STANDBY", "#404858");
+    };
+    connect(&m_radioModel, &RadioModel::ampStateChanged, this, updatePgxlStyle);
+
+    connect(&m_radioModel, &RadioModel::amplifierChanged, this, [this, updatePgxlStyle](bool present) {
         m_pgxlIndicator->setVisible(present);
         m_appletPanel->setAmpVisible(present);
+        if (present) updatePgxlStyle();
     });
     connect(&m_radioModel.meterModel(), &MeterModel::ampMetersChanged,
             this, [this](float fwdPwr, float swr, float temp) {
@@ -1672,6 +1703,24 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
         // Optimistic update — radio accepts this command (R|0) but doesn't
         // echo back a status update with the new value.
         m_radioModel.setFullDuplex(on);
+        return true;
+    }
+    if (obj == m_tgxlIndicator && event->type() == QEvent::MouseButtonPress) {
+        auto& t = m_radioModel.tunerModel();
+        // Cycle: OPERATE → BYPASS → STANDBY → OPERATE
+        if (t.isOperate() && !t.isBypass())
+            t.setBypass(true);
+        else if (t.isOperate() && t.isBypass())
+            t.setOperate(false);
+        else {
+            t.setBypass(false);
+            t.setOperate(true);
+        }
+        return true;
+    }
+    if (obj == m_pgxlIndicator && event->type() == QEvent::MouseButtonPress) {
+        // Simple toggle: OPERATE ↔ STANDBY (PGXL has no BYPASS)
+        m_radioModel.setAmpOperate(!m_radioModel.ampOperate());
         return true;
     }
     if (obj == m_panelToggle && event->type() == QEvent::MouseButtonPress) {
@@ -2553,7 +2602,7 @@ void MainWindow::buildUI()
         m_appletPanel->hide();
 
     // ── Status bar (SmartSDR-style, double height) ─────────────────────
-    statusBar()->setFixedHeight(40);
+    statusBar()->setFixedHeight(46);
     statusBar()->setSizeGripEnabled(false);
     statusBar()->setStyleSheet(
         "QStatusBar { background: #0a0a14; border-top: 1px solid #203040; }"
@@ -2749,13 +2798,23 @@ void MainWindow::buildUI()
 
     addSep();
 
-    m_tgxlIndicator = new QLabel("TGXL");
-    m_tgxlIndicator->setStyleSheet("QLabel { color: rgba(255,255,255,128); font-weight: bold; font-size: 21px; }");
+    m_tgxlIndicator = new QLabel;
+    m_tgxlIndicator->setTextFormat(Qt::RichText);
+    m_tgxlIndicator->setAlignment(Qt::AlignCenter);
+    m_tgxlIndicator->setCursor(Qt::PointingHandCursor);
+    m_tgxlIndicator->setToolTip("Tuner Genius XL — click to cycle OPERATE/BYPASS/STANDBY");
+    m_tgxlIndicator->installEventFilter(this);
     m_tgxlIndicator->setVisible(false);
     hbox->addWidget(m_tgxlIndicator);
 
-    m_pgxlIndicator = new QLabel("PGXL");
-    m_pgxlIndicator->setStyleSheet("QLabel { color: rgba(255,255,255,128); font-weight: bold; font-size: 21px; }");
+    addSep();
+
+    m_pgxlIndicator = new QLabel;
+    m_pgxlIndicator->setTextFormat(Qt::RichText);
+    m_pgxlIndicator->setAlignment(Qt::AlignCenter);
+    m_pgxlIndicator->setCursor(Qt::PointingHandCursor);
+    m_pgxlIndicator->setToolTip("Power Genius XL — click to toggle OPERATE/STANDBY");
+    m_pgxlIndicator->installEventFilter(this);
     m_pgxlIndicator->setVisible(false);
     hbox->addWidget(m_pgxlIndicator);
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1025,6 +1025,8 @@ void RadioModel::onDisconnected()
     m_tunerModel.setHandle({});       // clear TGXL presence
     m_xvtrList.clear();
     m_hasAmplifier = false;
+    m_ampHandle.clear();
+    m_ampOperate = false;
     m_fullDuplex = false;
     m_model.clear();
     m_version.clear();
@@ -1337,6 +1339,13 @@ void RadioModel::sendCommand(const QString& cmd)
 void RadioModel::sendCmdPublic(const QString& cmd, ResponseCallback cb)
 {
     sendCmd(cmd, cb);
+}
+
+void RadioModel::setAmpOperate(bool on)
+{
+    if (m_ampHandle.isEmpty()) return;
+    // FlexLib API: "amplifier set <handle> operate=0|1"
+    sendCmd(QString("amplifier set %1 operate=%2").arg(m_ampHandle).arg(on ? 1 : 0));
 }
 
 void RadioModel::createRxAudioStream()
@@ -1692,11 +1701,26 @@ void RadioModel::onStatusReceived(const QString& object,
                 m_tunerModel.applyStatus(kvs);
             }
 
-            // Detect power amplifier (PGXL or any non-TGXL amp)
-            if (!model.isEmpty() && model != "TunerGeniusXL" && !m_hasAmplifier) {
-                m_hasAmplifier = true;
-                qCDebug(lcProtocol) << "RadioModel: power amplifier detected, model=" << model;
-                emit amplifierChanged(true);
+            // Track power amplifier state (PGXL or any non-TGXL amp).
+            // PGXL uses "state=OPERATE|IDLE|BYPASS|..." (not operate=/bypass= like TGXL)
+            if (!model.isEmpty() && model != "TunerGeniusXL") {
+                m_ampHandle = handle;
+                if (!m_hasAmplifier) {
+                    m_hasAmplifier = true;
+                    qCDebug(lcProtocol) << "RadioModel: power amplifier detected, model=" << model;
+                    emit amplifierChanged(true);
+                }
+            }
+            if (!m_ampHandle.isEmpty() && handle == m_ampHandle) {
+                const QString state = kvs.value("state").toUpper();
+                if (!state.isEmpty()) {
+                    // PGXL states: IDLE = on/ready, STANDBY = off, POWERUP = transitioning
+                    bool op = (state == "IDLE" || state == "OPERATE");
+                    if (m_ampOperate != op) {
+                        m_ampOperate = op;
+                        emit ampStateChanged();
+                    }
+                }
             }
         }
         return;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -85,6 +85,8 @@ public:
     UsbCableModel&    usbCableModel()    { return m_usbCableModel; }
     DaxIqModel&       daxIqModel()       { return m_daxIqModel; }
     bool              hasAmplifier() const { return m_hasAmplifier; }
+    bool              ampOperate()   const { return m_ampOperate; }
+    QString           ampHandle()    const { return m_ampHandle; }
 
     // Getters
     QString name()    const { return m_name; }
@@ -93,6 +95,7 @@ public:
     bool isConnected() const;
     bool fullDuplexEnabled() const { return m_fullDuplex; }
     void setFullDuplex(bool on) { m_fullDuplex = on; emit infoChanged(); }
+    void setAmpOperate(bool on);
     float paTemp()    const { return m_paTemp; }
     float txPower()   const { return m_txPower; }
     QStringList antennaList() const { return m_antList; }
@@ -255,6 +258,7 @@ signals:
     void antListChanged(QStringList ants);
     // Emitted when a power amplifier (e.g. PGXL) is detected or lost.
     void amplifierChanged(bool present);
+    void ampStateChanged();   // amplifier operate/bypass changed
     void memoryRemoved(int index);
     void audioOutputChanged();
     // Emitted when TX ownership changes in Multi-Flex (another client transmitting)
@@ -410,6 +414,8 @@ private:
     QString m_activePanId;       // currently active panadapter
 
     bool    m_hasAmplifier{false};  // true if a power amp (PGXL) is detected
+    QString m_ampHandle;             // amplifier handle for commands
+    bool    m_ampOperate{false};
 
     // GPS state
     QString m_gpsStatus;           // "Locked", "Present", "Not Present"


### PR DESCRIPTION
Based on PR #579 by @boydsoftprez.

- TUN indicator: click cycles OPERATE → BYPASS → STANDBY (green/amber/grey)
- AMP indicator: click toggles OPERATE ↔ STANDBY (green/grey)
- PGXL handle and operate state tracked from amplifier status
- Uses FlexLib API: amplifier set <handle> operate=0|1
- Labels renamed from TGXL/PGXL to TUN/AMP with stacked status text
- Resolves PGXL standby/operate remote recovery request (#479)

Co-Authored-By: boydsoftprez <boydsoftprez@users.noreply.github.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
