### PR TITLE
Convert ConnectionPanel from frameless popup to QDialog (#560, #574)

### DIFF
--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -15,8 +15,7 @@ namespace AetherSDR {
 ConnectionPanel::ConnectionPanel(QWidget* parent)
     : QWidget(parent)
 {
-    setAttribute(Qt::WA_TranslucentBackground);
-    setStyleSheet("ConnectionPanel { background: transparent; }");
+    setStyleSheet("ConnectionPanel { background: #0f0f1a; }");
     const QString editStyle =
         "QLineEdit { border: 1px solid #304050; "
         "border-radius: 3px; padding: 2px 4px; }";
@@ -316,13 +315,9 @@ bool ConnectionPanel::event(QEvent* e)
 
 void ConnectionPanel::paintEvent(QPaintEvent*)
 {
+    // Solid fill — system window frame handles border/decorations (#574)
     QPainter p(this);
-    p.setRenderHint(QPainter::Antialiasing);
-    QPainterPath path;
-    path.addRoundedRect(rect().adjusted(1, 1, -1, -1), 8, 8);
-    p.fillPath(path, QColor(15, 15, 26));
-    p.setPen(QPen(QColor(255, 255, 255, 128), 1));
-    p.drawPath(path);
+    p.fillRect(rect(), QColor(15, 15, 26));
 }
 
 void ConnectionPanel::probeRadio(const QString& ip)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2528,9 +2528,10 @@ void MainWindow::buildUI()
     setCentralWidget(central);
     auto* splitter = m_splitter;
 
-    // Connection panel — floating popup (not in splitter)
+    // Connection panel — modeless dialog with standard decorations (#560, #574)
     m_connPanel = new ConnectionPanel(this);
-    m_connPanel->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
+    m_connPanel->setWindowFlags(Qt::Dialog);
+    m_connPanel->setWindowTitle("Choose Radio / SmartLink Setup");
     m_connPanel->setFixedSize(300, 420);
     m_connPanel->hide();
 


### PR DESCRIPTION
- Replace Qt::Tool|FramelessWindowHint|WindowStaysOnTopHint with Qt::Dialog
- Adds standard title bar with close button and window title
- Solid background fill replaces rounded rect paintEvent
- Remove WA_TranslucentBackground (no longer needed)
- Fixes: no close button, disappears on focus loss, inconsistent decorations

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
