### PR TITLE
Improve GPU spectrum fill gradient + persist heatmap setting

### DIFF
--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -919,18 +919,18 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         lbl->setStyleSheet(labelStyle);
         grid->addWidget(lbl, row, 0, 1, 2);
 
-        auto* btn = new QPushButton("Off");
-        btn->setCheckable(true);
-        btn->setFixedSize(36, 18);
-        btn->setStyleSheet(
+        m_heatMapBtn = new QPushButton("Off");
+        m_heatMapBtn->setCheckable(true);
+        m_heatMapBtn->setFixedSize(36, 18);
+        m_heatMapBtn->setStyleSheet(
             "QPushButton { background: #1a2a3a; color: #8090a0; border: 1px solid #304050;"
             " border-radius: 3px; font-size: 10px; font-weight: bold; }"
             "QPushButton:checked { background: #006040; color: #00ff88; border: 1px solid #00a060; }");
-        grid->addWidget(btn, row, 2, 1, 2);
+        grid->addWidget(m_heatMapBtn, row, 2, 1, 2);
         ++row;
 
-        connect(btn, &QPushButton::toggled, this, [this, btn](bool on) {
-            btn->setText(on ? "On" : "Off");
+        connect(m_heatMapBtn, &QPushButton::toggled, this, [this](bool on) {
+            m_heatMapBtn->setText(on ? "On" : "Off");
             emit fftHeatMapChanged(on);
         });
     }
@@ -1075,7 +1075,8 @@ void SpectrumOverlayMenu::buildDisplayPanel()
 void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
                                                bool weightedAvg, const QColor& fillColor,
                                                int gain, int black, bool autoBlack, int rate,
-                                               int floorPos, bool floorEnable)
+                                               int floorPos, bool floorEnable,
+                                               bool heatMap)
 {
     if (!m_avgSlider) return;  // panel not built yet
 
@@ -1088,6 +1089,7 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
     m_fpsSlider->setValue(fps);
     m_fpsLabel->setText(QString::number(fps));
     m_fillSlider->setValue(fillPct);
+    m_fillLabel->setText(QString::number(fillPct));
     m_weightedAvgBtn->setChecked(weightedAvg);
     m_weightedAvgBtn->setText(weightedAvg ? "On" : "Off");
     m_fillColor = fillColor;
@@ -1110,6 +1112,11 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
         m_floorEnableBtn->setChecked(floorEnable);
         m_floorEnableBtn->setText(floorEnable ? "On" : "Off");
         m_floorSlider->setEnabled(floorEnable);
+    }
+    if (m_heatMapBtn) {
+        QSignalBlocker bh(m_heatMapBtn);
+        m_heatMapBtn->setChecked(heatMap);
+        m_heatMapBtn->setText(heatMap ? "On" : "Off");
     }
 }
 

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -34,7 +34,8 @@ public:
     void syncDisplaySettings(int avg, int fps, int fillPct, bool weightedAvg,
                              const QColor& fillColor, int gain, int black,
                              bool autoBlack, int rate,
-                             int floorPos = 75, bool floorEnable = false);
+                             int floorPos = 75, bool floorEnable = false,
+                             bool heatMap = true);
 
     // Set the panadapter ID this overlay belongs to (for +RX routing).
     void setPanId(const QString& id) { m_panId = id; }
@@ -168,6 +169,7 @@ private:
     QLabel*      m_fillLabel{nullptr};
     QPushButton* m_fillColorBtn{nullptr};
     QColor       m_fillColor{0x00, 0xe5, 0xff};  // default cyan
+    QPushButton* m_heatMapBtn{nullptr};
     QPushButton* m_weightedAvgBtn{nullptr};
     QSlider*     m_gainSlider{nullptr};
     QLabel*      m_gainLabel{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -140,6 +140,7 @@ void SpectrumWidget::loadSettings()
     } else {
         m_bandPlanFontSize = s.value("BandPlanFontSize", "6").toInt();
     }
+    m_fftHeatMap     = s.value(settingsKey("DisplayFftHeatMap"), "True").toString() == "True";
     m_singleClickTune = s.value("SingleClickTune", "False").toString() == "True";
 
     // Background image — default to bundled logo, "none" = explicitly cleared
@@ -152,7 +153,8 @@ void SpectrumWidget::loadSettings()
     if (m_overlayMenu)
         m_overlayMenu->syncDisplaySettings(m_fftAverage, m_fftFps,
             static_cast<int>(m_fftFillAlpha * 100), m_fftWeightedAvg, m_fftFillColor,
-            m_wfColorGain, m_wfBlackLevel, m_wfAutoBlack, m_wfLineDuration);
+            m_wfColorGain, m_wfBlackLevel, m_wfAutoBlack, m_wfLineDuration,
+            75, false, m_fftHeatMap);
 }
 
 VfoWidget* SpectrumWidget::addVfoWidget(int sliceId)
@@ -210,6 +212,12 @@ void SpectrumWidget::setFftFps(int fps) {
     m_fftFps = fps;
     auto& s = AppSettings::instance();
     s.setValue(settingsKey("DisplayFftFps"), QString::number(fps));
+    s.save();
+}
+void SpectrumWidget::setFftHeatMap(bool on) {
+    m_fftHeatMap = on;
+    auto& s = AppSettings::instance();
+    s.setValue(settingsKey("DisplayFftHeatMap"), on ? "True" : "False");
     s.save();
 }
 void SpectrumWidget::setFftFillAlpha(float a) {
@@ -2090,10 +2098,32 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             const float yTop = 1.0f;
 
             // Colors from settings
-            float fr = m_fftFillColor.redF();
-            float fg = m_fftFillColor.greenF();
-            float fb = m_fftFillColor.blueF();
-            float fa = m_fftFillAlpha;
+            const float fr = m_fftFillColor.redF();
+            const float fg = m_fftFillColor.greenF();
+            const float fb = m_fftFillColor.blueF();
+            const float fa = m_fftFillAlpha;
+
+            // Solid fill: slider sweeps from translucent gradient to solid.
+            // At low slider: soft glow under curve (bright top, dark faint base)
+            // At high slider: converges to uniform solid fill color
+            const QColor dk = m_fftFillColor.darker(300);
+            const float topAlpha = fa;
+            const float botAlpha = fa * fa;
+            // Blend bottom color from darker(300) toward fill color as slider increases
+            const float colorBlend = fa;  // 0=full dark, 1=same as top
+            const float dr = fr + (1.0f - colorBlend) * (dk.redF() - fr);
+            const float dg = fg + (1.0f - colorBlend) * (dk.greenF() - fg);
+            const float db = fb + (1.0f - colorBlend) * (dk.blueF() - fb);
+            const float gradRange = yTop - yBot;
+
+            auto yColor = [&](float vy, float* out) {
+                const float gt = (gradRange > 0)
+                    ? qBound(0.0f, (yTop - vy) / gradRange, 1.0f) : 0.0f;
+                out[0] = fr + gt * (dr - fr);
+                out[1] = fg + gt * (dg - fg);
+                out[2] = fb + gt * (db - fb);
+                out[3] = topAlpha + gt * (botAlpha - topAlpha);
+            };
 
             // Line vertices: N × (x, y, r, g, b, a)
             QVector<float> lineVerts(n * kFftVertStride);
@@ -2135,30 +2165,28 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                 lineVerts[li + 4] = cb2;
                 lineVerts[li + 5] = 0.9f;
 
-                // Fill top vertex (at spectrum line): reduced alpha
+                // Fill vertices
                 int fi = i * 2 * kFftVertStride;
                 fillVerts[fi]     = x;
                 fillVerts[fi + 1] = y;
-                fillVerts[fi + 2] = cr;
-                fillVerts[fi + 3] = cg;
-                fillVerts[fi + 4] = cb2;
-                fillVerts[fi + 5] = fa * 0.3f;
+                fillVerts[fi + 6] = x;
+                fillVerts[fi + 7] = yBot;
 
-                // Fill bottom vertex
-                fillVerts[fi + 6]  = x;
-                fillVerts[fi + 7]  = yBot;
                 if (m_fftHeatMap) {
-                    // Fade to dark blue
+                    // Heatmap: line color at top, fade to dark blue at base
+                    fillVerts[fi + 2] = cr;
+                    fillVerts[fi + 3] = cg;
+                    fillVerts[fi + 4] = cb2;
+                    fillVerts[fi + 5] = fa * 0.3f;
                     fillVerts[fi + 8]  = 0.0f;
                     fillVerts[fi + 9]  = 0.0f;
                     fillVerts[fi + 10] = 0.3f;
+                    fillVerts[fi + 11] = fa;
                 } else {
-                    // Same color as fill
-                    fillVerts[fi + 8]  = fr;
-                    fillVerts[fi + 9]  = fg;
-                    fillVerts[fi + 10] = fb;
+                    // Solid: Y-based gradient (bright at line, dark+faint at base)
+                    yColor(y, &fillVerts[fi + 2]);
+                    yColor(yBot, &fillVerts[fi + 8]);
                 }
-                fillVerts[fi + 11] = fa;
             }
 
             batch->updateDynamicBuffer(m_fftLineVbo, 0,

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -141,7 +141,7 @@ public:
     void setFftFps(int fps);
     void setFftFillAlpha(float a);
     void setFftFillColor(const QColor& c);
-    void setFftHeatMap(bool on) { m_fftHeatMap = on; }
+    void setFftHeatMap(bool on);
     float fftFillAlpha() const         { return m_fftFillAlpha; }
     QColor fftFillColor() const        { return m_fftFillColor; }
     bool fftHeatMap() const            { return m_fftHeatMap; }


### PR DESCRIPTION
## Summary

Fixes #722

- **Y-based gradient fill** for solid (non-heatmap) spectrum mode: bright and opaque near the spectrum line, fading to darker and more transparent at the base — matching the QPainter CPU fallback. Previously the GPU fill was inverted (faint at top, opaque at bottom), making the custom fill color barely visible.
- **Full opacity range**: fill slider now sweeps from translucent gradient to completely solid fill. At 100% the fill is uniform solid color with no transparency.
- **Persist heatmap toggle**: `DisplayFftHeatMap` saved/restored in AppSettings. Previously the heatmap on/off state was lost on restart — heatmap defaulted to ON, making the custom fill color invisible until the user toggled heatmap off then on again (as reported in #722).
- **Fix fill slider label**: the numeric label next to the fill slider always showed "70" on launch regardless of the saved value.

Heatmap mode rendering is unchanged.

## Test plan

- [x] Heatmap OFF + fill slider at various positions: fill should glow bright near spectrum line, fade toward base
- [x] Fill slider at 100%: fill should be completely solid (no transparency)
- [x] Fill slider at ~10%: fill should be very translucent with soft gradient
- [x] Heatmap ON: unchanged behavior (blue→red intensity with dark blue base)
- [x] Change fill color: gradient should use the new color
- [x] Quit and relaunch: heatmap toggle, fill slider value, and fill label should all restore correctly
- [x] CPU unchanged (same vertex count and draw calls)

JJ Boyd ~KG4VCF
🤖 Generated with [Claude Code](https://claude.com/claude-code)