### PR TITLE
Bug: Fix go-to-frequency focus and recentering

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4915,7 +4915,9 @@ void MainWindow::registerShortcutActions()
         QKeySequence(), [nudgeFreq]() { nudgeFreq(-10000); });
     m_shortcutManager.registerAction("go_to_freq", "Go to Frequency", "Frequency",
         QKeySequence(Qt::Key_G), [this]() {
-            auto* vfo = spectrum() ? spectrum()->vfoWidget() : nullptr;
+            auto* s = activeSlice();
+            auto* sw = s ? spectrumForSlice(s) : nullptr;
+            auto* vfo = (s && sw) ? sw->vfoWidget(s->sliceId()) : nullptr;
             if (vfo) vfo->beginDirectEntry();
         });
 

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -424,7 +424,7 @@ void RxApplet::buildUI()
                     else if (ok && freqMhz > 54.0) freqMhz /= 1e3;
                 }
                 if (ok && freqMhz >= 0.001 && freqMhz <= maxMhz)
-                    m_slice->setFrequency(freqMhz);
+                    m_slice->tuneAndRecenter(freqMhz);
             }
             m_freqStack->setCurrentIndex(0);
         });

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -479,7 +479,7 @@ void VfoWidget::buildUI()
             }
 
             if (ok && freqMhz >= 0.001 && freqMhz <= maxMhz && m_slice)
-                m_slice->setFrequency(freqMhz);
+                m_slice->tuneAndRecenter(freqMhz);
         }
         m_freqStack->setCurrentIndex(0);  // back to label
     });
@@ -2083,7 +2083,13 @@ void VfoWidget::beginDirectEntry()
         m_freqEdit->selectAll();
     }
     m_freqStack->setCurrentIndex(1);
-    m_freqEdit->setFocus();
+    raise();
+    m_freqEdit->setFocus(Qt::ShortcutFocusReason);
+    QTimer::singleShot(0, m_freqEdit, [edit = m_freqEdit]() {
+        if (!edit) return;
+        edit->setFocus(Qt::ShortcutFocusReason);
+        edit->selectAll();
+    });
 }
 
 void VfoWidget::syncFromSlice()


### PR DESCRIPTION
## Summary

This PR fixes the `Go to Frequency` keyboard shortcut flow so direct frequency entry reliably opens the active slice frequency editor and recenters the panadapter on the tuned frequency.

## Problem

Binding `Go to Frequency` to a key such as `G` was inconsistent in three ways:

- the shortcut resolved the VFO editor through the generic active-spectrum alias instead of the active slices concrete VFO widget, so focus could miss the live editor
- the inline frequency editor asked for focus immediately during shortcut handling, which could fail to land cleanly while Qt was still processing the shortcut event
- after entering a new frequency, the slice tuned with `autopan=0`, so the panadapter could stay offset and leave the tuned frequency off screen

## What Changed

- `MainWindow::registerShortcutActions()` now resolves the active slice first, then looks up that slices VFO widget from the owning spectrum before calling `beginDirectEntry()`
- `VfoWidget::beginDirectEntry()` now switches to the inline editor, raises the widget, sets focus with `Qt::ShortcutFocusReason`, and reasserts that focus on the next event-loop tick with `QTimer::singleShot(0, ...)`
- direct frequency entry in both `VfoWidget` and `RxApplet` now uses `SliceModel::tuneAndRecenter()` instead of `setFrequency()` so the pan follows the tuned slice and keeps the destination frequency visible

## Why This Is Safe

- the fix uses existing shared Qt APIs and does not add platform-specific branches, so the focus behavior remains portable across macOS, Linux, and Windows
- `tuneAndRecenter()` is already an existing model API used elsewhere in the app for recentering workflows, so this change aligns manual frequency entry with established tuning behavior instead of introducing a new command path
- the PR is based directly on `main` and contains only the three files involved in the frequency-entry flow

## Validation

- built successfully from a clean `main`-based worktree with `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/qt`
- built successfully with `cmake --build build -j8`
- manually tested on macOS: the shortcut now opens the frequency editor, accepts entry without clicking into the box, and recenters the panadapter after tuning
