### PR TITLE
Fix background opacity slider not updating in GPU mode

### DIFF
--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -129,7 +129,7 @@ public:
     bool showCursorFreq() const { return m_showCursorFreq; }
     void setBackgroundImage(const QString& path);
     QString backgroundImagePath() const { return m_bgImagePath; }
-    void setBackgroundOpacity(int pct) { m_bgOpacity = qBound(0, pct, 100); update(); }
+    void setBackgroundOpacity(int pct) { m_bgOpacity = qBound(0, pct, 100); markOverlayDirty(); }
     int backgroundOpacity() const { return m_bgOpacity; }
     bool showBandPlan() const { return m_bandPlanFontSize > 0; }
     int  bandPlanFontSize() const { return m_bandPlanFontSize; }


### PR DESCRIPTION
## Summary

`setBackgroundOpacity()` called `update()` but not `markOverlayDirty()`. The background image is drawn inside the cached static overlay (`m_overlayStaticDirty` guard in `renderGpuFrame`), so changing opacity never triggered an overlay re-render. Same class of bug as the WNB indicator fix in #731.

One-line fix: `update()` → `markOverlayDirty()`.

## Test plan

- [x] Adjust background opacity slider — image should fade/darken immediately
- [x] Opacity persists across restart

JJ Boyd ~KG4VCF
🤖 Generated with [Claude Code](https://claude.com/claude-code)