### PR TITLE
Fix WNB indicator + waterfall sync on band change

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -228,21 +228,23 @@ void SpectrumWidget::setFftFillColor(const QColor& c) {
 }
 void SpectrumWidget::setWfColorGain(int gain) {
     int clamped = std::clamp(gain, 0, 100);
-    if (clamped == m_wfColorGain) return;
-    m_wfColorGain = clamped;
-    auto& s = AppSettings::instance();
-    s.setValue(settingsKey("DisplayWfColorGain"), QString::number(m_wfColorGain));
-    s.save();
-    update();  // Waterfall only — no overlay repaint needed
+    if (clamped != m_wfColorGain) {
+        m_wfColorGain = clamped;
+        auto& s = AppSettings::instance();
+        s.setValue(settingsKey("DisplayWfColorGain"), QString::number(m_wfColorGain));
+        s.save();
+    }
+    update();
 }
 void SpectrumWidget::setWfBlackLevel(int level) {
     int clamped = std::clamp(level, 0, 100);
-    if (clamped == m_wfBlackLevel) return;
-    m_wfBlackLevel = clamped;
-    auto& s = AppSettings::instance();
-    s.setValue(settingsKey("DisplayWfBlackLevel"), QString::number(m_wfBlackLevel));
-    s.save();
-    update();  // Waterfall only — no overlay repaint needed
+    if (clamped != m_wfBlackLevel) {
+        m_wfBlackLevel = clamped;
+        auto& s = AppSettings::instance();
+        s.setValue(settingsKey("DisplayWfBlackLevel"), QString::number(m_wfBlackLevel));
+        s.save();
+    }
+    update();
 }
 void SpectrumWidget::setWfAutoBlack(bool on) {
     m_wfAutoBlack = on;
@@ -1961,13 +1963,17 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     {
         static double lastCenter = 0, lastBw = 0;
         static float lastRef = 0, lastDyn = 0, lastFrac = 0;
+        static bool lastWnb = false;
+        static int lastRfGain = 0;
         if (m_centerMhz != lastCenter || m_bandwidthMhz != lastBw ||
             m_refLevel != lastRef || m_dynamicRange != lastDyn ||
-            m_spectrumFrac != lastFrac) {
+            m_spectrumFrac != lastFrac ||
+            m_wnbActive != lastWnb || m_rfGainValue != lastRfGain) {
             markOverlayDirty();
             lastCenter = m_centerMhz; lastBw = m_bandwidthMhz;
             lastRef = m_refLevel; lastDyn = m_dynamicRange;
             lastFrac = m_spectrumFrac;
+            lastWnb = m_wnbActive; lastRfGain = m_rfGainValue;
         }
     }
 

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -111,8 +111,8 @@ public:
     // WNB and RF gain state for on-screen indicators.
     bool wnbActive()   const { return m_wnbActive; }
     int  rfGainValue() const { return m_rfGainValue; }
-    void setWnbActive(bool on) { m_wnbActive = on; update(); }
-    void setRfGain(int gain) { m_rfGainValue = gain; update(); }
+    void setWnbActive(bool on) { m_wnbActive = on; markOverlayDirty(); }
+    void setRfGain(int gain) { m_rfGainValue = gain; markOverlayDirty(); }
 
     // NB Waterfall Blanker (#277) — client-side impulse suppression
     void setWfBlankerEnabled(bool on);


### PR DESCRIPTION
## Summary

Fixes #725

Three issues causing stale GPU overlay and spectrum/waterfall mismatch:

1. **WNB/RF gain indicators not updating**: `setWnbActive()` and `setRfGain()` called `update()` but not `markOverlayDirty()`. These indicators are drawn in the cached static overlay texture, so they never re-rendered until something else (frequency/zoom change) happened to dirty the overlay.

2. **State change detection gap**: The render-time fallback guard that catches missed `markOverlayDirty()` calls monitored center, bandwidth, refLevel, dynamicRange, spectrumFrac — but not `m_wnbActive` or `m_rfGainValue`. Added both.

3. **Waterfall not refreshing on band change**: `setWfBlackLevel()` and `setWfColorGain()` returned early when the value was unchanged, skipping `update()`. On band change, if the new band has the same waterfall parameters as the old band, the waterfall never got a fresh render frame. Fix: only skip the AppSettings write when unchanged, always call `update()`.

## Test plan

- [x] Toggle WNB on/off — "WNB" indicator should appear/disappear immediately
- [x] Change RF gain — "RF +X dB" indicator should update immediately
- [x] Change bands — spectrum and waterfall should be synchronized without needing to scroll/zoom
- [x] CPU should not regress (overlay only repaints on actual state changes, not every frame)

JJ Boyd ~KG4VCF
🤖 Generated with [Claude Code](https://claude.com/claude-code)