### PR TITLE
Fix DXCC spot colouring — ADIF parsing and mode inference

### DIFF
--- a/src/core/AdifParser.cpp
+++ b/src/core/AdifParser.cpp
@@ -15,7 +15,8 @@ namespace AetherSDR {
 static QString extractField(const QString& block, const QString& fieldName)
 {
     // e.g. <CALL:6>G3ABC  or <CALL:6:S>G3ABC
-    static const QRegularExpression re(
+    // NOTE: do NOT make this regex static — the pattern depends on fieldName.
+    const QRegularExpression re(
         R"(<)" + QRegularExpression::escape(fieldName) + R"((?::\d+(?::[A-Z])?)?:(\d+)>)",
         QRegularExpression::CaseInsensitiveOption);
     auto m = re.match(block);
@@ -101,8 +102,20 @@ QVector<QsoRecord> AdifParser::parse(const QByteArray& data)
         rec.callsign = extractField(block, "CALL").trimmed().toUpper();
         if (rec.callsign.isEmpty()) continue;
 
-        // Band: prefer explicit <BAND> field, fall back to <FREQ> → freqToBand
+        // Band: prefer explicit <BAND> field, fall back to <FREQ> → freqToBand.
+        // Some loggers export bare numbers ("10", "20") instead of ADIF-standard
+        // labels ("10m", "20m") — normalise those here.
         rec.band = extractField(block, "BAND").trimmed().toLower();
+        if (!rec.band.isEmpty() && !rec.band.endsWith('m') && !rec.band.endsWith("cm")) {
+            static const QHash<QString,QString> bandMap = {
+                {"160","160m"},{"80","80m"},{"60","60m"},{"40","40m"},
+                {"30","30m"},{"20","20m"},{"17","17m"},{"15","15m"},
+                {"12","12m"},{"10","10m"},{"6","6m"},{"4","4m"},
+                {"2","2m"},{"70","70cm"},
+            };
+            const QString mapped = bandMap.value(rec.band);
+            if (!mapped.isEmpty()) rec.band = mapped;
+        }
         if (rec.band.isEmpty()) {
             const QString freqStr = extractField(block, "FREQ").trimmed();
             if (!freqStr.isEmpty()) {

--- a/src/core/DxccColorProvider.cpp
+++ b/src/core/DxccColorProvider.cpp
@@ -99,11 +99,51 @@ QString DxccColorProvider::freqToBand(double mhz)
     return {};
 }
 
+// Infer a mode group from frequency using IARU Region 1/2 band-plan segments.
+// Used when a spot carries no explicit mode field.
+static QString inferModeFromFreq(double mhz)
+{
+    // Each entry: { lo, hi, modeGroup }
+    static const struct { double lo, hi; const char* mg; } segs[] = {
+        // 160m
+        {1.800, 1.838, "CW"},    {1.838, 1.840, "DATA"}, {1.840, 2.000, "PHONE"},
+        // 80m
+        {3.500, 3.570, "CW"},    {3.570, 3.600, "DATA"}, {3.600, 4.000, "PHONE"},
+        // 60m  (data/phone only)
+        {5.000, 5.060, "DATA"},  {5.060, 5.600, "PHONE"},
+        // 40m
+        {7.000, 7.040, "CW"},    {7.040, 7.100, "DATA"}, {7.100, 7.300, "PHONE"},
+        // 30m  (CW + data only)
+        {10.100,10.130,"CW"},    {10.130,10.150,"DATA"},
+        // 20m
+        {14.000,14.070,"CW"},    {14.070,14.112,"DATA"}, {14.112,14.350,"PHONE"},
+        // 17m
+        {18.068,18.095,"CW"},    {18.095,18.110,"DATA"}, {18.110,18.168,"PHONE"},
+        // 15m
+        {21.000,21.070,"CW"},    {21.070,21.150,"DATA"}, {21.150,21.450,"PHONE"},
+        // 12m
+        {24.890,24.915,"CW"},    {24.915,24.930,"DATA"}, {24.930,24.990,"PHONE"},
+        // 10m
+        {28.000,28.070,"CW"},    {28.070,28.300,"DATA"}, {28.300,29.700,"PHONE"},
+        // 6m
+        {50.000,50.100,"CW"},    {50.100,50.400,"DATA"}, {50.400,54.000,"PHONE"},
+        // 4m
+        {70.000,70.100,"CW"},    {70.100,70.200,"DATA"}, {70.200,70.500,"PHONE"},
+        // 2m
+        {144.000,144.060,"CW"},  {144.060,144.175,"DATA"},{144.175,148.000,"PHONE"},
+        // 70cm
+        {430.000,430.150,"CW"},  {430.150,430.600,"DATA"},{430.600,440.000,"PHONE"},
+    };
+    for (const auto& s : segs)
+        if (mhz >= s.lo && mhz < s.hi) return s.mg;
+    return "PHONE";  // default for anything outside defined segments
+}
+
 QString DxccColorProvider::normaliseMode(const QString& mode)
 {
     const QString m = mode.toUpper();
     if (m == "CW")   return "CW";
-    if (m == "USB" || m == "LSB" || m == "AM" || m == "FM" || m == "PHONE")
+    if (m == "SSB" || m == "USB" || m == "LSB" || m == "AM" || m == "FM" || m == "PHONE")
         return "PHONE";
     // FT8, RTTY, PSK, etc. -> DATA
     return "DATA";
@@ -119,7 +159,9 @@ DxccStatus DxccColorProvider::statusForSpot(const QString& callsign,
     const QString band = freqToBand(freqMhz);
     if (band.isEmpty()) return DxccStatus::Unknown;
 
-    const QString mg = normaliseMode(mode);
+    // If the spot carries no mode, infer it from frequency using the IARU band plan.
+    // Defaulting unknown modes to DATA would mask phone/CW needs for active FT8 operators.
+    const QString mg = mode.trimmed().isEmpty() ? inferModeFromFreq(freqMhz) : normaliseMode(mode);
     return m_workedStatus.query(prefix, band, mg);
 }
 


### PR DESCRIPTION
Further testing with different logbook providers (QRZ, etc.) uncovered several issues:

1. extractField static regex (AdifParser.cpp) extractField declared its QRegularExpression as static const. Because the pattern is built from the fieldName parameter, the regex was compiled once on the first call and reused for all subsequent calls regardless of field name. Fixed by removing static.

2. Non-standard ADIF band labels (AdifParser.cpp) Some logging software writes <BAND:2>10 instead of the ADIF-standard <BAND:3>10M. Added a normalisation map for bare-numeric band labels.

3. SSB not mapped to PHONE (DxccColorProvider.cpp) normaliseMode handled USB/LSB but not SSB as an explicit mode string. Added to the PHONE group.

4. No-mode spots defaulted to DATA (DxccColorProvider.cpp) DX cluster spots rarely carry a mode field. Without one, the previous code defaulted to DATA — meaning operators with FT8-heavy logs would see most spots as Worked regardless of actual mode need. Added inferModeFromFreq() using IARU Region 1/2 band-plan segments to infer CW/DATA/PHONE from frequency when no mode is present.