### PR TITLE
RADE: Prevent duplicate audio samples from being queued on RX audio device.

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -49,6 +49,25 @@ AudioEngine::AudioEngine(QObject* parent)
         emit txPacketReady(m_opusTxQueue.takeFirst());
     });
     m_opusTxPaceTimer->start();
+
+    // RX pacing timer -- similar to Opus logic but allows us to queue up
+    // enough buffer to prevent underruns. Also, this seems to be how QAudioSink
+    // in push mode needs to be implemented.
+    m_rxTimer = new QTimer(this);
+    m_rxTimer->setTimerType(Qt::PreciseTimer);
+    m_rxTimer->setInterval(10);
+    connect(m_rxTimer, &QTimer::timeout, this, [this]() {
+        if (!m_audioSink || !m_audioDevice || !m_audioDevice->isOpen() || m_audioSink->state() == QAudio::StoppedState) return;
+
+        qsizetype len = m_audioSink->bytesFree();
+        len = std::min(len, m_rxBuffer.size());
+        if (len > 0)
+        {
+            len = m_audioDevice->write(m_rxBuffer.left(len));
+            m_rxBuffer.remove(0, len);
+        }
+    });
+    m_rxTimer->start();
 }
 
 AudioEngine::~AudioEngine()
@@ -149,9 +168,9 @@ void AudioEngine::feedAudioData(const QByteArray& pcm)
     auto writeAudio = [this](const QByteArray& data) {
         if (!m_audioDevice || !m_audioDevice->isOpen()) return;
         if (m_resampleTo48k)
-            m_audioDevice->write(resampleStereo(data));
+            m_rxBuffer.append(resampleStereo(data));
         else
-            m_audioDevice->write(data);
+            m_rxBuffer.append(data); 
     };
 
     // Bypass client-side DSP during TX (#367). NR2/RN2/BNR adapt their
@@ -174,7 +193,7 @@ void AudioEngine::feedAudioData(const QByteArray& pcm)
         } else if (m_bnrEnabled && m_bnr && m_bnr->isConnected()) {
             processBnr(pcm);
             // processBnr writes audio and emits level internally
-        } else {
+        } else if (!m_radeMode) {
             writeAudio(pcm);
             emit levelChanged(computeRMS(pcm));
         }
@@ -421,9 +440,9 @@ void AudioEngine::processBnr(const QByteArray& stereoPcm)
 
         if (m_audioDevice && m_audioDevice->isOpen()) {
             if (m_resampleTo48k)
-                m_audioDevice->write(resampleStereo(chunk));
+                m_rxBuffer.append(resampleStereo(chunk));
             else
-                m_audioDevice->write(chunk);
+                m_rxBuffer.append(chunk); 
         }
         emit levelChanged(computeRMS(chunk));
     }
@@ -1072,10 +1091,12 @@ void AudioEngine::feedDaxTxAudio(const QByteArray& float32pcm)
 void AudioEngine::feedDecodedSpeech(const QByteArray& pcm)
 {
     if (!m_audioSink || !m_audioDevice || !m_audioDevice->isOpen()) return;
+
+    // note: RX timer will handle actual audio device write
     if (m_resampleTo48k)
-        m_audioDevice->write(resampleStereo(pcm));
+        m_rxBuffer.append(resampleStereo(pcm));
     else
-        m_audioDevice->write(pcm);
+        m_rxBuffer.append(pcm);
 }
 
 } // namespace AetherSDR

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -233,6 +233,10 @@ private:
     std::vector<int16_t> m_nr2Processed;
     QByteArray m_nr2Output;
 
+    // RX audio buffer handling
+    QTimer*       m_rxTimer{nullptr};
+    QByteArray    m_rxBuffer;
+
     // VITA-49 TX constants
     static constexpr int    TX_SAMPLES_PER_PACKET = 128;  // audio frames per packet
     static constexpr int    TX_PCM_BYTES_PER_PACKET = TX_SAMPLES_PER_PACKET * 2 * 2; // 128 frames × 2ch × int16

--- a/src/core/RADEEngine.cpp
+++ b/src/core/RADEEngine.cpp
@@ -240,37 +240,35 @@ void RADEEngine::feedRxAudio(int channel, const QByteArray& pcm)
 
         // 4. If features available, synthesize speech via FARGAN
         if (n_out > 0) {
+            m_rxFeatAccum.append(reinterpret_cast<const char*>(&features_out[0]), sizeof(float) * n_out);
+        }
+
+        while (m_rxFeatAccum.size() >= qsizetype(sizeof(float) * NB_TOTAL_FEATURES))
+        {
             // FARGAN warmup: need initial features
             if (!m_farganWarmedUp) {
                 // Feed zeros for warmup
                 float zeros[320] = {0};
                 float warmup_features[5 * NB_TOTAL_FEATURES] = {0};
-                // Copy first set of features for warmup
-                std::memcpy(warmup_features, features_out.data(),
-                            NB_TOTAL_FEATURES * sizeof(float));
                 fargan_cont(fargan, zeros, warmup_features);
                 m_farganWarmedUp = true;
             }
 
             // Process features frame by frame (NB_TOTAL_FEATURES per frame)
-            int nFrames = n_out / NB_TOTAL_FEATURES;
-            speech16k.reserve(speech16k.capacity() + (nFrames * LPCNET_FRAME_SIZE * sizeof(int16_t)));
+            // FARGAN uses only first NB_FEATURES (20) features
+            const float* feat = reinterpret_cast<const float*>(m_rxFeatAccum.constData());
+            float fpcm[LPCNET_FRAME_SIZE];
+            fargan_synthesize(fargan, fpcm, feat);
 
-            for (int f = 0; f < nFrames; ++f) {
-                float* feat = &features_out[f * NB_TOTAL_FEATURES];
-                // FARGAN uses only first NB_FEATURES (20) features
-                float fpcm[LPCNET_FRAME_SIZE];
-                fargan_synthesize(fargan, fpcm, feat);
-
-                // Convert float → int16
-                for (int i = 0; i < LPCNET_FRAME_SIZE; ++i) {
-                    float v = std::floor(0.5f + std::clamp(
-                        32768.0f * fpcm[i], -32767.0f, 32767.0f));
-                    int16_t s = static_cast<int16_t>(v);
-                    speech16k.append(reinterpret_cast<const char*>(&s), sizeof(int16_t));
-                }
+            // Convert float → int16
+            for (int i = 0; i < LPCNET_FRAME_SIZE; ++i) {
+                float v = std::floor(0.5f + std::clamp(
+                    32768.0f * fpcm[i], -32767.0f, 32767.0f));
+                int16_t s = static_cast<int16_t>(v);
+                speech16k.append(reinterpret_cast<const char*>(&s), sizeof(int16_t));
             }
 
+            m_rxFeatAccum.remove(0, sizeof(float) * NB_TOTAL_FEATURES);
         }
 
         nin = rade_nin(m_rade);
@@ -278,7 +276,10 @@ void RADEEngine::feedRxAudio(int channel, const QByteArray& pcm)
 
     // 5. Upsample 16kHz mono → 24kHz stereo for speaker
     if (!speech16k.isEmpty())
-        m_rxOutAccum.append(m_up16to24->processMonoToStereo(reinterpret_cast<const int16_t*>(speech16k.constData()), speech16k.size() / sizeof(int16_t)));
+    {
+        auto tmp = m_up16to24->processMonoToStereo(reinterpret_cast<const int16_t*>(speech16k.constData()), speech16k.size() / sizeof(int16_t));
+        m_rxOutAccum.append(tmp);
+    }
 
     if (m_rxOutAccum.size() >= pcm.size())
     {

--- a/src/core/RADEEngine.h
+++ b/src/core/RADEEngine.h
@@ -65,6 +65,7 @@ private:
 
     // RX accumulation: rade_nin() RADE_COMP samples
     QByteArray m_rxAccum;
+    QByteArray m_rxFeatAccum;
     QByteArray m_rxOutAccum;
 
     bool m_farganWarmedUp{false};


### PR DESCRIPTION
Followup PR that resolves remaining audio issues for RADE RX:

1. Prevents VITA-49 audio from being queued on output audio device when RADE is enabled. (Root cause of RX issue--this and the RADE-specific audio handler were fighting each other.)
2. Updates RX audio output code in `AudioEngine` to follow Qt example for push mode (mainly to have an audio output timer enqueue audio samples as there's available buffer).

See https://github.com/ten9876/AetherSDR/issues/614 for context.