### PR TITLE
[ux] Justify logo title and status bar alignment

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2904,8 +2904,13 @@ void MainWindow::buildUI()
     hbox->addStretch(1);
 
     // ── Right section ────────────────────────────────────────────────────
+    // Reserve consistent width for the compact telemetry stacks so updates
+    // do not cause the status bar to reshuffle as values change.
+    constexpr int kTelemetryStackMinWidth = 84;
+
     // GPS satellites (top) + lock status (bottom) stacked
     auto* gpsStack = new QWidget;
+    gpsStack->setMinimumWidth(kTelemetryStackMinWidth);
     auto* gpsVbox = new QVBoxLayout(gpsStack);
     gpsVbox->setContentsMargins(0, 0, 0, 0);
     gpsVbox->setSpacing(0);
@@ -2923,6 +2928,7 @@ void MainWindow::buildUI()
 
     // PA temp (top) + supply voltage (bottom) stacked
     auto* paStack = new QWidget;
+    paStack->setMinimumWidth(kTelemetryStackMinWidth);
     auto* paVbox = new QVBoxLayout(paStack);
     paVbox->setContentsMargins(0, 0, 0, 0);
     paVbox->setSpacing(0);
@@ -2940,6 +2946,7 @@ void MainWindow::buildUI()
 
     // Network label (top) + quality (bottom) stacked
     auto* netStack = new QWidget;
+    netStack->setMinimumWidth(kTelemetryStackMinWidth);
     netStack->setCursor(Qt::PointingHandCursor);
     auto* netVbox = new QVBoxLayout(netStack);
     netVbox->setContentsMargins(0, 0, 0, 0);
@@ -2990,15 +2997,18 @@ void MainWindow::buildUI()
 
     // Grid square (top) + UTC time (bottom) stacked, right-aligned
     auto* timeStack = new QWidget;
+    timeStack->setMinimumWidth(kTelemetryStackMinWidth);
     auto* timeVbox = new QVBoxLayout(timeStack);
     timeVbox->setContentsMargins(0, 0, 0, 0);
     timeVbox->setSpacing(0);
     m_gridLabel = new QLabel("");
     m_gridLabel->setStyleSheet("QLabel { color: #8aa8c0; font-size: 12px; }");
-    m_gridLabel->setAlignment(Qt::AlignRight);
+    m_gridLabel->setAlignment(Qt::AlignCenter);
+    m_gridLabel->setMinimumWidth(kTelemetryStackMinWidth);
     m_gpsTimeLabel = new QLabel("");
     m_gpsTimeLabel->setStyleSheet("QLabel { color: #607080; font-size: 12px; }");
-    m_gpsTimeLabel->setAlignment(Qt::AlignRight);
+    m_gpsTimeLabel->setAlignment(Qt::AlignCenter);
+    m_gpsTimeLabel->setMinimumWidth(kTelemetryStackMinWidth);
     timeVbox->addWidget(m_gridLabel);
     timeVbox->addWidget(m_gpsTimeLabel);
     hbox->addWidget(timeStack);

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -30,8 +30,8 @@ TitleBar::TitleBar(QWidget* parent)
     m_hbox->setContentsMargins(4, 2, 8, 2);
     m_hbox->setSpacing(6);
 
-    // ── Left: menu bar will be inserted here via setMenuBar() ───────────────
-    m_hbox->addStretch(1);
+    // Keep the identity/status cluster anchored on the left, immediately after
+    // the menu bar once it is inserted via setMenuBar().
 
     // ── Heartbeat indicator ─────────────────────────────────────────────────
     m_heartbeat = new QLabel;
@@ -39,8 +39,6 @@ TitleBar::TitleBar(QWidget* parent)
     m_heartbeat->setStyleSheet(
         "QLabel { background: #404858; border-radius: 5px; }");
     m_heartbeat->setToolTip("Radio discovery heartbeat");
-    m_hbox->addWidget(m_heartbeat);
-    m_hbox->addSpacing(2);
 
     // 100ms timer to return green flash back to grey
     m_heartbeatOffTimer = new QTimer(this);
@@ -78,6 +76,8 @@ TitleBar::TitleBar(QWidget* parent)
     m_mfBtn->setCursor(Qt::PointingHandCursor);
     connect(m_mfBtn, &QPushButton::clicked, this, &TitleBar::multiFlexClicked);
     m_hbox->addWidget(m_mfBtn);
+    m_hbox->addSpacing(4);
+    m_hbox->addWidget(m_heartbeat);
 
     m_hbox->addStretch(1);
 


### PR DESCRIPTION
## Summary

The AetherSDR badge and connection status indicator in the upper-left corner of the main window are not correctly positioned on macOS. The element appears off-center — neither left-justified to the window edge nor centered within the title bar area. Expected behavior is flush left-justified alignment consistent with the Linux rendering.

- Left-align the AetherSDR title cluster with the menu bar
- Move the heartbeat/network indicator to the right of the multiFLEX label
- Stabilize the bottom telemetry layout and center the grid/time stack to stop UTC time jitter causing all labels to move

This addresses issue #602.

## Why

These small UI adjustments fix alignment issues in the custom title bar and remove visible status-bar jitter caused by live time updates.

## Validation

- Built successfully on macOS with `cmake --build build -j8`
