### PR TITLE
Fix cursor frequency label not persisting across slices and restarts

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4567,6 +4567,15 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     // Set panId on the overlay menu so +RX routes to the correct pan
     menu->setPanId(applet->panId());
 
+    // Restore per-pan cursor freq state from AppSettings
+    {
+        auto& s = AppSettings::instance();
+        bool cursorFreq = s.value(sw->settingsKey("CursorFreqLabel"), "False").toString() == "True";
+        sw->setShowCursorFreq(cursorFreq);
+        if (menu->cursorFreqButton())
+            menu->cursorFreqButton()->setChecked(cursorFreq);
+    }
+
     // ── Pan activation: clicking on this pan makes it active ─────────────
     connect(applet, &PanadapterApplet::activated,
             m_panStack, &PanadapterStack::setActivePan);


### PR DESCRIPTION
## Summary

`wirePanadapter()` never restored the per-pan `CursorFreqLabel` setting from AppSettings, so new SpectrumWidgets always started with cursor frequency disabled. The setting was only restored once during initial connection for the first pan — opening a second slice or restarting the app lost the setting.

Now `wirePanadapter()` reads the saved state and applies it to both the SpectrumWidget and the overlay menu button for each pan. The setting key is per-pan via `settingsKey()`, so each panadapter remembers independently.

## Test plan

- [x] Enable cursor freq on first pan, open second slice — both pans show cursor label
- [x] Close second slice — first pan still shows cursor label
- [x] Quit and restart — cursor freq still enabled
- [x] Open second slice after restart — cursor freq works on both

JJ Boyd ~KG4VCF
🤖 Co-Authored with [Claude Code](https://claude.com/claude-code)