### PR TITLE
macOS: add Homebrew lib/include to global search paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,16 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
+# macOS: ensure Homebrew lib/include paths are in the search path
+# (universal builds with CMAKE_OSX_ARCHITECTURES may not search /opt/homebrew by default)
+if(APPLE)
+    execute_process(COMMAND brew --prefix OUTPUT_VARIABLE HOMEBREW_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(HOMEBREW_PREFIX)
+        link_directories("${HOMEBREW_PREFIX}/lib")
+        include_directories("${HOMEBREW_PREFIX}/include")
+    endif()
+endif()
+
 # Build type
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo)


### PR DESCRIPTION
Universal builds (x86_64;arm64) don't search /opt/homebrew by default.
pkg-config finds the libraries during configure but the linker can't
find them during build. Add Homebrew prefix to link_directories and
include_directories globally on Apple.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
