### PR TITLE
Fix GPU rendering on macOS: chain QRhiWidget::resizeEvent (#702)

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -24,8 +24,9 @@ jobs:
           arch: 'clang_64'
           modules: 'qtmultimedia qtserialport qtwebsockets qtshadertools'
 
-      - name: Install build tools
-        run: brew install ninja create-dmg autoconf automake libtool
+      - name: Install build tools and dependencies
+        run: brew install ninja create-dmg autoconf automake libtool \
+          fftw portaudio hidapi qtkeychain
 
       - name: Generate .icns from PNG
         run: |

--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -26,8 +26,9 @@ jobs:
           arch: 'clang_64'
           modules: 'qtmultimedia qtserialport qtwebsockets qtshadertools'
 
-      - name: Install build tools
-        run: brew install ninja autoconf automake libtool
+      - name: Install build tools and dependencies
+        run: brew install ninja autoconf automake libtool \
+          fftw portaudio hidapi qtkeychain
 
       - name: Generate .icns from PNG
         run: |

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1507,7 +1507,7 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
 
 void SpectrumWidget::resizeEvent(QResizeEvent* ev)
 {
-    QWidget::resizeEvent(ev);
+    SPECTRUM_BASE_CLASS::resizeEvent(ev);
 
     const int chromeH  = FREQ_SCALE_H + DIVIDER_H;
     const int contentH = height() - chromeH;


### PR DESCRIPTION
resizeEvent called QWidget::resizeEvent instead of the actual base
class (QRhiWidget when GPU enabled). QRhiWidget::resizeEvent syncs
the offscreen RHI texture size — skipping it leaves the texture out
of sync with the window, producing a blank spectrum on macOS Metal.

Also added fftw, portaudio, hidapi, qtkeychain to macOS release
workflows for full-featured DMG/PKG builds.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
