### PR TITLE
Fix TCI server not sending state to clients

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -602,9 +602,13 @@ void TciServer::sendInitBurst(QWebSocket* client)
     }
     if (!protocol) return;
 
+    // TCI protocol requires one command per WebSocket message.
+    // Split the concatenated burst into individual messages.
     QString burst = protocol->generateInitBurst();
-    client->sendTextMessage(burst);
-    qCDebug(lcCat) << "TCI: sent init burst," << burst.count(';') << "commands";
+    const auto commands = burst.split(';', Qt::SkipEmptyParts);
+    for (const auto& cmd : commands)
+        client->sendTextMessage(cmd + ';');
+    qCDebug(lcCat) << "TCI: sent init burst," << commands.size() << "commands";
 }
 
 void TciServer::broadcast(const QString& msg)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1913,6 +1913,9 @@ MainWindow::MainWindow(QWidget* parent)
         if (m_tciServer)
             m_tciServer->wireSlice(s->sliceId(), s);
     });
+    // Wire existing slices (radio may already be connected with slices)
+    for (auto* s : m_radioModel.slices())
+        m_tciServer->wireSlice(s->sliceId(), s);
     m_tciServer->wireSpotModel();
 
     // Wire RX audio from PanadapterStream → TCI server for audio streaming


### PR DESCRIPTION
## Summary

Fixes #739

Two bugs preventing TCI clients (SDC, QLog, RUMlogNG) from receiving frequency, mode, and other state data after connecting:

**1. Init burst sent as single concatenated WebSocket message:** `generateInitBurst()` builds all TCI commands into one string and `sendTextMessage()` sends it as a single WebSocket frame. TCI protocol (ExpertSDR3) requires one command per WebSocket message — clients parse one command per `onTextMessageReceived` callback. Split into individual `sendTextMessage()` calls per command.

**2. Existing slices not wired for state broadcasts:** `wireSlice()` was only connected to the `sliceAdded` signal, so slices that existed before the TCI server started never had their `frequencyChanged`/`modeChanged` signals connected to TCI broadcasts. Added a loop to wire all existing slices when the TCI server is created.

Tested with RUMlogNG and QLog on macOS — both receive frequency, mode, filter, and TX state correctly. Bidirectional control confirmed with QLog.

## Test plan

- [x] Connect SDC/QLog/RUMlogNG to TCI port — should show frequency and mode immediately
- [x] Change frequency in AetherSDR — TCI client updates
- [x] Change frequency in TCI client — AetherSDR updates
- [x] Mode changes sync both directions
- [x] Connect TCI client after radio is connected — works
- [x] Connect TCI client before radio connects — works after radio connects

JJ Boyd ~KG4VCF
🤖 Co-Authored with [Claude Code](https://claude.com/claude-code)