### PR TITLE
Fix macOS brew install: remove line continuation

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -25,8 +25,7 @@ jobs:
           modules: 'qtmultimedia qtserialport qtwebsockets qtshadertools'
 
       - name: Install build tools and dependencies
-        run: brew install ninja create-dmg autoconf automake libtool \
-          fftw portaudio hidapi qtkeychain
+        run: brew install ninja create-dmg autoconf automake libtool fftw portaudio hidapi qtkeychain
 
       - name: Generate .icns from PNG
         run: |

--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -27,8 +27,7 @@ jobs:
           modules: 'qtmultimedia qtserialport qtwebsockets qtshadertools'
 
       - name: Install build tools and dependencies
-        run: brew install ninja autoconf automake libtool \
-          fftw portaudio hidapi qtkeychain
+        run: brew install ninja autoconf automake libtool fftw portaudio hidapi qtkeychain
 
       - name: Generate .icns from PNG
         run: |


### PR DESCRIPTION
Backslash line continuation in YAML run: created " fftw" with leading
space. Homebrew doesn't recognize it. Single line instead.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
