### PR TITLE
Route all TUNE commands through TransmitModel for inhibit support (#694)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1359,8 +1359,10 @@ MainWindow::MainWindow(QWidget* parent)
         } else if (actionName == "ToggleMox") {
             m_radioModel.setTransmit(!m_radioModel.transmitModel().isTransmitting());
         } else if (actionName == "ToggleTune") {
-            bool tuning = m_radioModel.transmitModel().isTuning();
-            m_radioModel.sendCommand(QString("transmit tune %1").arg(tuning ? 0 : 1));
+            if (m_radioModel.transmitModel().isTuning())
+                m_radioModel.transmitModel().stopTune();
+            else
+                m_radioModel.transmitModel().startTune();
         } else if (actionName == "ToggleMute") {
             m_audio->setMuted(!m_audio->isMuted());
         } else if (actionName == "ToggleLock") {
@@ -1468,8 +1470,10 @@ MainWindow::MainWindow(QWidget* parent)
         if (actionName == "ToggleMox")
             m_radioModel.setTransmit(!m_radioModel.transmitModel().isTransmitting());
         else if (actionName == "ToggleTune") {
-            bool tuning = m_radioModel.transmitModel().isTuning();
-            m_radioModel.sendCommand(QString("transmit tune %1").arg(tuning ? 0 : 1));
+            if (m_radioModel.transmitModel().isTuning())
+                m_radioModel.transmitModel().stopTune();
+            else
+                m_radioModel.transmitModel().startTune();
         } else if (actionName == "ToggleMute")
             m_audio->setMuted(!m_audio->isMuted());
         else if (actionName == "ToggleLock") {
@@ -1668,8 +1672,10 @@ MainWindow::MainWindow(QWidget* parent)
                 auto& tuner = m_radioModel.tunerModel();
                 if (tuner.isPresent() && tuner.isOperate())
                     break;  // TGXL in Operate blocks manual TUNE
-                m_radioModel.sendCommand(QString("transmit tune %1")
-                    .arg(m_radioModel.transmitModel().isTuning() ? 0 : 1));
+                if (m_radioModel.transmitModel().isTuning())
+                    m_radioModel.transmitModel().stopTune();
+                else
+                    m_radioModel.transmitModel().startTune();
                 break;
             }
             case 7:  // ATU / TGXL autotune
@@ -1778,8 +1784,10 @@ MainWindow::MainWindow(QWidget* parent)
             m_audio->setMuted(!m_audio->isMuted());
             break;
         case 2:  // RF power push: toggle TUNE
-            m_radioModel.sendCommand(QString("transmit tune %1")
-                .arg(m_radioModel.transmitModel().isTuning() ? 0 : 1));
+            if (m_radioModel.transmitModel().isTuning())
+                m_radioModel.transmitModel().stopTune();
+            else
+                m_radioModel.transmitModel().startTune();
             break;
         case 3:  // Squelch push: toggle squelch on/off
             s->setSquelch(!s->squelchOn(), s->squelchLevel());
@@ -5734,8 +5742,10 @@ void MainWindow::registerShortcutActions()
     m_shortcutManager.registerAction("tune_toggle", "TUNE Toggle", "TX",
         QKeySequence(), [this]() {
             if (!m_radioModel.isConnected()) return;
-            bool tuning = m_radioModel.transmitModel().isTuning();
-            m_radioModel.sendCommand(QString("transmit tune %1").arg(tuning ? 0 : 1));
+            if (m_radioModel.transmitModel().isTuning())
+                m_radioModel.transmitModel().stopTune();
+            else
+                m_radioModel.transmitModel().startTune();
         });
 
     // ── Audio ───────────────────────────────────────────────────────────
@@ -6504,7 +6514,10 @@ void MainWindow::registerMidiParams()
 
     reg("tx.tune", "TUNE", "TX", P::Toggle, 0, 1,
         [this](float v) {
-            m_radioModel.sendCommand(QString("transmit tune %1").arg(v > 0.5f ? 1 : 0));
+            if (v > 0.5f)
+                m_radioModel.transmitModel().startTune();
+            else
+                m_radioModel.transmitModel().stopTune();
         },
         [this]() -> float { return m_radioModel.transmitModel().isTuning() ? 1 : 0; });
 


### PR DESCRIPTION
## Summary

Fixes #694

- Six callsites in `MainWindow.cpp` sent `"transmit tune 1/0"` directly via `RadioModel::sendCommand()`, bypassing the `TransmitModel` → `RadioModel::commandReady` pipeline where `applyTuneInhibit()` is called
- All six now route through `TransmitModel::startTune()`/`stopTune()`, matching the GUI TUNE button behavior

**Affected paths:**
| Location | Context |
|---|---|
| FlexControl button | `ToggleTune` action handler |
| HID encoder button | `ToggleTune` action handler |
| StreamDeck button 6 | TUNE button |
| StreamDeck dial push 2 | RF power push → toggle TUNE |
| Keyboard shortcut | `tune_toggle` action |
| MIDI parameter | `tx.tune` toggle |

## Test plan

- [ ] Connect FlexControl, enable "Inhibit During Tune", press TUNE button — verify PTT output is inhibited
- [ ] Verify GUI TUNE button still works correctly with inhibit enabled
- [ ] Verify TUNE toggle via keyboard shortcut respects inhibit setting
- [ ] If available, verify StreamDeck and MIDI TUNE paths also respect inhibit

🤖 Generated with [Claude Code](https://claude.com/claude-code)