### PR TITLE
Fix MinGW build: TCP_INFO_v0 and _dupenv_s compatibility

### DIFF
--- a/src/core/RadioConnection.cpp
+++ b/src/core/RadioConnection.cpp
@@ -11,7 +11,33 @@
 #include <sys/socket.h>
 #elif defined(Q_OS_WIN)
 #include <winsock2.h>
+#include <ws2tcpip.h>
 #include <mstcpip.h>
+// MinGW headers may lack TCP_INFO_v0 / SIO_TCP_INFO (Windows 10 1703+)
+#ifndef SIO_TCP_INFO
+#define SIO_TCP_INFO _WSAIORW(IOC_VENDOR, 39)
+typedef struct _TCP_INFO_v0 {
+    ULONG    State;  // TCPSTATE enum — not used, just padding
+    ULONG    Mss;
+    ULONG64  ConnectionTimeMs;
+    BOOLEAN  TimestampsEnabled;
+    ULONG    RttUs;
+    ULONG    MinRttUs;
+    ULONG    BytesInFlight;
+    ULONG    Cwnd;
+    ULONG    SndWnd;
+    ULONG    RcvWnd;
+    ULONG    RcvBuf;
+    ULONG64  BytesOut;
+    ULONG64  BytesIn;
+    ULONG    BytesReordered;
+    ULONG    BytesRetrans;
+    ULONG    FastRetrans;
+    ULONG    DupAcksIn;
+    ULONG    TimeoutEpisodes;
+    UCHAR    SynRetrans;
+} TCP_INFO_v0;
+#endif
 #endif
 
 namespace AetherSDR {

--- a/src/core/SpectralNR.cpp
+++ b/src/core/SpectralNR.cpp
@@ -189,12 +189,10 @@ bool SpectralNR::generateWisdom(const std::string& directory,
     // This gives us a head start if Thetis is installed
 #ifdef _WIN32
     {
-        char* appData = nullptr;
-        size_t len = 0;
-        if (_dupenv_s(&appData, &len, "APPDATA") == 0 && appData) {
+        const char* appData = std::getenv("APPDATA");
+        if (appData) {
             std::string thetisWisdom = std::string(appData)
                 + "\\OpenHPSDR\\Thetis-x64\\wdspWisdom00";
-            free(appData);
             std::lock_guard<std::mutex> lock(s_fftwMutex);
             if (fftw_import_wisdom_from_filename(thetisWisdom.c_str())) {
                 // Save as our own so we don't depend on Thetis in future


### PR DESCRIPTION
## Summary

- Add `TCP_INFO_v0` and `SIO_TCP_INFO` definitions for MinGW, guarded by `#ifndef SIO_TCP_INFO` — these Windows 10 1703+ APIs exist in MSVC's `<mstcpip.h>` but are missing from MinGW's headers
- Replace MSVC-only `_dupenv_s()` with standard `std::getenv()` in FFTW wisdom Thetis import path

## Files Changed

- `src/core/RadioConnection.cpp` — manual `TCP_INFO_v0` struct and `SIO_TCP_INFO` macro definition for MinGW, used by `kernelRttMs()`
- `src/core/SpectralNR.cpp` — `_dupenv_s` → `std::getenv("APPDATA")` for Thetis FFTW wisdom import

## Protocol Notes

No protocol changes. These are build-system compatibility fixes only.

## Test Plan

- [x] Builds clean on Windows MinGW-w64 (Qt 6.11, GCC 13.1)
- [x] Verify CI build passes (Linux GCC — these changes are `#ifdef _WIN32` guarded, no effect on Linux)
- [ ] Verify MSVC build still works (the `#ifndef SIO_TCP_INFO` guard preserves MSVC behavior)


🤖 Generated with [Claude Code](https://claude.com/claude-code)