### PR TITLE
Fix macOS TX audio: add audio-input entitlement for hardened runtime

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -91,8 +91,9 @@ jobs:
             codesign --force --options runtime --timestamp \
               --sign "Developer ID Application" "$item" 2>/dev/null || true
           done
-          # Sign the main executable and app bundle
+          # Sign the main executable and app bundle (with mic entitlement for TX audio)
           codesign --force --deep --options runtime --timestamp \
+            --entitlements macos/AetherSDR.entitlements \
             --sign "Developer ID Application" \
             build/AetherSDR.app
           # Verify

--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -82,7 +82,7 @@ jobs:
       # ── Ad-hoc sign ──────────────────────────────────────────────────────
       - name: Ad-hoc sign app and plugin
         run: |
-          codesign --force --deep --sign - build/AetherSDR.app
+          codesign --force --deep --entitlements macos/AetherSDR.entitlements --sign - build/AetherSDR.app
           codesign --force --deep --sign - build-hal/AetherSDRDAX.driver
 
       # ── Package as .pkg installer ────────────────────────────────────────

--- a/macos/AetherSDR.entitlements
+++ b/macos/AetherSDR.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Fixes the macOS SSB TX audio bug where the radio enters transmit state but no audio reaches it — the mic gauge shows nothing and forward power is zero on voice modes.

**Root cause:** The macOS DMG and PKG builds sign the app with hardened runtime (`--options runtime`) but do not include the `com.apple.security.device.audio-input` entitlement. Without it, macOS silently delivers **empty audio buffers** from CoreAudio when launched from Finder. The `NSMicrophoneUsageDescription` plist key and user permission grant are not sufficient — hardened runtime additionally requires the entitlement.

**Why it works from Terminal:** Terminal.app has its own mic permission, and the child process inherits it. This is why developers testing from the command line never see the bug.

### Diagnosis

macOS system log confirmed the issue:
```
AudioConverter: Input data proc returned inconsistent 256 packets
for 0 bytes; at 4 bytes per packet, that is actually 0 packets
```

And `codesign -d --entitlements -` showed zero entitlements on the signed app despite hardened runtime being active (`flags=0x10000(runtime)`).

### Fix

- **New file:** `macos/AetherSDR.entitlements` with `com.apple.security.device.audio-input`
- **`macos-dmg.yml`:** Add `--entitlements macos/AetherSDR.entitlements` to the `codesign` command for the app bundle
- **`macos-installer.yml`:** Same entitlements flag for the ad-hoc signed PKG build

### Files Changed

| File | Change |
|------|--------|
| `macos/AetherSDR.entitlements` | New — plist with `com.apple.security.device.audio-input` |
| `.github/workflows/macos-dmg.yml` | Add `--entitlements` to codesign of app bundle |
| `.github/workflows/macos-installer.yml` | Add `--entitlements` to ad-hoc codesign |

## Test Plan

- [ ] Build macOS DMG with updated workflow
- [ ] Install from DMG (drag to Applications)
- [ ] Launch from **Finder** (NOT terminal) — mic permission dialog should appear
- [ ] Grant mic access, connect to radio, key MOX in USB — verify TX audio and RF output
- [ ] Verify P/CW mic gauge shows audio level during TX
- [ ] Verify notarization still passes with the entitlement

## Workaround (for current builds)

Users hitting this bug can fix their local install:
```bash
cat > /tmp/AetherSDR.entitlements << 'PLIST'
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>com.apple.security.device.audio-input</key>
    <true/>
</dict>
</plist>
PLIST

codesign --force --deep --entitlements /tmp/AetherSDR.entitlements \
  --sign - /Applications/AetherSDR.app
xattr -cr /Applications/AetherSDR.app
```

Fixes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)