### PR TITLE
Normalize duplicate keyboard shortcut bindings on load

### DIFF
--- a/src/core/ShortcutManager.cpp
+++ b/src/core/ShortcutManager.cpp
@@ -1,5 +1,6 @@
 #include "ShortcutManager.h"
 #include "AppSettings.h"
+#include <QHash>
 #include <QWidget>
 #include <QDebug>
 
@@ -69,6 +70,41 @@ void ShortcutManager::loadBindings()
             a.currentKey = QKeySequence(val);
         // else keep default
     }
+
+    bool normalized = false;
+    QHash<QString, int> ownerByKey;
+    for (int i = 0; i < m_actions.size(); ++i) {
+        auto& action = m_actions[i];
+        if (action.currentKey.isEmpty()) continue;
+
+        const QString keyText = action.currentKey.toString();
+        auto it = ownerByKey.find(keyText);
+        if (it == ownerByKey.end()) {
+            ownerByKey.insert(keyText, i);
+            continue;
+        }
+
+        auto& incumbent = m_actions[*it];
+        const bool incumbentCustomized = incumbent.currentKey != incumbent.defaultKey;
+        const bool actionCustomized = action.currentKey != action.defaultKey;
+
+        if (actionCustomized && !incumbentCustomized) {
+            qWarning() << "ShortcutManager: clearing duplicate default binding"
+                       << incumbent.id << "for key" << keyText
+                       << "in favor of customized binding" << action.id;
+            incumbent.currentKey = QKeySequence();
+            *it = i;
+        } else {
+            qWarning() << "ShortcutManager: clearing duplicate binding"
+                       << action.id << "for key" << keyText
+                       << "owned by" << incumbent.id;
+            action.currentKey = QKeySequence();
+        }
+        normalized = true;
+    }
+
+    if (normalized)
+        saveBindings();
 }
 
 void ShortcutManager::saveBindings()


### PR DESCRIPTION
## Summary
This fixes a keyboard shortcut edge case where duplicate saved bindings can leave a key non-functional or unreliable at runtime.

## Problem
Shortcut bindings are loaded from settings without conflict resolution. If two actions end up saved with the same key, ShortcutManager rebuilds multiple QShortcuts for that key. In practice that can make the key behave ambiguously.

One real example was:
- mode_lsb = L
- lock_toggle = L

That let USB work with its unique binding while LSB appeared broken.

## Fix
During ShortcutManager load, normalize duplicate key assignments before shortcuts are rebuilt:
- keep the first unique binding for each key
- if a duplicate exists, prefer an explicit customized binding over a default binding
- clear the losing duplicate and save the normalized settings back out

## Why this is low risk
- only affects invalid duplicate bindings already present in saved settings
- does not change normal shortcut behavior for valid unique bindings
- uses existing QtCore APIs only, with no dependency or build-system changes

## Validation
- reproduced the issue by inspecting saved shortcut settings with both mode_lsb and lock_toggle bound to L
- isolated the fix onto a clean branch from main
- verified the branch contains only the ShortcutManager change
