### PR TITLE
Fix 3v/4v pan layouts not restoring on reconnect

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -864,7 +864,7 @@ MainWindow::MainWindow(QWidget* parent)
                     .value("PanadapterLayout", "1").toString();
                 // Only rearrange if the saved layout matches the pan count
                 static const QMap<QString, int> layoutPanCount = {
-                    {"2v", 2}, {"2h", 2}, {"2h1", 3}, {"12h", 3}, {"2x2", 4}, {"1", 1}
+                    {"1", 1}, {"2v", 2}, {"2h", 2}, {"2h1", 3}, {"12h", 3}, {"3v", 3}, {"2x2", 4}, {"4v", 4}
                 };
                 if (layoutPanCount.value(saved, 1) == panCount)
                     m_panStack->rearrangeLayout(saved);


### PR DESCRIPTION
## Summary

The layout restore map in `MainWindow.cpp` was missing the `"3v"` (3 stacked vertical) and `"4v"` (4 stacked vertical) layouts. When the user saved a 4-pan vertical stack layout, the map lookup failed on restart and the fallback hardcoded `"2x2"` (grid), losing the vertical arrangement every time.

One-line fix: add `{"3v", 3}` and `{"4v", 4}` to the `layoutPanCount` map that gates layout restoration.

## Test plan

- [x] Set 4 pans to vertical stack (4v layout), quit and relaunch — should restore as 4v, not 2x2
- [x] Set 3 pans to vertical stack (3v layout), quit and relaunch — should restore as 3v
- [x] Existing layouts (2v, 2h, 2h1, 12h, 2x2) still restore correctly

JJ Boyd ~KG4VCF
🤖 Generated with [Claude Code](https://claude.com/claude-code)