### PR TITLE
Persist waterfall color scheme across sessions (#733)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4778,6 +4778,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         m_radioModel.sendCommand(
             QString("display pan set %1 weighted_average=%2").arg(applet->panId()).arg(on ? 1 : 0));
     });
+    connect(menu, &SpectrumOverlayMenu::wfColorSchemeChanged,
+            sw, &SpectrumWidget::setWfColorScheme);
     connect(menu, &SpectrumOverlayMenu::wfColorGainChanged,
             this, [this, applet, sw](int v) {
         sw->setWfColorGain(v);

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1,4 +1,5 @@
 #include "SpectrumOverlayMenu.h"
+#include "SpectrumWidget.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
 #include "models/SliceModel.h"
@@ -962,6 +963,22 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     ++row;
 
     // ── Waterfall section ─────────────────────────────────────────────────
+    // Color scheme selector
+    {
+        auto* lbl = new QLabel("Scheme:");
+        lbl->setStyleSheet(labelStyle);
+        grid->addWidget(lbl, row, 0, 1, 2);
+        m_colorSchemeCmb = new QComboBox;
+        m_colorSchemeCmb->setFixedHeight(18);
+        m_colorSchemeCmb->setStyleSheet(comboStyleSheet());
+        for (int i = 0; i < static_cast<int>(WfColorScheme::Count); ++i)
+            m_colorSchemeCmb->addItem(wfSchemeName(static_cast<WfColorScheme>(i)));
+        grid->addWidget(m_colorSchemeCmb, row, 2, 1, 2);
+        connect(m_colorSchemeCmb, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this](int idx) { emit wfColorSchemeChanged(idx); });
+        ++row;
+    }
+
     makeRow("Gain:", 0, 100, 50, m_gainSlider, m_gainLabel);
     connect(m_gainSlider, &QSlider::valueChanged, this, [this](int v) {
         m_gainLabel->setText(QString::number(v));
@@ -1076,7 +1093,7 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
                                                bool weightedAvg, const QColor& fillColor,
                                                int gain, int black, bool autoBlack, int rate,
                                                int floorPos, bool floorEnable,
-                                               bool heatMap)
+                                               bool heatMap, int colorScheme)
 {
     if (!m_avgSlider) return;  // panel not built yet
 
@@ -1117,6 +1134,10 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
         QSignalBlocker bh(m_heatMapBtn);
         m_heatMapBtn->setChecked(heatMap);
         m_heatMapBtn->setText(heatMap ? "On" : "Off");
+    }
+    if (m_colorSchemeCmb) {
+        QSignalBlocker bc(m_colorSchemeCmb);
+        m_colorSchemeCmb->setCurrentIndex(colorScheme);
     }
 }
 

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -35,7 +35,7 @@ public:
                              const QColor& fillColor, int gain, int black,
                              bool autoBlack, int rate,
                              int floorPos = 75, bool floorEnable = false,
-                             bool heatMap = true);
+                             bool heatMap = true, int colorScheme = 0);
 
     // Set the panadapter ID this overlay belongs to (for +RX routing).
     void setPanId(const QString& id) { m_panId = id; }
@@ -82,6 +82,7 @@ signals:
     void wfBlackLevelChanged(int level);
     void wfAutoBlackChanged(bool on);
     void wfLineDurationChanged(int ms);
+    void wfColorSchemeChanged(int scheme);
     void noiseFloorPositionChanged(int pos);
     void noiseFloorEnableChanged(bool on);
     // Emitted when user selects a band from the sub-panel.
@@ -176,6 +177,7 @@ private:
     QSlider*     m_blackSlider{nullptr};
     QLabel*      m_blackLabel{nullptr};
     QPushButton* m_autoBlackBtn{nullptr};
+    QComboBox*   m_colorSchemeCmb{nullptr};
     QSlider*     m_rateSlider{nullptr};
     QLabel*      m_rateLabel{nullptr};
     // NB Waterfall Blanker (#277)

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -38,6 +38,77 @@
 
 namespace AetherSDR {
 
+// ─── Waterfall color scheme gradient presets ─────────────────────────────────
+
+static constexpr WfGradientStop kDefaultStops[] = {
+    {0.00f,   0,   0,   0},   // black
+    {0.15f,   0,   0, 128},   // dark blue
+    {0.30f,   0,  64, 255},   // blue
+    {0.45f,   0, 200, 255},   // cyan
+    {0.60f,   0, 220,   0},   // green
+    {0.80f, 255, 255,   0},   // yellow
+    {1.00f, 255,   0,   0},   // red
+};
+static constexpr WfGradientStop kGrayscaleStops[] = {
+    {0.00f,   0,   0,   0},
+    {1.00f, 255, 255, 255},
+};
+static constexpr WfGradientStop kBlueGreenStops[] = {
+    {0.00f,   0,   0,   0},
+    {0.25f,   0,  30, 120},
+    {0.50f,   0, 100, 180},
+    {0.75f,   0, 200, 130},
+    {1.00f, 220, 255, 220},
+};
+static constexpr WfGradientStop kFireStops[] = {
+    {0.00f,   0,   0,   0},
+    {0.25f, 128,   0,   0},
+    {0.50f, 220,  80,   0},
+    {0.75f, 255, 200,   0},
+    {1.00f, 255, 255, 220},
+};
+static constexpr WfGradientStop kPlasmaStops[] = {
+    {0.00f,   0,   0,   0},
+    {0.25f,  80,   0, 140},
+    {0.50f, 200,   0, 120},
+    {0.75f, 240, 120,   0},
+    {1.00f, 255, 255,  80},
+};
+
+const WfGradientStop* wfSchemeStops(WfColorScheme scheme, int& count)
+{
+    switch (scheme) {
+    case WfColorScheme::Grayscale: count = 2; return kGrayscaleStops;
+    case WfColorScheme::BlueGreen: count = 5; return kBlueGreenStops;
+    case WfColorScheme::Fire:      count = 5; return kFireStops;
+    case WfColorScheme::Plasma:    count = 5; return kPlasmaStops;
+    default:                       count = 7; return kDefaultStops;
+    }
+}
+
+const char* wfSchemeName(WfColorScheme scheme)
+{
+    switch (scheme) {
+    case WfColorScheme::Grayscale: return "Grayscale";
+    case WfColorScheme::BlueGreen: return "Blue-Green";
+    case WfColorScheme::Fire:      return "Fire";
+    case WfColorScheme::Plasma:    return "Plasma";
+    default:                       return "Default";
+    }
+}
+
+// Interpolate a normalized value t (0–1) through the given gradient stops.
+static QRgb interpolateGradient(float t, const WfGradientStop* stops, int n)
+{
+    int i = 0;
+    while (i < n - 2 && stops[i + 1].pos < t) ++i;
+    const float seg = (t - stops[i].pos) / (stops[i + 1].pos - stops[i].pos);
+    const int r = static_cast<int>(stops[i].r + seg * (stops[i + 1].r - stops[i].r));
+    const int g = static_cast<int>(stops[i].g + seg * (stops[i + 1].g - stops[i].g));
+    const int b = static_cast<int>(stops[i].b + seg * (stops[i + 1].b - stops[i].b));
+    return qRgb(qBound(0, r, 255), qBound(0, g, 255), qBound(0, b, 255));
+}
+
 SpectrumWidget::SpectrumWidget(QWidget* parent)
     : SPECTRUM_BASE_CLASS(parent)
 {
@@ -141,6 +212,9 @@ void SpectrumWidget::loadSettings()
         m_bandPlanFontSize = s.value("BandPlanFontSize", "6").toInt();
     }
     m_fftHeatMap     = s.value(settingsKey("DisplayFftHeatMap"), "True").toString() == "True";
+    m_wfColorScheme  = static_cast<WfColorScheme>(
+        std::clamp(s.value(settingsKey("DisplayWfColorScheme"), "0").toInt(),
+                   0, static_cast<int>(WfColorScheme::Count) - 1));
     m_singleClickTune = s.value("SingleClickTune", "False").toString() == "True";
 
     // Background image — default to bundled logo, "none" = explicitly cleared
@@ -154,7 +228,7 @@ void SpectrumWidget::loadSettings()
         m_overlayMenu->syncDisplaySettings(m_fftAverage, m_fftFps,
             static_cast<int>(m_fftFillAlpha * 100), m_fftWeightedAvg, m_fftFillColor,
             m_wfColorGain, m_wfBlackLevel, m_wfAutoBlack, m_wfLineDuration,
-            75, false, m_fftHeatMap);
+            75, false, m_fftHeatMap, static_cast<int>(m_wfColorScheme));
 }
 
 VfoWidget* SpectrumWidget::addVfoWidget(int sliceId)
@@ -267,6 +341,18 @@ void SpectrumWidget::setWfLineDuration(int ms) {
     s.save();
     // Re-calibrate the time scale for the new rate
     resetWfTimeScale();
+}
+
+void SpectrumWidget::setWfColorScheme(int scheme) {
+    auto clamped = static_cast<WfColorScheme>(
+        std::clamp(scheme, 0, static_cast<int>(WfColorScheme::Count) - 1));
+    if (clamped != m_wfColorScheme) {
+        m_wfColorScheme = clamped;
+        auto& s = AppSettings::instance();
+        s.setValue(settingsKey("DisplayWfColorScheme"), QString::number(static_cast<int>(m_wfColorScheme)));
+        s.save();
+    }
+    update();
 }
 
 // ── NB Waterfall Blanker setters (#277) ──────────────────────────────────────
@@ -1609,27 +1695,9 @@ QRgb SpectrumWidget::dbmToRgb(float dbm) const
 
     const float t = qBound(0.0f, (dbm - effectiveMin) / (effectiveMax - effectiveMin), 1.0f);
 
-    // Multi-stop gradient: black → blue → cyan → green → yellow → red
-    struct Stop { float pos; int r, g, b; };
-    static constexpr Stop stops[] = {
-        {0.00f,   0,   0,   0},   // black  (noise floor)
-        {0.15f,   0,   0, 128},   // dark blue
-        {0.30f,   0,  64, 255},   // blue
-        {0.45f,   0, 200, 255},   // cyan
-        {0.60f,   0, 220,   0},   // green
-        {0.80f, 255, 255,   0},   // yellow
-        {1.00f, 255,   0,   0},   // red     (strong signal)
-    };
-    static constexpr int N = sizeof(stops) / sizeof(stops[0]);
-
-    // Find the two stops bracketing t and interpolate.
-    int i = 0;
-    while (i < N - 2 && stops[i + 1].pos < t) ++i;
-    const float seg = (t - stops[i].pos) / (stops[i + 1].pos - stops[i].pos);
-    const int r = static_cast<int>(stops[i].r + seg * (stops[i + 1].r - stops[i].r));
-    const int g = static_cast<int>(stops[i].g + seg * (stops[i + 1].g - stops[i].g));
-    const int b = static_cast<int>(stops[i].b + seg * (stops[i + 1].b - stops[i].b));
-    return qRgb(qBound(0, r, 255), qBound(0, g, 255), qBound(0, b, 255));
+    int n = 0;
+    const auto* stops = wfSchemeStops(m_wfColorScheme, n);
+    return interpolateGradient(t, stops, n);
 }
 
 // Map native waterfall tile intensity to RGB.
@@ -1654,26 +1722,9 @@ QRgb SpectrumWidget::intensityToRgb(float intensity) const
 
     const float t = qBound(0.0f, (intensity - blackThresh) / rangeWidth, 1.0f);
 
-    // Same gradient as dbmToRgb
-    struct Stop { float pos; int r, g, b; };
-    static constexpr Stop stops[] = {
-        {0.00f,   0,   0,   0},
-        {0.15f,   0,   0, 128},
-        {0.30f,   0,  64, 255},
-        {0.45f,   0, 200, 255},
-        {0.60f,   0, 220,   0},
-        {0.80f, 255, 255,   0},
-        {1.00f, 255,   0,   0},
-    };
-    static constexpr int N = sizeof(stops) / sizeof(stops[0]);
-
-    int i = 0;
-    while (i < N - 2 && stops[i + 1].pos < t) ++i;
-    const float seg = (t - stops[i].pos) / (stops[i + 1].pos - stops[i].pos);
-    const int r = static_cast<int>(stops[i].r + seg * (stops[i + 1].r - stops[i].r));
-    const int g = static_cast<int>(stops[i].g + seg * (stops[i + 1].g - stops[i].g));
-    const int b = static_cast<int>(stops[i].b + seg * (stops[i + 1].b - stops[i].b));
-    return qRgb(qBound(0, r, 255), qBound(0, g, 255), qBound(0, b, 255));
+    int n = 0;
+    const auto* stops = wfSchemeStops(m_wfColorScheme, n);
+    return interpolateGradient(t, stops, n);
 }
 
 // ─── Waterfall update ─────────────────────────────────────────────────────────

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -21,6 +21,25 @@ namespace AetherSDR {
 class SpectrumOverlayMenu;
 class VfoWidget;
 
+// Waterfall color scheme presets.
+enum class WfColorScheme : int {
+    Default = 0,   // black → dark blue → blue → cyan → green → yellow → red
+    Grayscale,     // black → white
+    BlueGreen,     // black → blue → teal → green → white
+    Fire,          // black → red → orange → yellow → white
+    Plasma,        // black → purple → magenta → orange → yellow
+    Count          // sentinel — number of schemes
+};
+
+// Gradient stop used by waterfall color mapping.
+struct WfGradientStop { float pos; int r, g, b; };
+
+// Returns the gradient stops for a given color scheme.
+const WfGradientStop* wfSchemeStops(WfColorScheme scheme, int& count);
+
+// Returns the display name for a color scheme.
+const char* wfSchemeName(WfColorScheme scheme);
+
 // Panadapter / spectrum display widget.
 //
 // Layout (top to bottom):
@@ -154,11 +173,13 @@ public:
     void setWfBlackLevel(int level);
     void setWfAutoBlack(bool on);
     void setWfLineDuration(int ms);
+    void setWfColorScheme(int scheme);
     void resetWfTimeScale();
     int   wfColorGain() const          { return m_wfColorGain; }
     int   wfBlackLevel() const         { return m_wfBlackLevel; }
     bool  wfAutoBlack() const          { return m_wfAutoBlack; }
     int   wfLineDuration() const       { return m_wfLineDuration; }
+    int   wfColorScheme() const        { return static_cast<int>(m_wfColorScheme); }
 
     // Set slice info for the off-screen VFO indicator (legacy single-slice).
     void setSliceInfo(int sliceId, bool isTxSlice);
@@ -366,6 +387,7 @@ private:
     int   m_wfColorGain{50};         // 0-100, maps intensity to color range
     int   m_wfBlackLevel{15};        // 0-125, intensity floor (below = black)
     bool  m_wfAutoBlack{true};
+    WfColorScheme m_wfColorScheme{WfColorScheme::Default};
     float m_autoBlackThresh{145.0f}; // client-side auto-black: tracked noise floor
     int   m_wfLineDuration{100};     // ms per waterfall row
 


### PR DESCRIPTION
## Summary
- Fixes #733 — waterfall heat map color scheme not saved/restored across sessions
- Adds 5 color scheme presets with full AppSettings persistence

## Changes
- SpectrumWidget.h/.cpp — WfColorScheme enum, 5 gradient presets, persistence via AppSettings
- SpectrumOverlayMenu.h/.cpp — Scheme combo box in waterfall display panel
- MainWindow.cpp — Signal wiring for scheme changes

## Testing
1. Launch AetherSDR, open waterfall display settings
2. Change color scheme to any non-default option
3. Quit and relaunch — scheme should be restored
4. Verify all 5 presets render correctly

Fixes #733

---
Generated by AetherClaude (automated agent)