### PR TITLE
Add radio hardware meter applet (#27)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,7 @@ set(GUI_SOURCES
     src/gui/CwxPanel.cpp
     src/gui/DvkPanel.cpp
     src/gui/AmpApplet.cpp
+    src/gui/MeterApplet.cpp
     src/gui/ProfileManagerDialog.cpp
     src/gui/PanadapterApplet.cpp
     src/gui/PanadapterStack.cpp

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -11,6 +11,7 @@
 #include "EqApplet.h"
 #include "CatApplet.h"
 #include "AntennaGeniusApplet.h"
+#include "MeterApplet.h"
 #include "models/SliceModel.h"
 #include <QComboBox>
 #include <QLabel>
@@ -33,7 +34,7 @@
 namespace AetherSDR {
 
 const QStringList AppletPanel::kDefaultOrder = {
-    "RX", "TUN", "AMP", "TX", "PHNE", "P/CW", "EQ", "DIGI", "AG"
+    "RX", "TUN", "AMP", "TX", "PHNE", "P/CW", "EQ", "DIGI", "MTR", "AG"
 };
 
 // ── Drag-handle title bar ───────────────────────────────────────────────────
@@ -423,6 +424,9 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
     m_catApplet = new CatApplet;
     m_appletOrder.append(makeEntry("DIGI", "Digital Mode Controls", m_catApplet, false));
+
+    m_meterApplet = new MeterApplet;
+    m_appletOrder.append(makeEntry("MTR", "Meters", m_meterApplet, false));
 
     m_agApplet = new AntennaGeniusApplet;
     {

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -22,6 +22,7 @@ class PhoneApplet;
 class EqApplet;
 class CatApplet;
 class AntennaGeniusApplet;
+class MeterApplet;
 
 // AppletPanel — right-side panel with a row of toggle buttons at the top,
 // an S-Meter gauge below them, and a scrollable stack of applets.
@@ -46,6 +47,7 @@ public:
     EqApplet*       eqApplet()       { return m_eqApplet; }
     CatApplet*      catApplet()      { return m_catApplet; }
     AntennaGeniusApplet* agApplet()  { return m_agApplet; }
+    MeterApplet*  meterApplet()  { return m_meterApplet; }
 
     // Show/hide the TUNE button and applet based on tuner presence.
     void setTunerVisible(bool visible);
@@ -88,6 +90,7 @@ private:
     EqApplet*      m_eqApplet{nullptr};
     CatApplet*     m_catApplet{nullptr};
     AntennaGeniusApplet* m_agApplet{nullptr};
+    MeterApplet* m_meterApplet{nullptr};
     QPushButton* m_tuneBtn{nullptr};
     QPushButton* m_agBtn{nullptr};
     QVBoxLayout* m_stack{nullptr};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -31,6 +31,7 @@
 #include "DvkPanel.h"
 #include "core/DvkWavTransfer.h"
 #include "AmpApplet.h"
+#include "MeterApplet.h"
 #include "ProfileManagerDialog.h"
 #include "SupportDialog.h"
 #include "ShortcutDialog.h"
@@ -1257,6 +1258,9 @@ MainWindow::MainWindow(QWidget* parent)
     });
     connect(&m_radioModel.transmitModel(), &TransmitModel::maxPowerLevelChanged,
             this, updatePowerScale);
+
+    // ── Meter applet: all meters consolidated ──────────────────────────────
+    m_appletPanel->meterApplet()->setMeterModel(&m_radioModel.meterModel());
 
     // ── TX applet: meters + model ───────────────────────────────────────────
     connect(&m_radioModel.meterModel(), &MeterModel::txMetersChanged,

--- a/src/gui/MeterApplet.cpp
+++ b/src/gui/MeterApplet.cpp
@@ -1,0 +1,76 @@
+#include "MeterApplet.h"
+#include "HGauge.h"
+#include "models/MeterModel.h"
+
+#include <QVBoxLayout>
+#include <QLabel>
+
+namespace AetherSDR {
+
+static const char* kSectionStyle =
+    "QLabel { color: #8090a0; font-size: 10px; font-weight: bold; "
+    "padding-top: 2px; }";
+
+MeterApplet::MeterApplet(QWidget* parent)
+    : QWidget(parent)
+{
+    auto* vbox = new QVBoxLayout(this);
+    vbox->setContentsMargins(4, 2, 4, 2);
+    vbox->setSpacing(2);
+
+    auto* header = new QLabel("Radio Hardware");
+    header->setStyleSheet(kSectionStyle);
+    vbox->addWidget(header);
+
+    m_paTempGauge = new HGauge(0.0f, 120.0f, 70.0f, "PA Temp", "",
+        {{0, "0"}, {30, "30"}, {55, "55"}, {70, "70"}, {90, "90"}, {120, "120"}},
+        this, 55.0f);
+    vbox->addWidget(m_paTempGauge);
+
+    m_supplyGauge = new HGauge(10.0f, 16.0f, 15.0f, "+13.8V", "",
+        {{10.5f, "10.5"}, {12, "12"}, {13.8f, "13.8"}, {15, "15"}},
+        this, 14.0f);
+    vbox->addWidget(m_supplyGauge);
+
+    m_fanGauge = new HGauge(0.0f, 3000.0f, 2500.0f, "Main Fan", "",
+        {{0, "0"}, {500, "500"}, {1000, "1k"}, {1500, "1.5k"}, {2000, "2k"}, {3000, "3k"}},
+        this, 2000.0f);
+    vbox->addWidget(m_fanGauge);
+
+    vbox->addStretch();
+}
+
+void MeterApplet::setMeterModel(MeterModel* model)
+{
+    m_model = model;
+
+    connect(model, &MeterModel::hwTelemetryChanged,
+            this, [this](float paTemp, float supplyV) {
+        m_paTempGauge->setValue(paTemp);
+        m_supplyGauge->setValue(supplyV);
+    });
+
+    connect(model, &MeterModel::meterUpdated,
+            this, &MeterApplet::onMeterUpdated);
+
+    resolveIndices();
+}
+
+void MeterApplet::resolveIndices()
+{
+    if (!m_model || m_resolved) return;
+
+    m_fanIdx = m_model->findMeter("RAD", "MAINFAN");
+    m_resolved = (m_fanIdx >= 0);
+}
+
+void MeterApplet::onMeterUpdated(int index, float value)
+{
+    if (!m_resolved)
+        resolveIndices();
+
+    if (index == m_fanIdx && m_fanIdx >= 0)
+        m_fanGauge->setValue(value);
+}
+
+} // namespace AetherSDR

--- a/src/gui/MeterApplet.h
+++ b/src/gui/MeterApplet.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QWidget>
+
+namespace AetherSDR {
+
+class MeterModel;
+class HGauge;
+
+// Radio hardware telemetry applet — shows PA temperature, supply voltage,
+// and fan speed. Uses hwTelemetryChanged for cached meters (PATEMP, +13.8A)
+// and meterUpdated for additional RAD meters resolved by index (MAINFAN).
+//
+// Note: PACURRENT is intentionally omitted — on FLEX-8000 series the meter
+// range is capped at 10A (declared max) while real PA draw exceeds this at
+// full power, causing the reading to clip. See FlexRadio community thread
+// "PA Current Meter for 6xxx" and bug SMART-11281.
+class MeterApplet : public QWidget {
+    Q_OBJECT
+public:
+    explicit MeterApplet(QWidget* parent = nullptr);
+
+    void setMeterModel(MeterModel* model);
+
+private:
+    void resolveIndices();
+    void onMeterUpdated(int index, float value);
+
+    MeterModel* m_model{nullptr};
+
+    HGauge* m_paTempGauge{nullptr};
+    HGauge* m_supplyGauge{nullptr};
+    HGauge* m_fanGauge{nullptr};
+
+    // Lazy-resolved meter index (-1 = not yet found)
+    int m_fanIdx{-1};
+    bool m_resolved{false};
+};
+
+} // namespace AetherSDR


### PR DESCRIPTION
## Summary
- New **MeterApplet** showing live radio hardware telemetry: PA temperature, supply voltage (+13.8V), and main fan RPM
- Registered as "MTR" toggle in the applet panel (default off)
- Uses existing `hwTelemetryChanged` signal for PATEMP/+13.8A and generic `meterUpdated` with lazy index resolution for MAINFAN

## Note on PACURRENT
The FLEX-8000 firmware declares PACURRENT with a 0–10A range, but real PA draw exceeds this at full power (measured 10.0A constant at 100W TX, regardless of actual current). This is a known firmware limitation (SMART-11281). PACURRENT is intentionally omitted until FlexRadio fixes the meter range.

## Changes
| File | Change |
|------|--------|
| `src/gui/MeterApplet.h/cpp` | New applet: 3 HGauge widgets (PA Temp, +13.8V, Fan) |
| `src/gui/AppletPanel.h/cpp` | Register MTR applet + toggle button |
| `src/gui/MainWindow.cpp` | Wire MeterModel to MeterApplet |
| `CMakeLists.txt` | Add MeterApplet.cpp to build |

## Test plan
- [ ] Build succeeds without warnings
- [ ] Click MTR button in applet panel — meter panel appears
- [ ] PA Temp and +13.8V gauges update live (always active)
- [ ] Fan RPM gauge shows ~1000 RPM idle, increases under load
- [ ] Drag-reorder MTR applet — order persists after restart

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)