### PR TITLE
Fix split VFOs overlapping at same frequency (#789)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4315,9 +4315,8 @@ void MainWindow::onSliceAdded(SliceModel* s)
         m_splitTxSliceId = s->sliceId();
         s->setTxSlice(true);
         s->setAudioMute(true);  // TX slice in split has no audio output
-        // Tune TX slice to match RX slice frequency
-        if (auto* rxSlice = m_radioModel.slice(m_splitRxSliceId))
-            s->setFrequency(rxSlice->frequency());
+        // TX slice frequency is already set by the slice create command
+        // (with mode-dependent offset), so do NOT override it here (#789).
         spectrum()->setSplitPair(m_splitRxSliceId, m_splitTxSliceId);
         updateSplitState();
         // Auto-focus the TX VFO so the user can immediately tune the TX offset


### PR DESCRIPTION
## Summary

- The split VFO creation logic correctly calculates a mode-dependent offset (1 kHz for CW/CWL, 5 kHz for SSB/other) and passes it in the `slice create` command
- However, `onSliceAdded` unconditionally reset the TX slice frequency to match the RX slice, causing both VFOs to overlap
- Removed the frequency override so the offset from the create command is preserved

Fixes #789

## Test plan

- [ ] Activate split on a CW mode slice — TX VFO should appear 1 kHz above RX
- [ ] Activate split on an SSB mode slice — TX VFO should appear 5 kHz above RX
- [ ] Verify SWAP button still works correctly
- [ ] Verify disabling split removes the TX slice as before

🤖 Generated with [Claude Code](https://claude.ai/code)