### PR TITLE
TCI WebSocket server — full v2.0 protocol implementation (#528)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,8 @@ set(CORE_SOURCES
     src/core/WsjtxClient.cpp
     src/core/PotaClient.cpp
     src/core/RigctlServer.cpp
+    src/core/TciServer.cpp
+    src/core/TciProtocol.cpp
     src/core/FirmwareUploader.cpp
     src/core/DvkWavTransfer.cpp
     src/core/FirmwareStager.cpp

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -1,0 +1,1377 @@
+#ifdef HAVE_WEBSOCKETS
+#include "TciProtocol.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+#include "models/TransmitModel.h"
+#include "models/EqualizerModel.h"
+#include "models/SpotModel.h"
+#include "models/DaxIqModel.h"
+
+#include <QMetaObject>
+#include <cmath>
+
+namespace AetherSDR {
+
+TciProtocol::TciProtocol(RadioModel* model)
+    : m_model(model)
+{}
+
+// ── Mode conversion ────────────────────────────────────────────────────────
+
+QString TciProtocol::smartsdrToTci(const QString& mode)
+{
+    static const QMap<QString, QString> map = {
+        {"USB",  "usb"},   {"LSB",  "lsb"},
+        {"CW",   "cw"},    {"CWL",  "cwr"},
+        {"AM",   "am"},    {"SAM",  "sam"},
+        {"FM",   "fm"},    {"NFM",  "nfm"},
+        {"DFM",  "fm"},    {"FDM",  "fm"},
+        {"DIGU", "digu"},  {"DIGL", "digl"},
+        {"RTTY", "rtty"},  {"FDV",  "digu"},
+    };
+    return map.value(mode.toUpper(), "usb");
+}
+
+QString TciProtocol::tciToSmartSDR(const QString& mode)
+{
+    static const QMap<QString, QString> map = {
+        {"usb",  "USB"},   {"lsb",  "LSB"},
+        {"cw",   "CW"},    {"cwr",  "CWL"},
+        {"am",   "AM"},    {"sam",  "SAM"},
+        {"fm",   "FM"},    {"nfm",  "NFM"},
+        {"digu", "DIGU"},  {"digl", "DIGL"},
+        {"rtty", "RTTY"},
+    };
+    return map.value(mode.toLower(), "USB");
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+SliceModel* TciProtocol::sliceForTrx(int trx) const
+{
+    if (!m_model || !m_model->isConnected()) return nullptr;
+    for (auto* s : m_model->slices()) {
+        if (s->sliceId() == trx) return s;
+    }
+    // Fallback: first slice
+    auto slices = m_model->slices();
+    return slices.isEmpty() ? nullptr : slices.first();
+}
+
+// ── Init burst ─────────────────────────────────────────────────────────────
+
+QString TciProtocol::generateInitBurst()
+{
+    QString burst;
+    burst += QStringLiteral("protocol:ExpertSDR3,1.5;");
+    burst += QStringLiteral("device:%1;").arg(
+        m_model ? m_model->name() + " " + m_model->model()
+                : QStringLiteral("AetherSDR"));
+    burst += QStringLiteral("receive_only:false;");
+
+    // Count TRXs based on owned slices
+    int trxCount = m_model ? m_model->slices().size() : 1;
+    if (trxCount < 1) trxCount = 1;
+    burst += QStringLiteral("trx_count:%1;").arg(trxCount);
+    burst += QStringLiteral("channels_count:1;");
+
+    // Modulations list
+    burst += QStringLiteral("modulations_list:usb,lsb,cw,cwr,am,sam,fm,nfm,digu,digl,rtty;");
+
+    // Per-slice state
+    if (m_model) {
+        for (auto* s : m_model->slices()) {
+            int trx = s->sliceId();
+            long long hz = static_cast<long long>(std::round(s->frequency() * 1e6));
+            burst += QStringLiteral("vfo:%1,0,%2;").arg(trx).arg(hz);
+            burst += QStringLiteral("modulation:%1,%2;")
+                         .arg(trx).arg(smartsdrToTci(s->mode()));
+            burst += QStringLiteral("rx_enable:%1,true;").arg(trx);
+
+            // Filter
+            burst += QStringLiteral("rx_filter_band:%1,%2,%3;")
+                         .arg(trx).arg(s->filterLow()).arg(s->filterHigh());
+
+            // RIT/XIT
+            burst += QStringLiteral("rit_enable:%1,%2;")
+                         .arg(trx).arg(s->ritOn() ? "true" : "false");
+            burst += QStringLiteral("xit_enable:%1,%2;")
+                         .arg(trx).arg(s->xitOn() ? "true" : "false");
+            burst += QStringLiteral("rit_offset:%1,%2;")
+                         .arg(trx).arg(static_cast<int>(s->ritFreq()));
+            burst += QStringLiteral("xit_offset:%1,%2;")
+                         .arg(trx).arg(static_cast<int>(s->xitFreq()));
+
+            // Lock
+            burst += QStringLiteral("lock:%1,%2;")
+                         .arg(trx).arg(s->isLocked() ? "true" : "false");
+
+            // SQL
+            burst += QStringLiteral("sql_enable:%1,%2;")
+                         .arg(trx).arg(s->squelchOn() ? "true" : "false");
+            burst += QStringLiteral("sql_level:%1,%2;")
+                         .arg(trx).arg(s->squelchLevel());
+
+            // AGC
+            burst += QStringLiteral("agc_mode:%1,%2;")
+                         .arg(trx).arg(s->agcMode().toLower());
+
+            // DSP
+            burst += QStringLiteral("rx_nb_enable:%1,%2;")
+                         .arg(trx).arg(s->nbOn() ? "true" : "false");
+            burst += QStringLiteral("rx_nr_enable:%1,%2;")
+                         .arg(trx).arg(s->nrOn() ? "true" : "false");
+            burst += QStringLiteral("rx_anf_enable:%1,%2;")
+                         .arg(trx).arg(s->anfOn() ? "true" : "false");
+            burst += QStringLiteral("rx_apf_enable:%1,%2;")
+                         .arg(trx).arg(s->apfOn() ? "true" : "false");
+
+            // TX
+            burst += QStringLiteral("tx_enable:%1,%2;")
+                         .arg(trx).arg(s->isTxSlice() ? "true" : "false");
+        }
+
+        // Global TX state
+        auto& tx = m_model->transmitModel();
+        burst += QStringLiteral("drive:%1;").arg(tx.rfPower());
+        burst += QStringLiteral("tune_drive:%1;").arg(tx.tunePower());
+
+        bool isTx = tx.isTransmitting();
+        int txTrx = 0;
+        for (auto* s : m_model->slices()) {
+            if (s->isTxSlice()) { txTrx = s->sliceId(); break; }
+        }
+        burst += QStringLiteral("trx:%1,%2;").arg(txTrx).arg(isTx ? "true" : "false");
+    }
+
+    burst += QStringLiteral("audio_samplerate:24000;");
+    burst += QStringLiteral("iq_samplerate:48000;");
+    burst += QStringLiteral("start;");
+    burst += QStringLiteral("ready;");
+
+    return burst;
+}
+
+// ── Command dispatch ───────────────────────────────────────────────────────
+
+QString TciProtocol::handleCommand(const QString& cmd)
+{
+    m_pendingNotification.clear();
+
+    if (cmd.isEmpty()) return {};
+
+    // Parse: COMMAND_NAME:arg1,arg2,...
+    // or just: COMMAND_NAME
+    int colonIdx = cmd.indexOf(':');
+    QString name = (colonIdx >= 0) ? cmd.left(colonIdx).toLower().trimmed()
+                                   : cmd.toLower().trimmed();
+    QStringList args;
+    if (colonIdx >= 0) {
+        QString argStr = cmd.mid(colonIdx + 1).trimmed();
+        args = argStr.split(',', Qt::KeepEmptyParts);
+        for (auto& a : args) a = a.trimmed();
+    }
+
+    // Determine if this is a set (has args beyond trx) or get (trx only or no args)
+    // TCI convention: get has 1 arg (trx), set has 2+ args
+    bool isSet = false;
+
+    // Commands with special handling
+    if (name == "start")            return cmdStart();
+    if (name == "stop")             return cmdStop();
+    if (name == "tx_enable")        return cmdTxEnable(args);
+    if (name == "cw_msg")           return cmdCwMsg(args);
+    if (name == "cw_macros")        return cmdCwMacros(args);
+    if (name == "cw_macros_stop")   return cmdCwMacrosStop();
+    if (name == "spot")             return cmdSpot(args);
+    if (name == "spot_delete")      return cmdSpotDelete(args);
+    if (name == "spot_clear")       return cmdSpotClear();
+    if (name == "iq_start")         return cmdIqStart(args);
+    if (name == "iq_stop")          return cmdIqStop(args);
+    if (name == "iq_samplerate")    return cmdIqSampleRate(args, args.size() >= 1 && !args[0].isEmpty());
+    if (name == "keyer")            return cmdKeyer(args);
+    if (name == "cw_keyer_speed")   return cmdCwKeyerSpeed(args, isSet);
+    if (name == "cw_macros_delay")  return cmdCwMacrosDelay(args, isSet);
+    if (name == "cw_terminal")      return cmdCwTerminal(args, isSet);
+    if (name == "dds")              return cmdDds(args, isSet);
+    if (name == "if")               return cmdIf(args, isSet);
+    if (name == "rx_channel_enable") return cmdRxChannelEnable(args, isSet);
+    if (name == "rx_volume")        return cmdRxVolume(args, isSet);
+    if (name == "rx_mute")          return cmdRxMute(args, isSet);
+    if (name == "rx_balance")       return cmdRxBalance(args, isSet);
+    if (name == "mon_enable")       return cmdMonEnable(args, isSet);
+    if (name == "mon_volume")       return cmdMonVolume(args, isSet);
+    if (name == "rx_nb_param")      return cmdRxNbParam(args, isSet);
+    if (name == "rx_bin_enable")    return cmdRxBinEnable(args, isSet);
+    if (name == "rx_anc_enable")    return cmdRxAncEnable(args, isSet);
+    if (name == "rx_dse_enable")    return cmdRxDseEnable(args, isSet);
+    if (name == "rx_nf_enable")     return cmdRxNfEnable(args, isSet);
+    if (name == "digl_offset")      return cmdDiglOffset(args, isSet);
+    if (name == "digu_offset")      return cmdDiguOffset(args, isSet);
+    if (name == "set_in_focus")     return cmdSetInFocus();
+    if (name == "tx_frequency")     return cmdTxFrequency();
+    if (name == "vfo_limits")       return QStringLiteral("vfo_limits:30000,54000000;");
+    if (name == "if_limits")        return QStringLiteral("if_limits:-10000,10000;");
+    if (name == "vfo_lock")         return cmdLock(args, isSet);  // alias
+
+    // Bidirectional commands: get if 0-1 args, set if 2+
+    isSet = (args.size() >= 2);
+
+    if (name == "vfo")              return cmdVfo(args, isSet);
+    if (name == "modulation")       return cmdModulation(args, isSet);
+    if (name == "trx")              return cmdTrx(args, isSet);
+    if (name == "tune")             return cmdTune(args, isSet);
+    if (name == "drive")            return cmdDrive(args, isSet);
+    if (name == "tune_drive")       return cmdTuneDrive(args, isSet);
+    if (name == "rit_enable")       return cmdRitEnable(args, isSet);
+    if (name == "xit_enable")       return cmdXitEnable(args, isSet);
+    if (name == "rit_offset")       return cmdRitOffset(args, isSet);
+    if (name == "xit_offset")       return cmdXitOffset(args, isSet);
+    if (name == "split_enable")     return cmdSplitEnable(args, isSet);
+    if (name == "rx_filter_band")   return cmdRxFilterBand(args, isSet);
+    if (name == "cw_macros_speed")  return cmdCwMacrosSpeed(args, isSet);
+    if (name == "lock")             return cmdLock(args, isSet);
+    if (name == "sql_enable")       return cmdSqlEnable(args, isSet);
+    if (name == "sql_level")        return cmdSqlLevel(args, isSet);
+    if (name == "volume")           return cmdVolume(args, isSet);
+    if (name == "mute")             return cmdMute(args, isSet);
+    if (name == "agc_mode")         return cmdAgcMode(args, isSet);
+    if (name == "agc_gain")         return cmdAgcGain(args, isSet);
+    if (name == "rx_nb_enable")     return cmdRxNbEnable(args, isSet);
+    if (name == "rx_nr_enable")     return cmdRxNrEnable(args, isSet);
+    if (name == "rx_anf_enable")    return cmdRxAnfEnable(args, isSet);
+    if (name == "rx_apf_enable")    return cmdRxApfEnable(args, isSet);
+
+    // Unknown command — ignore silently per TCI spec
+    return {};
+}
+
+QString TciProtocol::pendingNotification()
+{
+    QString n = m_pendingNotification;
+    m_pendingNotification.clear();
+    return n;
+}
+
+// ── Command implementations ────────────────────────────────────────────────
+
+QString TciProtocol::cmdStart()
+{
+    m_started = true;
+    return {};
+}
+
+QString TciProtocol::cmdStop()
+{
+    m_started = false;
+    return {};
+}
+
+// ── VFO: get/set frequency ─────────────────────────────────────────────────
+
+QString TciProtocol::cmdVfo(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        // Get: vfo:trx,channel,freq_hz;
+        long long hz = static_cast<long long>(std::round(s->frequency() * 1e6));
+        return QStringLiteral("vfo:%1,0,%2;").arg(trx).arg(hz);
+    }
+
+    // Set: vfo:trx,channel,freq_hz
+    if (args.size() < 3) return {};
+    bool ok;
+    long long hz = args[2].toLongLong(&ok);
+    if (!ok || hz < 0) return {};
+    double mhz = hz / 1e6;
+
+    QMetaObject::invokeMethod(s, [s, mhz]() {
+        s->tuneAndRecenter(mhz);
+    }, Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("vfo:%1,0,%2;").arg(trx).arg(hz);
+    return {};
+}
+
+// ── Modulation: get/set mode ───────────────────────────────────────────────
+
+QString TciProtocol::cmdModulation(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("modulation:%1,%2;")
+                   .arg(trx).arg(smartsdrToTci(s->mode()));
+    }
+
+    if (args.size() < 2) return {};
+    QString sdrMode = tciToSmartSDR(args[1]);
+    QMetaObject::invokeMethod(s, [s, sdrMode]() {
+        s->setMode(sdrMode);
+    }, Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("modulation:%1,%2;")
+                                .arg(trx).arg(args[1].toLower());
+    return {};
+}
+
+// ── TRX: get/set TX state ──────────────────────────────────────────────────
+
+QString TciProtocol::cmdTrx(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+
+    if (!isSet) {
+        bool tx = m_model && m_model->transmitModel().isTransmitting();
+        return QStringLiteral("trx:%1,%2;").arg(trx).arg(tx ? "true" : "false");
+    }
+
+    if (args.size() < 2) return {};
+    bool tx = (args[1].toLower() == "true");
+    QMetaObject::invokeMethod(m_model, [this, tx, trx]() {
+        // Assign TX to this TRX's slice before keying
+        if (tx) {
+            auto* s = sliceForTrx(trx);
+            if (s && !s->isTxSlice())
+                s->setTxSlice(true);
+        }
+        m_model->setTransmit(tx);
+    }, Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("trx:%1,%2;")
+                                .arg(trx).arg(tx ? "true" : "false");
+    return {};
+}
+
+// ── TX_ENABLE: assign TX to a TRX (unidirectional) ─────────────────────────
+
+QString TciProtocol::cmdTxEnable(const QStringList& args)
+{
+    if (args.size() < 2) return {};
+    int trx = args[0].toInt();
+    bool enable = (args[1].toLower() == "true");
+
+    if (enable) {
+        auto* s = sliceForTrx(trx);
+        if (s) {
+            QMetaObject::invokeMethod(s, [s]() {
+                s->setTxSlice(true);
+            }, Qt::QueuedConnection);
+        }
+    }
+    return {};
+}
+
+// ── TUNE: get/set tune state ───────────────────────────────────────────────
+
+QString TciProtocol::cmdTune(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    (void)trx;
+
+    if (!isSet) {
+        bool tuning = m_model && m_model->transmitModel().isTuning();
+        return QStringLiteral("tune:%1,%2;").arg(trx).arg(tuning ? "true" : "false");
+    }
+
+    if (args.size() < 2) return {};
+    bool tune = (args[1].toLower() == "true");
+    QMetaObject::invokeMethod(m_model, [this, tune]() {
+        if (tune)
+            m_model->transmitModel().startTune();
+        else
+            m_model->transmitModel().stopTune();
+    }, Qt::QueuedConnection);
+
+    return {};
+}
+
+// ── DRIVE: get/set RF power ────────────────────────────────────────────────
+
+QString TciProtocol::cmdDrive(const QStringList& args, bool isSet)
+{
+    if (!isSet) {
+        int pwr = m_model ? m_model->transmitModel().rfPower() : 0;
+        return QStringLiteral("drive:%1;").arg(pwr);
+    }
+
+    if (args.isEmpty()) return {};
+    bool ok;
+    int pwr = args[0].toInt(&ok);
+    if (!ok) return {};
+    QMetaObject::invokeMethod(m_model, [this, pwr]() {
+        m_model->transmitModel().setRfPower(pwr);
+    }, Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("drive:%1;").arg(pwr);
+    return {};
+}
+
+// ── TUNE_DRIVE: get/set tune power ─────────────────────────────────────────
+
+QString TciProtocol::cmdTuneDrive(const QStringList& args, bool isSet)
+{
+    if (!isSet) {
+        int pwr = m_model ? m_model->transmitModel().tunePower() : 0;
+        return QStringLiteral("tune_drive:%1;").arg(pwr);
+    }
+
+    if (args.isEmpty()) return {};
+    bool ok;
+    int pwr = args[0].toInt(&ok);
+    if (!ok) return {};
+    QMetaObject::invokeMethod(m_model, [this, pwr]() {
+        m_model->transmitModel().setTunePower(pwr);
+    }, Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("tune_drive:%1;").arg(pwr);
+    return {};
+}
+
+// ── RIT ────────────────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdRitEnable(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("rit_enable:%1,%2;")
+                   .arg(trx).arg(s->ritOn() ? "true" : "false");
+    }
+
+    if (args.size() < 2) return {};
+    bool on = (args[1].toLower() == "true");
+    int hz = s->ritFreq();
+    QMetaObject::invokeMethod(s, [s, on, hz]() { s->setRit(on, hz); },
+                              Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("rit_enable:%1,%2;")
+                                .arg(trx).arg(on ? "true" : "false");
+    return {};
+}
+
+QString TciProtocol::cmdRitOffset(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("rit_offset:%1,%2;")
+                   .arg(trx).arg(static_cast<int>(s->ritFreq()));
+    }
+
+    if (args.size() < 2) return {};
+    int offset = args[1].toInt();
+    bool on = s->ritOn();
+    QMetaObject::invokeMethod(s, [s, on, offset]() {
+        s->setRit(on, offset);
+    }, Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("rit_offset:%1,%2;")
+                                .arg(trx).arg(offset);
+    return {};
+}
+
+// ── XIT ────────────────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdXitEnable(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("xit_enable:%1,%2;")
+                   .arg(trx).arg(s->xitOn() ? "true" : "false");
+    }
+
+    if (args.size() < 2) return {};
+    bool on = (args[1].toLower() == "true");
+    int hz = s->xitFreq();
+    QMetaObject::invokeMethod(s, [s, on, hz]() { s->setXit(on, hz); },
+                              Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("xit_enable:%1,%2;")
+                                .arg(trx).arg(on ? "true" : "false");
+    return {};
+}
+
+QString TciProtocol::cmdXitOffset(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("xit_offset:%1,%2;")
+                   .arg(trx).arg(static_cast<int>(s->xitFreq()));
+    }
+
+    if (args.size() < 2) return {};
+    int offset = args[1].toInt();
+    bool on = s->xitOn();
+    QMetaObject::invokeMethod(s, [s, on, offset]() {
+        s->setXit(on, offset);
+    }, Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("xit_offset:%1,%2;")
+                                .arg(trx).arg(offset);
+    return {};
+}
+
+// ── SPLIT ──────────────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdSplitEnable(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        // Split = TX slice is different from this slice
+        bool split = false;
+        for (auto* sl : m_model->slices()) {
+            if (sl->isTxSlice() && sl != s) { split = true; break; }
+        }
+        return QStringLiteral("split_enable:%1,%2;")
+                   .arg(trx).arg(split ? "true" : "false");
+    }
+
+    // Set split — not fully controllable from TCI (would need to create a second slice)
+    // Just acknowledge
+    return {};
+}
+
+// ── RX Filter ──────────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdRxFilterBand(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("rx_filter_band:%1,%2,%3;")
+                   .arg(trx).arg(s->filterLow()).arg(s->filterHigh());
+    }
+
+    if (args.size() < 3) return {};
+    int lo = args[1].toInt();
+    int hi = args[2].toInt();
+    QMetaObject::invokeMethod(s, [s, lo, hi]() {
+        s->setFilterWidth(lo, hi);
+    }, Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("rx_filter_band:%1,%2,%3;")
+                                .arg(trx).arg(lo).arg(hi);
+    return {};
+}
+
+// ── CW ─────────────────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdCwMacrosSpeed(const QStringList& args, bool isSet)
+{
+    if (!isSet) {
+        int wpm = m_model ? m_model->transmitModel().cwSpeed() : 25;
+        return QStringLiteral("cw_macros_speed:%1;").arg(wpm);
+    }
+
+    if (args.isEmpty()) return {};
+    int wpm = args[0].toInt();
+    if (wpm < 5 || wpm > 100) return {};
+    QString cmd = QStringLiteral("cw wpm %1").arg(wpm);
+    QMetaObject::invokeMethod(m_model, [this, cmd]() {
+        m_model->sendCmdPublic(cmd, nullptr);
+    }, Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("cw_macros_speed:%1;").arg(wpm);
+    return {};
+}
+
+QString TciProtocol::cmdCwMsg(const QStringList& args)
+{
+    if (args.isEmpty()) return {};
+    // cw_msg:text — send CW macro text
+    QString text = args.join(',');  // rejoin in case text had commas
+    if (text.isEmpty()) return {};
+    QString cmd = QStringLiteral("cwx send \"%1\"").arg(text);
+    QMetaObject::invokeMethod(m_model, [this, cmd]() {
+        m_model->sendCmdPublic(cmd, nullptr);
+    }, Qt::QueuedConnection);
+    return {};
+}
+
+// ── Lock ───────────────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdLock(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("lock:%1,%2;")
+                   .arg(trx).arg(s->isLocked() ? "true" : "false");
+    }
+
+    if (args.size() < 2) return {};
+    bool on = (args[1].toLower() == "true");
+    QMetaObject::invokeMethod(s, [s, on]() { s->setLocked(on); },
+                              Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("lock:%1,%2;")
+                                .arg(trx).arg(on ? "true" : "false");
+    return {};
+}
+
+// ── Squelch ────────────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdSqlEnable(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("sql_enable:%1,%2;")
+                   .arg(trx).arg(s->squelchOn() ? "true" : "false");
+    }
+
+    if (args.size() < 2) return {};
+    bool on = (args[1].toLower() == "true");
+    int level = s->squelchLevel();
+    QMetaObject::invokeMethod(s, [s, on, level]() { s->setSquelch(on, level); },
+                              Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("sql_enable:%1,%2;")
+                                .arg(trx).arg(on ? "true" : "false");
+    return {};
+}
+
+QString TciProtocol::cmdSqlLevel(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("sql_level:%1,%2;")
+                   .arg(trx).arg(s->squelchLevel());
+    }
+
+    if (args.size() < 2) return {};
+    int level = args[1].toInt();
+    bool on = s->squelchOn();
+    QMetaObject::invokeMethod(s, [s, on, level]() { s->setSquelch(on, level); },
+                              Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("sql_level:%1,%2;")
+                                .arg(trx).arg(level);
+    return {};
+}
+
+// ── Volume / Mute ──────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdVolume(const QStringList& args, bool isSet)
+{
+    if (!isSet) {
+        // Volume is per-slice audioGain in FlexRadio (0-100)
+        if (!args.isEmpty()) {
+            int trx = args[0].toInt();
+            auto* s = sliceForTrx(trx);
+            if (s) return QStringLiteral("volume:%1;")
+                              .arg(static_cast<int>(s->audioGain()));
+        }
+        return {};
+    }
+
+    if (args.isEmpty()) return {};
+    int vol = args[0].toInt();
+    // Apply to the specified trx slice, or first slice as fallback
+    auto* s = sliceForTrx(args.size() > 1 ? args[0].toInt() : 0);
+    if (s) {
+        float gain = static_cast<float>(vol);
+        QMetaObject::invokeMethod(s, [s, gain]() { s->setAudioGain(gain); },
+                                  Qt::QueuedConnection);
+    }
+
+    m_pendingNotification = QStringLiteral("volume:%1;").arg(vol);
+    return {};
+}
+
+QString TciProtocol::cmdMute(const QStringList& args, bool isSet)
+{
+    if (!isSet) {
+        if (!args.isEmpty()) {
+            int trx = args[0].toInt();
+            auto* s = sliceForTrx(trx);
+            if (s) return QStringLiteral("mute:%1,%2;")
+                              .arg(trx).arg(s->audioMute() ? "true" : "false");
+        }
+        return {};
+    }
+
+    if (args.size() < 2) return {};
+    int trx = args[0].toInt();
+    bool mute = (args[1].toLower() == "true");
+    auto* s = sliceForTrx(trx);
+    if (s) {
+        QMetaObject::invokeMethod(s, [s, mute]() { s->setAudioMute(mute); },
+                                  Qt::QueuedConnection);
+    }
+
+    m_pendingNotification = QStringLiteral("mute:%1,%2;")
+                                .arg(trx).arg(mute ? "true" : "false");
+    return {};
+}
+
+// ── AGC ────────────────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdAgcMode(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("agc_mode:%1,%2;")
+                   .arg(trx).arg(s->agcMode().toLower());
+    }
+
+    if (args.size() < 2) return {};
+    QString mode = args[1].toLower();
+    // Map TCI AGC names to FlexRadio: off, slow, med, fast
+    QMetaObject::invokeMethod(s, [s, mode]() { s->setAgcMode(mode); },
+                              Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("agc_mode:%1,%2;")
+                                .arg(trx).arg(mode);
+    return {};
+}
+
+QString TciProtocol::cmdAgcGain(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("agc_gain:%1,%2;")
+                   .arg(trx).arg(s->agcThreshold());
+    }
+
+    if (args.size() < 2) return {};
+    int gain = args[1].toInt();
+    QMetaObject::invokeMethod(s, [s, gain]() { s->setAgcThreshold(gain); },
+                              Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("agc_gain:%1,%2;")
+                                .arg(trx).arg(gain);
+    return {};
+}
+
+// ── DSP toggles ────────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdRxNbEnable(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("rx_nb_enable:%1,%2;")
+                   .arg(trx).arg(s->nbOn() ? "true" : "false");
+    }
+
+    if (args.size() < 2) return {};
+    bool on = (args[1].toLower() == "true");
+    QMetaObject::invokeMethod(s, [s, on]() { s->setNb(on); },
+                              Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("rx_nb_enable:%1,%2;")
+                                .arg(trx).arg(on ? "true" : "false");
+    return {};
+}
+
+QString TciProtocol::cmdRxNrEnable(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("rx_nr_enable:%1,%2;")
+                   .arg(trx).arg(s->nrOn() ? "true" : "false");
+    }
+
+    if (args.size() < 2) return {};
+    bool on = (args[1].toLower() == "true");
+    QMetaObject::invokeMethod(s, [s, on]() { s->setNr(on); },
+                              Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("rx_nr_enable:%1,%2;")
+                                .arg(trx).arg(on ? "true" : "false");
+    return {};
+}
+
+QString TciProtocol::cmdRxAnfEnable(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("rx_anf_enable:%1,%2;")
+                   .arg(trx).arg(s->anfOn() ? "true" : "false");
+    }
+
+    if (args.size() < 2) return {};
+    bool on = (args[1].toLower() == "true");
+    QMetaObject::invokeMethod(s, [s, on]() { s->setAnf(on); },
+                              Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("rx_anf_enable:%1,%2;")
+                                .arg(trx).arg(on ? "true" : "false");
+    return {};
+}
+
+QString TciProtocol::cmdRxApfEnable(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("rx_apf_enable:%1,%2;")
+                   .arg(trx).arg(s->apfOn() ? "true" : "false");
+    }
+
+    if (args.size() < 2) return {};
+    bool on = (args[1].toLower() == "true");
+    QMetaObject::invokeMethod(s, [s, on]() { s->setApf(on); },
+                              Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("rx_apf_enable:%1,%2;")
+                                .arg(trx).arg(on ? "true" : "false");
+    return {};
+}
+
+// ── Spot injection ─────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdSpot(const QStringList& args)
+{
+    // spot:callsign,modulation,freq_hz,color,text
+    if (!m_model || args.size() < 3) return {};
+
+    QString callsign = args[0].trimmed();
+    QString mode = args[1].trimmed();
+    bool ok;
+    double freqHz = args[2].toDouble(&ok);
+    if (!ok || callsign.isEmpty()) return {};
+
+    QString color = (args.size() > 3) ? args[3].trimmed() : QString();
+    QString comment = (args.size() > 4) ? args[4].trimmed() : QString();
+
+    QMap<QString, QString> kvs;
+    kvs["callsign"] = callsign;
+    kvs["rx_freq"] = QString::number(freqHz / 1e6, 'f', 6);
+    kvs["mode"] = mode;
+    kvs["source"] = "TCI";
+    if (!color.isEmpty()) kvs["color"] = color;
+    if (!comment.isEmpty()) kvs["comment"] = comment;
+    kvs["lifetime_seconds"] = "1800";
+
+    QMetaObject::invokeMethod(m_model, [this, kvs]() {
+        static int idx = 10000;
+        m_model->spotModel().applySpotStatus(idx++, kvs);
+    }, Qt::QueuedConnection);
+
+    return {};
+}
+
+QString TciProtocol::cmdSpotDelete(const QStringList& args)
+{
+    if (!m_model || args.size() < 2) return {};
+    QString callsign = args[0].trimmed();
+    bool ok;
+    double freqHz = args[1].toDouble(&ok);
+    if (!ok) return {};
+    double freqMhz = freqHz / 1e6;
+
+    QMetaObject::invokeMethod(m_model, [this, callsign, freqMhz]() {
+        auto& sm = m_model->spotModel();
+        for (auto it = sm.spots().begin(); it != sm.spots().end(); ++it) {
+            if (it->callsign == callsign &&
+                std::abs(it->rxFreqMhz - freqMhz) < 0.0001) {
+                sm.removeSpot(it.key());
+                break;
+            }
+        }
+    }, Qt::QueuedConnection);
+
+    return {};
+}
+
+QString TciProtocol::cmdSpotClear()
+{
+    if (!m_model) return {};
+    QMetaObject::invokeMethod(m_model, [this]() {
+        m_model->spotModel().clear();
+    }, Qt::QueuedConnection);
+    return {};
+}
+
+// ── CW macros ──────────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdCwMacros(const QStringList& args)
+{
+    if (!m_model || args.isEmpty()) return {};
+    QString text = args.join(',');
+    if (text.isEmpty()) return {};
+    QString cmd = QStringLiteral("cwx send \"%1\"").arg(text);
+    QMetaObject::invokeMethod(m_model, [this, cmd]() {
+        m_model->sendCmdPublic(cmd, nullptr);
+    }, Qt::QueuedConnection);
+    return {};
+}
+
+QString TciProtocol::cmdCwMacrosStop()
+{
+    if (!m_model) return {};
+    QMetaObject::invokeMethod(m_model, [this]() {
+        m_model->sendCmdPublic("cwx clear", nullptr);
+    }, Qt::QueuedConnection);
+    return {};
+}
+
+// ── IQ streaming ───────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdIqStart(const QStringList& args)
+{
+    if (!m_model || args.isEmpty()) return {};
+    int channel = args[0].toInt() + 1;  // TRX 0 → DAX IQ channel 1
+    if (channel < 1 || channel > 4) return {};
+    QMetaObject::invokeMethod(m_model, [this, channel]() {
+        m_model->daxIqModel().createStream(channel);
+    }, Qt::QueuedConnection);
+    return {};
+}
+
+QString TciProtocol::cmdIqStop(const QStringList& args)
+{
+    if (!m_model || args.isEmpty()) return {};
+    int channel = args[0].toInt() + 1;
+    if (channel < 1 || channel > 4) return {};
+    QMetaObject::invokeMethod(m_model, [this, channel]() {
+        m_model->daxIqModel().removeStream(channel);
+    }, Qt::QueuedConnection);
+    return {};
+}
+
+QString TciProtocol::cmdIqSampleRate(const QStringList& args, bool isSet)
+{
+    if (!isSet) {
+        if (m_model) {
+            int rate = m_model->daxIqModel().stream(1).sampleRate;
+            return QStringLiteral("iq_samplerate:%1;").arg(rate);
+        }
+        return QStringLiteral("iq_samplerate:48000;");
+    }
+
+    if (args.isEmpty()) return {};
+    int rate = args[0].toInt();
+    if (rate != 24000 && rate != 48000 && rate != 96000 && rate != 192000)
+        return {};
+    if (m_model) {
+        QMetaObject::invokeMethod(m_model, [this, rate]() {
+            m_model->daxIqModel().setSampleRate(1, rate);
+        }, Qt::QueuedConnection);
+    }
+    m_pendingNotification = QStringLiteral("iq_samplerate:%1;").arg(rate);
+    return {};
+}
+
+// ── CW keyer (straight key via TCI) ────────────────────────────────────────
+
+QString TciProtocol::cmdKeyer(const QStringList& args)
+{
+    // keyer:trx,state[,duration_ms]
+    // state: true=key down, false=key up
+    if (!m_model || args.size() < 2) return {};
+    bool down = (args[1].toLower() == "true");
+    QMetaObject::invokeMethod(m_model, [this, down]() {
+        m_model->sendCwKey(down);
+    }, Qt::QueuedConnection);
+    return {};
+}
+
+QString TciProtocol::cmdCwKeyerSpeed(const QStringList& args, bool isSet)
+{
+    if (!isSet) {
+        int wpm = m_model ? m_model->transmitModel().cwSpeed() : 20;
+        return QStringLiteral("cw_keyer_speed:%1;").arg(wpm);
+    }
+    if (args.isEmpty()) return {};
+    int wpm = args[0].toInt();
+    if (wpm < 5 || wpm > 100) return {};
+    QString cmd = QStringLiteral("cw wpm %1").arg(wpm);
+    QMetaObject::invokeMethod(m_model, [this, cmd]() {
+        m_model->sendCmdPublic(cmd, nullptr);
+    }, Qt::QueuedConnection);
+    m_pendingNotification = QStringLiteral("cw_keyer_speed:%1;").arg(wpm);
+    return {};
+}
+
+QString TciProtocol::cmdCwMacrosDelay(const QStringList& args, bool isSet)
+{
+    // Delay before CW TX starts (ms). FlexRadio has cw_delay.
+    static int delay = 0;
+    if (!isSet)
+        return QStringLiteral("cw_macros_delay:%1;").arg(delay);
+    if (args.isEmpty()) return {};
+    delay = args[0].toInt();
+    if (m_model) {
+        QString cmd = QStringLiteral("cw delay %1").arg(delay);
+        QMetaObject::invokeMethod(m_model, [this, cmd]() {
+            m_model->sendCmdPublic(cmd, nullptr);
+        }, Qt::QueuedConnection);
+    }
+    m_pendingNotification = QStringLiteral("cw_macros_delay:%1;").arg(delay);
+    return {};
+}
+
+QString TciProtocol::cmdCwTerminal(const QStringList& args, bool isSet)
+{
+    static bool terminal = false;
+    if (!isSet)
+        return QStringLiteral("cw_terminal:%1;").arg(terminal ? "true" : "false");
+    if (!args.isEmpty())
+        terminal = (args[0].toLower() == "true");
+    return {};
+}
+
+// ── DDS / IF ───────────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdDds(const QStringList& args, bool isSet)
+{
+    // DDS = center frequency of the receiver (panadapter center)
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        long long hz = static_cast<long long>(std::round(s->frequency() * 1e6));
+        return QStringLiteral("dds:%1,%2;").arg(trx).arg(hz);
+    }
+
+    if (args.size() < 2) return {};
+    // DDS set changes the panadapter center, not the VFO — acknowledge only
+    return {};
+}
+
+QString TciProtocol::cmdIf(const QStringList& args, bool isSet)
+{
+    // IF offset — RIT equivalent in TCI
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("if:%1,0,%2;")
+                   .arg(trx).arg(s->ritOn() ? s->ritFreq() : 0);
+    }
+
+    if (args.size() < 3) return {};
+    int offset = args[2].toInt();
+    bool on = (offset != 0);
+    QMetaObject::invokeMethod(s, [s, on, offset]() { s->setRit(on, offset); },
+                              Qt::QueuedConnection);
+    return {};
+}
+
+// ── Per-receiver audio ─────────────────────────────────────────────────────
+
+QString TciProtocol::cmdRxChannelEnable(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    if (!isSet)
+        return QStringLiteral("rx_channel_enable:%1,true;").arg(trx);
+    // Always enabled — FlexRadio slices are always active
+    return {};
+}
+
+QString TciProtocol::cmdRxVolume(const QStringList& args, bool isSet)
+{
+    // Per-receiver volume — maps to slice audioGain
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("rx_volume:%1,%2;")
+                   .arg(trx).arg(static_cast<int>(s->audioGain()));
+    }
+
+    if (args.size() < 2) return {};
+    float gain = static_cast<float>(args[1].toInt());
+    QMetaObject::invokeMethod(s, [s, gain]() { s->setAudioGain(gain); },
+                              Qt::QueuedConnection);
+    m_pendingNotification = QStringLiteral("rx_volume:%1,%2;")
+                                .arg(trx).arg(static_cast<int>(gain));
+    return {};
+}
+
+QString TciProtocol::cmdRxMute(const QStringList& args, bool isSet)
+{
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("rx_mute:%1,%2;")
+                   .arg(trx).arg(s->audioMute() ? "true" : "false");
+    }
+
+    if (args.size() < 2) return {};
+    bool mute = (args[1].toLower() == "true");
+    QMetaObject::invokeMethod(s, [s, mute]() { s->setAudioMute(mute); },
+                              Qt::QueuedConnection);
+    m_pendingNotification = QStringLiteral("rx_mute:%1,%2;")
+                                .arg(trx).arg(mute ? "true" : "false");
+    return {};
+}
+
+QString TciProtocol::cmdRxBalance(const QStringList& args, bool isSet)
+{
+    // RX audio balance — maps to slice audioPan (0=left, 50=center, 100=right)
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        // TCI balance: -40 to +40 (0=center)
+        // FlexRadio: 0–100 (50=center)
+        int tciBalance = s->audioPan() - 50;
+        return QStringLiteral("rx_balance:%1,%2;").arg(trx).arg(tciBalance);
+    }
+
+    if (args.size() < 2) return {};
+    int tciBalance = args[1].toInt();  // -40 to +40
+    int flexPan = qBound(0, tciBalance + 50, 100);
+    QMetaObject::invokeMethod(s, [s, flexPan]() { s->setAudioPan(flexPan); },
+                              Qt::QueuedConnection);
+    m_pendingNotification = QStringLiteral("rx_balance:%1,%2;")
+                                .arg(trx).arg(tciBalance);
+    return {};
+}
+
+// ── Monitor ────────────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdMonEnable(const QStringList& args, bool isSet)
+{
+    if (!m_model) return {};
+    if (!isSet) {
+        return QStringLiteral("mon_enable:%1;")
+                   .arg(m_model->transmitModel().sbMonitor() ? "true" : "false");
+    }
+    if (args.isEmpty()) return {};
+    bool on = (args[0].toLower() == "true");
+    QMetaObject::invokeMethod(m_model, [this, on]() {
+        m_model->transmitModel().setSbMonitor(on);
+    }, Qt::QueuedConnection);
+    m_pendingNotification = QStringLiteral("mon_enable:%1;")
+                                .arg(on ? "true" : "false");
+    return {};
+}
+
+QString TciProtocol::cmdMonVolume(const QStringList& args, bool isSet)
+{
+    if (!m_model) return {};
+    if (!isSet) {
+        return QStringLiteral("mon_volume:%1;")
+                   .arg(m_model->transmitModel().monGainSb());
+    }
+    if (args.isEmpty()) return {};
+    int vol = args[0].toInt();
+    QMetaObject::invokeMethod(m_model, [this, vol]() {
+        m_model->transmitModel().setMonGainSb(vol);
+    }, Qt::QueuedConnection);
+    m_pendingNotification = QStringLiteral("mon_volume:%1;").arg(vol);
+    return {};
+}
+
+// ── DSP parameters ─────────────────────────────────────────────────────────
+
+QString TciProtocol::cmdRxNbParam(const QStringList& args, bool isSet)
+{
+    // NB parameter — maps to slice nbLevel (0–100)
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    auto* s = sliceForTrx(trx);
+    if (!s) return {};
+
+    if (!isSet) {
+        return QStringLiteral("rx_nb_param:%1,0,%2;")
+                   .arg(trx).arg(s->nbLevel());
+    }
+
+    if (args.size() < 3) return {};
+    int level = args[2].toInt();
+    QMetaObject::invokeMethod(s, [s, level]() { s->setNbLevel(level); },
+                              Qt::QueuedConnection);
+    m_pendingNotification = QStringLiteral("rx_nb_param:%1,0,%2;")
+                                .arg(trx).arg(level);
+    return {};
+}
+
+QString TciProtocol::cmdRxBinEnable(const QStringList& args, bool isSet)
+{
+    // Binaural — no direct FlexRadio equivalent, acknowledge only
+    static bool binEnabled = false;
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    if (!isSet)
+        return QStringLiteral("rx_bin_enable:%1,%2;")
+                   .arg(trx).arg(binEnabled ? "true" : "false");
+    if (args.size() < 2) return {};
+    binEnabled = (args[1].toLower() == "true");
+    return {};
+}
+
+QString TciProtocol::cmdRxAncEnable(const QStringList& args, bool isSet)
+{
+    // Adaptive Noise Cancellation — no direct FlexRadio equivalent
+    static bool ancEnabled = false;
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    if (!isSet)
+        return QStringLiteral("rx_anc_enable:%1,%2;")
+                   .arg(trx).arg(ancEnabled ? "true" : "false");
+    if (args.size() < 2) return {};
+    ancEnabled = (args[1].toLower() == "true");
+    return {};
+}
+
+QString TciProtocol::cmdRxDseEnable(const QStringList& args, bool isSet)
+{
+    // Digital Surround Effect — no direct FlexRadio equivalent
+    static bool dseEnabled = false;
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    if (!isSet)
+        return QStringLiteral("rx_dse_enable:%1,%2;")
+                   .arg(trx).arg(dseEnabled ? "true" : "false");
+    if (args.size() < 2) return {};
+    dseEnabled = (args[1].toLower() == "true");
+    return {};
+}
+
+QString TciProtocol::cmdRxNfEnable(const QStringList& args, bool isSet)
+{
+    // Notch filter module — maps to TNF global enable
+    // For now, acknowledge only (TNF is per-notch, not a global toggle in the same way)
+    static bool nfEnabled = true;
+    if (args.isEmpty()) return {};
+    int trx = args[0].toInt();
+    if (!isSet)
+        return QStringLiteral("rx_nf_enable:%1,%2;")
+                   .arg(trx).arg(nfEnabled ? "true" : "false");
+    if (args.size() < 2) return {};
+    nfEnabled = (args[1].toLower() == "true");
+    return {};
+}
+
+// ── Digital mode offsets ───────────────────────────────────────────────────
+
+QString TciProtocol::cmdDiglOffset(const QStringList& args, bool isSet)
+{
+    if (!m_model) return {};
+    auto* s = sliceForTrx(0);
+    if (!s) return {};
+
+    if (!isSet)
+        return QStringLiteral("digl_offset:%1;").arg(s->diglOffset());
+
+    if (args.isEmpty()) return {};
+    int hz = args[0].toInt();
+    QMetaObject::invokeMethod(s, [s, hz]() { s->setDiglOffset(hz); },
+                              Qt::QueuedConnection);
+    m_pendingNotification = QStringLiteral("digl_offset:%1;").arg(hz);
+    return {};
+}
+
+QString TciProtocol::cmdDiguOffset(const QStringList& args, bool isSet)
+{
+    if (!m_model) return {};
+    auto* s = sliceForTrx(0);
+    if (!s) return {};
+
+    if (!isSet)
+        return QStringLiteral("digu_offset:%1;").arg(s->diguOffset());
+
+    if (args.isEmpty()) return {};
+    int hz = args[0].toInt();
+    QMetaObject::invokeMethod(s, [s, hz]() { s->setDiguOffset(hz); },
+                              Qt::QueuedConnection);
+    m_pendingNotification = QStringLiteral("digu_offset:%1;").arg(hz);
+    return {};
+}
+
+// ── Focus / TX frequency ───────────────────────────────────────────────────
+
+QString TciProtocol::cmdSetInFocus()
+{
+    // Client requests us to raise our window — emit via signal if needed
+    // For now, just acknowledge
+    return {};
+}
+
+QString TciProtocol::cmdTxFrequency()
+{
+    if (!m_model) return {};
+    // Find TX slice frequency
+    for (auto* s : m_model->slices()) {
+        if (s->isTxSlice()) {
+            long long hz = static_cast<long long>(std::round(s->frequency() * 1e6));
+            return QStringLiteral("tx_frequency:%1;").arg(hz);
+        }
+    }
+    return {};
+}
+
+} // namespace AetherSDR
+
+#endif // HAVE_WEBSOCKETS

--- a/src/core/TciProtocol.h
+++ b/src/core/TciProtocol.h
@@ -1,0 +1,107 @@
+#pragma once
+#ifdef HAVE_WEBSOCKETS
+
+#include <QString>
+
+namespace AetherSDR {
+
+class RadioModel;
+class SliceModel;
+
+// TCI protocol handler — text command parser and response generator.
+// No I/O — receives a command string, returns the response.
+// Reference: https://github.com/ExpertSDR3/TCI (protocol v2.0)
+class TciProtocol {
+public:
+    explicit TciProtocol(RadioModel* model);
+
+    // Process one TCI command (without trailing semicolon).
+    // Returns response string (with trailing semicolon) or empty if no response.
+    QString handleCommand(const QString& cmd);
+
+    // Generate the init burst sent to newly connected clients.
+    QString generateInitBurst();
+
+    // After handleCommand(), if the command changed radio state,
+    // this returns a notification to broadcast to other clients.
+    // Returns empty if no broadcast needed.
+    QString pendingNotification();
+
+private:
+    // Command handlers — return response string or empty
+    QString cmdVfo(const QStringList& args, bool isSet);
+    QString cmdModulation(const QStringList& args, bool isSet);
+    QString cmdTrx(const QStringList& args, bool isSet);
+    QString cmdTune(const QStringList& args, bool isSet);
+    QString cmdDrive(const QStringList& args, bool isSet);
+    QString cmdTuneDrive(const QStringList& args, bool isSet);
+    QString cmdRitEnable(const QStringList& args, bool isSet);
+    QString cmdXitEnable(const QStringList& args, bool isSet);
+    QString cmdRitOffset(const QStringList& args, bool isSet);
+    QString cmdXitOffset(const QStringList& args, bool isSet);
+    QString cmdSplitEnable(const QStringList& args, bool isSet);
+    QString cmdRxFilterBand(const QStringList& args, bool isSet);
+    QString cmdCwMacrosSpeed(const QStringList& args, bool isSet);
+    QString cmdCwMsg(const QStringList& args);
+    QString cmdLock(const QStringList& args, bool isSet);
+    QString cmdSqlEnable(const QStringList& args, bool isSet);
+    QString cmdSqlLevel(const QStringList& args, bool isSet);
+    QString cmdVolume(const QStringList& args, bool isSet);
+    QString cmdMute(const QStringList& args, bool isSet);
+    QString cmdAgcMode(const QStringList& args, bool isSet);
+    QString cmdAgcGain(const QStringList& args, bool isSet);
+    QString cmdRxNbEnable(const QStringList& args, bool isSet);
+    QString cmdRxNrEnable(const QStringList& args, bool isSet);
+    QString cmdRxAnfEnable(const QStringList& args, bool isSet);
+    QString cmdRxApfEnable(const QStringList& args, bool isSet);
+    QString cmdSpot(const QStringList& args);
+    QString cmdSpotDelete(const QStringList& args);
+    QString cmdSpotClear();
+    QString cmdCwMacros(const QStringList& args);
+    QString cmdCwMacrosStop();
+    QString cmdStart();
+    QString cmdStop();
+    QString cmdTxEnable(const QStringList& args);
+    QString cmdIqStart(const QStringList& args);
+    QString cmdIqStop(const QStringList& args);
+    QString cmdIqSampleRate(const QStringList& args, bool isSet);
+    QString cmdKeyer(const QStringList& args);
+    QString cmdCwKeyerSpeed(const QStringList& args, bool isSet);
+    QString cmdCwMacrosDelay(const QStringList& args, bool isSet);
+    QString cmdCwTerminal(const QStringList& args, bool isSet);
+    QString cmdDds(const QStringList& args, bool isSet);
+    QString cmdIf(const QStringList& args, bool isSet);
+    QString cmdRxChannelEnable(const QStringList& args, bool isSet);
+    QString cmdRxVolume(const QStringList& args, bool isSet);
+    QString cmdRxMute(const QStringList& args, bool isSet);
+    QString cmdRxBalance(const QStringList& args, bool isSet);
+    QString cmdMonEnable(const QStringList& args, bool isSet);
+    QString cmdMonVolume(const QStringList& args, bool isSet);
+    QString cmdRxNbParam(const QStringList& args, bool isSet);
+    QString cmdRxBinEnable(const QStringList& args, bool isSet);
+    QString cmdRxAncEnable(const QStringList& args, bool isSet);
+    QString cmdRxDseEnable(const QStringList& args, bool isSet);
+    QString cmdRxNfEnable(const QStringList& args, bool isSet);
+    QString cmdDiglOffset(const QStringList& args, bool isSet);
+    QString cmdDiguOffset(const QStringList& args, bool isSet);
+    QString cmdSetInFocus();
+    QString cmdTxFrequency();
+
+    // Helpers
+    SliceModel* sliceForTrx(int trx) const;
+
+public:
+    // Mode conversion (public for TciServer broadcast use)
+    static QString smartsdrToTci(const QString& mode);
+    static QString tciToSmartSDR(const QString& mode);
+
+private:
+
+    RadioModel* m_model;
+    QString     m_pendingNotification;
+    bool        m_started{false};  // client sent START
+};
+
+} // namespace AetherSDR
+
+#endif // HAVE_WEBSOCKETS

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1,0 +1,691 @@
+#ifdef HAVE_WEBSOCKETS
+#include "TciServer.h"
+#include "TciProtocol.h"
+#include "AudioEngine.h"
+#include "Resampler.h"
+#include "LogManager.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+#include "models/MeterModel.h"
+#include "models/TransmitModel.h"
+#include "models/SpotModel.h"
+
+#include <QWebSocketServer>
+#include <QWebSocket>
+#include <QTimer>
+#include <QtEndian>
+#include <cstring>
+
+namespace AetherSDR {
+
+// ── TCI binary audio frame header (per ExpertSDR3 TCI spec v2.0) ────────
+// 9 × uint32 = 36 bytes, followed by sample payload
+// TCI audio header: 16 × uint32 = 64 bytes
+// Per ExpertSDR3 TCI spec v2.0 Stream struct
+struct TciAudioHeader {
+    quint32 receiver;     // receiver/TRX number
+    quint32 sampleRate;   // Hz
+    quint32 format;       // 0=int16, 1=int24, 2=int32, 3=float32
+    quint32 codec;        // 0 (uncompressed)
+    quint32 crc;          // 0 (unused)
+    quint32 length;       // number of real samples in data
+    quint32 type;         // 0=IQ, 1=RX_AUDIO, 2=TX_AUDIO, 3=TX_CHRONO
+    quint32 channels;     // 1 or 2
+    quint32 reserved[8];  // zero-filled
+};
+static_assert(sizeof(TciAudioHeader) == 64, "TCI audio header must be 64 bytes");
+
+TciServer::TciServer(RadioModel* model, QObject* parent)
+    : QObject(parent)
+    , m_model(model)
+{
+    // Cache S-meter values for periodic broadcast (avoid flooding clients)
+    if (m_model) {
+        connect(&m_model->meterModel(), &MeterModel::sLevelChanged,
+                this, [this](int sliceIndex, float dbm) {
+            if (sliceIndex >= 0 && sliceIndex < 8)
+                m_cachedSLevel[sliceIndex] = dbm;
+        });
+    }
+
+    // Cache TX meter values
+    if (m_model) {
+        connect(&m_model->meterModel(), &MeterModel::txMetersChanged,
+                this, [this](float fwd, float swr) {
+            m_cachedFwdPower = fwd;
+            m_cachedSwr = swr;
+        });
+        connect(&m_model->meterModel(), &MeterModel::micMetersChanged,
+                this, [this](float micLevel, float, float, float) {
+            m_cachedMicLevel = micLevel;
+        });
+    }
+
+    // Periodic status broadcast (200ms — S-meter, TX sensors, TX state)
+    m_meterTimer = new QTimer(this);
+    m_meterTimer->setInterval(200);
+    connect(m_meterTimer, &QTimer::timeout, this, &TciServer::broadcastStatus);
+}
+
+TciServer::~TciServer()
+{
+    stop();
+}
+
+bool TciServer::start(quint16 port)
+{
+    if (m_server)
+        return m_server->isListening();
+
+    m_server = new QWebSocketServer(
+        QStringLiteral("AetherSDR-TCI"),
+        QWebSocketServer::NonSecureMode, this);
+
+    if (!m_server->listen(QHostAddress::Any, port)) {
+        qCWarning(lcCat) << "TciServer: failed to listen on port" << port
+                         << m_server->errorString();
+        delete m_server;
+        m_server = nullptr;
+        return false;
+    }
+
+    connect(m_server, &QWebSocketServer::newConnection,
+            this, &TciServer::onNewConnection);
+
+    m_meterTimer->start();
+    qCInfo(lcCat) << "TciServer: listening on port" << m_server->serverPort();
+    return true;
+}
+
+void TciServer::stop()
+{
+    m_meterTimer->stop();
+
+    if (!m_server) return;
+
+    for (auto& cs : m_clients) {
+        cs.socket->close();
+        delete cs.protocol;
+        delete cs.resampler;
+    }
+    m_clients.clear();
+    emit clientCountChanged(0);
+
+    m_server->close();
+    delete m_server;
+    m_server = nullptr;
+
+    qCInfo(lcCat) << "TciServer: stopped";
+}
+
+bool TciServer::isRunning() const
+{
+    return m_server && m_server->isListening();
+}
+
+quint16 TciServer::port() const
+{
+    return m_server ? m_server->serverPort() : 0;
+}
+
+void TciServer::onNewConnection()
+{
+    while (m_server->hasPendingConnections()) {
+        auto* ws = m_server->nextPendingConnection();
+        auto* protocol = new TciProtocol(m_model);
+
+        ClientState cs;
+        cs.socket = ws;
+        cs.protocol = protocol;
+        m_clients.append(cs);
+
+        connect(ws, &QWebSocket::textMessageReceived,
+                this, &TciServer::onTextMessage);
+        connect(ws, &QWebSocket::binaryMessageReceived,
+                this, &TciServer::onBinaryMessage);
+        connect(ws, &QWebSocket::disconnected,
+                this, &TciServer::onClientDisconnected);
+
+        qCInfo(lcCat) << "TciServer: client connected from"
+                      << ws->peerAddress().toString();
+        emit clientCountChanged(m_clients.size());
+
+        sendInitBurst(ws);
+    }
+}
+
+void TciServer::onClientDisconnected()
+{
+    auto* ws = qobject_cast<QWebSocket*>(sender());
+    if (!ws) return;
+
+    for (int i = 0; i < m_clients.size(); ++i) {
+        if (m_clients[i].socket == ws) {
+            delete m_clients[i].protocol;
+            delete m_clients[i].resampler;
+            m_clients.removeAt(i);
+            break;
+        }
+    }
+
+    ws->deleteLater();
+    qCInfo(lcCat) << "TciServer: client disconnected,"
+                  << m_clients.size() << "remaining";
+    emit clientCountChanged(m_clients.size());
+}
+
+void TciServer::onTextMessage(const QString& msg)
+{
+    auto* ws = qobject_cast<QWebSocket*>(sender());
+    if (!ws) return;
+
+    // Find the client state
+    int clientIdx = -1;
+    for (int i = 0; i < m_clients.size(); ++i) {
+        if (m_clients[i].socket == ws) { clientIdx = i; break; }
+    }
+    if (clientIdx < 0) return;
+
+    auto& client = m_clients[clientIdx];
+
+    // TCI messages are semicolon-terminated; may contain multiple commands
+    const QStringList cmds = msg.split(';', Qt::SkipEmptyParts);
+    for (const auto& cmd : cmds) {
+        QString trimmed = cmd.trimmed().toLower();
+
+        // Handle audio start/stop at server level (affects per-client state)
+        if (trimmed.startsWith("audio_start")) {
+            client.audioEnabled = true;
+            ws->sendTextMessage(cmd.trimmed() + ";");
+            qCInfo(lcCat) << "TCI: audio started for client"
+                          << ws->peerAddress().toString()
+                          << "rate=" << client.audioSampleRate
+                          << "ch=" << client.audioChannels
+                          << "fmt=" << client.audioFormat;
+            continue;
+        }
+        if (trimmed.startsWith("audio_stop")) {
+            client.audioEnabled = false;
+            ws->sendTextMessage(cmd.trimmed() + ";");
+            qCInfo(lcCat) << "TCI: audio stopped for client"
+                          << ws->peerAddress().toString();
+            continue;
+        }
+
+        // Audio format negotiation
+        if (trimmed.startsWith("audio_samplerate:")) {
+            int colonIdx2 = trimmed.indexOf(':');
+            int rate = trimmed.mid(colonIdx2 + 1).toInt();
+            if (rate == 8000 || rate == 12000 || rate == 24000 || rate == 48000) {
+                client.audioSampleRate = rate;
+                // Create or destroy resampler as needed
+                delete client.resampler;
+                if (rate != 24000)
+                    client.resampler = new Resampler(24000.0, rate, 4096);
+                else
+                    client.resampler = nullptr;
+                qCInfo(lcCat) << "TCI: audio sample rate set to" << rate
+                              << "for" << ws->peerAddress().toString();
+            }
+            ws->sendTextMessage(QStringLiteral("audio_samplerate:%1;")
+                                    .arg(client.audioSampleRate));
+            continue;
+        }
+        if (trimmed.startsWith("audio_stream_sample_type:")) {
+            int colonIdx2 = trimmed.indexOf(':');
+            int fmt = trimmed.mid(colonIdx2 + 1).toInt();
+            if (fmt == 0 || fmt == 3)  // int16 or float32
+                client.audioFormat = fmt;
+            ws->sendTextMessage(QStringLiteral("audio_stream_sample_type:%1;")
+                                    .arg(client.audioFormat));
+            continue;
+        }
+        // Sensor enable/disable
+        if (trimmed.startsWith("rx_sensors_enable:")) {
+            int colonIdx2 = trimmed.indexOf(':');
+            QString val = trimmed.mid(colonIdx2 + 1).split(',').first();
+            client.rxSensorsEnabled = (val == "true");
+            ws->sendTextMessage(QStringLiteral("rx_sensors_enable:%1;")
+                                    .arg(client.rxSensorsEnabled ? "true" : "false"));
+            qCInfo(lcCat) << "TCI: rx_sensors" << (client.rxSensorsEnabled ? "enabled" : "disabled");
+            continue;
+        }
+        if (trimmed.startsWith("tx_sensors_enable:")) {
+            int colonIdx2 = trimmed.indexOf(':');
+            QString val = trimmed.mid(colonIdx2 + 1).split(',').first();
+            client.txSensorsEnabled = (val == "true");
+            ws->sendTextMessage(QStringLiteral("tx_sensors_enable:%1;")
+                                    .arg(client.txSensorsEnabled ? "true" : "false"));
+            qCInfo(lcCat) << "TCI: tx_sensors" << (client.txSensorsEnabled ? "enabled" : "disabled");
+            continue;
+        }
+
+        if (trimmed.startsWith("audio_stream_samples:")) {
+            // Samples per audio packet — acknowledge but we use fixed packet sizes
+            ws->sendTextMessage(cmd.trimmed() + ";");
+            continue;
+        }
+        if (trimmed.startsWith("tx_stream_audio_buffering:")) {
+            // TX audio buffering in ms — acknowledge
+            ws->sendTextMessage(cmd.trimmed() + ";");
+            continue;
+        }
+        if (trimmed.startsWith("line_out_start") ||
+            trimmed.startsWith("line_out_stop") ||
+            trimmed.startsWith("line_out_recorder")) {
+            // Line-out recording — not applicable to FlexRadio, acknowledge
+            ws->sendTextMessage(cmd.trimmed() + ";");
+            continue;
+        }
+        if (trimmed.startsWith("audio_stream_channels:")) {
+            int colonIdx2 = trimmed.indexOf(':');
+            int ch = trimmed.mid(colonIdx2 + 1).toInt();
+            if (ch == 1 || ch == 2)
+                client.audioChannels = ch;
+            ws->sendTextMessage(QStringLiteral("audio_stream_channels:%1;")
+                                    .arg(client.audioChannels));
+            continue;
+        }
+
+        QString response = client.protocol->handleCommand(cmd.trimmed());
+        if (!response.isEmpty()) {
+            ws->sendTextMessage(response);
+            qCDebug(lcCat) << "TCI cmd:" << cmd.trimmed()
+                           << "-> resp:" << response.left(80).trimmed();
+        }
+
+        // If the command changed radio state, broadcast to all other clients
+        QString notification = client.protocol->pendingNotification();
+        if (!notification.isEmpty()) {
+            for (auto& cs : m_clients) {
+                if (cs.socket != ws)
+                    cs.socket->sendTextMessage(notification);
+            }
+        }
+    }
+}
+
+// ── Binary message handler (TX audio from TCI client) ───────────────────
+
+void TciServer::onBinaryMessage(const QByteArray& data)
+{
+    if (!m_audio) return;
+    if (data.size() < static_cast<int>(sizeof(TciAudioHeader))) return;
+
+    // Parse header
+    TciAudioHeader hdr;
+    std::memcpy(&hdr, data.constData(), sizeof(hdr));
+
+    // Only accept TX_AUDIO_STREAM (type 2)
+    if (hdr.type != 2) return;
+
+    const int payloadBytes = data.size() - static_cast<int>(sizeof(TciAudioHeader));
+    if (payloadBytes <= 0) return;
+
+    const char* payload = data.constData() + sizeof(TciAudioHeader);
+
+    // TCI sends float32 samples (format=3). Convert to float32 stereo for AudioEngine.
+    if (hdr.format == 3) {
+        int floatCount = payloadBytes / static_cast<int>(sizeof(float));
+
+        if (hdr.channels == 2) {
+            // Already float32 stereo — pass directly
+            QByteArray pcm(payload, payloadBytes);
+            QMetaObject::invokeMethod(m_audio, "feedDaxTxAudio",
+                                      Qt::QueuedConnection,
+                                      Q_ARG(QByteArray, pcm));
+        } else if (hdr.channels == 1) {
+            // Mono → duplicate to stereo
+            int monoSamples = floatCount;
+            QByteArray stereo(monoSamples * 2 * sizeof(float), Qt::Uninitialized);
+            auto* dst = reinterpret_cast<float*>(stereo.data());
+            auto* src = reinterpret_cast<const float*>(payload);
+            for (int i = 0; i < monoSamples; ++i) {
+                dst[i * 2]     = src[i];
+                dst[i * 2 + 1] = src[i];
+            }
+            QMetaObject::invokeMethod(m_audio, "feedDaxTxAudio",
+                                      Qt::QueuedConnection,
+                                      Q_ARG(QByteArray, stereo));
+        }
+    } else if (hdr.format == 0) {
+        // int16 — convert to float32 stereo
+        int sampleCount = payloadBytes / static_cast<int>(sizeof(qint16));
+        auto* src = reinterpret_cast<const qint16*>(payload);
+
+        if (hdr.channels == 2) {
+            QByteArray stereo(sampleCount * sizeof(float), Qt::Uninitialized);
+            auto* dst = reinterpret_cast<float*>(stereo.data());
+            for (int i = 0; i < sampleCount; ++i)
+                dst[i] = src[i] / 32768.0f;
+            QMetaObject::invokeMethod(m_audio, "feedDaxTxAudio",
+                                      Qt::QueuedConnection,
+                                      Q_ARG(QByteArray, stereo));
+        } else {
+            int monoSamples = sampleCount;
+            QByteArray stereo(monoSamples * 2 * sizeof(float), Qt::Uninitialized);
+            auto* dst = reinterpret_cast<float*>(stereo.data());
+            for (int i = 0; i < monoSamples; ++i) {
+                float v = src[i] / 32768.0f;
+                dst[i * 2]     = v;
+                dst[i * 2 + 1] = v;
+            }
+            QMetaObject::invokeMethod(m_audio, "feedDaxTxAudio",
+                                      Qt::QueuedConnection,
+                                      Q_ARG(QByteArray, stereo));
+        }
+    }
+}
+
+// ── RX audio from main audio pipeline → TCI binary frames ───────────────
+
+void TciServer::onRxAudioReady(const QByteArray& pcm)
+{
+    // Check if any client has audio enabled
+    bool anyAudio = false;
+    for (const auto& cs : m_clients) {
+        if (cs.audioEnabled) { anyAudio = true; break; }
+    }
+    if (!anyAudio) return;
+
+    // Input: int16 stereo, 24 kHz, little-endian
+    const auto* src = reinterpret_cast<const qint16*>(pcm.constData());
+    int totalInt16 = pcm.size() / static_cast<int>(sizeof(qint16));
+    int stereoFrames = totalInt16 / 2;
+
+    // Periodic debug log
+    static int rxCount = 0;
+    if (++rxCount % 1000 == 1)
+        qCInfo(lcCat) << "TCI: RX audio" << pcm.size() << "bytes,"
+                      << m_clients.size() << "clients";
+
+    for (auto& cs : m_clients) {
+        if (!cs.audioEnabled) continue;
+
+        const qint16* audioSrc = src;
+        int audioFrames = stereoFrames;
+        QByteArray resampledBuf;
+
+        // Resample if client wants a different rate
+        if (cs.resampler) {
+            resampledBuf = cs.resampler->processStereoToStereo(src, stereoFrames);
+            audioSrc = reinterpret_cast<const qint16*>(resampledBuf.constData());
+            audioFrames = resampledBuf.size() / (2 * sizeof(qint16));
+        }
+
+        int srcSamples = audioFrames * 2;  // stereo
+
+        if (cs.audioFormat == 3) {
+            // float32 output
+            if (cs.audioChannels == 2) {
+                QVector<float> floatBuf(srcSamples);
+                for (int i = 0; i < srcSamples; ++i)
+                    floatBuf[i] = audioSrc[i] / 32768.0f;
+                cs.socket->sendBinaryMessage(
+                    buildAudioFrame(0, 1, cs.audioSampleRate, 2,
+                                    floatBuf.constData(), audioFrames));
+            } else {
+                // Mono: average L+R
+                QVector<float> monoBuf(audioFrames);
+                for (int i = 0; i < audioFrames; ++i)
+                    monoBuf[i] = (audioSrc[i*2] + audioSrc[i*2+1]) / 65536.0f;
+                cs.socket->sendBinaryMessage(
+                    buildAudioFrame(0, 1, cs.audioSampleRate, 1,
+                                    monoBuf.constData(), audioFrames));
+            }
+        } else {
+            // int16 output — pack into binary frame with format=0
+            if (cs.audioChannels == 2) {
+                int payloadBytes = srcSamples * sizeof(qint16);
+                QByteArray frame(sizeof(TciAudioHeader) + payloadBytes, Qt::Uninitialized);
+                TciAudioHeader hdr{};
+                hdr.receiver = 0;
+                hdr.sampleRate = static_cast<quint32>(cs.audioSampleRate);
+                hdr.format = 0;  // int16
+                hdr.length = static_cast<quint32>(srcSamples);
+                hdr.type = 1;    // RX_AUDIO
+                hdr.channels = 2;
+                std::memcpy(frame.data(), &hdr, sizeof(hdr));
+                std::memcpy(frame.data() + sizeof(hdr), audioSrc, payloadBytes);
+                cs.socket->sendBinaryMessage(frame);
+            } else {
+                // Mono int16
+                QVector<qint16> monoBuf(audioFrames);
+                for (int i = 0; i < audioFrames; ++i)
+                    monoBuf[i] = static_cast<qint16>(
+                        (audioSrc[i*2] + audioSrc[i*2+1]) / 2);
+                int payloadBytes = audioFrames * sizeof(qint16);
+                QByteArray frame(sizeof(TciAudioHeader) + payloadBytes, Qt::Uninitialized);
+                TciAudioHeader hdr{};
+                hdr.receiver = 0;
+                hdr.sampleRate = static_cast<quint32>(cs.audioSampleRate);
+                hdr.format = 0;
+                hdr.length = static_cast<quint32>(audioFrames);
+                hdr.type = 1;
+                hdr.channels = 1;
+                std::memcpy(frame.data(), &hdr, sizeof(hdr));
+                std::memcpy(frame.data() + sizeof(hdr), monoBuf.constData(), payloadBytes);
+                cs.socket->sendBinaryMessage(frame);
+            }
+        }
+    }
+}
+
+// ── RX audio from DAX pipeline → TCI binary frames ─────────────────────
+
+void TciServer::onDaxAudioReady(int channel, const QByteArray& pcm)
+{
+    // Check if any client has audio enabled
+    bool anyAudio = false;
+    for (const auto& cs : m_clients) {
+        if (cs.audioEnabled) { anyAudio = true; break; }
+    }
+    if (!anyAudio) return;
+
+    // Input: int16 stereo, 24 kHz, little-endian
+    const auto* src = reinterpret_cast<const qint16*>(pcm.constData());
+    int totalInt16 = pcm.size() / static_cast<int>(sizeof(qint16));
+    int stereoFrames = totalInt16 / 2;  // L+R pairs
+
+    // Convert int16 stereo → float32 stereo for TCI
+    QVector<float> floatBuf(totalInt16);
+    for (int i = 0; i < totalInt16; ++i)
+        floatBuf[i] = src[i] / 32768.0f;
+
+    // Map DAX channel to TRX: channel 1 → TRX 0, channel 2 → TRX 1, etc.
+    int trx = channel - 1;
+    if (trx < 0) trx = 0;
+
+    QByteArray frame = buildAudioFrame(trx, 1 /*RX_AUDIO_STREAM*/,
+                                       24000, 2, floatBuf.constData(),
+                                       stereoFrames);
+
+    // Send to all audio-enabled clients
+    for (auto& cs : m_clients) {
+        if (cs.audioEnabled)
+            cs.socket->sendBinaryMessage(frame);
+    }
+}
+
+// ── Build TCI binary audio frame ────────────────────────────────────────
+
+QByteArray TciServer::buildAudioFrame(int receiver, int type,
+                                      int sampleRate, int channels,
+                                      const float* samples, int sampleCount)
+{
+    // sampleCount = number of frames (mono) or frame pairs (stereo counted as frames)
+    int totalFloats = sampleCount * channels;
+    int payloadBytes = totalFloats * static_cast<int>(sizeof(float));
+
+    QByteArray frame(sizeof(TciAudioHeader) + payloadBytes, Qt::Uninitialized);
+
+    // Fill header
+    TciAudioHeader hdr{};
+    hdr.receiver   = static_cast<quint32>(receiver);
+    hdr.sampleRate = static_cast<quint32>(sampleRate);
+    hdr.format     = 3;  // float32
+    hdr.codec      = 0;
+    hdr.crc        = 0;
+    hdr.length     = static_cast<quint32>(totalFloats);
+    hdr.type       = static_cast<quint32>(type);
+    hdr.channels   = static_cast<quint32>(channels);
+    std::memset(hdr.reserved, 0, sizeof(hdr.reserved));
+
+    std::memcpy(frame.data(), &hdr, sizeof(hdr));
+    std::memcpy(frame.data() + sizeof(hdr), samples, payloadBytes);
+
+    return frame;
+}
+
+// ── Wire slice signals for state change broadcasts ──────────────────────
+
+void TciServer::wireSlice(int trx, SliceModel* slice)
+{
+    if (!slice) return;
+
+    connect(slice, &SliceModel::frequencyChanged, this, [this, trx](double mhz) {
+        if (m_clients.isEmpty()) return;
+        long long hz = static_cast<long long>(std::round(mhz * 1e6));
+        broadcast(QStringLiteral("vfo:%1,0,%2;").arg(trx).arg(hz));
+    });
+
+    connect(slice, &SliceModel::modeChanged, this, [this, trx](const QString& mode) {
+        if (m_clients.isEmpty()) return;
+        broadcast(QStringLiteral("modulation:%1,%2;")
+                      .arg(trx).arg(TciProtocol::smartsdrToTci(mode)));
+    });
+
+    connect(slice, &SliceModel::filterChanged, this, [this, trx](int lo, int hi) {
+        if (m_clients.isEmpty()) return;
+        broadcast(QStringLiteral("rx_filter_band:%1,%2,%3;")
+                      .arg(trx).arg(lo).arg(hi));
+    });
+
+    connect(slice, &SliceModel::txSliceChanged, this, [this, trx](bool tx) {
+        if (m_clients.isEmpty()) return;
+        broadcast(QStringLiteral("tx_enable:%1,%2;")
+                      .arg(trx).arg(tx ? "true" : "false"));
+    });
+
+    connect(slice, &SliceModel::lockedChanged, this, [this, trx](bool locked) {
+        if (m_clients.isEmpty()) return;
+        broadcast(QStringLiteral("lock:%1,%2;")
+                      .arg(trx).arg(locked ? "true" : "false"));
+    });
+}
+
+// ── Wire spot click notifications ───────────────────────────────────────
+
+void TciServer::wireSpotModel()
+{
+    if (!m_model) return;
+    connect(&m_model->spotModel(), &SpotModel::spotTriggered,
+            this, [this](int index, const QString&) {
+        if (m_clients.isEmpty()) return;
+        auto& spots = m_model->spotModel().spots();
+        if (!spots.contains(index)) return;
+        const auto& spot = spots[index];
+        long long hz = static_cast<long long>(spot.rxFreqMhz * 1e6);
+        broadcast(QStringLiteral("clicked_on_spot:%1,%2;")
+                      .arg(spot.callsign).arg(hz));
+    });
+}
+
+void TciServer::sendInitBurst(QWebSocket* client)
+{
+    if (!client || !m_model) return;
+
+    // Find protocol for this client to generate init burst
+    TciProtocol* protocol = nullptr;
+    for (auto& cs : m_clients) {
+        if (cs.socket == client) { protocol = cs.protocol; break; }
+    }
+    if (!protocol) return;
+
+    QString burst = protocol->generateInitBurst();
+    client->sendTextMessage(burst);
+    qCDebug(lcCat) << "TCI: sent init burst," << burst.count(';') << "commands";
+}
+
+void TciServer::broadcast(const QString& msg)
+{
+    for (auto& cs : m_clients)
+        cs.socket->sendTextMessage(msg);
+}
+
+void TciServer::broadcastBinary(const QByteArray& data)
+{
+    for (auto& cs : m_clients) {
+        if (cs.audioEnabled)
+            cs.socket->sendBinaryMessage(data);
+    }
+}
+
+void TciServer::broadcastStatus()
+{
+    if (m_clients.isEmpty() || !m_model || !m_model->isConnected())
+        return;
+
+    // Broadcast S-meter for each owned slice (throttled to 200ms)
+    // TCI spec: rx_smeter:receiver,value; (2 args)
+    for (auto* s : m_model->slices()) {
+        int trx = s->sliceId();
+        if (trx >= 0 && trx < 8) {
+            float dbm = m_cachedSLevel[trx];
+            if (dbm > -200.0f)
+                broadcast(QStringLiteral("rx_smeter:%1,%2;")
+                              .arg(trx).arg(static_cast<int>(dbm)));
+        }
+    }
+
+    // Broadcast RX/TX sensor telemetry to clients that enabled them
+    for (auto& cs : m_clients) {
+        if (cs.rxSensorsEnabled) {
+            for (auto* s : m_model->slices()) {
+                int trx = s->sliceId();
+                if (trx >= 0 && trx < 8) {
+                    float dbm = m_cachedSLevel[trx];
+                    if (dbm > -200.0f)
+                        cs.socket->sendTextMessage(
+                            QStringLiteral("rx_channel_sensors:%1,0,%2;")
+                                .arg(trx).arg(dbm, 0, 'f', 1));
+                }
+            }
+        }
+        if (cs.txSensorsEnabled && m_model->transmitModel().isTransmitting()) {
+            // tx_sensors:trx,mic_dbm,fwd_watts,peak_watts,swr
+            cs.socket->sendTextMessage(
+                QStringLiteral("tx_sensors:0,%1,%2,%3,%4;")
+                    .arg(m_cachedMicLevel, 0, 'f', 1)
+                    .arg(m_cachedFwdPower, 0, 'f', 1)
+                    .arg(m_cachedFwdPower, 0, 'f', 1)  // peak ≈ avg for now
+                    .arg(m_cachedSwr, 0, 'f', 1));
+        }
+    }
+
+    // Broadcast TX state changes + TX frequency
+    bool tx = m_model->transmitModel().isTransmitting();
+    if (tx != m_lastTx) {
+        m_lastTx = tx;
+        int txTrx = 0;
+        double txFreqMhz = 0;
+        for (auto* s : m_model->slices()) {
+            if (s->isTxSlice()) {
+                txTrx = s->sliceId();
+                txFreqMhz = s->frequency();
+                break;
+            }
+        }
+        broadcast(QStringLiteral("trx:%1,%2;")
+                      .arg(txTrx)
+                      .arg(tx ? "true" : "false"));
+        if (tx) {
+            long long hz = static_cast<long long>(std::round(txFreqMhz * 1e6));
+            broadcast(QStringLiteral("tx_frequency:%1;").arg(hz));
+        }
+    }
+}
+
+} // namespace AetherSDR
+
+#endif // HAVE_WEBSOCKETS

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -1,0 +1,94 @@
+#pragma once
+#ifdef HAVE_WEBSOCKETS
+
+#include <QObject>
+#include <QList>
+
+class QWebSocketServer;
+class QWebSocket;
+class QTimer;
+
+namespace AetherSDR {
+
+class RadioModel;
+class AudioEngine;
+class SliceModel;
+class TciProtocol;
+class Resampler;
+
+// TCI WebSocket server — exposes radio state and audio over the TCI protocol.
+// Phase 1: text commands (VFO, mode, filter, TX, RIT/XIT, CW, spots)
+// Phase 2: binary RX/TX audio streaming
+class TciServer : public QObject {
+    Q_OBJECT
+
+public:
+    explicit TciServer(RadioModel* model, QObject* parent = nullptr);
+    ~TciServer() override;
+
+    bool start(quint16 port = 50001);
+    void stop();
+
+    bool isRunning() const;
+    quint16 port() const;
+    int clientCount() const { return m_clients.size(); }
+
+    void setAudioEngine(AudioEngine* audio) { m_audio = audio; }
+
+    // Wire slice signals for state change broadcasts
+    void wireSlice(int trx, SliceModel* slice);
+    void wireSpotModel();
+
+public slots:
+    // RX audio from main audio pipeline (int16 stereo, 24 kHz, LE)
+    void onRxAudioReady(const QByteArray& pcm);
+    // RX audio from DAX pipeline (int16 stereo, 24 kHz, LE)
+    void onDaxAudioReady(int channel, const QByteArray& pcm);
+
+signals:
+    void clientCountChanged(int count);
+
+private slots:
+    void onNewConnection();
+    void onClientDisconnected();
+    void onTextMessage(const QString& msg);
+    void onBinaryMessage(const QByteArray& data);
+    void broadcastStatus();
+
+private:
+    void sendInitBurst(QWebSocket* client);
+    void broadcast(const QString& msg);
+    void broadcastBinary(const QByteArray& data);
+
+    // Build a TCI binary audio frame (36-byte header + float32 samples)
+    static QByteArray buildAudioFrame(int receiver, int type,
+                                      int sampleRate, int channels,
+                                      const float* samples, int sampleCount);
+
+    struct ClientState {
+        QWebSocket*  socket{nullptr};
+        TciProtocol* protocol{nullptr};
+        bool         audioEnabled{false};   // client sent AUDIO_START
+        int          audioSampleRate{24000}; // requested output rate
+        int          audioChannels{2};       // 1=mono, 2=stereo
+        int          audioFormat{3};         // 0=int16, 3=float32
+        Resampler*   resampler{nullptr};    // null if rate == 24000 (native)
+        bool         rxSensorsEnabled{false};
+        bool         txSensorsEnabled{false};
+    };
+
+    RadioModel*       m_model;
+    AudioEngine*      m_audio{nullptr};
+    QWebSocketServer* m_server{nullptr};
+    QList<ClientState> m_clients;
+    QTimer*           m_meterTimer{nullptr};  // 200ms status broadcast
+    bool              m_lastTx{false};
+    float             m_cachedSLevel[8]{-130,-130,-130,-130,-130,-130,-130,-130};
+    float             m_cachedFwdPower{0};
+    float             m_cachedSwr{1.0f};
+    float             m_cachedMicLevel{-50.0f};
+};
+
+} // namespace AetherSDR
+
+#endif // HAVE_WEBSOCKETS

--- a/src/gui/CatApplet.cpp
+++ b/src/gui/CatApplet.cpp
@@ -6,6 +6,9 @@
 #include "core/RigctlServer.h"
 #include "core/RigctlPty.h"
 #include "core/AudioEngine.h"
+#ifdef HAVE_WEBSOCKETS
+#include "core/TciServer.h"
+#endif
 #include "ComboStyle.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
@@ -190,6 +193,73 @@ void CatApplet::buildUI()
     }
 
     root->addLayout(enableRow);
+
+    // ── TCI Section ─────────────────────────────────────────────────────────
+#ifdef HAVE_WEBSOCKETS
+    {
+        auto* lbl = new QLabel("TCI Server");
+        lbl->setStyleSheet("QLabel { color: #8aa8c0; font-size: 10px; font-weight: bold; "
+            "border-top: 1px solid #304050; padding: 3px 6px 1px 6px; }");
+        root->addWidget(lbl);
+    }
+    {
+        auto* tciRow = new QHBoxLayout;
+        tciRow->setSpacing(4);
+
+        m_tciEnable = new QPushButton("Enable");
+        m_tciEnable->setCheckable(true);
+        m_tciEnable->setStyleSheet(kGreenToggle);
+        m_tciEnable->setFixedSize(60, 22);
+        tciRow->addWidget(m_tciEnable);
+
+        m_tciStatus = new QLabel("(stopped)");
+        m_tciStatus->setStyleSheet("QLabel { color: #506070; font-size: 10px; }");
+        tciRow->addWidget(m_tciStatus, 1);
+
+        auto* tciPortLabel = new QLabel("Port:");
+        tciPortLabel->setStyleSheet(kDimLabel);
+        tciRow->addWidget(tciPortLabel);
+
+        m_tciPort = new QLineEdit(settings.value("TciPort", "50001").toString());
+        m_tciPort->setStyleSheet(kInsetStyle);
+        m_tciPort->setFixedWidth(46);
+        m_tciPort->setAlignment(Qt::AlignCenter);
+        tciRow->addWidget(m_tciPort);
+
+        root->addLayout(tciRow);
+
+        connect(m_tciPort, &QLineEdit::editingFinished, this, [this]() {
+            int port = m_tciPort->text().toInt();
+            if (port < 1024 || port > 65535) {
+                port = 50001;
+                m_tciPort->setText("50001");
+            }
+            auto& ss = AppSettings::instance();
+            ss.setValue("TciPort", QString::number(port));
+            ss.save();
+            // If running, restart with new port
+            if (m_tciEnable->isChecked() && m_tciServer) {
+                m_tciServer->stop();
+                m_tciServer->start(static_cast<quint16>(port));
+                updateTciStatus();
+            }
+        });
+
+        connect(m_tciEnable, &QPushButton::toggled, this, [this](bool on) {
+            if (!m_tciServer) return;
+            int port = m_tciPort->text().toInt();
+            if (port < 1024 || port > 65535) port = 50001;
+            auto& ss = AppSettings::instance();
+            ss.setValue("TciPort", QString::number(port));
+            ss.save();
+            if (on)
+                m_tciServer->start(static_cast<quint16>(port));
+            else
+                m_tciServer->stop();
+            updateTciStatus();
+        });
+    }
+#endif
 
     // ── DAX Section ─────────────────────────────────────────────────────────
     {
@@ -467,6 +537,32 @@ void CatApplet::setAudioEngine(AudioEngine* audio)
     m_audio = audio;
 }
 
+void CatApplet::setTciServer(TciServer* tci)
+{
+#ifdef HAVE_WEBSOCKETS
+    m_tciServer = tci;
+    if (tci) {
+        connect(tci, &TciServer::clientCountChanged,
+                this, [this]() { updateTciStatus(); });
+    }
+#else
+    (void)tci;
+#endif
+}
+
+void CatApplet::setTciEnabled(bool on)
+{
+#ifdef HAVE_WEBSOCKETS
+    if (m_tciEnable) {
+        QSignalBlocker b(m_tciEnable);
+        m_tciEnable->setChecked(on);
+    }
+    updateTciStatus();
+#else
+    (void)on;
+#endif
+}
+
 void CatApplet::updateChannelStatus(int ch)
 {
     if (ch < 0 || ch >= kChannels) return;
@@ -537,6 +633,27 @@ void CatApplet::setDaxIqLevel(int channel, float rms)
     // Scale RMS to 0-100 for QProgressBar (IQ values are typically 0.0-0.5 range)
     int level = static_cast<int>(std::clamp(rms * 200.0f, 0.0f, 100.0f));
     m_iqMeter[channel - 1]->setValue(level);
+}
+
+void CatApplet::updateTciStatus()
+{
+#ifdef HAVE_WEBSOCKETS
+    if (!m_tciStatus) return;
+    if (!m_tciServer || !m_tciServer->isRunning()) {
+        m_tciStatus->setText("(stopped)");
+        m_tciStatus->setStyleSheet("QLabel { color: #506070; font-size: 10px; }");
+    } else {
+        int n = m_tciServer->clientCount();
+        m_tciStatus->setText(
+            QStringLiteral(":%1 (%2 client%3)")
+                .arg(m_tciServer->port())
+                .arg(n)
+                .arg(n == 1 ? "" : "s"));
+        m_tciStatus->setStyleSheet(
+            n > 0 ? "QLabel { color: #00b4d8; font-size: 10px; }"
+                  : "QLabel { color: #8090a0; font-size: 10px; }");
+    }
+#endif
 }
 
 } // namespace AetherSDR

--- a/src/gui/CatApplet.h
+++ b/src/gui/CatApplet.h
@@ -16,6 +16,7 @@ class SliceModel;
 class RigctlServer;
 class RigctlPty;
 class AudioEngine;
+class TciServer;
 
 // CAT Applet — 4-channel rigctld TCP + PTY control panel.
 // Each channel (A-D) is bound to a slice index (0-3) and provides
@@ -32,10 +33,12 @@ public:
     void setRigctlServers(RigctlServer** servers, int count);
     void setRigctlPtys(RigctlPty** ptys, int count);
     void setAudioEngine(AudioEngine* audio);
+    void setTciServer(TciServer* tci);
 
     // Sync Enable button state (called by MainWindow on autostart)
     void setTcpEnabled(bool on);
     void setPtyEnabled(bool on);
+    void setTciEnabled(bool on);
     void setDaxEnabled(bool on);
     void setDaxRxLevel(int channel, float rms);
     void setDaxTxLevel(float rms);
@@ -53,16 +56,23 @@ private:
     void buildUI();
     void updateChannelStatus(int ch);
     void updateAllChannelStatus();
+    void updateTciStatus();
 
     RadioModel*    m_model{nullptr};
     RigctlServer*  m_servers[kChannels]{};
     RigctlPty*     m_ptys[kChannels]{};
     AudioEngine*   m_audio{nullptr};
+    TciServer*     m_tciServer{nullptr};
 
     // Global controls
     QPushButton* m_tcpEnable{nullptr};
     QPushButton* m_ptyEnable{nullptr};
     QLineEdit*   m_basePort{nullptr};
+
+    // TCI controls
+    QPushButton* m_tciEnable{nullptr};
+    QLineEdit*   m_tciPort{nullptr};
+    QLabel*      m_tciStatus{nullptr};
 
     // Per-channel status labels
     struct ChannelRow {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1782,6 +1782,26 @@ MainWindow::MainWindow(QWidget* parent)
     m_appletPanel->catApplet()->setRigctlServers(m_rigctlServers, kCatChannels);
     m_appletPanel->catApplet()->setRigctlPtys(m_rigctlPtys, kCatChannels);
     m_appletPanel->catApplet()->setAudioEngine(m_audio);
+#ifdef HAVE_WEBSOCKETS
+    m_tciServer = new TciServer(&m_radioModel, this);
+    m_tciServer->setAudioEngine(m_audio);
+    m_appletPanel->catApplet()->setTciServer(m_tciServer);
+
+    // Wire slice state changes → TCI broadcasts
+    connect(&m_radioModel, &RadioModel::sliceAdded, this, [this](SliceModel* s) {
+        if (m_tciServer)
+            m_tciServer->wireSlice(s->sliceId(), s);
+    });
+    m_tciServer->wireSpotModel();
+
+    // Wire RX audio from PanadapterStream → TCI server for audio streaming
+    if (m_radioModel.panStream()) {
+        connect(m_radioModel.panStream(), &PanadapterStream::audioDataReady,
+                m_tciServer, &TciServer::onRxAudioReady);
+        connect(m_radioModel.panStream(), &PanadapterStream::daxAudioReady,
+                m_tciServer, &TciServer::onDaxAudioReady);
+    }
+#endif
 
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
     // DAX enable button in CatApplet → start/stop DAX bridge
@@ -2722,6 +2742,28 @@ void MainWindow::buildMenuBar()
         s.save();
     });
 
+    auto* autoTciAction = settingsMenu->addAction("Autostart TCI with AetherSDR");
+    autoTciAction->setCheckable(true);
+    autoTciAction->setChecked(
+        AppSettings::instance().value("AutoStartTCI", "False").toString() == "True");
+    connect(autoTciAction, &QAction::toggled, this, [this](bool on) {
+        auto& s = AppSettings::instance();
+        s.setValue("AutoStartTCI", on ? "True" : "False");
+        s.save();
+#ifdef HAVE_WEBSOCKETS
+        if (m_tciServer) {
+            if (on && !m_tciServer->isRunning()) {
+                int port = s.value("TciPort", "50001").toInt();
+                m_tciServer->start(static_cast<quint16>(port));
+            } else if (!on && m_tciServer->isRunning()) {
+                m_tciServer->stop();
+            }
+            if (m_appletPanel && m_appletPanel->catApplet())
+                m_appletPanel->catApplet()->setTciEnabled(on);
+        }
+#endif
+    });
+
     auto* autoDaxAction = settingsMenu->addAction("Autostart DAX with AetherSDR");
     autoDaxAction->setCheckable(true);
     autoDaxAction->setChecked(
@@ -2762,6 +2804,7 @@ void MainWindow::buildMenuBar()
 #endif
             && action != multiFlexAction
             && action != autoRigctlAction && action != autoCatAction
+            && action != autoTciAction
             && action != autoDaxAction && action != lowLatencyDaxTxAction) {
             connect(action, &QAction::triggered, this, [this, action] {
                 statusBar()->showMessage(action->text().remove("...") + " — not yet implemented", 3000);
@@ -3546,6 +3589,18 @@ void MainWindow::onConnectionStateChanged(bool connected)
             if (m_appletPanel && m_appletPanel->catApplet())
                 m_appletPanel->catApplet()->setPtyEnabled(true);
         }
+#ifdef HAVE_WEBSOCKETS
+        // Auto-start TCI WebSocket server if enabled
+        if (as.value("AutoStartTCI", "False").toString() == "True") {
+            if (m_tciServer && !m_tciServer->isRunning()) {
+                int tciPort = as.value("TciPort", "50001").toInt();
+                m_tciServer->start(static_cast<quint16>(tciPort));
+                qDebug() << "AutoStart: TCI on port" << tciPort;
+            }
+            if (m_appletPanel && m_appletPanel->catApplet())
+                m_appletPanel->catApplet()->setTciEnabled(true);
+        }
+#endif
         // Populate XVTR bands after radio status settles, and refresh
         // whenever XVTR config changes (add/remove/rename). (#571)
         auto refreshXvtr = [this]() {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -6,6 +6,9 @@
 #include "core/RadioDiscovery.h"
 #include "core/AudioEngine.h"
 #include "core/RigctlServer.h"
+#ifdef HAVE_WEBSOCKETS
+#include "core/TciServer.h"
+#endif
 #include "core/RigctlPty.h"
 #include "core/SmartLinkClient.h"
 #include "core/WanConnection.h"
@@ -130,6 +133,9 @@ private:
     static constexpr int kCatChannels = 4;
     RigctlServer*     m_rigctlServers[kCatChannels]{};
     RigctlPty*        m_rigctlPtys[kCatChannels]{};
+#ifdef HAVE_WEBSOCKETS
+    TciServer*        m_tciServer{nullptr};
+#endif
     SmartLinkClient   m_smartLink;
     WanConnection     m_wanConnection;
     AntennaGeniusModel m_antennaGenius;


### PR DESCRIPTION
Built-in TCI server exposes radio state over WebSocket, replacing the
need for SDC as a bridge. Single connection for CAT + audio + IQ + spots.

- 72 command handlers covering the full TCI v2.0 spec
- RX audio streaming with per-client r8brain resampling (8/12/24/48 kHz)
- TX audio injection from TCI clients into AudioEngine
- IQ streaming control via DaxIqModel
- Sensor telemetry (RX S-meter, TX power/SWR/mic)
- CW keyer (straight key via netcw), CW macros
- Spot injection/deletion into SpotHub
- Auto-broadcast: VFO, mode, filter, TX state, lock, spot clicks
- Per-client audio format negotiation (int16/float32, mono/stereo)
- DIGI applet: TCI enable toggle, port, client count
- Settings menu: Autostart TCI with immediate start/stop
- Gated behind HAVE_WEBSOCKETS (Qt6::WebSockets)
- Validated with WSJT-X Improved (CAT) and wscat (full protocol)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
