### PR TITLE
Disable client-side DSP when RADE is active

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -226,6 +226,8 @@ void AudioEngine::generateWisdom(std::function<void(int,int,const std::string&)>
 void AudioEngine::setNr2Enabled(bool on)
 {
     if (m_nr2Enabled == on) return;
+    // RADE outputs decoded speech — client-side DSP has no effect
+    if (on && m_radeMode) return;
     std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (on) {
         // Disable RN2/BNR if on — they're mutually exclusive
@@ -253,6 +255,7 @@ void AudioEngine::setNr2Enabled(bool on)
 void AudioEngine::setRn2Enabled(bool on)
 {
     if (m_rn2Enabled == on) return;
+    if (on && m_radeMode) return;
     std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (on) {
         // Disable NR2/BNR first — they're mutually exclusive
@@ -280,6 +283,7 @@ void AudioEngine::setRn2Enabled(bool on)
 void AudioEngine::setBnrEnabled(bool on)
 {
     if (m_bnrEnabled == on) return;
+    if (on && m_radeMode) return;
     std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (on) {
         // Mutual exclusion with NR2 and RN2
@@ -928,6 +932,13 @@ void AudioEngine::setInputDevice(const QAudioDevice& dev)
 void AudioEngine::setRadeMode(bool on)
 {
     m_radeMode = on;
+    // RADE outputs decoded speech — client-side DSP has no effect.
+    // Disable any active DSP when entering RADE mode.
+    if (on) {
+        if (m_nr2Enabled) setNr2Enabled(false);
+        if (m_rn2Enabled) setRn2Enabled(false);
+        if (m_bnrEnabled) setBnrEnabled(false);
+    }
 }
 
 void AudioEngine::sendModemTxAudio(const QByteArray& float32pcm)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1876,8 +1876,11 @@ MainWindow::MainWindow(QWidget* parent)
         if (!grid.isEmpty())
             m_gridLabel->setText(grid);
 
-        // Use GPS UTC time if available, otherwise system UTC
-        if (!utcTime.isEmpty()) {
+        // Use GPS UTC time only when GPSDO is installed and locked.
+        // GPS with no antenna/lock sends stale "00:00:00Z" — fall back to system clock.
+        if (!utcTime.isEmpty()
+            && m_radioModel.oscState() == "gpsdo"
+            && m_radioModel.oscLocked()) {
             m_gpsTimeLabel->setText(utcTime);
             m_useSystemClock = false;
         } else {

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -16,6 +16,8 @@
 #include <QHBoxLayout>
 #include <QGridLayout>
 #include <QMenu>
+#include <QInputDialog>
+#include "core/AppSettings.h"
 #include <QAction>
 #include <QPainter>
 #include <QWheelEvent>
@@ -136,29 +138,29 @@ struct ModeSettings {
 
 static const ModeSettings& modeSettingsFor(const QString& mode)
 {
-    // USB / LSB (default)
+    // USB / LSB (default) — first 6 of VfoWidget's 8 presets
     static const ModeSettings ssbSettings{
-        {1800, 2100, 2400, 2700, 3300, 6000},
+        {1800, 2100, 2400, 2700, 2900, 3300},
         {1, 10, 50, 100, 500, 1000, 2000, 3000}
     };
     // AM / SAM — double-sideband: width split ±half around carrier
     static const ModeSettings amSettings{
-        {5600, 6000, 8000, 10000, 14000, 20000},
+        {5600, 6000, 8000, 10000, 12000, 14000},
         {250, 500, 2500, 3000, 5000, 9000, 10000}
     };
     // CW
     static const ModeSettings cwSettings{
-        {50, 100, 250, 400, 800, 3000},
+        {50, 100, 250, 400},
         {1, 5, 10, 50, 100, 200, 400}
     };
     // DIGL / DIGU
     static const ModeSettings digSettings{
-        {100, 300, 600, 1000, 3000, 6000},
+        {100, 300, 600, 1000, 1500, 2000},
         {1, 5, 10, 20, 100, 250, 500, 1000}
     };
     // RTTY
     static const ModeSettings rttySettings{
-        {250, 300, 350, 400, 1000, 3000},
+        {250, 300, 350, 400, 500, 1000},
         {1, 5, 10, 20, 100, 250, 500, 1000}
     };
     // FM / NFM / DFM — no filter presets
@@ -1243,6 +1245,14 @@ void RxApplet::applyFilterPreset(int widthHz)
     if (mode == "LSB" || mode == "DIGL") {
         lo = -widthHz;
         hi = 0;
+    } else if (mode == "RTTY") {
+        // RTTY: RF_frequency = mark. Filter is relative to mark.
+        // Space is at -rttyShift. Passband should encompass both tones.
+        // Expand symmetrically around the midpoint between mark(0) and space(-shift).
+        int shift = m_slice ? m_slice->rttyShift() : 170;
+        int mid = -shift / 2;  // midpoint between mark(0) and space(-shift)
+        lo = mid - widthHz / 2;
+        hi = mid + widthHz / 2;
     } else if (mode == "CW" || mode == "CWL") {
         // Centered on carrier — the radio's BFO/demodulator applies the
         // pitch offset internally so signals at 0 Hz are heard at the sidetone.
@@ -1263,7 +1273,28 @@ void RxApplet::applyFilterPreset(int widthHz)
 
 void RxApplet::updateFilterButtons()
 {
-    const int width = m_slice ? (m_slice->filterHigh() - m_slice->filterLow()) : -1;
+    if (!m_slice) return;
+
+    // Reload presets from AppSettings in case VfoWidget changed them.
+    // RxApplet shows at most 6 (first 6 of the shared preset list).
+    static constexpr int kMaxRxFilters = 6;
+    const QString key = QStringLiteral("FilterPresets_%1").arg(m_slice->mode());
+    const QString saved = AppSettings::instance().value(key, "").toString();
+    if (!saved.isEmpty()) {
+        QVector<int> loaded;
+        for (const auto& s : saved.split(',', Qt::SkipEmptyParts)) {
+            bool ok;
+            int w = s.toInt(&ok);
+            if (ok && w > 0) loaded.append(w);
+            if (loaded.size() >= kMaxRxFilters) break;
+        }
+        if (loaded != m_filterWidths) {
+            m_filterWidths = loaded;
+            rebuildFilterButtons();
+        }
+    }
+
+    const int width = m_slice->filterHigh() - m_slice->filterLow();
 
     // Find the single closest matching filter preset
     int bestIdx = -1;
@@ -1299,8 +1330,22 @@ void RxApplet::updateModeSettings(const QString& mode)
 
     const bool isFM = (mode == "FM" || mode == "NFM" || mode == "DFM");
 
-    // Update filter widths and rebuild buttons
-    m_filterWidths = settings.filterWidths;
+    // Load custom filter presets from AppSettings, fall back to defaults.
+    // RxApplet shows at most 6 (first 6 of VfoWidget's 8).
+    static constexpr int kMaxRxFilters = 6;
+    QString key = QStringLiteral("FilterPresets_%1").arg(mode);
+    QString saved = AppSettings::instance().value(key, "").toString();
+    if (!saved.isEmpty()) {
+        m_filterWidths.clear();
+        for (const auto& s : saved.split(',', Qt::SkipEmptyParts)) {
+            bool ok;
+            int w = s.toInt(&ok);
+            if (ok && w > 0) m_filterWidths.append(w);
+            if (m_filterWidths.size() >= kMaxRxFilters) break;
+        }
+    } else {
+        m_filterWidths = settings.filterWidths;
+    }
     rebuildFilterButtons();
     m_filterContainer->setVisible(!m_filterWidths.isEmpty() && !isFM);
 
@@ -1357,9 +1402,69 @@ void RxApplet::rebuildFilterButtons()
         connect(btn, &QPushButton::clicked, this, [this, w](bool) {
             applyFilterPreset(w);
         });
+
+        // Right-click to customize this preset
+        btn->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(btn, &QPushButton::customContextMenuRequested, this, [this, i, btn](const QPoint& pos) {
+            QMenu menu;
+            menu.addAction("Set Custom Width...", [this, i] {
+                if (!m_slice) return;
+                bool ok;
+                int hz = QInputDialog::getInt(this, "Custom Filter Width",
+                    "Enter filter width in Hz:", m_filterWidths[i],
+                    10, 20000, 10, &ok);
+                if (!ok) return;
+                m_filterWidths[i] = hz;
+                saveFilterPresets();
+                rebuildFilterButtons();
+                applyFilterPreset(hz);
+            });
+            menu.addAction("Reset to Defaults", [this] {
+                if (!m_slice) return;
+                const QString mode = m_slice->mode();
+                AppSettings::instance().remove(
+                    QStringLiteral("FilterPresets_%1").arg(mode));
+                AppSettings::instance().save();
+                updateModeSettings(mode);
+            });
+            menu.exec(btn->mapToGlobal(pos));
+        });
+
         m_filterBtns.append(btn);
         m_filterGrid->addWidget(btn, i / 3, i % 3);
     }
+}
+
+void RxApplet::saveFilterPresets()
+{
+    if (!m_slice) return;
+    const QString key = QStringLiteral("FilterPresets_%1").arg(m_slice->mode());
+    auto& s = AppSettings::instance();
+
+    // Preserve VfoWidget's extra entries (7th, 8th) if they exist
+    QVector<int> full;
+    QString existing = s.value(key, "").toString();
+    if (!existing.isEmpty()) {
+        for (const auto& p : existing.split(',', Qt::SkipEmptyParts)) {
+            bool ok;
+            int w = p.toInt(&ok);
+            if (ok && w > 0) full.append(w);
+        }
+    }
+
+    // Replace the first N entries with our (up to 6) values
+    for (int i = 0; i < m_filterWidths.size(); ++i) {
+        if (i < full.size())
+            full[i] = m_filterWidths[i];
+        else
+            full.append(m_filterWidths[i]);
+    }
+
+    QStringList parts;
+    for (int w : full)
+        parts.append(QString::number(w));
+    s.setValue(key, parts.join(','));
+    s.save();
 }
 
 void RxApplet::rebuildStepSizes()
@@ -1416,6 +1521,9 @@ void RxApplet::syncStepFromSlice(int stepHz, const QVector<int>& stepList)
     }
     m_stepIdx = bestIdx;
     m_stepLabel->setText(formatStepLabel(m_stepSizes[m_stepIdx]));
+
+    // Notify SpectrumWidget so scroll-to-tune uses the radio's step size
+    emit stepSizeChanged(m_stepSizes[m_stepIdx]);
 }
 
 void RxApplet::updateAgcCombo()

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -77,6 +77,7 @@ private:
     void updateFilterButtons();
     void updateModeSettings(const QString& mode);
     void rebuildFilterButtons();
+    void saveFilterPresets();
     void rebuildStepSizes();
     void updateAgcCombo();
     void updateOffsetDirButtons();

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1708,8 +1708,16 @@ void SpectrumWidget::paintEvent(QPaintEvent*)
         struct VfoPos { int sliceId; int x; VfoWidget* w; int splitPartner; };
         QVector<VfoPos> vfos;
         for (const auto& so : m_sliceOverlays) {
-            if (auto* w = m_vfoWidgets.value(so.sliceId, nullptr))
-                vfos.append({so.sliceId, mhzToX(so.freqMhz), w, so.splitPartnerId});
+            if (auto* w = m_vfoWidgets.value(so.sliceId, nullptr)) {
+                int x = mhzToX(so.freqMhz);
+                // In RTTY/DIGL, anchor the flag past the filter high edge
+                // so it doesn't cover the mark/space passband.
+                if (so.mode == "RTTY" || so.mode == "DIGL") {
+                    double hiMhz = so.freqMhz + so.filterHighHz / 1.0e6;
+                    x = mhzToX(hiMhz) + 4;  // 4px padding past filter edge
+                }
+                vfos.append({so.sliceId, x, w, so.splitPartnerId});
+            }
         }
         std::sort(vfos.begin(), vfos.end(), [](const VfoPos& a, const VfoPos& b) {
             return a.x < b.x;
@@ -1745,14 +1753,21 @@ void SpectrumWidget::paintEvent(QPaintEvent*)
         }
 
         // Second pass: assign remaining (non-split) VFOs
+        // In RTTY/DIGL, force flag to fly right so it doesn't cover M/S passband
+        for (const auto& so : m_sliceOverlays) {
+            if (so.mode == "RTTY" || so.mode == "DIGL")
+                dirMap[so.sliceId] = VfoWidget::ForceRight;
+        }
+
         if (vfos.size() == 1) {
-            vfos[0].w->updatePosition(vfos[0].x, specRect.top());
+            VfoWidget::FlagDir dir = dirMap.value(vfos[0].sliceId, VfoWidget::Auto);
+            vfos[0].w->updatePosition(vfos[0].x, specRect.top(), dir);
         } else {
             for (int i = 0; i < vfos.size(); ++i) {
                 VfoWidget::FlagDir dir = VfoWidget::Auto;
 
                 if (dirMap.contains(vfos[i].sliceId)) {
-                    // Split pair: use pre-assigned direction
+                    // Split pair or RTTY: use pre-assigned direction
                     dir = dirMap[vfos[i].sliceId];
                 } else if (vfos.size() == 2) {
                     dir = (i == 0) ? VfoWidget::ForceLeft : VfoWidget::ForceRight;
@@ -2319,33 +2334,29 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
         p.drawLine(fX1, specRect.top(), fX1, specRect.bottom());
         p.drawLine(fX2, specRect.top(), fX2, specRect.bottom());
 
-        // ── Center line ──────────────────────────────────────────────────
-        int markerX = vfoX;
+        // ── RTTY/DIGL: mark/space lines replace the VFO center line ────
+        const bool isRttyMode = (so.mode == "RTTY" || so.mode == "DIGL");
 
-        p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 220), 2.0));
-        p.drawLine(markerX, specRect.top(), markerX, wfRect.bottom());
-
-        // ── Triangle marker at top ───────────────────────────────────────
-        const int triHalf = 6;
-        const int triH = 10;
-        p.setPen(Qt::NoPen);
-        p.setBrush(col);
-        QPolygon tri;
-        tri << QPoint(markerX - triHalf, specRect.top())
-            << QPoint(markerX + triHalf, specRect.top())
-            << QPoint(markerX, specRect.top() + triH);
-        p.drawPolygon(tri);
-
-        // ── RTTY mark/space lines ──────────────────────────────────────
-        if (so.mode == "RTTY") {
-            const double markMhz  = so.freqMhz + so.rttyMark / 1.0e6;
-            const double spaceMhz = markMhz - so.rttyShift / 1.0e6;
+        if (isRttyMode) {
+            double markMhz, spaceMhz;
+            if (so.mode == "RTTY") {
+                // In RTTY mode, RF_frequency IS the mark (radio applies IF shift).
+                markMhz  = so.freqMhz;
+                spaceMhz = so.freqMhz - so.rttyShift / 1.0e6;
+            } else {
+                // In DIGL mode, RF_frequency is the carrier (no IF shift).
+                markMhz  = so.freqMhz - so.rttyMark / 1.0e6;
+                spaceMhz = markMhz - so.rttyShift / 1.0e6;
+            }
             const int markX  = mhzToX(markMhz);
             const int spaceX = mhzToX(spaceMhz);
 
-            QPen rttyPen(QColor(200, 200, 255, 180), 1, Qt::DashLine);
-            p.setPen(rttyPen);
-            p.drawLine(markX,  specRect.top(), markX,  wfRect.bottom());
+            // Mark line — green, dashed
+            p.setPen(QPen(QColor(0, 200, 80, 200), 1, Qt::DashLine));
+            p.drawLine(markX, specRect.top(), markX, wfRect.bottom());
+
+            // Space line — red, dashed
+            p.setPen(QPen(QColor(220, 60, 60, 200), 1, Qt::DashLine));
             p.drawLine(spaceX, specRect.top(), spaceX, wfRect.bottom());
 
             // Labels at top
@@ -2353,9 +2364,27 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
             f.setPixelSize(10);
             f.setBold(true);
             p.setFont(f);
-            p.setPen(QColor(200, 200, 255, 220));
-            p.drawText(markX + 2,  specRect.top() + 12, "M");
+            p.setPen(QColor(0, 200, 80, 240));
+            p.drawText(markX + 2, specRect.top() + 12, "M");
+            p.setPen(QColor(220, 60, 60, 240));
             p.drawText(spaceX + 2, specRect.top() + 12, "S");
+        } else {
+            // ── Standard VFO center line ─────────────────────────────────
+            int markerX = vfoX;
+
+            p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 220), 2.0));
+            p.drawLine(markerX, specRect.top(), markerX, wfRect.bottom());
+
+            // ── Triangle marker at top ───────────────────────────────────
+            const int triHalf = 6;
+            const int triH = 10;
+            p.setPen(Qt::NoPen);
+            p.setBrush(col);
+            QPolygon tri;
+            tri << QPoint(markerX - triHalf, specRect.top())
+                << QPoint(markerX + triHalf, specRect.top())
+                << QPoint(markerX, specRect.top() + triH);
+            p.drawPolygon(tri);
         }
 
         // ── RIT/XIT offset lines ──────────────────────────────────────

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -19,6 +19,7 @@
 #include <QHBoxLayout>
 #include <QGridLayout>
 #include <QMenu>
+#include <QInputDialog>
 #include <QDoubleSpinBox>
 #include <QSignalBlocker>
 #include <QDir>
@@ -910,7 +911,7 @@ void VfoWidget::buildTabContent()
                 markLbl->setStyleSheet(kDimLabel);
                 markLbl->setAlignment(Qt::AlignCenter);
                 lblRow->addWidget(markLbl, 1);
-                auto* shiftLbl = new QLabel("Shift");
+                auto* shiftLbl = new QLabel("Space");
                 shiftLbl->setStyleSheet(kDimLabel);
                 shiftLbl->setAlignment(Qt::AlignCenter);
                 lblRow->addWidget(shiftLbl, 1);
@@ -923,42 +924,52 @@ void VfoWidget::buildTabContent()
                 selRow->setContentsMargins(0, 0, 0, 0);
                 selRow->setSpacing(4);
 
+                static constexpr int MARK_STEP = 25;
+                static constexpr int SHIFT_STEP = 5;
+
                 // Mark selector: ◀ 2125 ▶
                 auto* markMinus = new TriBtn(TriBtn::Left);
                 selRow->addWidget(markMinus);
-                m_markLabel = new QLabel("2125");
+                m_markLabel = new ScrollableLabel("2125");
                 m_markLabel->setAlignment(Qt::AlignCenter);
                 m_markLabel->setStyleSheet(kStepLabelStyle);
                 selRow->addWidget(m_markLabel, 1);
                 auto* markPlus = new TriBtn(TriBtn::Right);
                 selRow->addWidget(markPlus);
 
+                auto markDown = [this] {
+                    if (m_slice) m_slice->setRttyMark(m_slice->rttyMark() - MARK_STEP);
+                };
+                auto markUp = [this] {
+                    if (m_slice) m_slice->setRttyMark(m_slice->rttyMark() + MARK_STEP);
+                };
+                connect(markMinus, &QPushButton::clicked, this, markDown);
+                connect(markPlus, &QPushButton::clicked, this, markUp);
+                connect(m_markLabel, &ScrollableLabel::scrolled, this,
+                        [markUp, markDown](int dir) { if (dir > 0) markUp(); else markDown(); });
+
                 selRow->addSpacing(4);
 
-                // Shift selector: ◀ 170 ▶
+                // Space selector: ◀ 170 ▶
                 auto* shiftMinus = new TriBtn(TriBtn::Left);
                 selRow->addWidget(shiftMinus);
-                m_shiftLabel = new QLabel("170");
+                m_shiftLabel = new ScrollableLabel("170");
                 m_shiftLabel->setAlignment(Qt::AlignCenter);
                 m_shiftLabel->setStyleSheet(kStepLabelStyle);
                 selRow->addWidget(m_shiftLabel, 1);
                 auto* shiftPlus = new TriBtn(TriBtn::Right);
                 selRow->addWidget(shiftPlus);
 
-                static constexpr int MARK_STEP = 25;
-                static constexpr int SHIFT_STEP = 5;
-                connect(markMinus, &QPushButton::clicked, this, [this] {
-                    if (m_slice) m_slice->setRttyMark(m_slice->rttyMark() - MARK_STEP);
-                });
-                connect(markPlus, &QPushButton::clicked, this, [this] {
-                    if (m_slice) m_slice->setRttyMark(m_slice->rttyMark() + MARK_STEP);
-                });
-                connect(shiftMinus, &QPushButton::clicked, this, [this] {
+                auto shiftDown = [this] {
                     if (m_slice) m_slice->setRttyShift(m_slice->rttyShift() - SHIFT_STEP);
-                });
-                connect(shiftPlus, &QPushButton::clicked, this, [this] {
+                };
+                auto shiftUp = [this] {
                     if (m_slice) m_slice->setRttyShift(m_slice->rttyShift() + SHIFT_STEP);
-                });
+                };
+                connect(shiftMinus, &QPushButton::clicked, this, shiftDown);
+                connect(shiftPlus, &QPushButton::clicked, this, shiftUp);
+                connect(m_shiftLabel, &ScrollableLabel::scrolled, this,
+                        [shiftUp, shiftDown](int dir) { if (dir > 0) shiftUp(); else shiftDown(); });
 
                 rvb->addLayout(selRow);
             }
@@ -2354,8 +2365,19 @@ void VfoWidget::updateModeTab()
     // Update quick-mode button labels and active state
     updateQuickModeButtons();
 
-    // Rebuild filter presets for new mode
-    m_filterWidths = filterPresetsFor(cur).filterWidths;
+    // Load custom filter presets from AppSettings, fall back to defaults
+    QString fkey = QStringLiteral("FilterPresets_%1").arg(cur);
+    QString saved = AppSettings::instance().value(fkey, "").toString();
+    if (!saved.isEmpty()) {
+        m_filterWidths.clear();
+        for (const auto& s : saved.split(',', Qt::SkipEmptyParts)) {
+            bool ok;
+            int w = s.toInt(&ok);
+            if (ok && w > 0) m_filterWidths.append(w);
+        }
+    } else {
+        m_filterWidths = filterPresetsFor(cur).filterWidths;
+    }
     rebuildFilterButtons();
 }
 
@@ -2408,6 +2430,34 @@ void VfoWidget::rebuildFilterButtons()
         connect(btn, &QPushButton::clicked, this, [this, w](bool) {
             applyFilterPreset(w);
         });
+
+        // Right-click to customize this preset
+        btn->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(btn, &QPushButton::customContextMenuRequested, this, [this, i, btn](const QPoint& pos) {
+            QMenu menu;
+            menu.addAction("Set Custom Width...", [this, i] {
+                if (!m_slice) return;
+                bool ok;
+                int hz = QInputDialog::getInt(this, "Custom Filter Width",
+                    "Enter filter width in Hz:", m_filterWidths[i],
+                    10, 20000, 10, &ok);
+                if (!ok) return;
+                m_filterWidths[i] = hz;
+                saveFilterPresets();
+                rebuildFilterButtons();
+                applyFilterPreset(hz);
+            });
+            menu.addAction("Reset to Defaults", [this] {
+                if (!m_slice) return;
+                const QString mode = m_slice->mode();
+                AppSettings::instance().remove(
+                    QStringLiteral("FilterPresets_%1").arg(mode));
+                AppSettings::instance().save();
+                updateModeTab();
+            });
+            menu.exec(btn->mapToGlobal(pos));
+        });
+
         m_filterBtns.append(btn);
         m_filterGrid->addWidget(btn, i / 4, i % 4);
     }
@@ -2458,6 +2508,23 @@ void VfoWidget::rebuildFilterButtons()
 void VfoWidget::updateFilterHighlight()
 {
     if (!m_slice) return;
+
+    // Reload presets from AppSettings in case RxApplet changed them
+    const QString key = QStringLiteral("FilterPresets_%1").arg(m_slice->mode());
+    const QString saved = AppSettings::instance().value(key, "").toString();
+    if (!saved.isEmpty()) {
+        QVector<int> loaded;
+        for (const auto& s : saved.split(',', Qt::SkipEmptyParts)) {
+            bool ok;
+            int w = s.toInt(&ok);
+            if (ok && w > 0) loaded.append(w);
+        }
+        if (loaded != m_filterWidths) {
+            m_filterWidths = loaded;
+            rebuildFilterButtons();
+        }
+    }
+
     const int width = m_slice->filterHigh() - m_slice->filterLow();
     int bestIdx = -1, bestDist = INT_MAX;
     for (int i = 0; i < m_filterWidths.size(); ++i) {
@@ -2480,6 +2547,14 @@ void VfoWidget::applyFilterPreset(int widthHz)
 
     if (mode == "LSB" || mode == "DIGL") {
         lo = -widthHz; hi = 0;
+    } else if (mode == "RTTY") {
+        // RTTY: RF_frequency = mark. Filter is relative to mark.
+        // Space is at -rttyShift. Passband should encompass both tones.
+        // Expand symmetrically around the midpoint between mark(0) and space(-shift).
+        int shift = m_slice->rttyShift();
+        int mid = -shift / 2;
+        lo = mid - widthHz / 2;
+        hi = mid + widthHz / 2;
     } else if (mode == "CW" || mode == "CWL") {
         // Centered on carrier — radio's BFO handles pitch offset
         lo = -widthHz / 2;
@@ -2490,6 +2565,18 @@ void VfoWidget::applyFilterPreset(int widthHz)
         lo = 0; hi = widthHz;
     }
     m_slice->setFilterWidth(lo, hi);
+}
+
+void VfoWidget::saveFilterPresets()
+{
+    if (!m_slice) return;
+    QStringList parts;
+    for (int w : m_filterWidths)
+        parts.append(QString::number(w));
+    auto& s = AppSettings::instance();
+    s.setValue(QStringLiteral("FilterPresets_%1").arg(m_slice->mode()),
+              parts.join(','));
+    s.save();
 }
 
 void VfoWidget::setAntennaList(const QStringList& ants)

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -104,6 +104,7 @@ private:
     void rebuildFilterButtons();
     void updateFilterHighlight();
     void applyFilterPreset(int widthHz);
+    void saveFilterPresets();
     static QString formatFilterLabel(int hz);
 
     SliceModel*    m_slice{nullptr};
@@ -197,8 +198,8 @@ private:
     QPushButton*   m_fmSimplexBtn{nullptr};
     QPushButton*   m_fmOffsetUp{nullptr};
     QPushButton*   m_fmRevBtn{nullptr};
-    QLabel*  m_markLabel{nullptr};
-    QLabel*  m_shiftLabel{nullptr};
+    ScrollableLabel* m_markLabel{nullptr};
+    ScrollableLabel* m_shiftLabel{nullptr};
     // Mode tab
     QComboBox* m_modeCombo{nullptr};
     QPushButton* m_quickModeBtns[3]{};


### PR DESCRIPTION
- Customizable filter width presets via right-click (#675)
- Fix RTTY mark/space overlay and filter presets (#660)
- Fix step size not applied to scroll-to-tune on restart (#666)
- Fix clock showing 00:00:00z when GPS has no lock (#682)
- Disable client-side DSP when RADE is active
