### PR TITLE
Add grid lines to TX Band Settings checkbox cells (#533)

### DIFF
--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -30,6 +30,21 @@ namespace AetherSDR {
 
 // ── SpotTableModel ──────────────────────────────────────────────────────────
 
+QString SpotTableModel::extractMode(const QString& comment)
+{
+    static const QSet<QString> known = {
+        "CW", "SSB", "USB", "LSB", "AM", "FM", "FT8", "FT4",
+        "JS8", "RTTY", "PSK31", "PSK63", "PSK", "OLIVIA",
+        "JT65", "JT9", "SAM", "NFM", "DIGU", "DIGL"
+    };
+    QStringList words = comment.split(' ', Qt::SkipEmptyParts);
+    if (!words.isEmpty() && known.contains(words.first().toUpper()))
+        return words.first().toUpper();
+    if (!words.isEmpty() && known.contains(words.last().toUpper()))
+        return words.last().toUpper();
+    return {};
+}
+
 QVariant SpotTableModel::data(const QModelIndex& index, int role) const
 {
     if (!index.isValid() || index.row() >= m_spots.size())
@@ -42,6 +57,7 @@ QVariant SpotTableModel::data(const QModelIndex& index, int role) const
         case ColTime:    return spot.utcTime.toString("HH:mm");
         case ColFreq:    return QString::number(spot.freqMhz * 1000.0, 'f', 1);
         case ColDxCall:  return spot.dxCall;
+        case ColMode:    return extractMode(spot.comment);
         case ColComment: return spot.comment;
         case ColSpotter: return spot.spotterCall;
         case ColBand:    return bandForFreq(spot.freqMhz);
@@ -75,6 +91,7 @@ QVariant SpotTableModel::headerData(int section, Qt::Orientation orientation, in
     case ColTime:    return "Time";
     case ColFreq:    return "Freq (kHz)";
     case ColDxCall:  return "DX Call";
+    case ColMode:    return "Mode";
     case ColComment: return "Comment";
     case ColSpotter: return "Spotter";
     case ColBand:    return "Band";
@@ -1486,6 +1503,7 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
     m_spotTable->setColumnWidth(SpotTableModel::ColTime, 50);
     m_spotTable->setColumnWidth(SpotTableModel::ColFreq, 80);
     m_spotTable->setColumnWidth(SpotTableModel::ColDxCall, 90);
+    m_spotTable->setColumnWidth(SpotTableModel::ColMode, 45);
     m_spotTable->setColumnWidth(SpotTableModel::ColComment, 200);
     m_spotTable->setColumnWidth(SpotTableModel::ColSpotter, 80);
     m_spotTable->setColumnWidth(SpotTableModel::ColBand, 45);
@@ -1576,6 +1594,23 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
         save("IsSpotsEnabled", on ? "True" : "False");
     });
     grid->addWidget(spotsToggle, row++, 1, Qt::AlignLeft);
+
+    // ── Auto-switch mode on spot click (#424) ───────────────────────────
+    grid->addWidget(new QLabel("Auto Mode:"), row, 0);
+    bool autoMode = s.value("SpotAutoSwitchMode", "False").toString() == "True";
+    auto* autoModeToggle = new QPushButton(autoMode ? "Enabled" : "Disabled");
+    autoModeToggle->setCheckable(true);
+    autoModeToggle->setChecked(autoMode);
+    autoModeToggle->setFixedWidth(80);
+    autoModeToggle->setToolTip("Automatically switch slice mode when clicking a spot\nthat includes mode information (e.g. CW, FT8, RTTY)");
+    autoModeToggle->setStyleSheet(
+        "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
+        "QPushButton:!checked { background: #603020; }");
+    connect(autoModeToggle, &QPushButton::toggled, this, [autoModeToggle, save](bool on) {
+        autoModeToggle->setText(on ? "Enabled" : "Disabled");
+        save("SpotAutoSwitchMode", on ? "True" : "False");
+    });
+    grid->addWidget(autoModeToggle, row++, 1, Qt::AlignLeft);
 
     // ── Levels slider ───────────────────────────────────────────────────
     grid->addWidget(new QLabel("Levels:"), row, 0);

--- a/src/gui/DxClusterDialog.h
+++ b/src/gui/DxClusterDialog.h
@@ -33,7 +33,8 @@ class SpotTableModel : public QAbstractTableModel {
     Q_OBJECT
 
 public:
-    enum Column { ColTime, ColFreq, ColDxCall, ColComment, ColSpotter, ColBand, ColSource, ColCount };
+    enum Column { ColTime, ColFreq, ColDxCall, ColComment, ColSpotter, ColBand, ColMode, ColSource, ColCount };
+    static QString extractMode(const QString& comment);
 
     explicit SpotTableModel(QObject* parent = nullptr) : QAbstractTableModel(parent) {}
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -70,6 +70,11 @@
 #include <QCloseEvent>
 #include <QMessageBox>
 #include <QShortcut>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include "core/VersionNumber.h"
 #include <QPointer>
 #include <QTextEdit>
 #include <QPlainTextEdit>
@@ -1516,15 +1521,40 @@ MainWindow::MainWindow(QWidget* parent)
     }
 
     // What's New dialog — show on version change (#483)
+    // Also check for newer release and offer upgrade (#486)
     QTimer::singleShot(600, this, [this]() {
         auto& settings = AppSettings::instance();
         QString lastSeen = settings.value("LastSeenVersion").toString();
         QString current = QCoreApplication::applicationVersion();
-        if (lastSeen == current) return;
-        settings.setValue("LastSeenVersion", current);
-        settings.save();
-        m_whatsNewDialog = new WhatsNewDialog(lastSeen, current, this);
-        m_whatsNewDialog->show();
+
+        // Version changed since last launch — show What's New immediately
+        if (lastSeen != current) {
+            settings.setValue("LastSeenVersion", current);
+            settings.save();
+            m_whatsNewDialog = new WhatsNewDialog(lastSeen, current, this);
+            m_whatsNewDialog->show();
+            return;  // don't also check for upgrade on the same launch
+        }
+
+        // Same version — check if a newer release is available
+        auto* nam = new QNetworkAccessManager(this);
+        auto* reply = nam->get(QNetworkRequest(
+            QUrl("https://api.github.com/repos/ten9876/AetherSDR/releases/latest")));
+        connect(reply, &QNetworkReply::finished, this, [this, reply, nam, current] {
+            reply->deleteLater();
+            nam->deleteLater();
+            if (reply->error() != QNetworkReply::NoError) return;
+            auto doc = QJsonDocument::fromJson(reply->readAll());
+            QString latest = doc.object().value("tag_name").toString();
+            if (latest.startsWith('v')) latest = latest.mid(1);
+            auto latestVer = VersionNumber::parse(latest);
+            auto currentVer = VersionNumber::parse(current);
+            if (latestVer.isNull() || currentVer >= latestVer) return;
+
+            // Newer version available — show What's New with upgrade button
+            m_whatsNewDialog = new WhatsNewDialog(current, latest, this, true);
+            m_whatsNewDialog->show();
+        });
     });
 }
 
@@ -1843,6 +1873,8 @@ void MainWindow::buildMenuBar()
         auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
         m_radioSetupDialog = dlg;
+        connect(dlg, &RadioSetupDialog::txBandSettingsRequested,
+                m_txBandAction, &QAction::trigger);
         connect(dlg, &QDialog::finished, this, [this, prevComp]() {
 #ifdef HAVE_SERIALPORT
             // Re-load serial port settings if changed (on worker thread)
@@ -1896,6 +1928,8 @@ void MainWindow::buildMenuBar()
     connect(flexControlAction, &QAction::triggered, this, [this] {
         auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
+        connect(dlg, &RadioSetupDialog::txBandSettingsRequested,
+                m_txBandAction, &QAction::trigger);
         if (auto* tabs = dlg->findChild<QTabWidget*>()) {
             for (int i = 0; i < tabs->count(); ++i) {
                 if (tabs->tabText(i) == "Serial") {
@@ -1928,6 +1962,8 @@ void MainWindow::buildMenuBar()
     connect(usbCablesAction, &QAction::triggered, this, [this] {
         auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
+        connect(dlg, &RadioSetupDialog::txBandSettingsRequested,
+                m_txBandAction, &QAction::trigger);
         // Switch to the USB Cables tab
         if (auto* tabs = dlg->findChild<QTabWidget*>()) {
             for (int i = 0; i < tabs->count(); ++i) {
@@ -2034,11 +2070,14 @@ void MainWindow::buildMenuBar()
         dlg->show();
     });
     auto* multiFlexAction = settingsMenu->addAction("multiFLEX...");
-    connect(multiFlexAction, &QAction::triggered, this, [this] {
+    auto openMultiFlex = [this] {
         MultiFlexDialog dlg(&m_radioModel, this);
         dlg.exec();
-    });
-    auto* txBandAct = settingsMenu->addAction("TX Band Settings...");
+    };
+    connect(multiFlexAction, &QAction::triggered, this, openMultiFlex);
+    // m_titleBar connect deferred — see after TitleBar creation (~line 2530)
+    m_txBandAction = settingsMenu->addAction("TX Band Settings...");
+    auto* txBandAct = m_txBandAction;
     connect(txBandAct, &QAction::triggered, this, [this] {
         if (!m_radioModel.isConnected()) {
             statusBar()->showMessage("Not connected to radio", 3000);
@@ -2052,7 +2091,10 @@ void MainWindow::buildMenuBar()
         dlg->setAttribute(Qt::WA_DeleteOnClose);
 
         auto* vb = new QVBoxLayout(dlg);
-        auto* headerGrid = new QGridLayout;
+        auto* gridContainer = new QWidget;
+        gridContainer->setStyleSheet("background: #506070;");
+        auto* headerGrid = new QGridLayout(gridContainer);
+        headerGrid->setContentsMargins(1, 1, 1, 1);
         headerGrid->setSpacing(1);
         const QStringList headers = {"Band", "RF PWR(%)", "Tune PWR(%)", "PTT Inhibit",
                                       "ACC TX", "RCA TX Req", "ACC TX Req",
@@ -2061,7 +2103,7 @@ void MainWindow::buildMenuBar()
             auto* lbl = new QLabel(headers[c]);
             lbl->setStyleSheet("QLabel { color: #8aa8c0; font-size: 10px; "
                                 "font-weight: bold; background: #1a2a3a; "
-                                "border: 1px solid #304050; padding: 2px 4px; }");
+                                "padding: 2px 4px; }");
             lbl->setAlignment(Qt::AlignCenter);
             headerGrid->addWidget(lbl, 0, c);
         }
@@ -2126,6 +2168,7 @@ void MainWindow::buildMenuBar()
                 chk->setChecked(cb.val);
                 chk->setStyleSheet(kCbStyle);
                 auto* w = new QWidget;
+                w->setStyleSheet("background: #0f0f1a;");
                 auto* hb = new QHBoxLayout(w);
                 hb->setContentsMargins(0, 0, 0, 0);
                 hb->setAlignment(Qt::AlignCenter);
@@ -2145,7 +2188,7 @@ void MainWindow::buildMenuBar()
             ++row;
         }
 
-        vb->addLayout(headerGrid);
+        vb->addWidget(gridContainer);
         vb->addStretch();
         dlg->show();
     });
@@ -2527,6 +2570,10 @@ void MainWindow::buildUI()
     m_titleBar = new TitleBar(this);
     // Embed the menu bar into the title bar (left side)
     m_titleBar->setMenuBar(menuBar());
+    connect(m_titleBar, &TitleBar::multiFlexClicked, this, [this] {
+        MultiFlexDialog dlg(&m_radioModel, this);
+        dlg.exec();
+    });
     connect(m_titleBar, &TitleBar::minimalModeRequested, this, [this]() {
         toggleMinimalMode(!m_minimalMode);
         if (m_minimalModeAction) {
@@ -3600,6 +3647,12 @@ void MainWindow::setActiveSlice(int sliceId)
 
     updateSplitState();
 
+    // TX follows active slice (#441) — auto-assign TX when switching slices
+    if (!m_splitActive && sliceId != prevId && !s->isTxSlice()
+        && AppSettings::instance().value("TxFollowsActiveSlice", "False").toString() == "True") {
+        s->setTxSlice(true);
+    }
+
     qDebug() << "MainWindow: active slice set to" << sliceId;
 }
 
@@ -3965,6 +4018,79 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     // ── Spot trigger — notify the radio when a spot label is clicked (#341)
     connect(sw, &SpectrumWidget::spotTriggered, this, [this](int spotIndex) {
         m_radioModel.sendCommand(QString("spot trigger %1").arg(spotIndex));
+
+        // Auto-switch mode from spot metadata (#424)
+        if (AppSettings::instance().value("SpotAutoSwitchMode", "False").toString() != "True")
+            return;
+        auto* s = activeSlice();
+        if (!s) return;
+        const auto& spots = m_radioModel.spotModel().spots();
+        auto it = spots.find(spotIndex);
+        if (it == spots.end()) return;
+
+        // Extract mode: prefer explicit mode field, fall back to comment text
+        QString spotMode = it->mode.toUpper().trimmed();
+        if (spotMode.isEmpty() && !it->comment.isEmpty()) {
+            // RBN: mode is first word ("CW  6 dB 28 WPM CQ")
+            // POTA/Cluster: mode is often last word ("JP-1277 Higashimurayama CW")
+            static const QSet<QString> knownModes = {
+                "CW", "SSB", "USB", "LSB", "AM", "FM", "FT8", "FT4",
+                "JS8", "RTTY", "PSK31", "PSK63", "PSK", "OLIVIA",
+                "JT65", "JT9", "SAM", "NFM", "DIGU", "DIGL"
+            };
+            QStringList words = it->comment.split(' ', Qt::SkipEmptyParts);
+            // Check first word (RBN format)
+            if (!words.isEmpty() && knownModes.contains(words.first().toUpper()))
+                spotMode = words.first().toUpper();
+            // Check last word (POTA/Cluster format)
+            else if (!words.isEmpty() && knownModes.contains(words.last().toUpper()))
+                spotMode = words.last().toUpper();
+        }
+        // Fallback: infer mode from frequency using band plan
+        if (spotMode.isEmpty()) {
+            double f = it->rxFreqMhz;
+            // CW sub-bands (bottom of each HF band)
+            if ((f >= 1.800 && f < 1.850) || (f >= 3.500 && f < 3.600) ||
+                (f >= 7.000 && f < 7.050) || (f >= 10.100 && f < 10.140) ||
+                (f >= 14.000 && f < 14.070) || (f >= 18.068 && f < 18.095) ||
+                (f >= 21.000 && f < 21.070) || (f >= 24.890 && f < 24.920) ||
+                (f >= 28.000 && f < 28.070) || (f >= 50.000 && f < 50.100))
+                spotMode = "CW";
+            // Digital sub-bands
+            else if ((f >= 1.840 && f < 1.850) || (f >= 3.570 && f < 3.600) ||
+                     (f >= 7.040 && f < 7.050) || (f >= 10.130 && f < 10.150) ||
+                     (f >= 14.070 && f < 14.100) || (f >= 18.095 && f < 18.110) ||
+                     (f >= 21.070 && f < 21.100) || (f >= 24.915 && f < 24.930) ||
+                     (f >= 28.070 && f < 28.150))
+                spotMode = "DIGU";
+            // Phone — default by convention
+            else if (f >= 10.0)
+                spotMode = "USB";
+            else if (f >= 1.8)
+                spotMode = "LSB";
+        }
+        if (spotMode.isEmpty()) return;
+
+        // Map spot mode string → radio mode
+        static const QMap<QString, QString> modeMap = {
+            {"CW", "CW"}, {"CWL", "CW"}, {"CWU", "CW"},
+            {"USB", "USB"}, {"LSB", "LSB"},
+            {"FT8", "DIGU"}, {"FT4", "DIGU"}, {"JS8", "DIGU"},
+            {"PSK31", "DIGU"}, {"PSK63", "DIGU"}, {"PSK", "DIGU"},
+            {"OLIVIA", "DIGU"}, {"JT65", "DIGU"}, {"JT9", "DIGU"},
+            {"RTTY", "DIGL"},
+            {"AM", "AM"}, {"SAM", "SAM"},
+            {"FM", "FM"}, {"NFM", "NFM"},
+        };
+        QString radioMode;
+        if (modeMap.contains(spotMode)) {
+            radioMode = modeMap[spotMode];
+        } else if (spotMode == "SSB") {
+            // SSB without sideband: ≥10 MHz → USB, <10 MHz → LSB
+            radioMode = (it->rxFreqMhz >= 10.0) ? "USB" : "LSB";
+        }
+        if (!radioMode.isEmpty() && radioMode != s->mode())
+            s->setMode(radioMode);
     });
 
     // ── Manual spot add/remove (#36)
@@ -4248,6 +4374,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     connect(menu, &SpectrumOverlayMenu::xvtrSetupRequested,
             this, [this]() {
         auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, this);
+        connect(dlg, &RadioSetupDialog::txBandSettingsRequested,
+                m_txBandAction, &QAction::trigger);
         dlg->selectTab("XVTR");
         dlg->show();
     });
@@ -4691,7 +4819,7 @@ void MainWindow::registerShortcutActions()
     }
 
     // ── Mode ────────────────────────────────────────────────────────────
-    static const char* modes[] = {"USB", "LSB", "CW", "CWL", "AM", "FM", "DIGU", "DIGL", "RTTY"};
+    static const char* modes[] = {"USB", "LSB", "CW", "CWL", "AM", "SAM", "FM", "NFM", "DFM", "DIGU", "DIGL", "RTTY"};
     for (const char* mode : modes) {
         QString m = mode;
         m_shortcutManager.registerAction(

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -189,6 +189,7 @@ private:
 
     // Menus
     QMenu*           m_profilesMenu{nullptr};
+    QAction*         m_txBandAction{nullptr};
 
     // Audio stream re-creation flag (after profile load)
     bool             m_needAudioStream{false};

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -755,122 +755,7 @@ QWidget* RadioSetupDialog::buildTxTab()
             "padding: 4px 12px; }"
             "QPushButton:hover { background: #203040; }");
         connect(bandSetBtn, &QPushButton::clicked, this, [this] {
-            // Build TX Band Settings popup
-            auto* dlg = new QDialog(this);
-            dlg->setWindowTitle(QString("TX Band Settings (Current TX Profile: %1)")
-                .arg(m_model->transmitModel().activeProfile()));
-            dlg->setMinimumSize(700, 450);
-            dlg->setStyleSheet("QDialog { background: #0f0f1a; }");
-            dlg->setAttribute(Qt::WA_DeleteOnClose);
-
-            auto* vb = new QVBoxLayout(dlg);
-
-            // Table header
-            auto* headerGrid = new QGridLayout;
-            headerGrid->setSpacing(1);
-            const QStringList headers = {"Band", "RF PWR(%)", "Tune PWR(%)", "PTT Inhibit",
-                                          "ACC TX", "RCA TX Req", "ACC TX Req",
-                                          "RCA TX1", "RCA TX2", "RCA TX3", "HWALC"};
-            for (int c = 0; c < headers.size(); ++c) {
-                auto* lbl = new QLabel(headers[c]);
-                lbl->setStyleSheet("QLabel { color: #8aa8c0; font-size: 10px; "
-                                    "font-weight: bold; background: #1a2a3a; "
-                                    "border: 1px solid #304050; padding: 2px 4px; }");
-                lbl->setAlignment(Qt::AlignCenter);
-                headerGrid->addWidget(lbl, 0, c);
-            }
-
-            // Data rows — sorted by band order
-            const auto& bands = m_model->txBandSettings();
-            QList<int> sortedIds = bands.keys();
-            std::sort(sortedIds.begin(), sortedIds.end());
-
-            int row = 1;
-            for (int id : sortedIds) {
-                const auto& b = bands[id];
-                int col = 0;
-
-                // Band name
-                auto* nameLbl = new QLabel(b.bandName);
-                nameLbl->setStyleSheet("QLabel { color: #c8d8e8; font-size: 11px; "
-                                        "font-weight: bold; background: #0f0f1a; "
-                                        "border: 1px solid #203040; padding: 2px 4px; }");
-                headerGrid->addWidget(nameLbl, row, col++);
-
-                // RF Power
-                auto* rfEdit = new QLineEdit(QString::number(b.rfPower));
-                rfEdit->setStyleSheet(kEditStyle);
-                rfEdit->setFixedWidth(50);
-                rfEdit->setAlignment(Qt::AlignCenter);
-                int bandId = id;
-                connect(rfEdit, &QLineEdit::editingFinished, dlg, [this, rfEdit, bandId] {
-                    m_model->sendCommand(
-                        QString("transmit bandset %1 rfpower=%2").arg(bandId).arg(rfEdit->text()));
-                });
-                headerGrid->addWidget(rfEdit, row, col++);
-
-                // Tune Power
-                auto* tuneEdit = new QLineEdit(QString::number(b.tunePower));
-                tuneEdit->setStyleSheet(kEditStyle);
-                tuneEdit->setFixedWidth(50);
-                tuneEdit->setAlignment(Qt::AlignCenter);
-                connect(tuneEdit, &QLineEdit::editingFinished, dlg, [this, tuneEdit, bandId] {
-                    m_model->sendCommand(
-                        QString("transmit bandset %1 tunepower=%2").arg(bandId).arg(tuneEdit->text()));
-                });
-                headerGrid->addWidget(tuneEdit, row, col++);
-
-                // Checkboxes: PTT Inhibit, ACC TX, RCA TX Req, ACC TX Req, TX1, TX2, TX3, HWALC
-                struct CbDef { bool val; const char* txCmd; const char* ilCmd; };
-                CbDef cbs[] = {
-                    {b.inhibit, "inhibit", nullptr},
-                    {b.accTx,   nullptr, "acc_tx_enabled"},
-                    {b.rcaTxReq,nullptr, "rca_txreq_enable"},
-                    {b.accTxReq,nullptr, "acc_txreq_enable"},
-                    {b.tx1,     nullptr, "tx1_enabled"},
-                    {b.tx2,     nullptr, "tx2_enabled"},
-                    {b.tx3,     nullptr, "tx3_enabled"},
-                    {b.hwAlc,   "hwalc_enabled", nullptr},
-                };
-
-                for (const auto& cb : cbs) {
-                    auto* chk = new QCheckBox;
-                    chk->setChecked(cb.val);
-                    chk->setStyleSheet(
-                        "QCheckBox { background: transparent; spacing: 0; }"
-                        "QCheckBox::indicator { width: 16px; height: 16px; "
-                        "border: 2px solid #506070; border-radius: 3px; background: #0a0a18; }"
-                        "QCheckBox::indicator:checked { background: #0070c0; "
-                        "border: 2px solid #00a0e0; }");
-                    auto cmdKey = cb.txCmd ? QString(cb.txCmd) : QString(cb.ilCmd);
-                    auto prefix = cb.txCmd ? QString("transmit") : QString("interlock");
-                    connect(chk, &QCheckBox::toggled, dlg, [this, bandId, prefix, cmdKey](bool on) {
-                        m_model->sendCommand(
-                            QString("%1 bandset %2 %3=%4").arg(prefix).arg(bandId).arg(cmdKey).arg(on ? 1 : 0));
-                    });
-                    auto* container = new QWidget;
-                    auto* hb = new QHBoxLayout(container);
-                    hb->setContentsMargins(0, 0, 0, 0);
-                    hb->setAlignment(Qt::AlignCenter);
-                    hb->addWidget(chk);
-                    headerGrid->addWidget(container, row, col++);
-                }
-
-                ++row;
-            }
-
-            vb->addLayout(headerGrid);
-            vb->addStretch(1);
-
-            auto* closeBtn = new QPushButton("Close");
-            closeBtn->setStyleSheet(
-                "QPushButton { background: #1a2a3a; border: 1px solid #304050; "
-                "border-radius: 3px; color: #c8d8e8; padding: 4px 16px; }"
-                "QPushButton:hover { background: #203040; }");
-            connect(closeBtn, &QPushButton::clicked, dlg, &QDialog::close);
-            vb->addWidget(closeBtn, 0, Qt::AlignRight);
-
-            dlg->show();
+            emit txBandSettingsRequested();
         });
         grid->addWidget(bandSetBtn, 3, 2, 1, 2);
 
@@ -965,6 +850,29 @@ QWidget* RadioSetupDialog::buildTxTab()
                 QString("transmit set show_tx_in_waterfall=%1").arg(on ? 1 : 0));
         });
         grid->addWidget(swBtn, 2, 1);
+
+        // TX Follows Active Slice (#441)
+        auto* tfLbl = new QLabel("TX Follows Active Slice:");
+        tfLbl->setStyleSheet(kLabelStyle);
+        grid->addWidget(tfLbl, 3, 0);
+        bool txFollows = AppSettings::instance().value("TxFollowsActiveSlice", "False").toString() == "True";
+        auto* tfBtn = new QPushButton(txFollows ? "Enabled" : "Disabled");
+        tfBtn->setCheckable(true);
+        tfBtn->setChecked(txFollows);
+        tfBtn->setToolTip("Automatically assign TX to the active slice.\nDisabled during Split operation.");
+        tfBtn->setStyleSheet(
+            "QPushButton { background: #1a2a3a; border: 1px solid #304050; "
+            "border-radius: 3px; color: #c8d8e8; font-size: 11px; font-weight: bold; "
+            "padding: 3px 10px; }"
+            "QPushButton:checked { background: #1a5030; color: #00e060; "
+            "border: 1px solid #20a040; }");
+        connect(tfBtn, &QPushButton::toggled, this, [tfBtn](bool on) {
+            tfBtn->setText(on ? "Enabled" : "Disabled");
+            auto& s = AppSettings::instance();
+            s.setValue("TxFollowsActiveSlice", on ? "True" : "False");
+            s.save();
+        });
+        grid->addWidget(tfBtn, 3, 1);
 
         vbox->addLayout(grid);
     }

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -26,6 +26,9 @@ public:
                               QWidget* parent = nullptr);
     void selectTab(const QString& tabName);
 
+signals:
+    void txBandSettingsRequested();
+
 private:
     QWidget* buildRadioTab();
     QWidget* buildNetworkTab();

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1300,18 +1300,23 @@ void RxApplet::updateModeSettings(const QString& mode)
     // QSK visibility — only meaningful in CW mode
     m_qskBtn->setVisible(mode == "CW");
 
-    // Disable squelch in digital modes (audio goes via DAX, SQL not meaningful)
-    bool isDig = (mode == "DIGU" || mode == "DIGL");
-    m_sqlBtn->setEnabled(!isDig);
-    m_sqlSlider->setEnabled(!isDig);
-    if (isDig && m_slice) {
+    // Disable squelch in digital and CW modes
+    // Digital: audio goes via DAX, SQL not meaningful
+    // CW: radio locks squelch on at fixed level, rejects changes
+    bool sqlDisabled = (mode == "DIGU" || mode == "DIGL" || mode == "CW" || mode == "CWL");
+    m_sqlBtn->setEnabled(!sqlDisabled);
+    m_sqlSlider->setEnabled(!sqlDisabled);
+    if (sqlDisabled && m_slice) {
         if (m_slice->squelchOn()) {
             m_savedSquelchOn = true;
-            m_slice->setSquelch(false, m_slice->squelchLevel());
-            QSignalBlocker sb(m_sqlBtn);
-            m_sqlBtn->setChecked(false);
+            if (mode == "DIGU" || mode == "DIGL") {
+                // Only send squelch off for digital modes; CW is radio-managed
+                m_slice->setSquelch(false, m_slice->squelchLevel());
+                QSignalBlocker sb(m_sqlBtn);
+                m_sqlBtn->setChecked(false);
+            }
         }
-    } else if (!isDig && m_slice && m_savedSquelchOn) {
+    } else if (!sqlDisabled && m_slice && m_savedSquelchOn) {
         m_savedSquelchOn = false;
         m_slice->setSquelch(true, m_slice->squelchLevel());
         QSignalBlocker sb(m_sqlBtn);

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -12,6 +12,11 @@
 #include <QClipboard>
 #include <QApplication>
 #include <QTimer>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include "core/VersionNumber.h"
 
 namespace AetherSDR {
 
@@ -62,13 +67,17 @@ TitleBar::TitleBar(QWidget* parent)
     appName->setAlignment(Qt::AlignCenter);
     m_hbox->addWidget(appName);
 
-    m_mfLabel = new QLabel("multiFLEX");
-    m_mfLabel->setStyleSheet(
-        "QLabel { color: #20c060; font-size: 11px; font-weight: bold; "
+    m_mfBtn = new QPushButton("multiFLEX");
+    m_mfBtn->setFlat(true);
+    m_mfBtn->setStyleSheet(
+        "QPushButton { color: #20c060; font-size: 11px; font-weight: bold; "
         "border: 1px solid #20c060; border-radius: 4px; "
-        "background: transparent; padding: 0px 3px; }");
-    m_mfLabel->setVisible(false);
-    m_hbox->addWidget(m_mfLabel);
+        "background: transparent; padding: 0px 3px; }"
+        "QPushButton:hover { background: rgba(32, 192, 96, 30); }");
+    m_mfBtn->setVisible(false);
+    m_mfBtn->setCursor(Qt::PointingHandCursor);
+    connect(m_mfBtn, &QPushButton::clicked, this, &TitleBar::multiFlexClicked);
+    m_hbox->addWidget(m_mfBtn);
 
     m_hbox->addStretch(1);
 
@@ -260,14 +269,14 @@ void TitleBar::setHeadphoneVolume(int pct)
 void TitleBar::setMultiFlexStatus(int count, const QStringList& names)
 {
     if (count > 0) {
-        m_mfLabel->setVisible(true);
+        m_mfBtn->setVisible(true);
         QString tip = QString("multiFLEX — %1 other client%2:\n")
             .arg(count).arg(count > 1 ? "s" : "");
         for (const QString& n : names)
             tip += "  " + n + "\n";
-        m_mfLabel->setToolTip(tip.trimmed());
+        m_mfBtn->setToolTip(tip.trimmed());
     } else {
-        m_mfLabel->setVisible(false);
+        m_mfBtn->setVisible(false);
     }
 }
 
@@ -282,6 +291,38 @@ void TitleBar::setOtherClientTx(bool transmitting, const QString& station)
 }
 
 void TitleBar::showFeatureRequestDialog()
+{
+    // Version check guard (#486) — warn if not on latest release
+    auto* nam = new QNetworkAccessManager(this);
+    auto* reply = nam->get(QNetworkRequest(
+        QUrl("https://api.github.com/repos/ten9876/AetherSDR/releases/latest")));
+    connect(reply, &QNetworkReply::finished, this, [this, reply, nam] {
+        reply->deleteLater();
+        nam->deleteLater();
+
+        if (reply->error() == QNetworkReply::NoError) {
+            auto doc = QJsonDocument::fromJson(reply->readAll());
+            QString latest = doc.object().value("tag_name").toString();
+            if (latest.startsWith('v')) latest = latest.mid(1);
+            auto latestVer = VersionNumber::parse(latest);
+            auto currentVer = VersionNumber::parse(QCoreApplication::applicationVersion());
+            if (!latestVer.isNull() && currentVer < latestVer) {
+                auto answer = QMessageBox::warning(this, "Outdated Version",
+                    QString("<p>You are running <b>v%1</b> but <b>v%2</b> is available.</p>"
+                            "<p>Your issue may already be fixed in the latest release. "
+                            "Please update before filing a bug report.</p>"
+                            "<p>Continue anyway?</p>")
+                        .arg(QCoreApplication::applicationVersion(), latest),
+                    QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+                if (answer != QMessageBox::Yes) return;
+            }
+        }
+        // Proceed to show the feature request dialog
+        showFeatureRequestDialogImpl();
+    });
+}
+
+void TitleBar::showFeatureRequestDialogImpl()
 {
     static const QString kPrompt =
         "Before responding, please read the AetherSDR project context at\n"
@@ -384,7 +425,7 @@ void TitleBar::setMinimalMode(bool on)
     m_hpSlider->setVisible(!on);
     m_masterLabel->setVisible(!on);
     m_hpLabel->setVisible(!on);
-    // Don't touch m_otherTxLabel or m_mfLabel — their visibility is
+    // Don't touch m_otherTxLabel or m_mfBtn — their visibility is
     // managed by setOtherClientTx() and setMultiFlexStatus() respectively
 
     // Swap icon and tooltip

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -36,13 +36,15 @@ signals:
     void lineoutMuteChanged(bool muted);
     void headphoneMuteChanged(bool muted);
     void minimalModeRequested();
+    void multiFlexClicked();
 
 private:
     void showFeatureRequestDialog();
+    void showFeatureRequestDialogImpl();
     QHBoxLayout* m_hbox{nullptr};
     QMenuBar*    m_menuBar{nullptr};
     QLabel*      m_otherTxLabel{nullptr};
-    QLabel*      m_mfLabel{nullptr};
+    QPushButton* m_mfBtn{nullptr};
     QPushButton* m_pcBtn{nullptr};
     QPushButton* m_speakerBtn{nullptr};
     QPushButton* m_headphoneBtn{nullptr};

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1745,19 +1745,22 @@ void VfoWidget::setSlice(SliceModel* slice)
         // CW: show APF, hide ANF/RNN/ANFL/ANFT
         // RTTY/DIG/FDV: hide ANF/ANFL/ANFT
         bool isVoice = !isRtty && !isCw && !isDig && !isFm && !isFdv;
-        // Disable squelch in digital modes (not meaningful — audio goes via DAX)
-        m_sqlBtn->setEnabled(!isDig);
-        m_sqlSlider->setEnabled(!isDig);
-        if (isDig && m_slice) {
-            // Save and disable squelch when entering digital mode
+        // Disable squelch in digital and CW modes
+        // Digital: audio goes via DAX, SQL not meaningful
+        // CW: radio locks squelch on at fixed level, rejects changes
+        bool sqlDisabled = isDig || isCw;
+        m_sqlBtn->setEnabled(!sqlDisabled);
+        m_sqlSlider->setEnabled(!sqlDisabled);
+        if (sqlDisabled && m_slice) {
             if (m_slice->squelchOn()) {
                 m_savedSquelchOn = true;
-                m_slice->setSquelch(false, m_slice->squelchLevel());
-                QSignalBlocker sb(m_sqlBtn);
-                m_sqlBtn->setChecked(false);
+                if (isDig) {
+                    m_slice->setSquelch(false, m_slice->squelchLevel());
+                    QSignalBlocker sb(m_sqlBtn);
+                    m_sqlBtn->setChecked(false);
+                }
             }
-        } else if (!isDig && m_slice && m_savedSquelchOn) {
-            // Restore squelch when leaving digital mode
+        } else if (!sqlDisabled && m_slice && m_savedSquelchOn) {
             m_savedSquelchOn = false;
             m_slice->setSquelch(true, m_slice->squelchLevel());
             QSignalBlocker sb(m_sqlBtn);
@@ -2215,6 +2218,9 @@ void VfoWidget::syncFromSlice()
     m_apfContainer->setVisible(isCw);
     m_digContainer->setVisible(isDig);
     m_fmContainer->setVisible(isFm);
+    // CW: radio locks squelch on at fixed level; Digital: not meaningful
+    m_sqlBtn->setEnabled(!isDig && !isCw);
+    m_sqlSlider->setEnabled(!isDig && !isCw);
     if (isFm) {
         QSignalBlocker b1(m_fmToneModeCmb), b2(m_fmToneValueCmb), b3(m_fmOffsetSpin);
         int tmIdx = m_fmToneModeCmb->findData(m_slice->fmToneMode());

--- a/src/gui/WhatsNewDialog.cpp
+++ b/src/gui/WhatsNewDialog.cpp
@@ -1,23 +1,27 @@
 #include "WhatsNewDialog.h"
 #include "generated/WhatsNewData.h"
 #include "core/VersionNumber.h"
+#include "core/AppSettings.h"
 
 #include <QCoreApplication>
 #include <QLabel>
 #include <QPushButton>
 #include <QTextBrowser>
 #include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QDesktopServices>
 
 namespace AetherSDR {
 
 WhatsNewDialog::WhatsNewDialog(const QString& lastSeenVersion,
                                const QString& currentVersion,
-                               QWidget* parent)
+                               QWidget* parent,
+                               bool showUpgrade)
     : QDialog(parent)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-    buildUI(lastSeenVersion, currentVersion);
+    buildUI(lastSeenVersion, currentVersion, showUpgrade);
 }
 
 WhatsNewDialog* WhatsNewDialog::showAll(QWidget* parent)
@@ -28,7 +32,8 @@ WhatsNewDialog* WhatsNewDialog::showAll(QWidget* parent)
 }
 
 void WhatsNewDialog::buildUI(const QString& lastSeenVersion,
-                              const QString& currentVersion)
+                              const QString& currentVersion,
+                              bool showUpgrade)
 {
     setWindowTitle("What's New — AetherSDR");
     resize(580, 540);
@@ -77,6 +82,15 @@ void WhatsNewDialog::buildUI(const QString& lastSeenVersion,
     header->setStyleSheet("QLabel { background: #0a0a14; }");
     layout->addWidget(header);
 
+    // Lightbulb hint (#485)
+    auto* hint = new QLabel(
+        "<span style='color: #8090a0; font-size: 11px;'>"
+        "Found a bug or have an idea? Click the \xf0\x9f\x92\xa1 button in the title bar.</span>");
+    hint->setAlignment(Qt::AlignCenter);
+    hint->setContentsMargins(16, 0, 16, 4);
+    hint->setStyleSheet("QLabel { background: #0a0a14; }");
+    layout->addWidget(hint);
+
     // Separator
     auto* sep = new QWidget;
     sep->setFixedHeight(1);
@@ -102,15 +116,36 @@ void WhatsNewDialog::buildUI(const QString& lastSeenVersion,
     auto* footerLayout = new QVBoxLayout(footer);
     footerLayout->setContentsMargins(16, 12, 16, 16);
 
-    auto* btn = new QPushButton("Got it — 73!");
-    btn->setFixedHeight(36);
-    btn->setCursor(Qt::PointingHandCursor);
-    btn->setStyleSheet(
+    auto* btnRow = new QHBoxLayout;
+    btnRow->setSpacing(12);
+
+    auto* gotItBtn = new QPushButton("Got it \xe2\x80\x94 73!");
+    gotItBtn->setFixedHeight(36);
+    gotItBtn->setCursor(Qt::PointingHandCursor);
+    gotItBtn->setStyleSheet(
         "QPushButton { background: #00b4d8; color: #0f0f1a; font-weight: bold; "
         "font-size: 14px; border-radius: 18px; padding: 0 32px; }"
         "QPushButton:hover { background: #00c8f0; }");
-    connect(btn, &QPushButton::clicked, this, &QDialog::close);
-    footerLayout->addWidget(btn, 0, Qt::AlignCenter);
+    connect(gotItBtn, &QPushButton::clicked, this, &QDialog::close);
+    btnRow->addWidget(gotItBtn);
+
+    if (showUpgrade) {
+        auto* upgradeBtn = new QPushButton("Upgrade");
+        upgradeBtn->setFixedHeight(36);
+        upgradeBtn->setCursor(Qt::PointingHandCursor);
+        upgradeBtn->setStyleSheet(
+            "QPushButton { background: #20a040; color: #ffffff; font-weight: bold; "
+            "font-size: 14px; border-radius: 18px; padding: 0 32px; }"
+            "QPushButton:hover { background: #28c050; }");
+        connect(upgradeBtn, &QPushButton::clicked, this, [this] {
+            QDesktopServices::openUrl(QUrl("https://github.com/ten9876/AetherSDR/releases/latest"));
+            close();
+        });
+        btnRow->addWidget(upgradeBtn);
+    }
+
+    footerLayout->addLayout(btnRow);
+    footerLayout->setAlignment(btnRow, Qt::AlignCenter);
     layout->addWidget(footer);
 
     setStyleSheet("WhatsNewDialog { background: #0f0f1a; }");

--- a/src/gui/WhatsNewDialog.h
+++ b/src/gui/WhatsNewDialog.h
@@ -19,13 +19,15 @@ public:
     // If lastSeen is empty (first install), shows only the current version.
     explicit WhatsNewDialog(const QString& lastSeenVersion,
                             const QString& currentVersion,
-                            QWidget* parent = nullptr);
+                            QWidget* parent = nullptr,
+                            bool showUpgrade = false);
 
     // Show all entries for the current version (for Help menu).
     static WhatsNewDialog* showAll(QWidget* parent);
 
 private:
-    void buildUI(const QString& lastSeenVersion, const QString& currentVersion);
+    void buildUI(const QString& lastSeenVersion, const QString& currentVersion,
+                  bool showUpgrade);
     QString renderHtml(const std::vector<ReleaseEntry>& entries, bool isWelcome) const;
 };
 


### PR DESCRIPTION
- Make multiFLEX badge clickable to open dashboard (#599)
- Add SAM, NFM, DFM to keyboard shortcut bindable modes (#601)
- Disable squelch controls in CW mode — radio-authoritative (#285)
- Auto-switch mode on spot click and add Mode column to Spot List (#424)
- Add "TX Follows Active Slice" option (#441)
- Add lightbulb hint to What's New dialog header (#485)
- Add version check before issue/feature submission (#486)
- Add upgrade check on launch with What's New + Upgrade button (#486)
- Add grid lines to TX Band Settings checkbox cells (#533)
