### PR TITLE
Auto-disable NR2/RN2/BNR filters in CW/CWL modes (#784)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4196,10 +4196,11 @@ void MainWindow::onSliceAdded(SliceModel* s)
             // Update CWX/DVK indicator availability for new mode
             updateKeyerAvailability(mode);
 
-            // Disable client-side DSP in digital modes — NR2/RN2/BNR would
-            // corrupt the data signal passing through DAX (#534)
-            bool isDigital = (mode == "DIGU" || mode == "DIGL" || mode == "RTTY");
-            if (isDigital) {
+            // Disable client-side DSP in digital and CW modes — NR2/RN2/BNR
+            // corrupt digital data (#534) and suppress CW tones (#784)
+            bool disableDsp = (mode == "DIGU" || mode == "DIGL" || mode == "RTTY"
+                            || mode == "CW"   || mode == "CWL");
+            if (disableDsp) {
                 if (m_audio->nr2Enabled())
                     QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setNr2Enabled(false); });
                 if (m_audio->rn2Enabled())


### PR DESCRIPTION
## Summary
- Extends the existing digital-mode DSP disable logic to also cover CW and CWL modes
- When switching to CW/CWL, NR2/RN2/BNR filters are now auto-disabled, matching how the VfoWidget already hides their buttons
- RNNoise (speech-trained neural denoiser) was suppressing CW tones, causing silence until manually unchecked

Fixes #784

## Test plan
- [ ] Enable RN2 filter in USB mode, verify audio works
- [ ] Switch to CW mode, verify RN2 is automatically disabled and CW tones are audible
- [ ] Repeat with NR2 and BNR filters
- [ ] Repeat with CWL mode
- [ ] Verify digital modes (DIGU/DIGL/RTTY) still auto-disable filters as before (#534)
- [ ] Verify switching back to USB/LSB does not auto-disable filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)