### PR TITLE
Fix filter passband edge drag + 95 Hz low cut on presets

### DIFF
--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -239,9 +239,9 @@ QString RigctlProtocol::cmdSetMode(const QString& args)
                 // Center the filter around 0 for SSB modes
                 QString m = slice->mode();
                 if (m == "LSB" || m == "DIGL" || m == "CWL") {
-                    slice->setFilterWidth(-passband, 0);
+                    slice->setFilterWidth(-passband, -95);
                 } else {
-                    slice->setFilterWidth(0, passband);
+                    slice->setFilterWidth(95, passband);
                 }
             }, Qt::QueuedConnection);
         }

--- a/src/gui/FilterPassbandWidget.cpp
+++ b/src/gui/FilterPassbandWidget.cpp
@@ -108,22 +108,39 @@ void FilterPassbandWidget::mousePressEvent(QMouseEvent* ev)
     m_dragStartLo = m_lo;
     m_dragStartHi = m_hi;
 
-    // Detect edge grab: ±8px from the dashed vertical lines
-    constexpr int margin = 16, SKIRT = 16, GRAB = 8;
+    // Three zones: left of lo line = drag low edge, right of hi line = drag high edge, center = shift
+    constexpr int margin = 16, SKIRT = 16;
     const int loLineX = margin + SKIRT + 8;
     const int hiLineX = width() - margin - SKIRT - 8;
 
-    if (std::abs(ev->pos().x() - loLineX) <= GRAB)
+    if (ev->pos().x() <= loLineX) {
         m_dragMode = DragLo;
-    else if (std::abs(ev->pos().x() - hiLineX) <= GRAB)
+        setCursor(Qt::SizeHorCursor);
+    } else if (ev->pos().x() >= hiLineX) {
         m_dragMode = DragHi;
-    else
+        setCursor(Qt::SizeHorCursor);
+    } else {
         m_dragMode = DragShift;
+        setCursor(Qt::SizeAllCursor);
+    }
 }
 
 void FilterPassbandWidget::mouseMoveEvent(QMouseEvent* ev)
 {
-    if (m_dragMode == DragNone) return;
+    // Hover cursor feedback — three zones: left edge, center, right edge
+    if (m_dragMode == DragNone) {
+        constexpr int margin = 16, SKIRT = 16;
+        const int loLineX = margin + SKIRT + 8;
+        const int hiLineX = width() - margin - SKIRT - 8;
+        const int x = ev->pos().x();
+        if (x <= loLineX)
+            setCursor(Qt::SizeHorCursor);
+        else if (x >= hiLineX)
+            setCursor(Qt::SizeHorCursor);
+        else
+            setCursor(Qt::SizeAllCursor);
+        return;
+    }
 
     const int dx = ev->pos().x() - m_dragStartPos.x();
     const int dy = ev->pos().y() - m_dragStartPos.y();

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1244,7 +1244,7 @@ void RxApplet::applyFilterPreset(int widthHz)
 
     if (mode == "LSB" || mode == "DIGL") {
         lo = -widthHz;
-        hi = 0;
+        hi = -95;
     } else if (mode == "RTTY") {
         // RTTY: RF_frequency = mark. Filter is relative to mark.
         // Space is at -rttyShift. Passband should encompass both tones.
@@ -1263,8 +1263,8 @@ void RxApplet::applyFilterPreset(int widthHz)
         lo = -(widthHz / 2);
         hi =  (widthHz / 2);
     } else {
-        // USB, DIGU, RTTY, etc.
-        lo = 0;
+        // USB, DIGU, FDV, etc. — low cut at 95 Hz to reject carrier/hum
+        lo = 95;
         hi = widthHz;
     }
 

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2548,7 +2548,7 @@ void VfoWidget::applyFilterPreset(int widthHz)
     const QString& mode = m_slice->mode();
 
     if (mode == "LSB" || mode == "DIGL") {
-        lo = -widthHz; hi = 0;
+        lo = -widthHz; hi = -95;
     } else if (mode == "RTTY") {
         // RTTY: RF_frequency = mark. Filter is relative to mark.
         // Space is at -rttyShift. Passband should encompass both tones.
@@ -2564,7 +2564,8 @@ void VfoWidget::applyFilterPreset(int widthHz)
     } else if (mode == "AM" || mode == "SAM" || mode == "DSB") {
         lo = -(widthHz / 2); hi = (widthHz / 2);
     } else {
-        lo = 0; hi = widthHz;
+        // USB/DIGU/FDV: low cut at 95 Hz to reject carrier/hum
+        lo = 95; hi = widthHz;
     }
     m_slice->setFilterWidth(lo, hi);
 }


### PR DESCRIPTION
## Summary

Fixes #689
Fixes #684

**1. Filter passband edge drag discoverability:**
The RX panel `FilterPassbandWidget` had working `DragLo`/`DragHi` code but never changed the cursor on hover — the cursor was always a 4-way arrow, so users didn't know individual edges were draggable. Added three-zone cursor feedback: left section shows ↔ (drag low edge), right section shows ↔ (drag high edge), center shows 4-way arrow (shift entire passband). Click zones match the cursor zones for consistent UX.

**2. Filter presets start at 95 Hz instead of 0:**
SSB/DIGI filter presets were setting the low cut to 0 Hz, passing carrier and mains hum through the audio. Changed to 95 Hz low cut matching SmartSDR behavior. Fixed in all three preset locations:
- `VfoWidget::applyFilterPreset()` — VFO panel presets
- `RxApplet::applyFilterPreset()` — RX applet panel presets
- `RigctlProtocol` — CAT/rigctld passband commands

RADE OFDM passthrough (`MainWindow.cpp`) intentionally left at 0 Hz (needs full bandwidth for digital modem).

## Test plan

- [x] Hover over filter widget left section → cursor shows ↔
- [x] Hover over right section → cursor shows ↔
- [x] Hover over center → cursor shows 4-way arrow
- [x] Drag left edge → only low cutoff changes
- [x] Drag right edge → only high cutoff changes
- [x] Click USB/DIGU filter preset → low cut starts at 95 Hz, not 0
- [x] Click LSB/DIGL filter preset → high cut starts at -95 Hz, not 0
- [x] RX applet filter presets match VFO presets

JJ Boyd ~KG4VCF
🤖 Generated with [Claude Code](https://claude.com/claude-code)