### PR TITLE
Fix macOS build: skip Qt6GuiPrivate to avoid Homebrew/aqtinstall conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,12 @@ if(AETHER_GPU_SPECTRUM)
         message(STATUS "GPU spectrum rendering disabled (requires Qt 6.7+, found ${Qt6_VERSION})")
     else()
         find_package(Qt6 REQUIRED COMPONENTS ShaderTools)
-        find_package(Qt6GuiPrivate QUIET)
+        # Qt6GuiPrivate provides QRhi headers. On Qt 6.7+, try to find it
+        # but don't fail — the headers may be accessible without it.
+        # Skip on macOS to avoid Homebrew/aqtinstall Qt version conflicts.
+        if(NOT APPLE)
+            find_package(Qt6GuiPrivate QUIET)
+        endif()
         message(STATUS "GPU spectrum rendering enabled (QRhi, Qt ${Qt6_VERSION})")
     endif()
 else()


### PR DESCRIPTION
macOS CI has two Qt installations — Homebrew system Qt and aqtinstall
Qt 6.7.3. find_package(Qt6GuiPrivate) finds Homebrew's version which
is incompatible. Skip it on Apple — QRhi headers are accessible via
Qt6::Gui on Qt 6.7+.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
