### PR TITLE
Fix macOS linker: add Homebrew prefix to CMAKE_PREFIX_PATH

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -47,7 +47,8 @@ jobs:
           cmake -B build -G "Unix Makefiles" \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0"
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0" \
+            -DCMAKE_PREFIX_PATH="$(brew --prefix)"
 
       - name: Build
         run: cmake --build build -j$(sysctl -n hw.ncpu)

--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -50,7 +50,8 @@ jobs:
           cmake -B build -G "Unix Makefiles" \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0"
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0" \
+            -DCMAKE_PREFIX_PATH="$(brew --prefix)"
 
       - name: Build AetherSDR
         run: cmake --build build -j$(sysctl -n hw.ncpu)


### PR DESCRIPTION
Homebrew libs (hidapi, fftw, portaudio, qtkeychain) were found by
pkg-config during configure but not by the linker during build.
The aqtinstall Qt sets CMAKE_PREFIX_PATH to its own prefix only,
excluding /opt/homebrew. Adding $(brew --prefix) fixes the link.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
