### PR TITLE
Fix MSVC build: avoid capturing static variable in lambda (#655)

### DIFF
--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -426,8 +426,9 @@ void TitleBar::showFeatureRequestDialogImpl()
         auto* btn = new QPushButton(p.name, dlg);
         btn->setStyleSheet(btnStyle);
         QString url = p.url;
-        connect(btn, &QPushButton::clicked, dlg, [url, statusLabel, &kPrompt] {
-            QApplication::clipboard()->setText(kPrompt);
+        const QString& prompt = kPrompt;  // local ref for lambda capture
+        connect(btn, &QPushButton::clicked, dlg, [url, statusLabel, prompt] {
+            QApplication::clipboard()->setText(prompt);
             QDesktopServices::openUrl(QUrl(url));
             statusLabel->setText("Prompt copied to clipboard — paste into the AI, "
                                  "then come back and click Submit Your Idea");


### PR DESCRIPTION
MSVC rejects &kPrompt capture in lambda — static variables are not
automatic storage. Use a local const ref copy for the capture.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
