### PR TITLE
Fix PROC compression gauge not displaying

### DIFF
--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -678,10 +678,10 @@ void PhoneCwApplet::updateMeters(float micLevel, float compLevel,
 
 void PhoneCwApplet::updateCompression(float compPeak)
 {
-    // TODO (#345): Compression meter disabled — raw COMPPEAK reads as a reversed
-    // level meter, not gain reduction. Need to determine correct gain reduction
-    // calculation. See docs/tx-audio-signal-path.md for meter details.
-    Q_UNUSED(compPeak);
+    // compPeak is gain reduction in dB (0.0 = none, -25.0 = heavy compression).
+    // Calculated in MeterModel as AFTEREQ - COMPPEAK (both smoothed, α=0.3).
+    // Gauge is reversed: fills right-to-left as compression increases.
+    m_compGauge->setValue(compPeak);
 }
 
 void PhoneCwApplet::updateAlc(float alc)


### PR DESCRIPTION
## Summary

Fixes #754
Related: #661, #667

The compander command path was correctly fixed in 0.8.2 (`speech_processor` → `compander`), but the **compression gauge in the P/CW applet was still disabled** with a TODO comment from #345.

The entire data pipeline was already working:
- **MeterModel** correctly computes gain reduction: `AFTEREQ - COMPPEAK` (both smoothed with α=0.3)
- **MainWindow** gates the value on `companderOn()` and throttles to 5fps
- **HGauge** widget was configured with the correct reversed range (-25 to 0 dB)
- The only missing piece: `PhoneCwApplet::updateCompression()` had `Q_UNUSED(compPeak)` instead of `m_compGauge->setValue(compPeak)`

One-line fix to re-enable the gauge. The outdated TODO comment (which incorrectly stated the gain reduction calculation was missing) has been replaced with documentation of how the value actually flows.

## Test plan

- [ ] Enable PROC, key up and speak into mic — compression gauge should deflect (fills right-to-left)
- [ ] Toggle PROC off — gauge returns to zero
- [ ] Switch NOR/DX/DX+ — compression amount should vary (DX+ = most compression)
- [ ] With PROC off, gauge stays at zero regardless of mic input

JJ Boyd ~KG4VCF
🤖 Co-Authored with [Claude Code](https://claude.com/claude-code)