### PR TITLE
Remove duplicate title bar from AmpApplet

### DIFF
--- a/src/gui/AmpApplet.cpp
+++ b/src/gui/AmpApplet.cpp
@@ -13,19 +13,6 @@ AmpApplet::AmpApplet(QWidget* parent)
     vbox->setContentsMargins(4, 2, 4, 2);
     vbox->setSpacing(2);
 
-    // Title bar (matches TGXL / S-Meter / other applet title bars)
-    auto* titleBar = new QWidget;
-    titleBar->setFixedHeight(16);
-    titleBar->setStyleSheet(
-        "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
-        "stop:0 #3a4a5a, stop:0.5 #2a3a4a, stop:1 #1a2a38); "
-        "border-bottom: 1px solid #0a1a28; }");
-    m_titleLabel = new QLabel("POWER GENIUS XL", titleBar);
-    m_titleLabel->setStyleSheet("QLabel { background: transparent; color: #8aa8c0; "
-                                "font-size: 10px; font-weight: bold; }");
-    m_titleLabel->setGeometry(6, 1, 200, 14);
-    vbox->addWidget(titleBar);
-
     // Fwd Power gauge: 0-2000W
     m_fwdGauge = new HGauge(0.0f, 2000.0f, 1500.0f, "Fwd Pwr", "",
         {{0, "0"}, {500, "500"}, {1000, "1000"}, {1500, "1.5k"}, {2000, "2k"}});
@@ -57,9 +44,5 @@ void AmpApplet::setTemp(float degC)
     m_tempGauge->setValue(degC);
 }
 
-void AmpApplet::setModel(const QString& model)
-{
-    m_titleLabel->setText(model);
-}
 
 } // namespace AetherSDR

--- a/src/gui/AmpApplet.h
+++ b/src/gui/AmpApplet.h
@@ -16,10 +16,8 @@ public:
     void setFwdPower(float watts);
     void setSwr(float swr);
     void setTemp(float degC);
-    void setModel(const QString& model);
 
 private:
-    QLabel*  m_titleLabel{nullptr};
     HGauge*  m_fwdGauge{nullptr};
     HGauge*  m_swrGauge{nullptr};
     HGauge*  m_tempGauge{nullptr};

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -59,14 +59,15 @@ public:
         grip->setStyleSheet("QLabel { background: transparent; color: #607080; font-size: 10px; }");
         layout->addWidget(grip);
 
-        auto* lbl = new QLabel(text);
-        lbl->setStyleSheet("QLabel { background: transparent; color: #8aa8c0; "
+        m_label = new QLabel(text);
+        m_label->setStyleSheet("QLabel { background: transparent; color: #8aa8c0; "
                            "font-size: 10px; font-weight: bold; }");
-        layout->addWidget(lbl);
+        layout->addWidget(m_label);
         layout->addStretch();
     }
 
     const QString& appletId() const { return m_appletId; }
+    void setTitle(const QString& text) { m_label->setText(text); }
 
 protected:
     void mousePressEvent(QMouseEvent* ev) override {
@@ -99,6 +100,7 @@ protected:
 private:
     QString m_appletId;
     QPoint  m_dragStartPos;
+    QLabel* m_label{nullptr};
 };
 
 // ── Drop-aware scroll area ──────────────────────────────────────────────────


### PR DESCRIPTION
AmpApplet had its own internal title bar plus the AppletPanel's
drag-reorderable title bar, causing double headers. Removed the
internal one to match TunerApplet's pattern. Added setTitle() to
AppletTitleBar for future use.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
