### PR TITLE
Replace QComboBox with GuardedComboBox in all applets (#618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [v0.7.18.3] — 2026-04-03
 
-### Background Image, Dynamic About & Bug Fixes
+### Background Image, Community PRs & Bug Fixes
 
 ### New Features
 
@@ -32,6 +32,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 **TX Band Settings grid lines and dedup (#533)**
 - Visible grid lines on all cells, removed duplicate dialog from Radio Setup
+
+**GuardedComboBox across all applets (#618)**
+- All combo boxes now consume scroll wheel events at boundaries
+- Prevents accidental mode/antenna/profile changes from scroll leaking
+
+### Community PRs
+
+**Fix PC mic TX audio (PR #623 by @boydsoftprez)**
+- Opus VITA-49 padding fix — trailing zeros corrupted radio's decoder
+- Mono USB mic support with extended fallback chain
+- r8brain resampling for TX downsampling (Fixes #363, #387)
+
+**Fix TGXL Fwd Power/SWR gauges (PR #627 by @boydsoftprez)**
+- Parse meters from TGXL direct TCP connection (port 9010)
+- TGXL reports power/SWR via R responses, not VITA-49 (Fixes #625)
+
+**Fix MinGW build (PR #622 by @boydsoftprez)**
+- Add TCP_INFO_v0 and SIO_TCP_INFO definitions for MinGW
+- Replace MSVC-only _dupenv_s with std::getenv
 
 ### Documentation
 

--- a/src/generated/WhatsNewData.cpp
+++ b/src/generated/WhatsNewData.cpp
@@ -6,13 +6,14 @@ namespace AetherSDR {
 
 const std::vector<ReleaseEntry>& whatsNewEntries() {
     static const std::vector<ReleaseEntry> entries = {
-        {QStringLiteral("0.7.18.3"), QStringLiteral("2026-04-03"), QStringLiteral("Documentation"), {
+        {QStringLiteral("0.7.18.3"), QStringLiteral("2026-04-03"), QStringLiteral("Community PRs"), {
             {ChangeCategory::Feature, QStringLiteral("Background image behind FFT spectrum"), QStringLiteral("Custom background image with adjustable dark overlay (0-100% opacity) Bundled AetherSDR logo as default background Choose/Clear buttons in Display overlay panel, persisted across sessions")},
             {ChangeCategory::Feature, QStringLiteral("Dynamic contributors in About dialog"), QStringLiteral("Live contributor list fetched from GitHub API with scrollable inset Falls back to hardcoded list when offline")},
             {ChangeCategory::Feature, QStringLiteral("GPG signed commits badge"), QStringLiteral("README badge linking to commit history")},
             {ChangeCategory::BugFix, QStringLiteral("External 10MHz reference showing as TCXO"), QStringLiteral("Radio sends `state=external` but we only checked `state=ext`")},
             {ChangeCategory::BugFix, QStringLiteral("TGXL power meter zero with PGXL connected"), QStringLiteral("AMP meter definitions arrived before TGXL handle was known, routing all meters to PGXL. Re-scan meter routing when handle arrives.")},
             {ChangeCategory::BugFix, QStringLiteral("TX Band Settings grid lines and dedup"), QStringLiteral("Visible grid lines on all cells, removed duplicate dialog from Radio Setup")},
+            {ChangeCategory::BugFix, QStringLiteral("GuardedComboBox across all applets"), QStringLiteral("All combo boxes now consume scroll wheel events at boundaries Prevents accidental mode/antenna/profile changes from scroll leaking")},
         }},
         {QStringLiteral("0.7.18.2"), QStringLiteral("2026-04-03"), QStringLiteral("Quality of Life & Issue Triage"), {
             {ChangeCategory::Feature, QStringLiteral("Clickable multiFLEX badge"), QStringLiteral("Click the green \"multiFLEX\" badge in the title bar to open the dashboard Hover highlight and pointing hand cursor")},

--- a/src/gui/AntennaGeniusApplet.cpp
+++ b/src/gui/AntennaGeniusApplet.cpp
@@ -1,4 +1,5 @@
 #include "AntennaGeniusApplet.h"
+#include "GuardedSlider.h"
 #include "models/AntennaGeniusModel.h"
 
 #include <QPushButton>
@@ -68,7 +69,7 @@ void AntennaGeniusApplet::buildUI()
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
 
-        m_deviceCombo = new QComboBox;
+        m_deviceCombo = new GuardedComboBox;
         m_deviceCombo->setStyleSheet(
             "QComboBox { background: #1a2a3a; border: 1px solid #203040; "
             "border-radius: 3px; padding: 2px 4px; color: #c8d8e8; font-size: 10px; }"

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -1,4 +1,5 @@
 #include "AppletPanel.h"
+#include "GuardedSlider.h"
 #include "ComboStyle.h"
 #include "RxApplet.h"
 #include "SMeterWidget.h"
@@ -222,7 +223,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     auto* txLabel = new QLabel("TX Select", selectRow);
     txLabel->setStyleSheet(labelStyle);
     txLabel->setAlignment(Qt::AlignCenter);
-    m_txSelect = new QComboBox(selectRow);
+    m_txSelect = new GuardedComboBox(selectRow);
     m_txSelect->addItems({"Power", "SWR", "Level", "Compression"});
     AetherSDR::applyComboStyle(m_txSelect);
 
@@ -234,7 +235,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     auto* rxLabel = new QLabel("RX Select", selectRow);
     rxLabel->setStyleSheet(labelStyle);
     rxLabel->setAlignment(Qt::AlignCenter);
-    m_rxSelect = new QComboBox(selectRow);
+    m_rxSelect = new GuardedComboBox(selectRow);
     m_rxSelect->addItems({"S-Meter", "S-Meter Peak"});
     m_rxSelect->setCurrentIndex(0);
     AetherSDR::applyComboStyle(m_rxSelect);

--- a/src/gui/CatApplet.cpp
+++ b/src/gui/CatApplet.cpp
@@ -1,4 +1,5 @@
 #include "CatApplet.h"
+#include "GuardedSlider.h"
 #include "SliceColors.h"
 #include <algorithm>
 #include <cmath>
@@ -314,7 +315,7 @@ void CatApplet::buildUI()
         label->setFixedWidth(28);
         row->addWidget(label);
 
-        m_iqRateCombo[i] = new QComboBox;
+        m_iqRateCombo[i] = new GuardedComboBox;
         applyComboStyle(m_iqRateCombo[i]);
         m_iqRateCombo[i]->addItem("24k",  24000);
         m_iqRateCombo[i]->addItem("48k",  48000);

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -138,7 +138,7 @@ void PhoneCwApplet::buildPhonePanel()
     vbox->addSpacing(4);
 
     // ── Mic profile dropdown ─────────────────────────────────────────────
-    m_micProfileCombo = new QComboBox;
+    m_micProfileCombo = new GuardedComboBox;
     m_micProfileCombo->setFixedHeight(22);
     AetherSDR::applyComboStyle(m_micProfileCombo);
     connect(m_micProfileCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
@@ -156,7 +156,7 @@ void PhoneCwApplet::buildPhonePanel()
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
 
-        m_micSourceCombo = new QComboBox;
+        m_micSourceCombo = new GuardedComboBox;
         m_micSourceCombo->setFixedWidth(55);
         m_micSourceCombo->setFixedHeight(22);
         AetherSDR::applyComboStyle(m_micSourceCombo);

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -353,7 +353,7 @@ void RxApplet::buildUI()
         m_freqRow->addSpacing(4);
 
         // Mode selector combo
-        m_modeCombo = new QComboBox;
+        m_modeCombo = new GuardedComboBox;
         m_modeCombo->setFixedHeight(20);
         m_modeCombo->addItems({"USB", "LSB", "CW", "AM", "SAM", "FM",
                                "NFM", "DFM", "DIGU", "DIGL", "RTTY"});
@@ -517,7 +517,7 @@ void RxApplet::buildUI()
         {
             auto* row = new QHBoxLayout;
             row->setSpacing(4);
-            m_toneModeCmb = new QComboBox;
+            m_toneModeCmb = new GuardedComboBox;
             m_toneModeCmb->addItem("Off",      QString("off"));
             m_toneModeCmb->addItem("CTCSS TX", QString("ctcss_tx"));
             AetherSDR::applyComboStyle(m_toneModeCmb);
@@ -535,7 +535,7 @@ void RxApplet::buildUI()
 
         // CTCSS tone value dropdown
         {
-            m_toneValueCmb = new QComboBox;
+            m_toneValueCmb = new GuardedComboBox;
             for (int i = 0; i < CTCSS_COUNT; ++i) {
                 const auto& t = CTCSS_TONES[i];
                 m_toneValueCmb->addItem(
@@ -733,7 +733,7 @@ void RxApplet::buildUI()
         agcRow->setContentsMargins(0, 0, 0, 0);
         agcRow->setSpacing(4);
 
-        m_agcCombo = new QComboBox;
+        m_agcCombo = new GuardedComboBox;
         m_agcCombo->addItem("Off",  QString("off"));
         m_agcCombo->addItem("Slow", QString("slow"));
         m_agcCombo->addItem("Med",  QString("med"));

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -245,7 +245,7 @@ void SpectrumOverlayMenu::buildAntPanel()
     antLabel->setStyleSheet(kLabelStyle);
     antLabel->setFixedWidth(kLabelW);
     antRow->addWidget(antLabel);
-    m_rxAntCmb = new QComboBox;
+    m_rxAntCmb = new GuardedComboBox;
     AetherSDR::applyComboStyle(m_rxAntCmb);
     antRow->addWidget(m_rxAntCmb, 1);
     vbox->addLayout(antRow);
@@ -635,7 +635,7 @@ void SpectrumOverlayMenu::buildDaxPanel()
     auto* lbl = new QLabel("DAX Ch");
     lbl->setStyleSheet(kLabelStyle);
     row->addWidget(lbl);
-    m_daxCmb = new QComboBox;
+    m_daxCmb = new GuardedComboBox;
     m_daxCmb->addItems({"Off", "1", "2", "3", "4"});
     AetherSDR::applyComboStyle(m_daxCmb);
     row->addWidget(m_daxCmb, 1);
@@ -652,7 +652,7 @@ void SpectrumOverlayMenu::buildDaxPanel()
     auto* iqLbl = new QLabel("IQ Ch");
     iqLbl->setStyleSheet(kLabelStyle);
     iqRow->addWidget(iqLbl);
-    m_daxIqCmb = new QComboBox;
+    m_daxIqCmb = new GuardedComboBox;
     m_daxIqCmb->addItems({"None", "1", "2", "3", "4"});
     AetherSDR::applyComboStyle(m_daxIqCmb);
     iqRow->addWidget(m_daxIqCmb, 1);

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -125,7 +125,7 @@ void TxApplet::buildUI()
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
 
-        m_profileCombo = new QComboBox;
+        m_profileCombo = new GuardedComboBox;
         AetherSDR::applyComboStyle(m_profileCombo);
         m_profileCombo->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         row->addWidget(m_profileCombo, 1);  // 1 out of 2 = 50%

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -606,7 +606,7 @@ void VfoWidget::buildTabContent()
         // AGC-T row: mode combo + threshold slider
         auto* agcRow = new QHBoxLayout;
         agcRow->setSpacing(3);
-        m_agcCmb = new QComboBox;
+        m_agcCmb = new GuardedComboBox;
         m_agcCmb->addItems({"Off", "Slow", "Med", "Fast"});
         m_agcCmb->setFixedHeight(20);
         m_agcCmb->setFixedWidth(60);
@@ -1040,14 +1040,14 @@ void VfoWidget::buildTabContent()
             // Tone mode + tone value on one row
             auto* toneRow = new QHBoxLayout;
             toneRow->setSpacing(2);
-            m_fmToneModeCmb = new QComboBox;
+            m_fmToneModeCmb = new GuardedComboBox;
             m_fmToneModeCmb->addItem("Off", QString("off"));
             m_fmToneModeCmb->addItem("CTCSS TX", QString("ctcss_tx"));
             AetherSDR::applyComboStyle(m_fmToneModeCmb);
             toneRow->addWidget(m_fmToneModeCmb, 1);
 
             // Tone value — simplified list of common CTCSS tones
-            m_fmToneValueCmb = new QComboBox;
+            m_fmToneValueCmb = new GuardedComboBox;
             const double tones[] = {67.0,71.9,74.4,77.0,79.7,82.5,85.4,88.5,91.5,94.8,
                 97.4,100.0,103.5,107.2,110.9,114.8,118.8,123.0,127.3,131.8,
                 136.5,141.3,146.2,151.4,156.7,162.2,167.9,173.8,179.9,186.2,
@@ -1180,7 +1180,7 @@ void VfoWidget::buildTabContent()
         vb->setSpacing(3);
 
         // Mode dropdown (same style as RxApplet)
-        m_modeCombo = new QComboBox;
+        m_modeCombo = new GuardedComboBox;
         m_modeCombo->setFixedHeight(26);
         // Default modes — replaced dynamically when slice connects and sends mode_list
         m_modeCombo->addItems({"USB", "LSB", "CW", "AM", "SAM", "FM",
@@ -1418,7 +1418,7 @@ void VfoWidget::buildTabContent()
         auto* lbl = new QLabel("DAX Ch");
         lbl->setStyleSheet(kLabelStyle);
         row->addWidget(lbl);
-        m_daxCmb = new QComboBox;
+        m_daxCmb = new GuardedComboBox;
         m_daxCmb->addItems({"Off", "1", "2", "3", "4"});
         AetherSDR::applyComboStyle(m_daxCmb);
         row->addWidget(m_daxCmb, 1);


### PR DESCRIPTION
Prevents accidental mode/antenna/profile changes from scroll wheel
events propagating through combo boxes. Same pattern as GuardedSlider
(#570). 19 combos across 8 files.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
