### PR TITLE
Fix macOS crash from rapid setCursor calls in filter widget

### DIFF
--- a/src/gui/FilterPassbandWidget.cpp
+++ b/src/gui/FilterPassbandWidget.cpp
@@ -128,17 +128,17 @@ void FilterPassbandWidget::mousePressEvent(QMouseEvent* ev)
 void FilterPassbandWidget::mouseMoveEvent(QMouseEvent* ev)
 {
     // Hover cursor feedback — three zones: left edge, center, right edge
+    // Only call setCursor when the shape actually changes to avoid
+    // excessive CGImageCreate calls on macOS (EXC_BREAKPOINT in Qt cursor code).
     if (m_dragMode == DragNone) {
         constexpr int margin = 16, SKIRT = 16;
         const int loLineX = margin + SKIRT + 8;
         const int hiLineX = width() - margin - SKIRT - 8;
         const int x = ev->pos().x();
-        if (x <= loLineX)
-            setCursor(Qt::SizeHorCursor);
-        else if (x >= hiLineX)
-            setCursor(Qt::SizeHorCursor);
-        else
-            setCursor(Qt::SizeAllCursor);
+        Qt::CursorShape wanted = (x <= loLineX || x >= hiLineX)
+            ? Qt::SizeHorCursor : Qt::SizeAllCursor;
+        if (cursor().shape() != wanted)
+            setCursor(wanted);
         return;
     }
 


### PR DESCRIPTION
## Summary

`FilterPassbandWidget` called `setCursor()` on every `mouseMoveEvent`, triggering hundreds of `QImage::toCGImage()` → `CGImageCreate` calls per second on macOS. This caused an `EXC_BREAKPOINT` crash in CoreGraphics `CGColorSpaceGetType` during cursor image conversion.

Crash stack:
```
CoreFoundation: __CF_IS_OBJC
CoreGraphics: CGColorSpaceGetType → valid_image_colorspace → CGImageCreate
QtGui: QImage::toCGImage()
libqcocoa.dylib: QCocoaCursor::createCursorData → changeCursor
```

Fix: only call `setCursor()` when the cursor shape actually needs to change. Compares `cursor().shape()` against the desired shape before calling.

## Test plan

- [ ] Move mouse rapidly over filter passband widget — no crash
- [ ] Cursor still changes between ↔ (edges) and 4-way (center)
- [ ] Edge drag and center drag still work correctly

JJ Boyd ~KG4VCF
🤖 Co-Authored with [Claude Code](https://claude.com/claude-code)