### PR TITLE
[platform] Add slice troubleshooting diagnostics dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ set(GUI_SOURCES
     src/gui/AntennaGeniusApplet.cpp
     src/gui/TitleBar.cpp
     src/gui/SupportDialog.cpp
+    src/gui/SliceTroubleshootingDialog.cpp
     src/gui/KeyboardMapWidget.cpp
     src/gui/ShortcutDialog.cpp
     src/gui/MultiFlexDialog.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -34,6 +34,7 @@
 #include "MeterApplet.h"
 #include "ProfileManagerDialog.h"
 #include "SupportDialog.h"
+#include "SliceTroubleshootingDialog.h"
 #include "ShortcutDialog.h"
 #include "MultiFlexDialog.h"
 #include "WhatsNewDialog.h"
@@ -3133,6 +3134,10 @@ void MainWindow::buildMenuBar()
     helpMenu->addAction("Support...", this, [this]() {
         SupportDialog dlg(this);
         dlg.setRadioModel(&m_radioModel);
+        dlg.exec();
+    });
+    helpMenu->addAction("Slice Troubleshooting...", this, [this]() {
+        SliceTroubleshootingDialog dlg(&m_radioModel, this);
         dlg.exec();
     });
     helpMenu->addAction("What's New...", this, [this]() {

--- a/src/gui/SliceTroubleshootingDialog.cpp
+++ b/src/gui/SliceTroubleshootingDialog.cpp
@@ -1,0 +1,626 @@
+#include "SliceTroubleshootingDialog.h"
+#include "models/RadioModel.h"
+
+#include <QApplication>
+#include <QClipboard>
+#include <QDateTime>
+#include <QDir>
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLabel>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QSaveFile>
+#include <QTabWidget>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+namespace {
+
+QString yesNo(bool value)
+{
+    return value ? "Yes" : "No";
+}
+
+QString orPlaceholder(const QString& value, const QString& placeholder = "n/a")
+{
+    return value.trimmed().isEmpty() ? placeholder : value;
+}
+
+QString joinArray(const QJsonArray& array, const QString& emptyText = "(none)")
+{
+    QStringList values;
+    values.reserve(array.size());
+    for (const QJsonValue& value : array) {
+        if (value.isString())
+            values << value.toString();
+        else if (value.isDouble())
+            values << QString::number(value.toDouble());
+        else if (value.isBool())
+            values << (value.toBool() ? "true" : "false");
+    }
+    return values.isEmpty() ? emptyText : values.join(", ");
+}
+
+QString formatNumber(const QJsonValue& value, int decimals = 2, const QString& suffix = {})
+{
+    if (!value.isDouble())
+        return QString("n/a");
+
+    QString text = QString::number(value.toDouble(), 'f', decimals);
+    if (!suffix.isEmpty())
+        text += suffix;
+    return text;
+}
+
+QString formatMeterBullet(const QJsonObject& meter, const QString& prefix = "- ")
+{
+    const QString valueText = meter["has_value"].toBool()
+        ? formatNumber(meter["value"], 2)
+        : QString("n/a");
+    const QString unit = meter["unit"].toString();
+    const QString range = QString("[%1, %2]")
+        .arg(QString::number(meter["low"].toDouble(), 'f', 2))
+        .arg(QString::number(meter["high"].toDouble(), 'f', 2));
+
+    QString line = QString("%1[%2] `%3/%4 %5` = `%6%7` range `%8`")
+        .arg(prefix)
+        .arg(meter["index"].toInt())
+        .arg(orPlaceholder(meter["source"].toString()))
+        .arg(meter["source_index"].toInt())
+        .arg(orPlaceholder(meter["name"].toString()))
+        .arg(valueText)
+        .arg(unit.isEmpty() ? QString() : QString(" %1").arg(unit))
+        .arg(range);
+
+    const QString description = meter["description"].toString().trimmed();
+    if (!description.isEmpty())
+        line += QString(" — %1").arg(description);
+    return line;
+}
+
+QString formatPanBullet(const QJsonObject& pan)
+{
+    return QString(
+        "- `%1` active `%2`, center `%3 MHz`, bandwidth `%4 MHz`, RF gain `%5`, "
+        "preamp `%6`, WNB `%7` (`%8`), waterfall `%9`")
+        .arg(orPlaceholder(pan["pan_id"].toString()))
+        .arg(yesNo(pan["active"].toBool()))
+        .arg(formatNumber(pan["center_mhz"], 6))
+        .arg(formatNumber(pan["bandwidth_mhz"], 6))
+        .arg(formatNumber(pan["rf_gain"], 0))
+        .arg(orPlaceholder(pan["preamp"].toString()))
+        .arg(yesNo(pan["wnb_active"].toBool()))
+        .arg(formatNumber(pan["wnb_level"], 0))
+        .arg(orPlaceholder(pan["waterfall_id"].toString()));
+}
+
+QString formatClientBullet(const QJsonObject& client)
+{
+    return QString("- `%1`: program `%2`, owns TX `%3`, local PTT `%4`, TX ant `%5`, TX freq `%6 MHz`")
+        .arg(orPlaceholder(client["role"].toString()))
+        .arg(orPlaceholder(client["program"].toString()))
+        .arg(yesNo(client["owns_tx"].toBool()))
+        .arg(yesNo(client["local_ptt"].toBool()))
+        .arg(orPlaceholder(client["tx_antenna"].toString()))
+        .arg(formatNumber(client["tx_freq_mhz"], 6));
+}
+
+QString formatTxBandBullet(const QJsonObject& band)
+{
+    return QString("- `%1` (ID `%2`): RF `%3`, tune `%4`, inhibit `%5`, HWALC `%6`, "
+                   "ACC TX `%7`, ACC TX Req `%8`, RCA TX Req `%9`, TX1 `%10`, TX2 `%11`, TX3 `%12`")
+        .arg(orPlaceholder(band["band_name"].toString()))
+        .arg(band["band_id"].toInt())
+        .arg(formatNumber(band["rf_power"], 0))
+        .arg(formatNumber(band["tune_power"], 0))
+        .arg(yesNo(band["inhibit"].toBool()))
+        .arg(yesNo(band["hw_alc"].toBool()))
+        .arg(yesNo(band["acc_tx"].toBool()))
+        .arg(yesNo(band["acc_tx_req"].toBool()))
+        .arg(yesNo(band["rca_tx_req"].toBool()))
+        .arg(yesNo(band["tx1"].toBool()))
+        .arg(yesNo(band["tx2"].toBool()))
+        .arg(yesNo(band["tx3"].toBool()));
+}
+
+} // namespace
+
+SliceTroubleshootingDialog::SliceTroubleshootingDialog(RadioModel* model, QWidget* parent)
+    : QDialog(parent), m_model(model)
+{
+    setWindowTitle("Slice Troubleshooting");
+    setMinimumSize(920, 720);
+    resize(980, 760);
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+    auto* root = new QVBoxLayout(this);
+    root->setSpacing(8);
+
+    auto* intro = new QLabel(
+        "Capture AetherSDR's current in-memory radio, panadapter, slice, and meter state. "
+        "Use <b>Issue Summary</b> for GitHub reports and <b>JSON</b> for AI-assisted troubleshooting. "
+        "This dialog does not re-query the radio.");
+    intro->setWordWrap(true);
+    intro->setStyleSheet("QLabel { color: #c8d8e8; }");
+    root->addWidget(intro);
+
+    auto* tabs = new QTabWidget;
+    m_summaryView = new QPlainTextEdit;
+    m_summaryView->setReadOnly(true);
+    m_summaryView->setLineWrapMode(QPlainTextEdit::NoWrap);
+    m_summaryView->setStyleSheet(
+        "QPlainTextEdit {"
+        "  background: #0a0a14;"
+        "  color: #d6e4f2;"
+        "  font-family: monospace;"
+        "  font-size: 11px;"
+        "  border: 1px solid #203040;"
+        "}");
+    tabs->addTab(m_summaryView, "Issue Summary");
+
+    m_jsonView = new QPlainTextEdit;
+    m_jsonView->setReadOnly(true);
+    m_jsonView->setLineWrapMode(QPlainTextEdit::NoWrap);
+    m_jsonView->setStyleSheet(
+        "QPlainTextEdit {"
+        "  background: #0a0a14;"
+        "  color: #9ed4ff;"
+        "  font-family: monospace;"
+        "  font-size: 11px;"
+        "  border: 1px solid #203040;"
+        "}");
+    tabs->addTab(m_jsonView, "JSON");
+    root->addWidget(tabs, 1);
+
+    auto* footer = new QHBoxLayout;
+    m_statusLabel = new QLabel;
+    m_statusLabel->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; }");
+    footer->addWidget(m_statusLabel, 1);
+
+    auto* refreshBtn = new QPushButton("Refresh Snapshot");
+    auto* copySummaryBtn = new QPushButton("Copy Summary");
+    auto* copyJsonBtn = new QPushButton("Copy JSON");
+    auto* exportJsonBtn = new QPushButton("Export JSON...");
+    auto* closeBtn = new QPushButton("Close");
+
+    footer->addWidget(refreshBtn);
+    footer->addWidget(copySummaryBtn);
+    footer->addWidget(copyJsonBtn);
+    footer->addWidget(exportJsonBtn);
+    footer->addWidget(closeBtn);
+    root->addLayout(footer);
+
+    connect(refreshBtn, &QPushButton::clicked, this, [this] { refreshSnapshot(); });
+    connect(copySummaryBtn, &QPushButton::clicked, this, [this] { copySummary(); });
+    connect(copyJsonBtn, &QPushButton::clicked, this, [this] { copyJson(); });
+    connect(exportJsonBtn, &QPushButton::clicked, this, [this] { exportJson(); });
+    connect(closeBtn, &QPushButton::clicked, this, &QDialog::accept);
+
+    refreshSnapshot();
+}
+
+void SliceTroubleshootingDialog::refreshSnapshot()
+{
+    if (m_model)
+        m_snapshot = m_model->troubleshootingSnapshot();
+    else
+        m_snapshot = QJsonObject{};
+
+    m_summaryText = buildSummary(m_snapshot);
+    m_jsonText = QString::fromUtf8(QJsonDocument(m_snapshot).toJson(QJsonDocument::Indented));
+
+    m_summaryView->setPlainText(m_summaryText);
+    m_jsonView->setPlainText(m_jsonText);
+
+    const QJsonObject counts = m_snapshot["counts"].toObject();
+    setStatusMessage(QString("Snapshot refreshed: %1 slice(s), %2 global meter(s), %3 total meter(s).")
+                         .arg(counts["slices"].toInt())
+                         .arg(counts["global_meters"].toInt())
+                         .arg(counts["meters_total"].toInt()));
+}
+
+void SliceTroubleshootingDialog::copySummary()
+{
+    QApplication::clipboard()->setText(m_summaryText);
+    setStatusMessage("Issue summary copied to clipboard.");
+}
+
+void SliceTroubleshootingDialog::copyJson()
+{
+    QApplication::clipboard()->setText(m_jsonText);
+    setStatusMessage("JSON copied to clipboard.");
+}
+
+void SliceTroubleshootingDialog::exportJson()
+{
+    const QString defaultPath = QDir::homePath() + QString("/aethersdr-slice-troubleshooting-%1.json")
+        .arg(QDateTime::currentDateTime().toString("yyyyMMdd-HHmmss"));
+
+    const QString path = QFileDialog::getSaveFileName(
+        this,
+        "Export Slice Troubleshooting JSON",
+        defaultPath,
+        "JSON Files (*.json)");
+
+    if (path.isEmpty())
+        return;
+
+    QSaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        setStatusMessage(QString("Unable to write `%1`.").arg(path));
+        return;
+    }
+
+    if (file.write(m_jsonText.toUtf8()) < 0 || !file.commit()) {
+        setStatusMessage(QString("Failed to export JSON to `%1`.").arg(path));
+        return;
+    }
+
+    setStatusMessage(QString("Exported JSON to `%1`.").arg(path));
+}
+
+void SliceTroubleshootingDialog::setStatusMessage(const QString& message)
+{
+    m_statusLabel->setText(message);
+}
+
+QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
+{
+    QStringList lines;
+
+    const QJsonObject app = snapshot["app"].toObject();
+    const QJsonObject radio = snapshot["radio"].toObject();
+    const QJsonObject network = radio["network"].toObject();
+    const QJsonObject ownership = radio["ownership"].toObject();
+    const QJsonObject oscillator = radio["oscillator"].toObject();
+    const QJsonObject audioOutputs = radio["audio_outputs"].toObject();
+    const QJsonObject filterSharpness = radio["filter_sharpness"].toObject();
+    const QJsonObject telemetry = radio["telemetry"].toObject();
+    const QJsonObject amplifier = radio["amplifier"].toObject();
+    const QJsonObject transmit = snapshot["transmit"].toObject();
+    const QJsonObject txPower = transmit["power"].toObject();
+    const QJsonObject mic = transmit["mic"].toObject();
+    const QJsonObject vox = transmit["vox"].toObject();
+    const QJsonObject cw = transmit["cw"].toObject();
+    const QJsonObject interlock = transmit["interlock"].toObject();
+    const QJsonObject atu = transmit["atu"].toObject();
+    const QJsonObject apd = transmit["apd"].toObject();
+    const QJsonObject profiles = transmit["profiles"].toObject();
+    const QJsonObject counts = snapshot["counts"].toObject();
+
+    lines << "# Slice Troubleshooting Snapshot";
+    lines << "";
+    lines << "> Captured from AetherSDR's in-memory models and cached meter values.";
+    lines << "> This report does not query the radio directly.";
+    lines << "> Privacy filter is enabled: radio name, nickname, callsign, serials, MAC/IPs, GPS data, and client station names are omitted.";
+    lines << "";
+    lines << QString("- Captured: `%1`").arg(orPlaceholder(snapshot["captured_at"].toString()));
+    lines << QString("- App: `%1 %2` on `%3` (`Qt %4`, `%5`)")
+                 .arg(orPlaceholder(app["name"].toString(), "AetherSDR"))
+                 .arg(orPlaceholder(app["version"].toString()))
+                 .arg(orPlaceholder(app["os"].toString()))
+                 .arg(orPlaceholder(app["qt_version"].toString()))
+                 .arg(orPlaceholder(app["cpu_arch"].toString()));
+    lines << QString("- Radio: model `%1`, software `%2`, protocol `%3`")
+                 .arg(orPlaceholder(radio["model"].toString()))
+                 .arg(orPlaceholder(radio["software_version"].toString()))
+                 .arg(orPlaceholder(radio["protocol_version"].toString()));
+    lines << QString("- Connection: `%1`, connected `%2`, network `%3`, RTT `%4 ms` (max `%5 ms`)")
+                 .arg(orPlaceholder(radio["transport"].toString()))
+                 .arg(yesNo(radio["connected"].toBool()))
+                 .arg(orPlaceholder(network["quality"].toString()))
+                 .arg(network["last_ping_rtt_ms"].toInt())
+                 .arg(network["max_ping_rtt_ms"].toInt());
+    lines << QString("- Ownership: TX owned by us `%1`, multiple clients present `%2`")
+                 .arg(yesNo(ownership["tx_owned_by_us"].toBool()))
+                 .arg(yesNo(ownership["multiple_clients_present"].toBool()));
+    lines << QString("- Profiles: global count `%1` (active set `%2`), TX count `%3` (active set `%4`), mic count `%5` (active set `%6`)")
+                 .arg(radio["global_profile_count"].toInt())
+                 .arg(yesNo(radio["active_global_profile_set"].toBool()))
+                 .arg(profiles["tx_profile_count"].toInt())
+                 .arg(yesNo(profiles["active_tx_profile_set"].toBool()))
+                 .arg(profiles["mic_profile_count"].toInt())
+                 .arg(yesNo(profiles["active_mic_profile_set"].toBool()));
+    lines << QString("- Counts: `%1` slice(s), `%2` panadapter(s), `%3` total meter(s), `%4` slice meter(s)")
+                 .arg(counts["slices"].toInt())
+                 .arg(counts["panadapters"].toInt())
+                 .arg(counts["meters_total"].toInt())
+                 .arg(counts["slice_meters"].toInt());
+    lines << "";
+
+    lines << "## Global Radio State";
+    lines << QString("- Region / Options: `%1` / `%2`")
+                 .arg(orPlaceholder(radio["region"].toString()))
+                 .arg(orPlaceholder(radio["radio_options"].toString()));
+    lines << QString("- Antennas: `%1`").arg(joinArray(radio["antenna_list"].toArray()));
+    lines << QString("- Owned slice IDs: `%1`").arg(joinArray(radio["owned_slice_ids"].toArray()));
+    lines << QString("- Audio outputs: lineout `%1` (mute `%2`), headphones `%3` (mute `%4`), front speaker mute `%5`")
+                 .arg(audioOutputs["lineout_gain"].toInt())
+                 .arg(yesNo(audioOutputs["lineout_mute"].toBool()))
+                 .arg(audioOutputs["headphone_gain"].toInt())
+                 .arg(yesNo(audioOutputs["headphone_mute"].toBool()))
+                 .arg(yesNo(audioOutputs["front_speaker_mute"].toBool()));
+    lines << QString("- Oscillator: setting `%1`, locked `%2`, ext `%3`, TCXO `%4`")
+                 .arg(orPlaceholder(oscillator["setting"].toString()))
+                 .arg(yesNo(oscillator["locked"].toBool()))
+                 .arg(yesNo(oscillator["ext_present"].toBool()))
+                 .arg(yesNo(oscillator["tcxo_present"].toBool()));
+    lines << QString("- RX globals: binaural `%1`, mute local when remote `%2`, low-latency digital `%3`, "
+                      "enforce private IP `%4`, remote on `%5`, multiFLEX `%6`, full duplex `%7`")
+                 .arg(yesNo(radio["binaural_rx"].toBool()))
+                 .arg(yesNo(radio["mute_local_audio_when_remote"].toBool()))
+                 .arg(yesNo(radio["low_latency_digital_modes"].toBool()))
+                 .arg(yesNo(radio["enforce_private_ip_connections"].toBool()))
+                 .arg(yesNo(radio["remote_on_enabled"].toBool()))
+                 .arg(yesNo(radio["mf_enable"].toBool()))
+                 .arg(yesNo(radio["full_duplex_enabled"].toBool()));
+    lines << QString("- Filter sharpness: voice `%1` (auto `%2`), CW `%3` (auto `%4`), digital `%5` (auto `%6`)")
+                 .arg(filterSharpness["voice_level"].toInt())
+                 .arg(yesNo(filterSharpness["voice_auto"].toBool()))
+                 .arg(filterSharpness["cw_level"].toInt())
+                 .arg(yesNo(filterSharpness["cw_auto"].toBool()))
+                 .arg(filterSharpness["digital_level"].toInt())
+                 .arg(yesNo(filterSharpness["digital_auto"].toBool()));
+    lines << QString("- Telemetry: PA `%1 C`, supply `%2 V`, TX forward `%3 W`, TX SWR `%4`, "
+                      "ALC `%5`, mic `%6` dBFS, comp `%7` dB")
+                 .arg(formatNumber(telemetry["pa_temp_c"]))
+                 .arg(formatNumber(telemetry["supply_volts"]))
+                 .arg(formatNumber(telemetry["tx_forward_power_w"]))
+                 .arg(formatNumber(telemetry["tx_swr"]))
+                 .arg(formatNumber(telemetry["alc"]))
+                 .arg(formatNumber(telemetry["mic_level_dbfs"]))
+                 .arg(formatNumber(telemetry["comp_level_db"]));
+    lines << QString("- Amplifier: present `%1`, model `%2`, handle `%3`, operate `%4`")
+                 .arg(yesNo(amplifier["present"].toBool()))
+                 .arg(orPlaceholder(amplifier["model"].toString()))
+                 .arg(orPlaceholder(amplifier["handle"].toString()))
+                 .arg(yesNo(amplifier["operate"].toBool()));
+    lines << "";
+
+    lines << "## Clients";
+    if (ownership["clients"].toArray().isEmpty()) {
+        lines << "- No client metadata is currently tracked.";
+    } else {
+        for (const QJsonValue& value : ownership["clients"].toArray())
+            lines << formatClientBullet(value.toObject());
+    }
+    lines << "";
+
+    lines << "## Panadapters";
+    if (snapshot["panadapters"].toArray().isEmpty()) {
+        lines << "- None";
+    } else {
+        for (const QJsonValue& value : snapshot["panadapters"].toArray())
+            lines << formatPanBullet(value.toObject());
+    }
+    lines << "";
+
+    lines << "## Transmit State";
+    lines << QString("- Power: RF `%1`, tune `%2`, max `%3`, tune mode `%4`, show TX in waterfall `%5`")
+                 .arg(txPower["rf_power"].toInt())
+                 .arg(txPower["tune_power"].toInt())
+                 .arg(txPower["max_power_level"].toInt())
+                 .arg(orPlaceholder(txPower["tune_mode"].toString()))
+                 .arg(yesNo(txPower["show_tx_in_waterfall"].toBool()));
+    lines << QString("- TX state: tuning `%1`, MOX `%2`, transmitting `%3`, ATU `%4` "
+                      "(enabled `%5`, memories `%6`, using memory `%7`), APD `%8` "
+                      "(configurable `%9`, EQ active `%10`)")
+                 .arg(yesNo(txPower["tuning"].toBool()))
+                 .arg(yesNo(txPower["mox"].toBool()))
+                 .arg(yesNo(txPower["transmitting"].toBool()))
+                 .arg(orPlaceholder(atu["status"].toString()))
+                 .arg(yesNo(atu["enabled"].toBool()))
+                 .arg(yesNo(atu["memories_enabled"].toBool()))
+                 .arg(yesNo(atu["using_memory"].toBool()))
+                 .arg(yesNo(apd["enabled"].toBool()))
+                 .arg(yesNo(apd["configurable"].toBool()))
+                 .arg(yesNo(apd["equalizer_active"].toBool()));
+    lines << QString("- Mic/phone: input `%1`, mic level `%2`, mic boost `%3`, mic bias `%4`, DAX `%5`, "
+                      "monitor `%6` (`%7`), speech processor `%8` (`%9`), compander `%10` (`%11`), "
+                      "dexp `%12` (`%13`), met-in-RX `%14`, sync CWX `%15`, AM carrier `%16`, "
+                      "TX filter `%17..%18 Hz`")
+                 .arg(orPlaceholder(mic["selection"].toString()))
+                 .arg(mic["level"].toInt())
+                 .arg(yesNo(mic["mic_boost"].toBool()))
+                 .arg(yesNo(mic["mic_bias"].toBool()))
+                 .arg(yesNo(mic["dax_on"].toBool()))
+                 .arg(yesNo(mic["sb_monitor"].toBool()))
+                 .arg(mic["mon_gain_sb"].toInt())
+                 .arg(yesNo(mic["speech_processor_enable"].toBool()))
+                 .arg(mic["speech_processor_level"].toInt())
+                 .arg(yesNo(mic["compander_on"].toBool()))
+                 .arg(mic["compander_level"].toInt())
+                 .arg(yesNo(mic["dexp_on"].toBool()))
+                 .arg(mic["dexp_level"].toInt())
+                 .arg(yesNo(mic["met_in_rx"].toBool()))
+                 .arg(yesNo(mic["sync_cwx"].toBool()))
+                 .arg(mic["am_carrier_level"].toInt())
+                 .arg(mic["tx_filter_low"].toInt())
+                 .arg(mic["tx_filter_high"].toInt());
+    lines << QString("- VOX: enabled `%1`, level `%2`, delay `%3`")
+                 .arg(yesNo(vox["enabled"].toBool()))
+                 .arg(vox["level"].toInt())
+                 .arg(vox["delay"].toInt());
+    lines << QString("- CW: speed `%1` WPM, pitch `%2 Hz`, break-in `%3`, delay `%4 ms`, sidetone `%5`, "
+                      "iambic `%6`, mode `%7`, swap paddles `%8`, CWL `%9`, monitor `%10`")
+                 .arg(cw["speed_wpm"].toInt())
+                 .arg(cw["pitch_hz"].toInt())
+                 .arg(yesNo(cw["break_in"].toBool()))
+                 .arg(cw["delay_ms"].toInt())
+                 .arg(yesNo(cw["sidetone"].toBool()))
+                 .arg(yesNo(cw["iambic"].toBool()))
+                 .arg(cw["iambic_mode"].toInt())
+                 .arg(yesNo(cw["swap_paddles"].toBool()))
+                 .arg(yesNo(cw["cwl_enabled"].toBool()))
+                 .arg(cw["monitor_gain"].toInt());
+    lines << QString("- Interlock: ACC TX delay `%1`, TX1 `%2`, TX2 `%3`, TX3 `%4`, TX delay `%5`, timeout `%6`, "
+                      "ACC polarity `%7`, RCA polarity `%8`")
+                 .arg(interlock["acc_tx_delay"].toInt())
+                 .arg(interlock["tx1_delay"].toInt())
+                 .arg(interlock["tx2_delay"].toInt())
+                 .arg(interlock["tx3_delay"].toInt())
+                 .arg(interlock["tx_delay"].toInt())
+                 .arg(interlock["timeout"].toInt())
+                 .arg(interlock["acc_tx_req_polarity"].toInt())
+                 .arg(interlock["rca_tx_req_polarity"].toInt());
+    lines << "";
+
+    lines << "## TX Band Settings";
+    if (snapshot["tx_band_settings"].toArray().isEmpty()) {
+        lines << "- None";
+    } else {
+        for (const QJsonValue& value : snapshot["tx_band_settings"].toArray())
+            lines << formatTxBandBullet(value.toObject());
+    }
+    lines << "";
+
+    lines << "## Global Meter Cache";
+    if (snapshot["global_meters"].toArray().isEmpty()) {
+        lines << "- None";
+    } else {
+        for (const QJsonValue& value : snapshot["global_meters"].toArray())
+            lines << formatMeterBullet(value.toObject());
+    }
+    lines << "";
+
+    lines << "## Slices";
+    const QJsonArray slices = snapshot["slices"].toArray();
+    if (slices.isEmpty()) {
+        lines << "- No app-owned slices are currently tracked.";
+    } else {
+        for (const QJsonValue& value : slices) {
+            const QJsonObject slice = value.toObject();
+            const QJsonObject filter = slice["filter"].toObject();
+            const QJsonObject audio = slice["audio"].toObject();
+            const QJsonObject antennas = slice["antennas"].toObject();
+            const QJsonObject control = slice["control"].toObject();
+            const QJsonObject dsp = slice["dsp"].toObject();
+            const QJsonObject nb = dsp["nb"].toObject();
+            const QJsonObject nr = dsp["nr"].toObject();
+            const QJsonObject anf = dsp["anf"].toObject();
+            const QJsonObject lmsNr = dsp["lms_nr"].toObject();
+            const QJsonObject speexNr = dsp["speex_nr"].toObject();
+            const QJsonObject nrf = dsp["nrf"].toObject();
+            const QJsonObject lmsAnf = dsp["lms_anf"].toObject();
+            const QJsonObject apfObj = dsp["apf"].toObject();
+            const QJsonObject diversity = slice["diversity"].toObject();
+            const QJsonObject tuning = slice["tuning"].toObject();
+            const QJsonObject digital = slice["digital"].toObject();
+            const QJsonObject fm = slice["fm"].toObject();
+            const QJsonObject pan = slice["panadapter_state"].toObject();
+
+            lines << QString("### Slice %1").arg(slice["slice_id"].toInt());
+            lines << QString("- Pan `%1`, active `%2`, TX slice `%3`, frequency `%4 MHz`, mode `%5`")
+                         .arg(orPlaceholder(slice["pan_id"].toString()))
+                         .arg(yesNo(slice["active"].toBool()))
+                         .arg(yesNo(slice["tx_slice"].toBool()))
+                         .arg(formatNumber(slice["frequency_mhz"], 6))
+                         .arg(orPlaceholder(slice["mode"].toString()));
+            lines << QString("- Filter: `%1..%2 Hz`, step `%3 Hz`, modes `%4`")
+                         .arg(filter["low_hz"].toInt())
+                         .arg(filter["high_hz"].toInt())
+                         .arg(tuning["step_hz"].toInt())
+                         .arg(joinArray(slice["mode_list"].toArray()));
+            lines << QString("- Audio / RF: audio gain `%1`, audio pan `%2`, audio mute `%3`, RF gain `%4`")
+                         .arg(formatNumber(audio["gain"]))
+                         .arg(audio["pan"].toInt())
+                         .arg(yesNo(audio["mute"].toBool()))
+                         .arg(formatNumber(slice["rf_gain"], 1));
+            lines << QString("- Antennas / control: RX `%1`, TX `%2`, locked `%3`, QSK `%4`, "
+                              "record `%5`, play `%6` (enabled `%7`)")
+                         .arg(orPlaceholder(antennas["rx"].toString()))
+                         .arg(orPlaceholder(antennas["tx"].toString()))
+                         .arg(yesNo(control["locked"].toBool()))
+                         .arg(yesNo(control["qsk"].toBool()))
+                         .arg(yesNo(control["record_on"].toBool()))
+                         .arg(yesNo(control["play_on"].toBool()))
+                         .arg(yesNo(control["play_enabled"].toBool()));
+            lines << QString("- AGC / squelch: mode `%1`, threshold `%2`, squelch `%3` (`%4`)")
+                         .arg(orPlaceholder(dsp["agc_mode"].toString()))
+                         .arg(dsp["agc_threshold"].toInt())
+                         .arg(yesNo(tuning["squelch_on"].toBool()))
+                         .arg(tuning["squelch_level"].toInt());
+            lines << QString("- RIT / XIT: RIT `%1` (`%2 Hz`), XIT `%3` (`%4 Hz`), DAX channel `%5`")
+                         .arg(yesNo(tuning["rit_on"].toBool()))
+                         .arg(tuning["rit_hz"].toInt())
+                         .arg(yesNo(tuning["xit_on"].toBool()))
+                         .arg(tuning["xit_hz"].toInt())
+                         .arg(digital["dax_channel"].toInt());
+            lines << QString("- Diversity / ESC: diversity `%1`, parent `%2`, child `%3`, index `%4`, "
+                              "ESC `%5`, gain `%6`, phase `%7`")
+                         .arg(yesNo(diversity["enabled"].toBool()))
+                         .arg(yesNo(diversity["is_parent"].toBool()))
+                         .arg(yesNo(diversity["is_child"].toBool()))
+                         .arg(diversity["index"].toInt())
+                         .arg(yesNo(diversity["esc_enabled"].toBool()))
+                         .arg(formatNumber(diversity["esc_gain"], 2))
+                         .arg(formatNumber(diversity["esc_phase_shift_deg"], 2));
+            lines << QString("- DSP: NB `%1` (`%2`), NR `%3` (`%4`), ANF `%5` (`%6`), "
+                              "LMS NR `%7` (`%8`), Speex NR `%9` (`%10`), RNNoise `%11`, "
+                              "NRF `%12` (`%13`), LMS ANF `%14` (`%15`), ANFT `%16`, APF `%17` (`%18`)")
+                         .arg(yesNo(nb["enabled"].toBool()))
+                         .arg(nb["level"].toInt())
+                         .arg(yesNo(nr["enabled"].toBool()))
+                         .arg(nr["level"].toInt())
+                         .arg(yesNo(anf["enabled"].toBool()))
+                         .arg(anf["level"].toInt())
+                         .arg(yesNo(lmsNr["enabled"].toBool()))
+                         .arg(lmsNr["level"].toInt())
+                         .arg(yesNo(speexNr["enabled"].toBool()))
+                         .arg(speexNr["level"].toInt())
+                         .arg(yesNo(dsp["rnnoise"].toBool()))
+                         .arg(yesNo(nrf["enabled"].toBool()))
+                         .arg(nrf["level"].toInt())
+                         .arg(yesNo(lmsAnf["enabled"].toBool()))
+                         .arg(lmsAnf["level"].toInt())
+                         .arg(yesNo(dsp["anft"].toBool()))
+                         .arg(yesNo(apfObj["enabled"].toBool()))
+                         .arg(apfObj["level"].toInt());
+            lines << QString("- Digital / RTTY: mark `%1`, shift `%2`, DIGL `%3`, DIGU `%4`, step list `%5`")
+                         .arg(digital["rtty_mark_hz"].toInt())
+                         .arg(digital["rtty_shift_hz"].toInt())
+                         .arg(digital["digl_offset_hz"].toInt())
+                         .arg(digital["digu_offset_hz"].toInt())
+                         .arg(joinArray(tuning["step_list"].toArray()));
+            lines << QString("- FM: tone mode `%1`, tone `%2`, repeater dir `%3`, repeater offset `%4 MHz`, "
+                              "TX offset `%5 MHz`, deviation `%6 Hz`")
+                         .arg(orPlaceholder(fm["tone_mode"].toString()))
+                         .arg(orPlaceholder(fm["tone_value"].toString()))
+                         .arg(orPlaceholder(fm["repeater_offset_dir"].toString()))
+                         .arg(formatNumber(fm["repeater_offset_mhz"], 6))
+                         .arg(formatNumber(fm["tx_offset_mhz"], 6))
+                         .arg(fm["deviation_hz"].toInt());
+
+            if (!pan.isEmpty()) {
+                lines << QString("- Pan state: center `%1 MHz`, bandwidth `%2 MHz`, RF gain `%3`, preamp `%4`, "
+                                  "WNB `%5` (`%6`), waterfall `%7`")
+                             .arg(formatNumber(pan["center_mhz"], 6))
+                             .arg(formatNumber(pan["bandwidth_mhz"], 6))
+                             .arg(formatNumber(pan["rf_gain"], 0))
+                             .arg(orPlaceholder(pan["preamp"].toString()))
+                             .arg(yesNo(pan["wnb_active"].toBool()))
+                             .arg(formatNumber(pan["wnb_level"], 0))
+                             .arg(orPlaceholder(pan["waterfall_id"].toString()));
+            }
+
+            lines << "- Meters:";
+            const QJsonArray meters = slice["meters"].toArray();
+            if (meters.isEmpty()) {
+                lines << "  - None";
+            } else {
+                for (const QJsonValue& meterValue : meters)
+                    lines << formatMeterBullet(meterValue.toObject(), "  - ");
+            }
+            lines << "";
+        }
+    }
+
+    return lines.join('\n').trimmed() + '\n';
+}
+
+} // namespace AetherSDR

--- a/src/gui/SliceTroubleshootingDialog.h
+++ b/src/gui/SliceTroubleshootingDialog.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QDialog>
+#include <QJsonObject>
+
+class QLabel;
+class QPlainTextEdit;
+
+namespace AetherSDR {
+
+class RadioModel;
+
+class SliceTroubleshootingDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit SliceTroubleshootingDialog(RadioModel* model, QWidget* parent = nullptr);
+
+private:
+    void refreshSnapshot();
+    void copySummary();
+    void copyJson();
+    void exportJson();
+    void setStatusMessage(const QString& message);
+
+    static QString buildSummary(const QJsonObject& snapshot);
+
+    RadioModel* m_model{nullptr};
+    QJsonObject m_snapshot;
+    QString m_summaryText;
+    QString m_jsonText;
+
+    QPlainTextEdit* m_summaryView{nullptr};
+    QPlainTextEdit* m_jsonView{nullptr};
+    QLabel* m_statusLabel{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -1,9 +1,31 @@
 #include "MeterModel.h"
 #include "core/LogManager.h"
 #include <QDebug>
+#include <QJsonArray>
+#include <QJsonObject>
 #include <cmath>
 
 namespace AetherSDR {
+
+namespace {
+
+QJsonObject meterToJson(const MeterDef& def, bool hasValue, float value)
+{
+    QJsonObject obj;
+    obj["index"] = def.index;
+    obj["source"] = def.source;
+    obj["source_index"] = def.sourceIndex;
+    obj["name"] = def.name;
+    obj["unit"] = def.unit;
+    obj["low"] = def.low;
+    obj["high"] = def.high;
+    obj["description"] = def.description;
+    obj["has_value"] = hasValue;
+    obj["value"] = hasValue ? QJsonValue(value) : QJsonValue();
+    return obj;
+}
+
+} // namespace
 
 MeterModel::MeterModel(QObject* parent)
     : QObject(parent)
@@ -277,6 +299,34 @@ int MeterModel::findMeter(const QString& source, const QString& name, int source
 float MeterModel::value(int index) const
 {
     return m_values.value(index, 0.0f);
+}
+
+QJsonArray MeterModel::allMeters() const
+{
+    QJsonArray meters;
+    for (auto it = m_defs.constBegin(); it != m_defs.constEnd(); ++it) {
+        const auto valueIt = m_values.constFind(it.key());
+        const bool hasValue = valueIt != m_values.constEnd();
+        meters.append(meterToJson(*it, hasValue, hasValue ? valueIt.value() : 0.0f));
+    }
+    return meters;
+}
+
+QJsonArray MeterModel::metersForSource(const QString& source, int sourceIndex) const
+{
+    QJsonArray meters;
+    for (auto it = m_defs.constBegin(); it != m_defs.constEnd(); ++it) {
+        const MeterDef& def = *it;
+        if (def.source != source)
+            continue;
+        if (sourceIndex >= 0 && def.sourceIndex != sourceIndex)
+            continue;
+
+        const auto valueIt = m_values.constFind(it.key());
+        const bool hasValue = valueIt != m_values.constEnd();
+        meters.append(meterToJson(def, hasValue, hasValue ? valueIt.value() : 0.0f));
+    }
+    return meters;
 }
 
 } // namespace AetherSDR

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QMap>
+#include <QJsonArray>
 #include <QString>
 
 namespace AetherSDR {
@@ -58,6 +59,10 @@ public:
 
     // Current converted value for a meter index. Returns 0 if unknown.
     float value(int index) const;
+
+    // Snapshot helpers for diagnostics and issue reporting.
+    QJsonArray allMeters() const;
+    QJsonArray metersForSource(const QString& source, int sourceIndex = -1) const;
 
     // Convenience: S-meter (slice LEVEL meter) in dBm.
     float sLevel() const { return m_sLevel; }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2,14 +2,105 @@
 #include "core/CommandParser.h"
 #include "core/AppSettings.h"
 #include "core/LogManager.h"
+#include <QCoreApplication>
 #include <QDebug>
+#include <QJsonArray>
+#include <QJsonObject>
 #include <QRegularExpression>
 #include <QDateTime>
+#include <QSysInfo>
 #include <QtEndian>
+#include <algorithm>
 #include <cmath>
 #include "core/AppSettings.h"
 
 namespace AetherSDR {
+
+namespace {
+
+QJsonArray toJsonArray(const QStringList& values)
+{
+    QJsonArray array;
+    for (const QString& value : values)
+        array.append(value);
+    return array;
+}
+
+QJsonArray toJsonArray(const QVector<int>& values)
+{
+    QJsonArray array;
+    for (int value : values)
+        array.append(value);
+    return array;
+}
+
+QJsonArray toJsonArray(const QSet<int>& values)
+{
+    QList<int> sorted = values.values();
+    std::sort(sorted.begin(), sorted.end());
+
+    QJsonArray array;
+    for (int value : sorted)
+        array.append(value);
+    return array;
+}
+
+QString atuStatusToString(ATUStatus status)
+{
+    switch (status) {
+    case ATUStatus::None:         return "None";
+    case ATUStatus::NotStarted:   return "NotStarted";
+    case ATUStatus::InProgress:   return "InProgress";
+    case ATUStatus::Bypass:       return "Bypass";
+    case ATUStatus::Successful:   return "Successful";
+    case ATUStatus::OK:           return "OK";
+    case ATUStatus::FailBypass:   return "FailBypass";
+    case ATUStatus::Fail:         return "Fail";
+    case ATUStatus::Aborted:      return "Aborted";
+    case ATUStatus::ManualBypass: return "ManualBypass";
+    }
+    return "Unknown";
+}
+
+QJsonObject panToJson(const PanadapterModel* pan, const QString& activePanId)
+{
+    QJsonObject obj;
+    obj["pan_id"] = pan->panId();
+    obj["active"] = pan->panId() == activePanId;
+    obj["waterfall_id"] = pan->waterfallId();
+    obj["center_mhz"] = pan->centerMhz();
+    obj["bandwidth_mhz"] = pan->bandwidthMhz();
+    obj["min_dbm"] = pan->minDbm();
+    obj["max_dbm"] = pan->maxDbm();
+    obj["antennas"] = toJsonArray(pan->antList());
+    obj["rf_gain"] = pan->rfGain();
+    obj["rf_gain_low"] = pan->rfGainLow();
+    obj["rf_gain_high"] = pan->rfGainHigh();
+    obj["rf_gain_step"] = pan->rfGainStep();
+    obj["preamp"] = pan->preamp();
+    obj["wnb_active"] = pan->wnbActive();
+    obj["wnb_level"] = pan->wnbLevel();
+    obj["resized"] = pan->isResized();
+    obj["waterfall_configured"] = pan->isWaterfallConfigured();
+    return obj;
+}
+
+QJsonObject clientInfoToJson(quint32 handle,
+                             quint32 ourHandle,
+                             quint32 txHandle,
+                             const RadioModel::ClientInfo& info)
+{
+    QJsonObject obj;
+    obj["role"] = (handle == ourHandle) ? "current_app" : "other_client";
+    obj["owns_tx"] = (txHandle != 0 && handle == txHandle);
+    obj["program"] = info.program;
+    obj["local_ptt"] = info.localPtt;
+    obj["tx_antenna"] = info.txAntenna;
+    obj["tx_freq_mhz"] = info.txFreqMhz;
+    return obj;
+}
+
+} // namespace
 
 RadioModel::RadioModel(QObject* parent)
     : QObject(parent)
@@ -2517,6 +2608,383 @@ void RadioModel::createAudioStream()
                 emit txAudioStreamReady(id);
             }
         });
+}
+
+QJsonObject RadioModel::troubleshootingSnapshot() const
+{
+    QJsonObject snapshot;
+    snapshot["schema_version"] = 1;
+    snapshot["captured_at"] = QDateTime::currentDateTime().toString(Qt::ISODate);
+    snapshot["captured_from"] = "AetherSDR in-memory application state";
+    snapshot["note"] =
+        "This snapshot is built from the app's cached radio, panadapter, slice, "
+        "and meter models. It does not query the radio directly.";
+    snapshot["privacy"] =
+        "Sensitive identifiers are omitted by design, including radio name, "
+        "nickname, callsign, serial numbers, MAC/IP addresses, GPS data, and "
+        "client station names.";
+
+    QJsonObject app;
+    app["name"] = QCoreApplication::applicationName();
+    app["version"] = QCoreApplication::applicationVersion();
+    app["qt_version"] = qVersion();
+    app["os"] = QSysInfo::prettyProductName();
+    app["cpu_arch"] = QSysInfo::currentCpuArchitecture();
+    snapshot["app"] = app;
+
+    QJsonObject radio;
+    radio["connected"] = isConnected();
+    radio["transport"] = isWan() ? "WAN" : "LAN";
+    radio["model"] = m_model;
+    radio["software_version"] = m_version;
+    radio["protocol_version"] = m_protocolVersion;
+    radio["region"] = m_region;
+    radio["radio_options"] = m_radioOptions;
+    radio["max_slices"] = m_maxSlices;
+    radio["full_duplex_enabled"] = m_fullDuplex;
+    radio["binaural_rx"] = m_binauralRx;
+    radio["mute_local_audio_when_remote"] = m_muteLocalWhenRemote;
+    radio["low_latency_digital_modes"] = m_lowLatencyDigital;
+    radio["enforce_private_ip_connections"] = m_enforcePrivateIp;
+    radio["remote_on_enabled"] = m_remoteOnEnabled;
+    radio["mf_enable"] = m_multiFlexEnabled;
+    radio["rtty_mark_default"] = m_rttyMarkDefault;
+    radio["antenna_list"] = toJsonArray(m_antList);
+    radio["owned_slice_ids"] = toJsonArray(m_ownedSliceIds);
+    radio["global_profile_count"] = m_globalProfiles.size();
+    radio["active_global_profile_set"] = !m_activeGlobalProfile.trimmed().isEmpty();
+
+    QJsonObject oscillator;
+    oscillator["setting"] = m_oscSetting;
+    oscillator["locked"] = m_oscLocked;
+    oscillator["ext_present"] = m_extPresent;
+    oscillator["tcxo_present"] = m_tcxoPresent;
+    radio["oscillator"] = oscillator;
+
+    QJsonObject audioOutputs;
+    audioOutputs["lineout_gain"] = m_lineoutGain;
+    audioOutputs["lineout_mute"] = m_lineoutMute;
+    audioOutputs["headphone_gain"] = m_headphoneGain;
+    audioOutputs["headphone_mute"] = m_headphoneMute;
+    audioOutputs["front_speaker_mute"] = m_frontSpeakerMute;
+    radio["audio_outputs"] = audioOutputs;
+
+    QJsonObject filterSharpness;
+    filterSharpness["voice_level"] = m_filterVoice;
+    filterSharpness["voice_auto"] = m_filterVoiceAuto;
+    filterSharpness["cw_level"] = m_filterCw;
+    filterSharpness["cw_auto"] = m_filterCwAuto;
+    filterSharpness["digital_level"] = m_filterDigital;
+    filterSharpness["digital_auto"] = m_filterDigitalAuto;
+    radio["filter_sharpness"] = filterSharpness;
+
+    QJsonObject amplifier;
+    amplifier["present"] = m_hasAmplifier;
+    amplifier["handle"] = m_ampHandle;
+    amplifier["model"] = m_ampModel;
+    amplifier["operate"] = m_ampOperate;
+    radio["amplifier"] = amplifier;
+
+    QJsonObject ownership;
+    ownership["tx_owned_by_us"] = m_txOwnedByUs;
+    QJsonArray clients;
+    QSet<quint32> seenHandles;
+    const quint32 ourHandle = ourClientHandle();
+    for (auto it = m_clientStations.cbegin(); it != m_clientStations.cend(); ++it) {
+        clients.append(clientInfoToJson(it.key(), ourHandle, m_txClientHandle,
+                                        m_clientInfoMap.value(it.key())));
+        seenHandles.insert(it.key());
+    }
+    for (auto it = m_clientInfoMap.cbegin(); it != m_clientInfoMap.cend(); ++it) {
+        if (seenHandles.contains(it.key()))
+            continue;
+        clients.append(clientInfoToJson(it.key(), ourHandle, m_txClientHandle,
+                                        it.value()));
+    }
+    ownership["clients"] = clients;
+    ownership["client_count"] = clients.size();
+    ownership["multiple_clients_present"] = clients.size() > 1;
+    radio["ownership"] = ownership;
+
+    auto categoryStatsToJson = [this](PanadapterStream::StreamCategory cat) {
+        const auto stats = categoryStats(cat);
+        QJsonObject obj;
+        obj["bytes"] = static_cast<qint64>(stats.bytes);
+        obj["packets"] = stats.packets;
+        obj["errors"] = stats.errors;
+        return obj;
+    };
+
+    QJsonObject network;
+    network["quality"] = networkQuality();
+    network["last_ping_rtt_ms"] = m_lastPingRtt;
+    network["max_ping_rtt_ms"] = m_maxPingRtt;
+    network["packet_drop_count"] = packetDropCount();
+    network["packet_total_count"] = packetTotalCount();
+    network["rx_bytes"] = static_cast<qint64>(rxBytes());
+    network["tx_bytes"] = static_cast<qint64>(txBytes());
+    QJsonObject streamCategories;
+    streamCategories["audio"] = categoryStatsToJson(PanadapterStream::CatAudio);
+    streamCategories["fft"] = categoryStatsToJson(PanadapterStream::CatFFT);
+    streamCategories["waterfall"] = categoryStatsToJson(PanadapterStream::CatWaterfall);
+    streamCategories["meter"] = categoryStatsToJson(PanadapterStream::CatMeter);
+    streamCategories["dax"] = categoryStatsToJson(PanadapterStream::CatDAX);
+    network["stream_categories"] = streamCategories;
+    radio["network"] = network;
+
+    QJsonObject telemetry;
+    telemetry["pa_temp_c"] = m_meterModel.paTemp();
+    telemetry["supply_volts"] = m_meterModel.supplyVolts();
+    telemetry["tx_forward_power_w"] = m_meterModel.fwdPower();
+    telemetry["tx_swr"] = m_meterModel.swr();
+    telemetry["alc"] = m_meterModel.alc();
+    telemetry["mic_level_dbfs"] = m_meterModel.micLevel();
+    telemetry["mic_peak_dbfs"] = m_meterModel.micPeak();
+    telemetry["comp_level_db"] = m_meterModel.compLevel();
+    telemetry["comp_peak_db"] = m_meterModel.compPeak();
+    radio["telemetry"] = telemetry;
+
+    snapshot["radio"] = radio;
+
+    QJsonObject transmit;
+
+    QJsonObject txPower;
+    txPower["rf_power"] = m_transmitModel.rfPower();
+    txPower["tune_power"] = m_transmitModel.tunePower();
+    txPower["max_power_level"] = m_transmitModel.maxPowerLevel();
+    txPower["tune_mode"] = m_transmitModel.tuneMode();
+    txPower["show_tx_in_waterfall"] = m_transmitModel.showTxInWaterfall();
+    txPower["tuning"] = m_transmitModel.isTuning();
+    txPower["mox"] = m_transmitModel.isMox();
+    txPower["transmitting"] = m_transmitModel.isTransmitting();
+    transmit["power"] = txPower;
+
+    QJsonObject mic;
+    mic["selection"] = m_transmitModel.micSelection();
+    mic["level"] = m_transmitModel.micLevel();
+    mic["mic_acc"] = m_transmitModel.micAcc();
+    mic["speech_processor_enable"] = m_transmitModel.speechProcessorEnable();
+    mic["speech_processor_level"] = m_transmitModel.speechProcessorLevel();
+    mic["compander_on"] = m_transmitModel.companderOn();
+    mic["compander_level"] = m_transmitModel.companderLevel();
+    mic["dax_on"] = m_transmitModel.daxOn();
+    mic["sb_monitor"] = m_transmitModel.sbMonitor();
+    mic["mon_gain_sb"] = m_transmitModel.monGainSb();
+    mic["mic_boost"] = m_transmitModel.micBoost();
+    mic["mic_bias"] = m_transmitModel.micBias();
+    mic["met_in_rx"] = m_transmitModel.metInRx();
+    mic["sync_cwx"] = m_transmitModel.syncCwx();
+    mic["am_carrier_level"] = m_transmitModel.amCarrierLevel();
+    mic["dexp_on"] = m_transmitModel.dexpOn();
+    mic["dexp_level"] = m_transmitModel.dexpLevel();
+    mic["tx_filter_low"] = m_transmitModel.txFilterLow();
+    mic["tx_filter_high"] = m_transmitModel.txFilterHigh();
+    transmit["mic"] = mic;
+
+    QJsonObject vox;
+    vox["enabled"] = m_transmitModel.voxEnable();
+    vox["level"] = m_transmitModel.voxLevel();
+    vox["delay"] = m_transmitModel.voxDelay();
+    transmit["vox"] = vox;
+
+    QJsonObject cw;
+    cw["speed_wpm"] = m_transmitModel.cwSpeed();
+    cw["pitch_hz"] = m_transmitModel.cwPitch();
+    cw["break_in"] = m_transmitModel.cwBreakIn();
+    cw["delay_ms"] = m_transmitModel.cwDelay();
+    cw["sidetone"] = m_transmitModel.cwSidetone();
+    cw["iambic"] = m_transmitModel.cwIambic();
+    cw["iambic_mode"] = m_transmitModel.cwIambicMode();
+    cw["swap_paddles"] = m_transmitModel.cwSwapPaddles();
+    cw["cwl_enabled"] = m_transmitModel.cwlEnabled();
+    cw["monitor_gain"] = m_transmitModel.monGainCw();
+    transmit["cw"] = cw;
+
+    QJsonObject interlock;
+    interlock["acc_tx_delay"] = m_transmitModel.accTxDelay();
+    interlock["tx1_delay"] = m_transmitModel.tx1Delay();
+    interlock["tx2_delay"] = m_transmitModel.tx2Delay();
+    interlock["tx3_delay"] = m_transmitModel.tx3Delay();
+    interlock["tx_delay"] = m_transmitModel.txDelay();
+    interlock["timeout"] = m_transmitModel.interlockTimeout();
+    interlock["acc_tx_req_polarity"] = m_transmitModel.accTxReqPolarity();
+    interlock["rca_tx_req_polarity"] = m_transmitModel.rcaTxReqPolarity();
+    transmit["interlock"] = interlock;
+
+    QJsonObject atu;
+    atu["enabled"] = m_transmitModel.atuEnabled();
+    atu["status"] = atuStatusToString(m_transmitModel.atuStatus());
+    atu["memories_enabled"] = m_transmitModel.memoriesEnabled();
+    atu["using_memory"] = m_transmitModel.usingMemory();
+    transmit["atu"] = atu;
+
+    QJsonObject apd;
+    apd["enabled"] = m_transmitModel.apdEnabled();
+    apd["configurable"] = m_transmitModel.apdConfigurable();
+    apd["equalizer_active"] = m_transmitModel.apdEqualizerActive();
+    transmit["apd"] = apd;
+
+    QJsonObject profiles;
+    profiles["tx_profile_count"] = m_transmitModel.profileList().size();
+    profiles["active_tx_profile_set"] = !m_transmitModel.activeProfile().trimmed().isEmpty();
+    profiles["mic_profile_count"] = m_transmitModel.micProfileList().size();
+    profiles["active_mic_profile_set"] = !m_transmitModel.activeMicProfile().trimmed().isEmpty();
+    profiles["mic_inputs"] = toJsonArray(m_transmitModel.micInputList());
+    transmit["profiles"] = profiles;
+
+    snapshot["transmit"] = transmit;
+
+    QJsonArray panadapters;
+    for (auto it = m_panadapters.cbegin(); it != m_panadapters.cend(); ++it)
+        panadapters.append(panToJson(it.value(), m_activePanId));
+    snapshot["panadapters"] = panadapters;
+
+    auto txBandInfoToJson = [](const TxBandInfo& band) {
+        QJsonObject obj;
+        obj["band_id"] = band.bandId;
+        obj["band_name"] = band.bandName;
+        obj["rf_power"] = band.rfPower;
+        obj["tune_power"] = band.tunePower;
+        obj["inhibit"] = band.inhibit;
+        obj["hw_alc"] = band.hwAlc;
+        obj["acc_tx_req"] = band.accTxReq;
+        obj["rca_tx_req"] = band.rcaTxReq;
+        obj["acc_tx"] = band.accTx;
+        obj["tx1"] = band.tx1;
+        obj["tx2"] = band.tx2;
+        obj["tx3"] = band.tx3;
+        return obj;
+    };
+
+    QJsonArray txBands;
+    for (auto it = m_txBandSettings.cbegin(); it != m_txBandSettings.cend(); ++it)
+        txBands.append(txBandInfoToJson(it.value()));
+    snapshot["tx_band_settings"] = txBands;
+
+    QJsonArray allMeters = m_meterModel.allMeters();
+    QJsonArray globalMeters;
+    int sliceMeterCount = 0;
+    for (const QJsonValue& value : allMeters) {
+        const QJsonObject meter = value.toObject();
+        if (meter["source"].toString() == "SLC")
+            ++sliceMeterCount;
+        else
+            globalMeters.append(meter);
+    }
+    snapshot["global_meters"] = globalMeters;
+
+    QList<SliceModel*> sortedSlices = m_slices;
+    std::sort(sortedSlices.begin(), sortedSlices.end(), [](SliceModel* lhs, SliceModel* rhs) {
+        return lhs->sliceId() < rhs->sliceId();
+    });
+
+    QJsonArray slices;
+    for (SliceModel* sliceModel : sortedSlices) {
+        QJsonObject slice;
+        slice["slice_id"] = sliceModel->sliceId();
+        slice["pan_id"] = sliceModel->panId();
+        slice["frequency_mhz"] = sliceModel->frequency();
+        slice["mode"] = sliceModel->mode();
+        slice["mode_list"] = toJsonArray(sliceModel->modeList());
+        slice["active"] = sliceModel->isActive();
+        slice["tx_slice"] = sliceModel->isTxSlice();
+
+        QJsonObject filter;
+        filter["low_hz"] = sliceModel->filterLow();
+        filter["high_hz"] = sliceModel->filterHigh();
+        slice["filter"] = filter;
+
+        QJsonObject audio;
+        audio["gain"] = sliceModel->audioGain();
+        audio["pan"] = sliceModel->audioPan();
+        audio["mute"] = sliceModel->audioMute();
+        slice["audio"] = audio;
+
+        slice["rf_gain"] = sliceModel->rfGain();
+
+        QJsonObject antennas;
+        antennas["rx"] = sliceModel->rxAntenna();
+        antennas["tx"] = sliceModel->txAntenna();
+        slice["antennas"] = antennas;
+
+        QJsonObject control;
+        control["locked"] = sliceModel->isLocked();
+        control["qsk"] = sliceModel->qskOn();
+        control["record_on"] = sliceModel->recordOn();
+        control["play_on"] = sliceModel->playOn();
+        control["play_enabled"] = sliceModel->playEnabled();
+        slice["control"] = control;
+
+        QJsonObject dsp;
+        dsp["agc_mode"] = sliceModel->agcMode();
+        dsp["agc_threshold"] = sliceModel->agcThreshold();
+        dsp["nb"] = QJsonObject{{"enabled", sliceModel->nbOn()}, {"level", sliceModel->nbLevel()}};
+        dsp["nr"] = QJsonObject{{"enabled", sliceModel->nrOn()}, {"level", sliceModel->nrLevel()}};
+        dsp["anf"] = QJsonObject{{"enabled", sliceModel->anfOn()}, {"level", sliceModel->anfLevel()}};
+        dsp["lms_nr"] = QJsonObject{{"enabled", sliceModel->nrlOn()}, {"level", sliceModel->nrlLevel()}};
+        dsp["speex_nr"] = QJsonObject{{"enabled", sliceModel->nrsOn()}, {"level", sliceModel->nrsLevel()}};
+        dsp["rnnoise"] = sliceModel->rnnOn();
+        dsp["nrf"] = QJsonObject{{"enabled", sliceModel->nrfOn()}, {"level", sliceModel->nrfLevel()}};
+        dsp["lms_anf"] = QJsonObject{{"enabled", sliceModel->anflOn()}, {"level", sliceModel->anflLevel()}};
+        dsp["anft"] = sliceModel->anftOn();
+        dsp["apf"] = QJsonObject{{"enabled", sliceModel->apfOn()}, {"level", sliceModel->apfLevel()}};
+        slice["dsp"] = dsp;
+
+        QJsonObject diversity;
+        diversity["enabled"] = sliceModel->diversity();
+        diversity["is_parent"] = sliceModel->isDiversityParent();
+        diversity["is_child"] = sliceModel->isDiversityChild();
+        diversity["index"] = sliceModel->diversityIndex();
+        diversity["esc_enabled"] = sliceModel->escEnabled();
+        diversity["esc_gain"] = sliceModel->escGain();
+        diversity["esc_phase_shift_deg"] = sliceModel->escPhaseShift();
+        slice["diversity"] = diversity;
+
+        QJsonObject tuning;
+        tuning["squelch_on"] = sliceModel->squelchOn();
+        tuning["squelch_level"] = sliceModel->squelchLevel();
+        tuning["rit_on"] = sliceModel->ritOn();
+        tuning["rit_hz"] = sliceModel->ritFreq();
+        tuning["xit_on"] = sliceModel->xitOn();
+        tuning["xit_hz"] = sliceModel->xitFreq();
+        tuning["step_hz"] = sliceModel->stepHz();
+        tuning["step_list"] = toJsonArray(sliceModel->stepList());
+        slice["tuning"] = tuning;
+
+        QJsonObject digital;
+        digital["dax_channel"] = sliceModel->daxChannel();
+        digital["rtty_mark_hz"] = sliceModel->rttyMark();
+        digital["rtty_shift_hz"] = sliceModel->rttyShift();
+        digital["digl_offset_hz"] = sliceModel->diglOffset();
+        digital["digu_offset_hz"] = sliceModel->diguOffset();
+        slice["digital"] = digital;
+
+        QJsonObject fm;
+        fm["tone_mode"] = sliceModel->fmToneMode();
+        fm["tone_value"] = sliceModel->fmToneValue();
+        fm["repeater_offset_dir"] = sliceModel->repeaterOffsetDir();
+        fm["repeater_offset_mhz"] = sliceModel->fmRepeaterOffsetFreq();
+        fm["tx_offset_mhz"] = sliceModel->txOffsetFreq();
+        fm["deviation_hz"] = sliceModel->fmDeviation();
+        slice["fm"] = fm;
+
+        if (PanadapterModel* pan = panadapter(sliceModel->panId()))
+            slice["panadapter_state"] = panToJson(pan, m_activePanId);
+
+        slice["meters"] = m_meterModel.metersForSource("SLC", sliceModel->sliceId());
+        slices.append(slice);
+    }
+    snapshot["slices"] = slices;
+
+    QJsonObject counts;
+    counts["panadapters"] = panadapters.size();
+    counts["slices"] = slices.size();
+    counts["meters_total"] = allMeters.size();
+    counts["global_meters"] = globalMeters.size();
+    counts["slice_meters"] = sliceMeterCount;
+    snapshot["counts"] = counts;
+
+    return snapshot;
 }
 
 } // namespace AetherSDR

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -20,6 +20,7 @@
 #include <QObject>
 #include <QString>
 #include <QList>
+#include <QJsonObject>
 #include <QMap>
 #include <QSet>
 
@@ -167,6 +168,7 @@ public:
     void loadGlobalProfile(const QString& name);
     void resetPanState();
     void createAudioStream();
+    QJsonObject troubleshootingSnapshot() const;
 
     // Memory channel cache
     const QMap<int, MemoryEntry>& memories() const { return m_memories; }


### PR DESCRIPTION
<img width="1092" height="904" alt="Screenshot 2026-04-05 at 11 36 41 AM" src="https://github.com/user-attachments/assets/864cc356-3ee0-4e31-a860-10f97deb4192" />

## Summary

This change adds a new `Help -> Slice Troubleshooting...` dialog that captures AetherSDR's current in-memory view of the connected radio, panadapters, slices, transmit state, and cached meter values without re-querying the radio. The goal is to make a class of state-related bugs much easier to troubleshoot, especially issues where a setting appears wrong in the app because the wrong value was read, written, cached, mapped to the wrong slice, or not persisted correctly across app actions.

The new workflow is designed around the exact debugging problem we have been seeing with FlexRadio architecture: many values can exist both globally and per-slice, and failures are often ambiguous. When a user reports a power, AGC, filter, meter, or slice-state problem, we need to know whether AetherSDR's local model is wrong, whether cached meter state is stale or mismapped, or whether the radio itself is reporting or applying something unexpected. This dialog intentionally reports the app's local model rather than asking the radio again so the snapshot shows what the app actually believes at the time the bug occurs.

## What Changed

- Added a new `SliceTroubleshootingDialog` available from `Help -> Slice Troubleshooting...`.
- Added an issue-oriented summary view for direct copy/paste into GitHub issues.
- Added a structured JSON view for AI-assisted troubleshooting and machine parsing.
- Added copy actions for both the summary and the JSON payload.
- Added JSON export through `QFileDialog` + `QSaveFile`.
- Added `RadioModel::troubleshootingSnapshot()` to build a single privacy-filtered app-state snapshot.
- Added meter serialization helpers to `MeterModel` so cached meter definitions and values can be included in the snapshot.
- Added the portability fix for explicit `std::sort` usage by including `<algorithm>` in `RadioModel.cpp`.

## Included Data

The snapshot is built from app-side state that already exists in memory and is grouped to make both human and AI analysis easier:

- app metadata
- radio connection and global radio settings
- ownership and multi-client context
- network quality and stream counters
- transmit settings
- TX band settings
- panadapter state
- global meter cache
- per-slice state
- per-slice meter cache

This gives us a consistent, structured picture of the state the app is operating on when a bug is reported.

## Privacy / Redaction

The export is intentionally privacy-filtered so users can attach it to issues or share it with AI tools more safely. The snapshot omits sensitive identifiers including:

- radio name
- nickname
- callsign
- serial numbers
- MAC and IP address information
- GPS data
- client station names
- raw client handles
- profile names

The final shape keeps technically useful state while removing identifiers that are not needed for troubleshooting the app's slice and meter logic.

## Why This Helps

This feature is aimed directly at a recurring class of bugs involving:

- wrong meter values being shown
- settings applied to the wrong slice
- global values leaking into slice-specific state
- slice values not being persisted or restored correctly
- cached values becoming stale or inconsistent after mode/profile/band changes

Before this change, issue reports often depended on manual description or live radio behavior, which made it harder to distinguish between an app-state problem and a radio-state problem. With this dialog, users and developers can capture the exact in-memory state AetherSDR was using when the problem happened.

The JSON export also makes the data much easier to analyze with AI agents, since the snapshot is structured, versioned, and grouped by subsystem.

## Validation

- Built successfully on macOS with `cmake --build build -j8`
- Launched the app and exercised the new dialog manually
- Verified summary and JSON generation
- Verified copy/export actions
- Iterated on privacy redaction using live sample snapshots
- Reviewed the new code for Qt cross-platform behavior and added the explicit `<algorithm>` include to avoid brittle compiler behavior on Windows/Linux toolchains

## Notes

This PR intentionally favors observability over minimal output size. The summary is optimized for GitHub issue reports, while the JSON is optimized for structured inspection and AI-assisted diagnosis. The dialog does not query the radio directly by design; it reports the app's cached understanding of the current state so we can isolate whether a bug lives in the app model and meter plumbing.
