### PR TITLE
Fix cursor frequency label missing in GPU mode

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2111,6 +2111,26 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                            specRect.top() + (m_wnbActive ? 38 : 20), label);
             }
 
+            // Cursor frequency label (#726)
+            if (m_showCursorFreq && m_cursorPos.x() >= 0
+                && m_cursorPos.y() >= 0) {
+                const double freqMhz = xToMhz(m_cursorPos.x());
+                const QString label = QString::number(freqMhz, 'f', 6);
+                QFont f = p.font();
+                f.setPointSize(9);
+                p.setFont(f);
+                const QFontMetrics fm(f);
+                const int tw = fm.horizontalAdvance(label) + 8;
+                const int th = fm.height() + 4;
+                int lx = m_cursorPos.x() + 12;
+                if (lx + tw > w) lx = m_cursorPos.x() - tw - 4;
+                int ly = m_cursorPos.y() - th - 4;
+                if (ly < 0) ly = m_cursorPos.y() + 16;
+                p.fillRect(lx, ly, tw, th, QColor(0x0f, 0x0f, 0x1a, 200));
+                p.setPen(QColor(0xc8, 0xd8, 0xe8));
+                p.drawText(lx + 4, ly + fm.ascent() + 2, label);
+            }
+
             m_overlayStaticDirty = false;
             m_overlayNeedsUpload = true;
         }


### PR DESCRIPTION
## Summary

Fixes #726

The cursor frequency overlay was only drawn in the QPainter `paintEvent` path. In GPU rendering mode (`AETHER_GPU_SPECTRUM`), `paintEvent` returns early and delegates to `render()` → `renderGpuFrame()`, so the cursor frequency label never appeared.

Added the cursor frequency drawing to the GPU overlay QPainter section in `renderGpuFrame()`, where it renders into the cached overlay texture alongside the grid, scales, and markers. The overlay is already marked dirty on mouse move when cursor freq is enabled (line 1238), so the label updates as the cursor moves.

## Test plan

- [x] Enable "Cursor Freq" in Display settings
- [x] Move mouse over spectrum — frequency label should appear next to cursor
- [x] Label should flip sides near edges (right edge → label on left, top edge → label below)
- [x] Disable "Cursor Freq" — label disappears
- [x] CPU not affected (overlay already repaints on mouse move when enabled)

JJ Boyd ~KG4VCF
🤖 Generated with [Claude Code](https://claude.com/claude-code)