### PR TITLE
Fix DAX TX external PTT, SpotHub hang, scroll-to-tune step bugs

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -975,6 +975,11 @@ void AudioEngine::setTransmitting(bool tx)
     }
 }
 
+void AudioEngine::setRadioTransmitting(bool tx)
+{
+    m_radioTransmitting = tx;
+}
+
 void AudioEngine::setDaxTxUseRadioRoute(bool on)
 {
     if (m_daxTxUseRadioRoute == on) return;
@@ -1019,7 +1024,10 @@ void AudioEngine::feedDaxTxAudio(const QByteArray& float32pcm)
         // exactly like voice TX (PCC 0x03E3 float32 stereo).
         constexpr int FLOAT_BYTES_PER_PKT = TX_SAMPLES_PER_PACKET * 2 * sizeof(float);
 
-        if (!m_transmitting) {
+        // Gate on raw radio TX state, not ownership. When an external app
+        // (WSJT-X) triggers PTT, m_transmitting is false (we don't own TX)
+        // but the radio IS transmitting and needs our DAX audio. (#752)
+        if (!m_radioTransmitting) {
             // Deterministic edge behavior: do not carry pre-TX audio history.
             // Any backlog here directly appears as TX start/stop mismatch.
             m_daxPreTxBuffer.clear();

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -93,6 +93,7 @@ public:
     void setDaxTxUseRadioRoute(bool on);
     bool daxTxUseRadioRoute() const { return m_daxTxUseRadioRoute.load(); }
     void setTransmitting(bool tx);
+    void setRadioTransmitting(bool tx);  // raw interlock state (regardless of TX ownership)
     void clearTxAccumulators() { m_txAccumulator.clear(); m_txFloatAccumulator.clear(); m_daxPreTxBuffer.clear(); }
     Q_INVOKABLE void feedDaxTxAudio(const QByteArray& float32pcm);
 
@@ -182,7 +183,8 @@ private:
     std::atomic<float> m_pcMicGain{1.0f};     // client-side PC mic gain (0.0-1.0)
     std::atomic<bool>  m_daxTxMode{false};    // DAX TX mode: VirtualAudioBridge handles TX
     std::atomic<bool>  m_daxTxUseRadioRoute{false}; // false = low-latency route (dax=0)
-    std::atomic<bool>  m_transmitting{false}; // true when radio is in TX (MOX on)
+    std::atomic<bool>  m_transmitting{false}; // true when radio is in TX AND we own TX
+    std::atomic<bool>  m_radioTransmitting{false}; // true when radio is in TX (any owner)
     std::atomic<bool>  m_opusTxEnabled{false}; // Opus TX encoding for SmartLink
     std::unique_ptr<class OpusCodec> m_opusTxCodec; // lazy-init on first TX with Opus
     QByteArray    m_opusTxAccumulator;  // accumulate stereo samples for Opus frame

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -25,8 +25,50 @@
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QRegularExpression>
+#include <QTimer>
 
 namespace AetherSDR {
+
+// Read the last N lines of a file without loading the entire thing.
+static QStringList tailFile(const QString& path, int maxLines = 500)
+{
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
+        return {};
+
+    // For small files, just read everything
+    if (f.size() < 64 * 1024) {
+        QStringList lines;
+        while (!f.atEnd()) {
+            QString line = QString::fromUtf8(f.readLine()).trimmed();
+            if (!line.isEmpty())
+                lines.append(line);
+        }
+        if (lines.size() > maxLines)
+            lines = lines.mid(lines.size() - maxLines);
+        return lines;
+    }
+
+    // For large files, seek backwards to find enough newlines
+    constexpr qint64 CHUNK = 8192;
+    qint64 pos = f.size();
+    QByteArray tail;
+    int nlCount = 0;
+    while (pos > 0 && nlCount <= maxLines) {
+        qint64 readSize = qMin(CHUNK, pos);
+        pos -= readSize;
+        f.seek(pos);
+        QByteArray chunk = f.read(readSize);
+        tail.prepend(chunk);
+        nlCount += chunk.count('\n');
+    }
+    QStringList all = QString::fromUtf8(tail).split('\n', Qt::SkipEmptyParts);
+    for (auto& s : all) s = s.trimmed();
+    all.removeAll(QString());
+    if (all.size() > maxLines)
+        all = all.mid(all.size() - maxLines);
+    return all;
+}
 
 // ── SpotTableModel ──────────────────────────────────────────────────────────
 
@@ -275,39 +317,20 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
         m_console->appendPlainText("--- Error: " + err + " ---");
     });
 
-    // Load existing log file into console and replay spots into table
-    QFile logFile(clusterClient->logFilePath());
-    if (logFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        // Static regex — same as DxClusterClient::parseDxSpotLine
-        static const QRegularExpression rx(
-            R"(^DX\s+de\s+(\S+?):\s+(\d+\.?\d*)\s+(\S+)\s+(.*?)\s+(\d{4})Z)",
-            QRegularExpression::CaseInsensitiveOption);
-
-        while (!logFile.atEnd()) {
-            QString line = QString::fromUtf8(logFile.readLine()).trimmed();
-            if (line.isEmpty()) continue;
-            m_console->appendPlainText(line);
-
-            // Try to parse as spot for the table
-            auto match = rx.match(line);
-            if (match.hasMatch()) {
-                DxSpot spot;
-                spot.spotterCall = match.captured(1);
-                spot.freqMhz = match.captured(2).toDouble() / 1000.0;
-                spot.dxCall = match.captured(3);
-                spot.comment = match.captured(4).trimmed();
-                QString timeStr = match.captured(5);
-                spot.utcTime = QTime(timeStr.left(2).toInt(), timeStr.mid(2, 2).toInt());
-                if (spot.freqMhz > 0.0 && !spot.dxCall.isEmpty()) {
-                    spot.source = "Cluster";
-                    m_spotModel->addSpot(spot);
-                }
-            }
-        }
-        // Scroll console to bottom
-        auto* sb = m_console->verticalScrollBar();
-        sb->setValue(sb->maximum());
-    }
+    // Defer log file loading until after the dialog is shown (#748).
+    // Reads only the last 500 lines per file to avoid blocking on large logs.
+    auto clusterLogPath = clusterClient->logFilePath();
+    auto rbnLogPath = rbnClient->logFilePath();
+    auto wsjtxLogPath = wsjtxClient->logFilePath();
+    auto potaLogPath = potaClient->logFilePath();
+    QString freedvLogPath;
+#ifdef HAVE_WEBSOCKETS
+    freedvLogPath = freedvClient->logFilePath();
+#endif
+    QTimer::singleShot(0, this, [this, clusterLogPath, rbnLogPath,
+                                  wsjtxLogPath, potaLogPath, freedvLogPath]() {
+        loadLogFiles(clusterLogPath, rbnLogPath, wsjtxLogPath, potaLogPath, freedvLogPath);
+    });
 
     // ── Live updates from RBN client ──────────────────────────────────
     connect(rbnClient, &DxClusterClient::rawLineReceived, this, [this, isAtBottom](const QString& line) {
@@ -346,36 +369,7 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
         m_rbnConsole->appendPlainText("--- Error: " + err + " ---");
     });
 
-    // Load RBN log file into console and replay spots
-    QFile rbnLogFile(rbnClient->logFilePath());
-    if (rbnLogFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        static const QRegularExpression rx2(
-            R"(^DX\s+de\s+(\S+?):\s+(\d+\.?\d*)\s+(\S+)\s+(.*?)\s+(\d{4})Z)",
-            QRegularExpression::CaseInsensitiveOption);
-
-        while (!rbnLogFile.atEnd()) {
-            QString line = QString::fromUtf8(rbnLogFile.readLine()).trimmed();
-            if (line.isEmpty()) continue;
-            m_rbnConsole->appendPlainText(line);
-
-            auto match = rx2.match(line);
-            if (match.hasMatch()) {
-                DxSpot spot;
-                spot.spotterCall = match.captured(1);
-                spot.freqMhz = match.captured(2).toDouble() / 1000.0;
-                spot.dxCall = match.captured(3);
-                spot.comment = match.captured(4).trimmed();
-                QString timeStr = match.captured(5);
-                spot.utcTime = QTime(timeStr.left(2).toInt(), timeStr.mid(2, 2).toInt());
-                if (spot.freqMhz > 0.0 && !spot.dxCall.isEmpty()) {
-                    spot.source = "RBN";
-                    m_spotModel->addSpot(spot);
-                }
-            }
-        }
-        auto* sb = m_rbnConsole->verticalScrollBar();
-        sb->setValue(sb->maximum());
-    }
+    // RBN log loaded in deferred loadLogFiles() (#748)
 
     // ── Live updates from WSJT-X client ───────────────────────────────
     connect(wsjtxClient, &WsjtxClient::rawLineReceived, this, [this, isAtBottom](const QString& line) {
@@ -448,19 +442,7 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
         m_wsjtxConsole->appendPlainText("--- Stopped ---");
     });
 
-    // Load WSJT-X log file and replay spots
-    QFile wsjtxLogFile(wsjtxClient->logFilePath());
-    if (wsjtxLogFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        // WSJT-X log lines: "HH:mm:ss  CALL  FREQ kHz  SNR dB  message"
-        // Spots don't follow DX de format — just display in console, parse from fields
-        while (!wsjtxLogFile.atEnd()) {
-            QString line = QString::fromUtf8(wsjtxLogFile.readLine()).trimmed();
-            if (line.isEmpty()) continue;
-            m_wsjtxConsole->appendPlainText(line);
-        }
-        auto* sb = m_wsjtxConsole->verticalScrollBar();
-        sb->setValue(sb->maximum());
-    }
+    // WSJT-X log loaded in deferred loadLogFiles() (#748)
 
     // ── Live updates from POTA client ─────────────────────────────────
     connect(potaClient, &PotaClient::rawLineReceived, this, [this, isAtBottom](const QString& line) {
@@ -496,17 +478,7 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
         m_potaStatusLabel->setText(QString("Polling... (%1 active, %2 new)").arg(total).arg(newCount));
     });
 
-    // Load POTA log
-    QFile potaLogFile(potaClient->logFilePath());
-    if (potaLogFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        while (!potaLogFile.atEnd()) {
-            QString line = QString::fromUtf8(potaLogFile.readLine()).trimmed();
-            if (line.isEmpty()) continue;
-            m_potaConsole->appendPlainText(line);
-        }
-        auto* sb = m_potaConsole->verticalScrollBar();
-        sb->setValue(sb->maximum());
-    }
+    // POTA log loaded in deferred loadLogFiles() (#748)
 
 #ifdef HAVE_WEBSOCKETS
     // ── Live updates from FreeDV client ───────────────────────────────
@@ -546,17 +518,7 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
         }
     });
 
-    // Load FreeDV log
-    QFile freedvLogFile(freedvClient->logFilePath());
-    if (freedvLogFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        while (!freedvLogFile.atEnd()) {
-            QString line = QString::fromUtf8(freedvLogFile.readLine()).trimmed();
-            if (line.isEmpty()) continue;
-            m_freedvConsole->appendPlainText(line);
-        }
-        auto* sb = m_freedvConsole->verticalScrollBar();
-        sb->setValue(sb->maximum());
-    }
+    // FreeDV log loaded in deferred loadLogFiles() (#748)
 #endif
 
     // Scroll spot table to show newest entries
@@ -568,6 +530,77 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
         btn->setAutoDefault(false);
 
     updateStatus();
+}
+
+void DxClusterDialog::loadLogFiles(const QString& clusterLog, const QString& rbnLog,
+                                    const QString& wsjtxLog, const QString& potaLog,
+                                    const QString& freedvLog)
+{
+    static const QRegularExpression rx(
+        R"(^DX\s+de\s+(\S+?):\s+(\d+\.?\d*)\s+(\S+)\s+(.*?)\s+(\d{4})Z)",
+        QRegularExpression::CaseInsensitiveOption);
+
+    auto parseSpots = [&](const QStringList& lines, const QString& source) {
+        QVector<DxSpot> spots;
+        for (const auto& line : lines) {
+            auto match = rx.match(line);
+            if (match.hasMatch()) {
+                DxSpot spot;
+                spot.spotterCall = match.captured(1);
+                spot.freqMhz = match.captured(2).toDouble() / 1000.0;
+                spot.dxCall = match.captured(3);
+                spot.comment = match.captured(4).trimmed();
+                QString timeStr = match.captured(5);
+                spot.utcTime = QTime(timeStr.left(2).toInt(), timeStr.mid(2, 2).toInt());
+                if (spot.freqMhz > 0.0 && !spot.dxCall.isEmpty()) {
+                    spot.source = source;
+                    spots.append(spot);
+                }
+            }
+        }
+        return spots;
+    };
+
+    auto loadConsole = [](QPlainTextEdit* console, const QStringList& lines) {
+        if (!console || lines.isEmpty()) return;
+        console->setPlainText(lines.join('\n'));
+        auto* sb = console->verticalScrollBar();
+        sb->setValue(sb->maximum());
+    };
+
+    // Cluster log — parse spots + display in console
+    auto clusterLines = tailFile(clusterLog);
+    loadConsole(m_console, clusterLines);
+    auto clusterSpots = parseSpots(clusterLines, "Cluster");
+
+    // RBN log — parse spots + display in console
+    auto rbnLines = tailFile(rbnLog);
+    loadConsole(m_rbnConsole, rbnLines);
+    auto rbnSpots = parseSpots(rbnLines, "RBN");
+
+    // WSJT-X log — display only (no DX de format)
+    loadConsole(m_wsjtxConsole, tailFile(wsjtxLog));
+
+    // POTA log — display only
+    loadConsole(m_potaConsole, tailFile(potaLog));
+
+    // FreeDV log — display only
+#ifdef HAVE_WEBSOCKETS
+    if (!freedvLog.isEmpty())
+        loadConsole(m_freedvConsole, tailFile(freedvLog));
+#else
+    Q_UNUSED(freedvLog);
+#endif
+
+    // Batch all spots into the model at once
+    QVector<DxSpot> allSpots;
+    allSpots.reserve(clusterSpots.size() + rbnSpots.size());
+    allSpots.append(clusterSpots);
+    allSpots.append(rbnSpots);
+    if (!allSpots.isEmpty())
+        m_spotModel->addSpots(allSpots);
+
+    m_spotTable->scrollToBottom();
 }
 
 void DxClusterDialog::buildClusterTab(QTabWidget* tabs)

--- a/src/gui/DxClusterDialog.h
+++ b/src/gui/DxClusterDialog.h
@@ -119,6 +119,9 @@ private:
 #endif
     void buildSpotListTab(QTabWidget* tabs);
     void buildDisplayTab(QTabWidget* tabs);
+    void loadLogFiles(const QString& clusterLog, const QString& rbnLog,
+                      const QString& wsjtxLog, const QString& potaLog,
+                      const QString& freedvLog = {});
 
     DxClusterClient* m_client;
     DxClusterClient* m_rbnClient;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -694,6 +694,13 @@ MainWindow::MainWindow(QWidget* parent)
         }
     });
 
+    // Raw radio TX state for DAX passthrough — allows DAX TX audio to flow
+    // even when an external app (WSJT-X) triggers PTT (#752).
+    connect(&m_radioModel, &RadioModel::radioTransmittingChanged,
+            this, [this](bool tx) {
+        m_audio->setRadioTransmitting(tx);
+    });
+
     // Sync show-TX-in-waterfall setting to all spectrum widgets
     auto syncShowTxWf = [this]() {
         bool show = m_radioModel.transmitModel().showTxInWaterfall();
@@ -1034,9 +1041,9 @@ MainWindow::MainWindow(QWidget* parent)
             this, [this](bool on, int sliceId) { if (on) activateRADE(sliceId); else deactivateRADE(); });
 #endif
 
-    // ── Tuning step size → spectrum widget ─────────────────────────────────
-    connect(m_appletPanel->rxApplet(), &RxApplet::stepSizeChanged,
-            spectrum(), &SpectrumWidget::setStepSize);
+    // ── Tuning step size → AppSettings + radio command ─────────────────────
+    // Per-pan SpectrumWidget::setStepSize connections are made in wirePanadapter()
+    // so all pans (including new ones added at runtime) stay in sync.
     connect(m_appletPanel->rxApplet(), &RxApplet::stepSizeChanged,
             this, [this](int step) {
         // Send step to radio for the active slice
@@ -4592,6 +4599,13 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         if (menu->cursorFreqButton())
             menu->cursorFreqButton()->setChecked(cursorFreq);
     }
+
+    // ── Tuning step size → this pan's spectrum widget ─────────────────────
+    // The global connection only covers AppSettings + radio command.
+    // Each pan must also receive stepSizeChanged so scroll-to-tune
+    // uses the correct step regardless of which pan is active.
+    connect(m_appletPanel->rxApplet(), &RxApplet::stepSizeChanged,
+            sw, &SpectrumWidget::setStepSize);
 
     // ── Pan activation: clicking on this pan makes it active ─────────────
     connect(applet, &PanadapterApplet::activated,

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1524,6 +1524,9 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
         m_scrollAccum += ev->pixelDelta().y();
         steps = m_scrollAccum / 15;
         m_scrollAccum -= steps * 15;
+        // Clamp to ±1: on Linux/libinput regular mice often report pixelDelta
+        // (e.g. 120px per notch) which would produce 8 steps and an 8× jump.
+        steps = qBound(-1, steps, 1);
     } else {
         // Standard mouse wheel: angleDelta is in 1/8° units, one notch = 120.
         // Some desktops (KDE Plasma, Cinnamon) send inflated deltas
@@ -1546,7 +1549,12 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
 
     const auto* ao = activeOverlay();
     const double vfoMhz = ao ? ao->freqMhz : m_centerMhz;
-    const double newMhz = snapToStep(vfoMhz + steps * m_stepHz / 1e6, m_stepHz);
+    // Snap the base frequency to the step grid first, then add the delta.
+    // This ensures every scroll moves by exactly m_stepHz rather than snapping
+    // the destination, which would cause an alignment artifact on the first
+    // scroll (e.g. step=500 Hz at .100 MHz → effective 400 Hz jump).
+    const double baseMhz = snapToStep(vfoMhz, m_stepHz);
+    const double newMhz  = baseMhz + steps * m_stepHz / 1e6;
     emit frequencyClicked(newMhz);
     ev->accept();
 }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1964,6 +1964,11 @@ void RadioModel::onStatusReceived(const QString& object,
         if (kvs.contains("state")) {
             const QString state = kvs["state"].toUpper();
 
+            // Emit raw radio TX state regardless of ownership — used by DAX
+            // passthrough when an external app triggers PTT (#752).
+            const bool radioTx = (state == "TRANSMITTING");
+            emit radioTransmittingChanged(radioTx);
+
             if (!m_txOwnedByUs || (!m_txRequested && !m_transmitModel.isTuning())) {
                 // Another client owns TX, or local unkey requested:
                 // force local TX/audio gate off through all interlock states.

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -286,6 +286,8 @@ signals:
     void remoteTxStreamReady(quint32 streamId);
     // Audio TX gate for sample pipeline (separate from optimistic MOX UI state).
     void txAudioGateChanged(bool transmitting);
+    // Raw interlock TX state (regardless of ownership — for DAX passthrough).
+    void radioTransmittingChanged(bool transmitting);
     // Emitted when global profile list or active profile changes.
     void globalProfilesChanged();
     // Emitted on each successful ping response from the radio.


### PR DESCRIPTION
- DAX TX audio no longer dropped when external app triggers PTT (#752).
  New m_radioTransmitting flag tracks raw interlock state regardless of
  TX ownership, allowing DAX passthrough while gating mic audio correctly.

- SpotHub dialog no longer hangs on open (#748). Log file loading deferred
  via QTimer::singleShot, limited to last 500 lines per file, and spots
  batched into a single addSpots() call instead of per-line addSpot().

- Scroll-to-tune pixelDelta clamped to ±1 step per event, fixing 8× jumps
  on Linux libinput mice. Snap alignment fixed so first scroll is exactly
  one step. Step size synced to all pans via wirePanadapter(). (#770)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
