### PR TITLE
[spots] Add radio memories to SpotHub

### DIFF
--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -1552,6 +1552,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
 
     auto& s = AppSettings::instance();
     bool spotsEnabled     = s.value("IsSpotsEnabled", "True").toString() == "True";
+    bool memoriesEnabled  = s.value("IsMemorySpotsEnabled", "False").toString() == "True";
     bool overrideColors   = s.value("IsSpotsOverrideColorsEnabled", "False").toString() == "True";
     bool overrideBg       = s.value("IsSpotsOverrideBackgroundColorsEnabled", "True").toString() == "True";
     bool overrideBgAuto   = s.value("IsSpotsOverrideToAutoBackgroundColorEnabled", "True").toString() == "True";
@@ -1594,6 +1595,23 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
         save("IsSpotsEnabled", on ? "True" : "False");
     });
     grid->addWidget(spotsToggle, row++, 1, Qt::AlignLeft);
+
+    // ── Memory feed visibility ──────────────────────────────────────────
+    grid->addWidget(new QLabel("Memories:"), row, 0);
+    auto* memoriesToggle = new QPushButton(memoriesEnabled ? "Enabled" : "Disabled");
+    memoriesToggle->setCheckable(true);
+    memoriesToggle->setChecked(memoriesEnabled);
+    memoriesToggle->setFixedWidth(80);
+    memoriesToggle->setToolTip(
+        "Show radio memory channels as a spot-like feed on the panadapter.");
+    memoriesToggle->setStyleSheet(
+        "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
+        "QPushButton:!checked { background: #603020; }");
+    connect(memoriesToggle, &QPushButton::toggled, this, [memoriesToggle, save](bool on) {
+        memoriesToggle->setText(on ? "Enabled" : "Disabled");
+        save("IsMemorySpotsEnabled", on ? "True" : "False");
+    });
+    grid->addWidget(memoriesToggle, row++, 1, Qt::AlignLeft);
 
     // ── Auto-switch mode on spot click (#424) ───────────────────────────
     grid->addWidget(new QLabel("Auto Mode:"), row, 0);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -106,8 +106,47 @@ namespace AetherSDR {
 // ─── Shortcut guard (file-scope for use as std::function<bool()>) ───────────
 
 static constexpr const char* kPaTempUnitSettingKey = "PaTempDisplayUnit";
+static constexpr int kMemorySpotIdBase = 1000000;
 
 static bool s_keyboardShortcutsEnabled = false;
+
+static int memorySpotId(int memoryIndex)
+{
+    return -(kMemorySpotIdBase + memoryIndex);
+}
+
+static int memoryIndexFromSpotId(int spotIndex)
+{
+    if (spotIndex > -kMemorySpotIdBase)
+        return -1;
+    return -spotIndex - kMemorySpotIdBase;
+}
+
+static QString memorySpotLabel(const MemoryEntry& memory)
+{
+    if (!memory.name.trimmed().isEmpty())
+        return memory.name.trimmed();
+    if (!memory.group.trimmed().isEmpty())
+        return memory.group.trimmed();
+    return QString("Memory %1").arg(memory.index);
+}
+
+static QString memorySpotComment(const MemoryEntry& memory)
+{
+    QStringList parts;
+    if (!memory.group.trimmed().isEmpty())
+        parts << QString("Group: %1").arg(memory.group.trimmed());
+    if (!memory.owner.trimmed().isEmpty())
+        parts << QString("Owner: %1").arg(memory.owner.trimmed());
+    if (!memory.mode.trimmed().isEmpty())
+        parts << QString("Mode: %1").arg(memory.mode.trimmed());
+    if (memory.rxFilterLow != 0 || memory.rxFilterHigh != 0) {
+        parts << QString("Filter: %1..%2 Hz")
+                    .arg(memory.rxFilterLow)
+                    .arg(memory.rxFilterHigh);
+    }
+    return parts.join(" | ");
+}
 
 static bool isTextInputFocused()
 {
@@ -168,7 +207,7 @@ MainWindow::MainWindow(QWidget* parent)
         }
     }
     connect(&m_dxccProvider, &DxccColorProvider::importFinished,
-            this, [this](int, int) { emit m_radioModel.spotModel().spotsCleared(); });
+            this, [this](int, int) { m_radioModel.spotModel().refresh(); });
 
     // Install event filter on the application to intercept Space PTT
     // before child widgets (buttons, combos) consume the key event.
@@ -516,6 +555,14 @@ MainWindow::MainWindow(QWidget* parent)
             this, &MainWindow::onSliceAdded);
     connect(&m_radioModel, &RadioModel::sliceRemoved,
             this, &MainWindow::onSliceRemoved);
+    connect(&m_radioModel, &RadioModel::memoryChanged,
+            this, &MainWindow::syncMemorySpot);
+    connect(&m_radioModel, &RadioModel::memoryRemoved,
+            this, &MainWindow::removeMemorySpot);
+    connect(&m_radioModel, &RadioModel::memoriesCleared,
+            this, &MainWindow::clearMemorySpotFeed);
+    connect(&m_radioModel.spotModel(), &SpotModel::spotsCleared,
+            this, &MainWindow::rebuildMemorySpotFeed);
 
     // ── TX audio stream: set stream ID for DAX TX path ──────────────────
     // DAX TX audio is sent via PanadapterStream::sendToRadio() (the
@@ -2501,6 +2548,9 @@ void MainWindow::buildMenuBar()
                 sw->setSpotBgColor(bgColor);
                 sw->setSpotBgOpacity(bgOpacity);
             }
+            // Rebuild markers so source-level visibility changes, such as the
+            // Memories feed toggle, apply immediately without mutating the cache.
+            m_radioModel.spotModel().refresh();
         };
         connect(dlg, &DxClusterDialog::settingsChanged, this, refreshSpots);
         connect(dlg, &DxClusterDialog::connectRequested,
@@ -3794,6 +3844,75 @@ void MainWindow::onConnectionError(const QString& msg)
     statusBar()->showMessage("Connection error: " + msg, 5000);
 }
 
+void MainWindow::syncMemorySpot(int memoryIndex)
+{
+    auto it = m_radioModel.memories().constFind(memoryIndex);
+    if (it == m_radioModel.memories().constEnd()) {
+        removeMemorySpot(memoryIndex);
+        return;
+    }
+
+    const MemoryEntry& memory = it.value();
+    if (memory.freq <= 0.0) {
+        removeMemorySpot(memoryIndex);
+        return;
+    }
+
+    QMap<QString, QString> kvs;
+    kvs["callsign"] = memorySpotLabel(memory).replace(' ', QChar(0x7f));
+    kvs["rx_freq"] = QString::number(memory.freq, 'f', 6);
+    kvs["tx_freq"] = QString::number(memory.freq, 'f', 6);
+    kvs["source"] = "Memory";
+    kvs["mode"] = memory.mode;
+    kvs["color"] = "#FFFFC857";
+    const QString comment = memorySpotComment(memory);
+    if (!comment.isEmpty())
+        kvs["comment"] = QString(comment).replace(' ', QChar(0x7f));
+
+    m_radioModel.spotModel().applySpotStatus(memorySpotId(memoryIndex), kvs);
+}
+
+void MainWindow::removeMemorySpot(int memoryIndex)
+{
+    m_radioModel.spotModel().removeSpot(memorySpotId(memoryIndex));
+}
+
+void MainWindow::clearMemorySpotFeed()
+{
+    QVector<int> ids;
+    const auto& spots = m_radioModel.spotModel().spots();
+    for (auto it = spots.cbegin(); it != spots.cend(); ++it) {
+        if (it.value().source == "Memory")
+            ids.append(it.key());
+    }
+    for (int id : ids)
+        m_radioModel.spotModel().removeSpot(id);
+}
+
+void MainWindow::rebuildMemorySpotFeed()
+{
+    for (auto it = m_radioModel.memories().cbegin(); it != m_radioModel.memories().cend(); ++it)
+        syncMemorySpot(it.key());
+}
+
+void MainWindow::activateMemorySpot(int memoryIndex)
+{
+    if (auto* slice = activeSlice(); !slice || slice->isLocked())
+        return;
+
+    const auto it = m_radioModel.memories().constFind(memoryIndex);
+    if (it == m_radioModel.memories().constEnd())
+        return;
+
+    m_radioModel.sendCommand(QString("memory apply %1").arg(memoryIndex));
+
+    // The radio should push the rest of the applied memory state, but keep the
+    // local tuning step in sync immediately so wheel/click snap follows along.
+    if (it->step > 0 && activeSlice())
+        m_radioModel.sendCommand(QString("slice set %1 step=%2")
+            .arg(activeSlice()->sliceId()).arg(it->step));
+}
+
 void MainWindow::onSliceAdded(SliceModel* s)
 {
     // During layout transition, spectrums are being destroyed/recreated — skip
@@ -4468,13 +4587,20 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     auto rebuildSpots = [this, swGuard]() {
         if (!swGuard) return;  // widget destroyed (layout change)
         auto* s = &m_radioModel.spotModel();
+        const bool showMemories =
+            AppSettings::instance().value("IsMemorySpotsEnabled", "False").toString() == "True";
         QVector<SpectrumWidget::SpotMarker> markers;
         for (const auto& spot : s->spots()) {
-            qint64 tsMs = (spot.timestamp.isValid() && spot.timestamp.toMSecsSinceEpoch() > 0)
-                ? spot.timestamp.toMSecsSinceEpoch()
-                : spot.addedMs;
+            if (spot.source == "Memory" && !showMemories)
+                continue;
+            qint64 tsMs = 0;
+            if (spot.source != "Memory") {
+                tsMs = (spot.timestamp.isValid() && spot.timestamp.toMSecsSinceEpoch() > 0)
+                    ? spot.timestamp.toMSecsSinceEpoch()
+                    : spot.addedMs;
+            }
             QColor dxccCol;
-            if (m_dxccProvider.isEnabled())
+            if (m_dxccProvider.isEnabled() && spot.source != "Memory")
                 dxccCol = m_dxccProvider.colorForSpot(spot.callsign, spot.rxFreqMhz, spot.mode);
             markers.append({spot.index, spot.callsign, spot.rxFreqMhz, spot.color, spot.mode,
                             dxccCol, spot.source, spot.spotterCallsign, spot.comment, tsMs});
@@ -4485,6 +4611,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     connect(spots, &SpotModel::spotUpdated, this, rebuildSpots);
     connect(spots, &SpotModel::spotRemoved, this, rebuildSpots);
     connect(spots, &SpotModel::spotsCleared,this, rebuildSpots);
+    connect(spots, &SpotModel::spotsRefreshed, this, rebuildSpots);
     {
         auto& s = AppSettings::instance();
         sw->setShowSpots(s.value("IsSpotsEnabled", "True").toString() == "True");
@@ -4653,6 +4780,17 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 
     // ── Spot trigger — notify the radio when a spot label is clicked (#341)
     connect(sw, &SpectrumWidget::spotTriggered, this, [this](int spotIndex) {
+        const auto& spots = m_radioModel.spotModel().spots();
+        auto it = spots.find(spotIndex);
+        if (it == spots.end()) return;
+
+        if (it->source == "Memory") {
+            int memoryIndex = memoryIndexFromSpotId(spotIndex);
+            if (memoryIndex >= 0)
+                activateMemorySpot(memoryIndex);
+            return;
+        }
+
         m_radioModel.sendCommand(QString("spot trigger %1").arg(spotIndex));
 
         // Auto-switch mode from spot metadata (#424)
@@ -4660,9 +4798,6 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             return;
         auto* s = activeSlice();
         if (!s) return;
-        const auto& spots = m_radioModel.spotModel().spots();
-        auto it = spots.find(spotIndex);
-        if (it == spots.end()) return;
 
         // Extract mode: prefer explicit mode field, fall back to comment text
         QString spotMode = it->mode.toUpper().trimmed();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -120,6 +120,11 @@ private:
                                 std::shared_ptr<QStringList> panIds, int created);
     void updatePaTempLabel();
     void setPaTempDisplayUnit(bool useFahrenheit);
+    void syncMemorySpot(int memoryIndex);
+    void removeMemorySpot(int memoryIndex);
+    void clearMemorySpotFeed();
+    void rebuildMemorySpotFeed();
+    void activateMemorySpot(int memoryIndex);
 
     BandSnapshot captureCurrentBandState() const;
     void restoreBandState(const BandSnapshot& snap);

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -8,6 +8,7 @@
 #include <QPushButton>
 #include <QHeaderView>
 #include <QDebug>
+#include <QPointer>
 #include <QTimer>
 
 namespace AetherSDR {
@@ -27,6 +28,104 @@ public:
         return QTableWidgetItem::operator<(other);
     }
 };
+
+QString encodeMemoryText(const QString& value)
+{
+    return QString(value).replace(' ', QChar(0x7f));
+}
+
+bool buildMemoryFieldUpdate(int col, const QTableWidgetItem* item,
+                            QString& commandSuffix, QMap<QString, QString>& kvs)
+{
+    if (!item)
+        return false;
+
+    const QString value = item->text();
+    switch (col) {
+    case 0: {
+        const QString encoded = encodeMemoryText(value);
+        commandSuffix = "group=" + encoded;
+        kvs["group"] = encoded;
+        return true;
+    }
+    case 1: {
+        const QString encoded = encodeMemoryText(value);
+        commandSuffix = "owner=" + encoded;
+        kvs["owner"] = encoded;
+        return true;
+    }
+    case 2:
+        commandSuffix = "freq=" + value;
+        kvs["freq"] = value;
+        return true;
+    case 3: {
+        const QString encoded = encodeMemoryText(value);
+        commandSuffix = "name=" + encoded;
+        kvs["name"] = encoded;
+        return true;
+    }
+    case 4:
+        commandSuffix = "mode=" + value;
+        kvs["mode"] = value;
+        return true;
+    case 5:
+        commandSuffix = "step=" + value;
+        kvs["step"] = value;
+        return true;
+    case 6:
+        commandSuffix = "repeater=" + value;
+        kvs["repeater"] = value;
+        return true;
+    case 7:
+        commandSuffix = "repeater_offset=" + value;
+        kvs["repeater_offset"] = value;
+        return true;
+    case 8:
+        commandSuffix = "tone_mode=" + value;
+        kvs["tone_mode"] = value;
+        return true;
+    case 9:
+        commandSuffix = "tone_value=" + value;
+        kvs["tone_value"] = value;
+        return true;
+    case 10: {
+        const QString squelch = item->checkState() == Qt::Checked ? "1" : "0";
+        commandSuffix = "squelch=" + squelch;
+        kvs["squelch"] = squelch;
+        return true;
+    }
+    case 11:
+        commandSuffix = "squelch_level=" + value;
+        kvs["squelch_level"] = value;
+        return true;
+    case 12:
+        commandSuffix = "rx_filter_low=" + value;
+        kvs["rx_filter_low"] = value;
+        return true;
+    case 13:
+        commandSuffix = "rx_filter_high=" + value;
+        kvs["rx_filter_high"] = value;
+        return true;
+    case 14:
+        commandSuffix = "rtty_mark=" + value;
+        kvs["rtty_mark"] = value;
+        return true;
+    case 15:
+        commandSuffix = "rtty_shift=" + value;
+        kvs["rtty_shift"] = value;
+        return true;
+    case 16:
+        commandSuffix = "digl_offset=" + value;
+        kvs["digl_offset"] = value;
+        return true;
+    case 17:
+        commandSuffix = "digu_offset=" + value;
+        kvs["digu_offset"] = value;
+        return true;
+    default:
+        return false;
+    }
+}
 
 } // namespace
 
@@ -93,49 +192,22 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     connect(removeBtn, &QPushButton::clicked, this, &MemoryDialog::onRemove);
 
     // Listen for live memory updates while dialog is open
-    connect(model, &RadioModel::statusReceived,
-            this, [this](const QString& object, const QMap<QString, QString>&) {
-        if (object.startsWith("memory "))
-            QTimer::singleShot(50, this, [this]() { populateTable(); });
+    connect(model, &RadioModel::memoryChanged,
+            this, [this](int) {
+        QTimer::singleShot(50, this, [this]() { populateTable(); });
     });
     connect(model, &RadioModel::memoryRemoved,
             this, [this](int) {
         populateTable();
     });
+    connect(model, &RadioModel::memoriesCleared,
+            this, [this]() {
+        populateTable();
+    });
 
     // Send edits to the radio when any cell changes
     connect(m_table, &QTableWidget::cellChanged, this, [this](int row, int col) {
-        auto* indexItem = m_table->item(row, 0);
-        if (!indexItem) return;
-        int memIdx = indexItem->data(Qt::UserRole).toInt();
-        auto* item = m_table->item(row, col);
-        if (!item) return;
-        QString val = item->text();
-        QString base = QString("memory set %1 ").arg(memIdx);
-
-        // Map column index to memory set parameter
-        switch (col) {
-        case 0:  m_model->sendCommand(base + "group=" + val.replace(' ', '\x7f')); break;
-        case 1:  m_model->sendCommand(base + "owner=" + val.replace(' ', '\x7f')); break;
-        case 2:  m_model->sendCommand(base + "freq=" + val); break;
-        case 3:  m_model->sendCommand(base + "name=" + val.replace(' ', '\x7f')); break;
-        case 4:  m_model->sendCommand(base + "mode=" + val); break;
-        case 5:  m_model->sendCommand(base + "step=" + val); break;
-        case 6:  m_model->sendCommand(base + "repeater=" + val); break;
-        case 7:  m_model->sendCommand(base + "repeater_offset=" + val); break;
-        case 8:  m_model->sendCommand(base + "tone_mode=" + val); break;
-        case 9:  m_model->sendCommand(base + "tone_value=" + val); break;
-        case 10: m_model->sendCommand(base + QString("squelch=%1")
-                     .arg(item->checkState() == Qt::Checked ? 1 : 0)); break;
-        case 11: m_model->sendCommand(base + "squelch_level=" + val); break;
-        case 12: m_model->sendCommand(base + "rx_filter_low=" + val); break;
-        case 13: m_model->sendCommand(base + "rx_filter_high=" + val); break;
-        case 14: m_model->sendCommand(base + "rtty_mark=" + val); break;
-        case 15: m_model->sendCommand(base + "rtty_shift=" + val); break;
-        case 16: m_model->sendCommand(base + "digl_offset=" + val); break;
-        case 17: m_model->sendCommand(base + "digu_offset=" + val); break;
-        default: break;
-        }
+        submitCellEdit(row, col);
     });
 
     // The radio doesn't support "sub memory all" or "memory list".
@@ -222,71 +294,121 @@ bool MemoryDialog::isSortableColumn(int column) const
     return column == 2 || column == 3 || column == 4;
 }
 
+void MemoryDialog::submitCellEdit(int row, int col)
+{
+    auto* indexItem = m_table->item(row, 0);
+    auto* item = m_table->item(row, col);
+    if (!indexItem || !item)
+        return;
+
+    QString commandSuffix;
+    QMap<QString, QString> kvs;
+    if (!buildMemoryFieldUpdate(col, item, commandSuffix, kvs))
+        return;
+
+    const int memIdx = indexItem->data(Qt::UserRole).toInt();
+    RadioModel* const model = m_model;
+    const QPointer<MemoryDialog> dialogGuard(this);
+    model->sendCmdPublic(QString("memory set %1 %2").arg(memIdx).arg(commandSuffix),
+        [model, dialogGuard, memIdx, kvs](int code, const QString&) {
+        if (code == 0) {
+            model->handleMemoryStatus(memIdx, kvs);
+            return;
+        }
+        if (dialogGuard)
+            dialogGuard->populateTable();
+    });
+}
+
 void MemoryDialog::onAdd()
 {
     // memory create returns the new index in the response body.
     // We then populate it from the current active slice state.
+    RadioModel* const model = m_model;
+    const QPointer<MemoryDialog> dialogGuard(this);
     m_model->sendCmdPublic("memory create",
-        [this](int code, const QString& body) {
+        [model, dialogGuard](int code, const QString& body) {
         if (code != 0) return;
         bool ok;
         int idx = body.trimmed().toInt(&ok);
         if (!ok) return;
 
-        // Get current slice state to populate the memory
-        const auto& mems = m_model->memories();
-        Q_UNUSED(mems);
-
         // The radio created the memory but won't push status.
         // We need to set each field from the active slice.
-        auto slices = m_model->slices();
+        const auto slices = model->slices();
         if (slices.isEmpty()) return;
-        auto* s = slices.first();
+        SliceModel* s = nullptr;
+        for (auto* candidate : slices) {
+            if (candidate && candidate->isActive()) {
+                s = candidate;
+                break;
+            }
+        }
+        if (!s)
+            s = slices.first();
 
         // Set memory fields from current slice
-        auto send = [this](const QString& cmd) { m_model->sendCommand(cmd); };
+        auto send = [model](const QString& cmd) { model->sendCommand(cmd); };
         QString base = QString("memory set %1 ").arg(idx);
         send(base + QString("freq=%1").arg(s->frequency(), 0, 'f', 6));
         send(base + QString("mode=%1").arg(s->mode()));
-        send(base + QString("owner=%1").arg(m_model->callsign().replace(' ', '\x7f')));
+        send(base + QString("owner=%1").arg(encodeMemoryText(model->callsign())));
+        send(base + QString("step=%1").arg(s->stepHz()));
         send(base + QString("rx_filter_low=%1").arg(s->filterLow()));
         send(base + QString("rx_filter_high=%1").arg(s->filterHigh()));
         send(base + QString("squelch=%1").arg(s->squelchOn() ? 1 : 0));
         send(base + QString("squelch_level=%1").arg(s->squelchLevel()));
         send(base + QString("repeater=%1").arg(s->repeaterOffsetDir()));
+        send(base + QString("repeater_offset=%1").arg(s->fmRepeaterOffsetFreq(), 0, 'f', 6));
+        send(base + QString("tone_mode=%1").arg(s->fmToneMode()));
+        send(base + QString("tone_value=%1").arg(s->fmToneValue()));
         send(base + QString("rtty_mark=%1").arg(s->rttyMark()));
         send(base + QString("rtty_shift=%1").arg(s->rttyShift()));
+        send(base + QString("digl_offset=%1").arg(s->diglOffset()));
+        send(base + QString("digu_offset=%1").arg(s->diguOffset()));
 
         // Create a local cache entry immediately for the table
         MemoryEntry m;
         m.index = idx;
         m.freq = s->frequency();
         m.mode = s->mode();
-        m.owner = m_model->callsign();
+        m.owner = model->callsign();
+        m.step = s->stepHz();
         m.rxFilterLow = s->filterLow();
         m.rxFilterHigh = s->filterHigh();
         m.squelch = s->squelchOn();
         m.squelchLevel = s->squelchLevel();
         m.offsetDir = s->repeaterOffsetDir();
+        m.repeaterOffset = s->fmRepeaterOffsetFreq();
+        m.toneMode = s->fmToneMode();
+        m.toneValue = s->fmToneValue().toDouble();
         m.rttyMark = s->rttyMark();
         m.rttyShift = s->rttyShift();
+        m.diglOffset = s->diglOffset();
+        m.diguOffset = s->diguOffset();
 
         // Insert into RadioModel's cache via handleMemoryStatus
-        // Insert directly into RadioModel's cache
         QMap<QString, QString> kvs;
         kvs["freq"] = QString::number(m.freq, 'f', 6);
         kvs["mode"] = m.mode;
-        kvs["owner"] = m.owner.replace(' ', '\x7f');
+        kvs["owner"] = encodeMemoryText(m.owner);
+        kvs["step"] = QString::number(m.step);
         kvs["rx_filter_low"] = QString::number(m.rxFilterLow);
         kvs["rx_filter_high"] = QString::number(m.rxFilterHigh);
         kvs["squelch"] = m.squelch ? "1" : "0";
         kvs["squelch_level"] = QString::number(m.squelchLevel);
         kvs["repeater"] = m.offsetDir;
+        kvs["repeater_offset"] = QString::number(m.repeaterOffset, 'f', 6);
+        kvs["tone_mode"] = m.toneMode;
+        kvs["tone_value"] = QString::number(m.toneValue, 'f', 1);
         kvs["rtty_mark"] = QString::number(m.rttyMark);
         kvs["rtty_shift"] = QString::number(m.rttyShift);
-        m_model->handleMemoryStatus(idx, kvs);
+        kvs["digl_offset"] = QString::number(m.diglOffset);
+        kvs["digu_offset"] = QString::number(m.diguOffset);
+        model->handleMemoryStatus(idx, kvs);
 
-        populateTable();
+        if (dialogGuard)
+            dialogGuard->populateTable();
     });
 }
 
@@ -303,7 +425,19 @@ void MemoryDialog::onRemove()
     const int row = m_table->currentRow();
     if (row < 0) return;
     const int idx = m_table->item(row, 0)->data(Qt::UserRole).toInt();
-    m_model->sendCommand(QString("memory remove %1").arg(idx));
+    RadioModel* const model = m_model;
+    const QPointer<MemoryDialog> dialogGuard(this);
+    m_model->sendCmdPublic(QString("memory remove %1").arg(idx),
+        [model, dialogGuard, idx](int code, const QString&) {
+        if (code == 0) {
+            QMap<QString, QString> kvs;
+            kvs["removed"] = QString{};
+            model->handleMemoryStatus(idx, kvs);
+            return;
+        }
+        if (dialogGuard)
+            dialogGuard->populateTable();
+    });
 }
 
 } // namespace AetherSDR

--- a/src/gui/MemoryDialog.h
+++ b/src/gui/MemoryDialog.h
@@ -16,6 +16,7 @@ public:
 
 private:
     void populateTable();
+    void submitCellEdit(int row, int col);
     void onAdd();
     void onSelect();
     void onRemove();

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -815,6 +815,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
         int hitSpotIdx = -1;
         QString hitSpotCall;
         double hitSpotFreq = 0;
+        QString hitSpotSource;
         for (const auto& hr : m_spotClickRects) {
             if (hr.rect.contains(mx, static_cast<int>(ev->position().y()))) {
                 if (hr.markerIndex >= 0 && hr.markerIndex < m_spotMarkers.size()) {
@@ -822,6 +823,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
                     hitSpotIdx = sm.index;
                     hitSpotCall = sm.callsign;
                     hitSpotFreq = sm.freqMhz;
+                    hitSpotSource = sm.source;
                 }
                 break;
             }
@@ -831,17 +833,27 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
 
         // Spot-on-label context menu
         if (hitSpotIdx >= 0) {
-            menu.addAction(QString("Tune to %1").arg(hitSpotCall), this,
-                [this, hitSpotFreq]{ emit frequencyClicked(hitSpotFreq); });
-            menu.addAction("Copy Callsign", this, [hitSpotCall]{
-                QApplication::clipboard()->setText(hitSpotCall);
-            });
-            menu.addAction("Lookup on QRZ", this, [hitSpotCall]{
-                QDesktopServices::openUrl(QUrl("https://www.qrz.com/db/" + hitSpotCall));
-            });
-            menu.addSeparator();
-            menu.addAction("Remove Spot", this,
-                [this, hitSpotIdx]{ emit spotRemoveRequested(hitSpotIdx); });
+            if (hitSpotSource == "Memory") {
+                const QString title = hitSpotCall.isEmpty()
+                    ? QStringLiteral("Apply Memory")
+                    : QString("Apply %1").arg(hitSpotCall);
+                menu.addAction(title, this, [this, hitSpotFreq, hitSpotIdx]{
+                    emit frequencyClicked(hitSpotFreq);
+                    emit spotTriggered(hitSpotIdx);
+                });
+            } else {
+                menu.addAction(QString("Tune to %1").arg(hitSpotCall), this,
+                    [this, hitSpotFreq]{ emit frequencyClicked(hitSpotFreq); });
+                menu.addAction("Copy Callsign", this, [hitSpotCall]{
+                    QApplication::clipboard()->setText(hitSpotCall);
+                });
+                menu.addAction("Lookup on QRZ", this, [hitSpotCall]{
+                    QDesktopServices::openUrl(QUrl("https://www.qrz.com/db/" + hitSpotCall));
+                });
+                menu.addSeparator();
+                menu.addAction("Remove Spot", this,
+                    [this, hitSpotIdx]{ emit spotRemoveRequested(hitSpotIdx); });
+            }
         }
         // TNF context menu (when clicking on a TNF marker)
         else if (hitTnf >= 0) {
@@ -2937,8 +2949,11 @@ void SpectrumWidget::showSpotClusterPopup(const SpotCluster& cluster, const QPoi
         if (!spot.mode.isEmpty())
             text += "  " + spot.mode;
         auto* action = menu->addAction(text);
-        connect(action, &QAction::triggered, this, [this, freq = spot.freqMhz] {
+        connect(action, &QAction::triggered, this, [this, spot] {
+            const double freq = spot.freqMhz;
             emit frequencyClicked(freq);
+            if (spot.source == "Memory")
+                emit spotTriggered(spot.index);
         });
     }
 

--- a/src/gui/SpotSettingsDialog.cpp
+++ b/src/gui/SpotSettingsDialog.cpp
@@ -14,11 +14,13 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     : QDialog(parent), m_model(model)
 {
     setWindowTitle("Spot Settings");
-    setFixedSize(380, 480);
+    setMinimumSize(380, 520);
+    resize(380, 520);
 
     // Load persisted settings
     auto& s = AppSettings::instance();
     m_spotsEnabled       = s.value("IsSpotsEnabled", "True").toString() == "True";
+    m_memoriesEnabled    = s.value("IsMemorySpotsEnabled", "False").toString() == "True";
     m_overrideColors     = s.value("IsSpotsOverrideColorsEnabled", "False").toString() == "True";
     m_overrideBg         = s.value("IsSpotsOverrideBackgroundColorsEnabled", "True").toString() == "True";
     m_overrideBgAutoMode = s.value("IsSpotsOverrideToAutoBackgroundColorEnabled", "True").toString() == "True";
@@ -64,6 +66,24 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
         save("IsSpotsEnabled", on ? "True" : "False");
     });
     grid->addWidget(m_spotsToggle, row++, 1, Qt::AlignLeft);
+
+    // ── Memories: Enabled/Disabled ──────────────────────────────────────
+    grid->addWidget(new QLabel("Memories:"), row, 0);
+    m_memoriesToggle = new QPushButton(m_memoriesEnabled ? "Enabled" : "Disabled");
+    m_memoriesToggle->setCheckable(true);
+    m_memoriesToggle->setChecked(m_memoriesEnabled);
+    m_memoriesToggle->setFixedWidth(80);
+    m_memoriesToggle->setToolTip(
+        "Show radio memory channels as a spot-like feed on the panadapter.");
+    m_memoriesToggle->setStyleSheet(
+        "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
+        "QPushButton:!checked { background: #603020; }");
+    connect(m_memoriesToggle, &QPushButton::toggled, this, [this, save](bool on) {
+        m_memoriesEnabled = on;
+        m_memoriesToggle->setText(on ? "Enabled" : "Disabled");
+        save("IsMemorySpotsEnabled", on ? "True" : "False");
+    });
+    grid->addWidget(m_memoriesToggle, row++, 1, Qt::AlignLeft);
 
     // ── Levels slider ───────────────────────────────────────────────────
     grid->addWidget(new QLabel("Levels:"), row, 0);

--- a/src/gui/SpotSettingsDialog.h
+++ b/src/gui/SpotSettingsDialog.h
@@ -26,6 +26,7 @@ private:
     RadioModel* m_model;
 
     QPushButton* m_spotsToggle;
+    QPushButton* m_memoriesToggle;
     QSlider*     m_levelsSlider;
     QLabel*      m_levelsValue;
     QSlider*     m_positionSlider;
@@ -42,6 +43,7 @@ private:
     QLabel*      m_totalSpotsLabel;
 
     bool   m_spotsEnabled{true};
+    bool   m_memoriesEnabled{false};
     bool   m_overrideColors{false};
     bool   m_overrideBg{true};
     bool   m_overrideBgAutoMode{true};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1049,6 +1049,10 @@ void RadioModel::onDisconnected()
     m_panadapters.clear();
     m_activePanId.clear();
     m_ownedSliceIds.clear();
+    if (!m_memories.isEmpty()) {
+        m_memories.clear();
+        emit memoriesCleared();
+    }
     m_clientStations.clear();
     m_clientInfoMap.clear();
     emit otherClientsChanged(0, {});
@@ -1277,6 +1281,8 @@ void RadioModel::handleMemoryStatus(int index, const QMap<QString, QString>& kvs
         else if (k == "digl_offset")     m.diglOffset = v.toInt();
         else if (k == "digu_offset")     m.diguOffset = v.toInt();
     }
+
+    emit memoryChanged(index);
 }
 
 // ─── Raw message handler (for meter status with '#' separators) ──────────────

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -259,7 +259,9 @@ signals:
     // Emitted when a power amplifier (e.g. PGXL) is detected or lost.
     void amplifierChanged(bool present);
     void ampStateChanged();   // amplifier operate/bypass changed
+    void memoryChanged(int index);
     void memoryRemoved(int index);
+    void memoriesCleared();
     void audioOutputChanged();
     // Emitted when TX ownership changes in Multi-Flex (another client transmitting)
     void txOwnerChanged(bool ownedByUs, const QString& otherStation);

--- a/src/models/SpotModel.cpp
+++ b/src/models/SpotModel.cpp
@@ -63,4 +63,9 @@ void SpotModel::clear()
     emit spotsCleared();
 }
 
+void SpotModel::refresh()
+{
+    emit spotsRefreshed();
+}
+
 } // namespace AetherSDR

--- a/src/models/SpotModel.h
+++ b/src/models/SpotModel.h
@@ -34,12 +34,14 @@ public:
     void applySpotStatus(int index, const QMap<QString, QString>& kvs);
     void removeSpot(int index);
     void clear();
+    void refresh();
 
 signals:
     void spotAdded(const SpotData& spot);
     void spotUpdated(const SpotData& spot);
     void spotRemoved(int index);
     void spotsCleared();
+    void spotsRefreshed();
     void spotTriggered(int index, const QString& panId);
 
 private:


### PR DESCRIPTION
<img width="1710" height="1107" alt="Screenshot 2026-04-04 at 5 12 11 PM" src="https://github.com/user-attachments/assets/e183e19b-d206-4dd1-9ab1-7a8350df3c9b" />

## What changed
- Add radio memories as a SpotModel-backed feed for the panadapter
- Add a Memories toggle in SpotHub display settings and the legacy spot settings dialog
- Make memory spot clicks apply the selected memory instead of following the normal DX spot trigger path
- Keep memory spots in sync when memories are added, edited, or removed from the memory dialog

## Why
- This lets saved memories be visualized on the panadapter and clicked to tune around quickly
- It keeps the feature Qt-native and cross-platform without changing existing DX spot behavior
- This PR resolves issue #568 

## Validation
- `cmake -S . -B build`
- `cmake --build build -j4`
- `cmake -S . -B build-cpu-spectrum -DAETHER_GPU_SPECTRUM=OFF`
- `cmake --build build-cpu-spectrum -j4`