### PR TITLE
Fix GPU rendering on macOS: Metal API + WA_NativeWindow for QRhiWidge…

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7,6 +7,9 @@
 #include "core/CommandParser.h"
 #include "models/PanadapterModel.h"
 #include "SpectrumWidget.h"
+#ifdef AETHER_GPU_SPECTRUM
+#include <QRhiWidget>
+#endif
 #include "SpectrumOverlayMenu.h"
 #include "VfoWidget.h"
 #include "AppletPanel.h"
@@ -3173,6 +3176,7 @@ void MainWindow::buildUI()
     vbox->addWidget(m_titleBar);
     vbox->addWidget(m_splitter, 1);
     setCentralWidget(central);
+
     auto* splitter = m_splitter;
 
     // Connection panel — modeless dialog with standard decorations (#560, #574)

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -44,7 +44,18 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     setMinimumHeight(150);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setAutoFillBackground(false);
-#ifndef AETHER_GPU_SPECTRUM
+#ifdef AETHER_GPU_SPECTRUM
+    // Explicitly request Metal on macOS.
+#  ifdef Q_OS_MAC
+    setApi(QRhiWidget::Api::Metal);
+    // WA_NativeWindow forces Qt to create a dedicated native NSView for this widget.
+    // Without it, QRhiWidget embedded in a QWidget hierarchy (especially one whose
+    // backing store was created before this widget was added) fails to obtain a QRhi
+    // context because the parent window's surface type is RasterSurface, not MetalSurface.
+    // A native window gives QRhiWidget its own Metal-capable surface to render into.
+    setAttribute(Qt::WA_NativeWindow);
+#  endif
+#else
     setAttribute(Qt::WA_OpaquePaintEvent);
 #endif
     setCursor(Qt::CrossCursor);


### PR DESCRIPTION
…t (#702)

Set Metal backend explicitly and WA_NativeWindow on macOS so QRhiWidget gets its own native NSView with a MetalSurface. Without this, the widget embeds in a RasterSurface hierarchy and QRhi initialization silently fails, causing initialize() to never be called and render() to no-op every frame.