### PR TITLE
[platform] Add offline help system and operator guides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,7 @@ set(GUI_SOURCES
     src/gui/KeyboardMapWidget.cpp
     src/gui/ShortcutDialog.cpp
     src/gui/MultiFlexDialog.cpp
+    src/gui/HelpDialog.cpp
     src/gui/WhatsNewDialog.cpp
 )
 

--- a/resources.qrc
+++ b/resources.qrc
@@ -10,4 +10,10 @@
         <file alias="iaru-region2.json">resources/bandplans/iaru-region2.json</file>
         <file alias="iaru-region3.json">resources/bandplans/iaru-region3.json</file>
     </qresource>
+    <qresource prefix="/help">
+        <file alias="getting-started.md">resources/help/getting-started.md</file>
+        <file alias="aethersdr-help.md">resources/help/aethersdr-help.md</file>
+        <file alias="understanding-data-modes.md">resources/help/understanding-data-modes.md</file>
+        <file alias="contributing-to-aethersdr.md">resources/help/contributing-to-aethersdr.md</file>
+    </qresource>
 </RCC>

--- a/resources/help/aethersdr-help.md
+++ b/resources/help/aethersdr-help.md
@@ -1,0 +1,378 @@
+# AetherSDR Help
+
+## The Main Window at a Glance
+
+If you only remember one mental map of AetherSDR, make it this:
+
+- The title bar is the station-status strip.
+- The center is the live radio workspace.
+- The right side is the deep control stack.
+- The status bar is the quick sanity check row.
+
+Everything else in the program supports those four ideas.
+
+## Title Bar and Top Controls
+
+The title bar combines identity, status, and quick client controls in one narrow strip.
+
+### What you can read there quickly
+
+- Discovery heartbeat
+- Application identity
+- multiFLEX presence
+- Whether another client currently owns transmit
+- Whether `PC Audio` is enabled
+- Speaker and headphone levels
+
+### What you can do there quickly
+
+- Toggle `PC Audio`
+- Mute or unmute line out
+- Mute or unmute headphones
+- Change local output levels
+- Enter `Minimal Mode`
+- Open the feature request and AI-assisted reporting flow
+
+This is the best place to look when you want to answer, "Is this a station problem, an audio problem, or simply the wrong client state?"
+
+## Menu Reference
+
+### `File`
+
+- `Quit` closes the application.
+
+### `Settings`
+
+This is the operational configuration menu. It contains most dialogs that affect station behavior, radio setup, control surfaces, and external integrations.
+
+- `Radio Setup...`: the main multi-tab radio configuration dialog.
+- `Choose Radio / SmartLink Setup...`: opens the floating Connection panel.
+- `FlexControl...`: jumps directly into the serial and FlexControl setup area when serial support is available.
+- `Network...`: opens network diagnostics.
+- `Memory...`: opens the memory channel manager.
+- `USB Cables...`: opens cable definitions and USB cable behavior.
+- `MIDI Mapping...`: opens controller mapping when MIDI support is available.
+- `StreamDeck...`: opens Stream Deck integration when HID support is available.
+- `SpotHub...`: opens the unified spots and spotting workflow dialog.
+- `multiFLEX...`: opens the multi-operator dashboard.
+- `TX Band Settings...`: opens band-specific transmit settings such as RF power, tune power, and inhibit or interlock choices.
+- Autostart items for rigctld, CAT, TCI, and DAX let you decide which services should come up automatically.
+- `Low-Latency DAX (FreeDV)` affects digital voice and low-latency routing behavior.
+
+### `Profiles`
+
+This menu manages operating profiles.
+
+- `Profile Manager...` is the main profile dialog.
+- `Import/Export Profiles...` is reserved for profile transfer workflows.
+- Below the separator, global profiles are listed dynamically and can be loaded directly.
+
+### `View`
+
+This menu changes how the operator workspace is presented.
+
+- `Applet Panel` shows or hides the right-side panel.
+- `Band Plan` controls band-plan overlays and region selection.
+- `Single-Click to Tune` changes tuning behavior on the spectrum.
+- `UI Scale` changes the overall application scale and requires a restart.
+- `Reset Applet Order` restores the default applet arrangement.
+- `Minimal Mode` removes visual clutter for a compact operating view.
+- `Keyboard Shortcuts` enables or disables shortcut handling.
+- `Configure Shortcuts...` opens the shortcut editor.
+
+### `Help`
+
+This menu gives you both offline guidance and troubleshooting tools.
+
+- `Getting Started...`
+- `AetherSDR Help...`
+- `Understanding Data Modes...`
+- `Contributing to AetherSDR...`
+- `Support...`
+- `Slice Troubleshooting...`
+- `What's New...`
+- `About AetherSDR`
+
+The bundled help guides are intentionally separate windows so you can keep one open while continuing to operate.
+
+## Center Workspace
+
+### Panadapter stack
+
+The center column is a vertical stack of panadapters. AetherSDR supports multiple panadapters, so this area is meant to be watched, not hidden behind dialogs.
+
+Each panadapter contains:
+
+- FFT spectrum
+- Waterfall
+- Slice markers and VFO overlays
+- Tracking notch filters
+- Optional CW decode panel when CW decoding is in use
+
+### Spectrum overlay menu
+
+The floating left-side overlay is a fast operator menu for the currently focused panadapter. Its buttons are:
+
+- `+RX`: add a new receive slice on that panadapter
+- `+TNF`: add a tracking notch filter
+- `Band`: jump by band and open XVTR setup
+- `ANT`: receive antenna, RF gain, and WNB controls
+- `DSP`: per-slice DSP toggles and levels
+- `Display`: FFT, waterfall, color, averaging, and background presentation
+- `DAX`: DAX channel and IQ channel choices for that panadapter or slice context
+
+This overlay is important because it keeps the most common "I need to adjust the picture or slice quickly" controls next to the spectrum instead of burying them in a large dialog.
+
+## VFO and Slice Controls
+
+Each slice has a VFO overlay that acts as a compact operating head.
+
+### What the VFO area shows
+
+- Slice letter
+- Frequency
+- Mode
+- Filter width
+- RX antenna
+- TX antenna
+- TX assignment
+- split status
+- signal level
+
+### What the VFO area lets you do
+
+- Tune directly on the frequency display
+- Change antennas
+- Lock or unlock tuning
+- Close a slice
+- Work with AF, SQL, AGC, diversity, ESC, APF, digital offsets, FM options, RIT, XIT, DAX, and mode-specific functions
+
+The exact controls change with mode. For example:
+
+- FM adds offset and simplex or reverse controls.
+- DIGU and DIGL expose digital offset controls.
+- CW adds APF and CW-specific handling.
+- diversity-capable contexts expose ESC controls.
+
+That is why it is better to think of the VFO as a live mode-sensitive operating surface, not just a frequency label.
+
+## The Applet Panel
+
+The applet panel is a persistent right-side control column. It has two always-visible toggle rows, a separate S-meter section, and a reorderable vertical stack of applets below.
+
+Default applet order is:
+
+- `RX`
+- `TUN`
+- `AMP`
+- `TX`
+- `PHNE`
+- `P/CW`
+- `EQ`
+- `DIGI`
+- `MTR`
+- `AG`
+
+### `VU`
+
+The meter section is separate from the main stack and is useful for constant visibility. It can show receive and transmit meter selections without forcing the rest of the applet panel to remain expanded.
+
+### `RX`
+
+The RX applet is the slice-centric receive control surface. It repeats the most important slice identity information at the top, then exposes receive controls such as step size, filter, mute, pan, and offset-related functions. Use this when you want more detail than the compact VFO overlay offers.
+
+### `TUN`
+
+This applet appears when tuner hardware or tuner support is relevant. Use it to manage tuning state, watch SWR and power behavior, and confirm that the RF path is behaving as expected before staying on the air.
+
+### `AMP`
+
+This applet is for amplifier integration when available. It is part of the station-status side of the app rather than the slice side, so always confirm whether you are making a station-wide change or a single-slice change.
+
+### `TX`
+
+The TX applet is the main transmit command surface. It includes:
+
+- forward power and SWR gauges
+- RF power
+- tune power
+- TX profile selection
+- TUNE
+- MOX
+- ATU
+- MEM
+- APD state
+
+Before transmitting, this is the applet that should match your intention.
+
+### `PHNE`
+
+The Phone applet is focused on voice-mode shaping and behavior:
+
+- AM carrier level
+- VOX
+- VOX level
+- VOX delay
+- DEXP
+- TX low-cut and high-cut filters
+
+Use it when you want to shape the transmit voice path without opening the larger setup dialog.
+
+### `P/CW`
+
+This applet is mode-sensitive. In phone-oriented modes it exposes microphone-oriented controls such as mic source, level, processing, monitor, and DAX. In CW modes it switches to keyer-oriented controls such as delay, speed, sidetone, break-in, iambic mode, and pitch.
+
+### `EQ`
+
+The EQ applet is for transmit and receive equalization. Small moves are best. Shape the audio, then listen and measure before making another large adjustment.
+
+### `DIGI`
+
+The DIGI applet is the bridge between AetherSDR and external software. It handles:
+
+- CAT over TCP
+- virtual TTY or PTY control
+- TCI server enablement
+- DAX enablement
+- DAX receive and transmit levels
+- DAX IQ integration
+
+If you use computer-driven digital modes, this applet deserves a permanent place in your operating layout.
+
+### `MTR`
+
+The meter applet provides additional visibility into operating state when the dedicated VU area is not enough.
+
+### `AG`
+
+The Antenna Genius applet appears when that station accessory is present. Use it to confirm band and port routing at a glance.
+
+## Status Bar
+
+The status bar is easy to underestimate. It carries both fast actions and live telemetry.
+
+### Left side
+
+- Add panadapter
+- Applet panel toggle
+- TNF
+- CWX
+- DVK
+- FDX
+- radio and station context
+
+### Center
+
+- station label or station name
+
+### Right side
+
+- GPS state
+- PA temperature
+- supply voltage
+- network quality
+- TGXL or PGXL accessory state
+- transmit indicator
+- grid
+- date and time
+
+If you are operating quickly, this row helps prevent "silent failures" where the radio is connected but not in the state you assume.
+
+## Connection and Station Management Windows
+
+### Connection panel
+
+The floating Connection panel is the gateway to the radio. It includes:
+
+- discovered radio list
+- `Low Bandwidth` mode
+- connect or disconnect button
+- SmartLink login section
+- manual IP connection section
+
+This panel is meant to be simple enough for initial connection but detailed enough to support remote and manual workflows.
+
+### multiFLEX dashboard
+
+The multiFLEX dialog shows connected stations and highlights local PTT control. Use it whenever more than one client may be affecting the shared radio environment.
+
+### Memory dialog
+
+The Memory dialog is an editable table for storing and recalling operating setups. It includes columns for frequency, mode, offsets, tones, filters, and digital details. It is useful for repeaters, nets, digital working frequencies, and recurring field-operation setups.
+
+### Profile manager
+
+The Profile Manager is where operating profiles become reusable station setups. Use it when you want repeatable combinations of settings instead of rebuilding a session manually.
+
+### SpotHub
+
+SpotHub brings spot sources together in one place so you can compare cluster information with the live panadapter. It is not just a list window; it is part of the tune-and-find workflow.
+
+## `Radio Setup...` Tab Guide
+
+`Settings -> Radio Setup...` is the main radio-configuration dialog. It currently contains these tabs:
+
+- `Radio`: radio information, identification, firmware update, remote-on, multiFLEX, and station identity
+- `Network`: network parameters, advanced options, and IP configuration
+- `GPS`: GPS-related status and configuration
+- `Audio`: radio outputs, SmartLink audio compression, local PC audio devices, and optional NVIDIA BNR
+- `TX`: timings, interlocks, max power, tune behavior, and TX-follow rules
+- `Phone/CW`: microphone, CW, and digital-specific setup
+- `RX`: frequency offset, 10 MHz reference, and receive-related global settings
+- `Filters`: filter behavior and low-latency digital choices
+- `XVTR`: transverter definitions and management
+- `USB Cables`: CAT, BCD, bit, and passthrough cable definitions
+- `Serial`: serial port behavior, pin assignments, and FlexControl tuning knob setup when serial support is built in
+
+This dialog affects radio-wide behavior more often than slice-local behavior, so change settings carefully and intentionally.
+
+## Operating Advice by Area
+
+### Before transmitting
+
+Check these three places in order:
+
+1. Slice or VFO `TX` assignment
+2. TX applet power and antenna context
+3. status bar and title bar warnings
+
+### When receive audio sounds wrong
+
+Work outward from the slice:
+
+1. confirm the active slice and mode
+2. confirm AF, mute, and AGC behavior
+3. check `PC Audio`
+4. check local output device selection in `Radio Setup -> Audio`
+
+### When the display feels cluttered
+
+Use:
+
+- `View -> Minimal Mode`
+- `View -> Applet Panel`
+- reordered applets
+- fewer panadapters
+- the spectrum overlay instead of opening larger dialogs
+
+### When tuning becomes confusing
+
+Focus on:
+
+- which slice is active
+- which slice owns transmit
+- whether single-click tuning is enabled
+- whether you are acting on the VFO, the RX applet, or the spectrum overlay
+
+## Keyboard and External Controls
+
+Keyboard shortcuts exist for tuning, mode changes, TX actions, filter control, display work, and more. Enable them from `View -> Keyboard Shortcuts`, then use `Configure Shortcuts...` to tailor the bindings.
+
+External control surfaces are also supported:
+
+- FlexControl-style tuning knobs
+- MIDI controllers
+- Stream Deck layouts
+- serial PTT or CW devices
+
+These devices are powerful once they are set up, but the simplest approach is still best: map one function, test it immediately, then add the next one.

--- a/resources/help/contributing-to-aethersdr.md
+++ b/resources/help/contributing-to-aethersdr.md
@@ -1,0 +1,196 @@
+# Contributing to AetherSDR
+
+## Why Feedback Matters
+
+AetherSDR grows through the ideas, bug reports, testing notes, and operating experience shared by the people who use it. The future of software defined radio is shaped by operators who take a moment to say what worked well, what felt confusing, and what would make the station experience even better.
+
+Every contribution helps move the project forward:
+
+- layout feedback that makes the window easier to read at a glance
+- workflow ideas that make operating smoother and more intuitive
+- bug reports that help close the gap between the software and real station use
+- documentation improvements that help the next operator get on the air faster
+
+You do not need to write code to make a real impact. If you operate, experiment, explore, test, or simply notice where the app could be clearer, your feedback is welcome and genuinely valuable.
+
+## The Most Helpful Kinds of Contributions
+
+Useful contributions include:
+
+- clear bug reports
+- operator-focused feature requests
+- screenshots that show a confusing layout or state mismatch
+- testing on unusual radios, operating systems, or network conditions
+- better wording for menus, tooltips, help guides, and setup instructions
+
+High-value feedback often comes from moments like these:
+
+- "I could not tell which slice owned transmit."
+- "The right control exists, but it is buried in the wrong window."
+- "The panadapter looked correct, but the applet state was misleading."
+- "A remote or multiFLEX workflow made the status hard to read."
+
+Those are exactly the kinds of observations that make the software safer and easier to operate.
+
+## Project Home
+
+GitHub:
+
+[https://github.com/ten9876/AetherSDR](https://github.com/ten9876/AetherSDR)
+
+This is the main place for issues, discussions, releases, and pull requests.
+
+## Reporting Bugs Well
+
+When filing a bug, include enough context that someone else can reproduce both the station state and the screen state.
+
+### Minimum information
+
+1. Operating system
+2. AetherSDR version
+3. Radio model
+4. Local LAN or SmartLink remote use
+5. What you expected to happen
+6. What actually happened
+7. Whether the issue is repeatable
+
+### Extra details that are especially helpful
+
+- which menu path or button you used
+- which window or dialog was open
+- which slice letter was active
+- which mode you were in
+- whether the slice also owned transmit
+- whether the applet panel was visible
+- whether `Minimal Mode` was on
+- whether `PC Audio` was on
+- whether external devices such as MIDI, FlexControl, Stream Deck, or USB serial hardware were involved
+
+### For layout or clarity bugs
+
+Include a full-window screenshot if possible, not just a cropped control. Layout problems are often caused by the relationship between the title bar, panadapter, applet panel, and status bar rather than one isolated widget.
+
+### For digital-mode bugs
+
+Also include:
+
+- whether you used CAT over TCP, CAT over TTY, or TCI
+- the port or channel you used
+- whether DAX was enabled
+- whether receive worked, transmit worked, both worked, or neither worked
+
+### For transmit-path bugs
+
+State clearly whether RF was actually transmitted or whether the bug was caught before transmitting. That helps prioritize safety issues correctly.
+
+## Use the In-App Tools
+
+Before filing a report, check the built-in tools:
+
+- `Help -> Support...` gathers logs, settings, and support-bundle information.
+- `Help -> Slice Troubleshooting...` exposes detailed slice and state information that can explain many operating mismatches.
+- The lightbulb button in the title bar opens the feature-request and AI-assisted reporting workflow.
+
+These tools can save time for both operators and maintainers.
+
+## Feature Requests That Lead to Good Design
+
+A good feature request starts with an operating problem, not just a missing button.
+
+Useful requests usually explain:
+
+1. what task you were trying to perform
+2. which current window, menu, or applet you had to use
+3. why the current workflow is slow, confusing, or unsafe
+4. what change would reduce friction or operator error
+5. whether the request matters most for local, remote, contest, CW, voice, or digital use
+
+Requests about layout are especially valuable when they describe what needs to stay visible at the same time. For example:
+
+- transmit ownership plus tuner state
+- DIGI controls plus active slice
+- spots plus panadapter plus memory recall
+
+## Documentation Contributions
+
+Documentation is part of the operator experience. If something in the app is accurate but still confusing, that is a valid contribution target.
+
+Helpful documentation feedback includes:
+
+- menu labels that are unclear
+- setup steps that assume too much prior knowledge
+- controls whose name does not match the operator's mental model
+- missing explanations for which settings are global and which are slice-specific
+- missing examples for remote, digital, or multi-operator workflows
+
+When suggesting a doc fix, cite the exact menu path, dialog tab, or control label so the wording can be matched to the UI.
+
+## Testing Contributions
+
+Testers are especially helpful when they can describe the environment around the bug:
+
+- radio model and firmware family
+- LAN vs WAN
+- accessory hardware
+- operating mode
+- whether more than one slice or panadapter was open
+- whether another multiFLEX station was connected
+
+Reports from less-common environments are often the ones that uncover the most important edge cases.
+
+## If You Want to Contribute Code
+
+Read the repository guidance first:
+
+- `README.md`
+- `CONTRIBUTING.md`
+- `CLAUDE.md`
+
+Those files explain the project's expectations, build flow, conventions, and architecture.
+
+### Useful source-tree landmarks
+
+- `src/core`: protocol, transport, audio, and integration infrastructure
+- `src/models`: radio, slice, transmit, panadapter, cable, and settings state
+- `src/gui`: the operator-facing windows and controls
+
+### GUI files that matter often
+
+- `MainWindow`: top-level layout and menu wiring
+- `TitleBar`: station state and top-strip controls
+- `AppletPanel`: right-side control stack
+- `SpectrumOverlayMenu`: left-side panadapter quick controls
+- `RadioSetupDialog`: radio-wide configuration
+- `MemoryDialog`, `ProfileManagerDialog`, `MultiFlexDialog`, and `SpotHub` dialogs for workflow support
+
+### Project expectations
+
+- use Qt6 and C++20 patterns
+- use `AppSettings`, not `QSettings`
+- keep classes focused
+- protect slice and transmit correctness
+- do not break core receive flow while adding features elsewhere
+
+Pull requests should follow the project conventions, pass CI, and use GPG-signed commits.
+
+## AI-Assisted Development
+
+The project actively uses AI-assisted workflows for development, debugging, and triage. That makes clear structure even more valuable:
+
+- precise reproduction steps
+- exact menu paths
+- exact control names
+- logs and screenshots with context
+
+The clearer your report is, the easier it is for both humans and tools to turn that report into a fix.
+
+## A Simple Way to Start Helping
+
+If you want an easy first contribution:
+
+1. operate normally for a while
+2. write down one moment where the UI forced you to stop and think
+3. identify the window, menu, or applet involved
+4. describe what information should have been clearer or what action should have been easier
+
+That kind of feedback often turns directly into a better window layout, a safer workflow, or a better help guide.

--- a/resources/help/getting-started.md
+++ b/resources/help/getting-started.md
@@ -1,0 +1,185 @@
+# Getting Started
+
+## Welcome to AetherSDR
+
+AetherSDR is a native SmartSDR-compatible desktop client for FlexRadio transceivers. It is built to let you discover a radio, create slices and panadapters, manage receive and transmit paths, and run daily operating tasks without relying on a browser or an always-online station computer.
+
+If this is your first day with software defined radio, do not try to learn every control at once. Your first goal is much simpler:
+
+1. Connect to the radio.
+2. Identify the active slice and transmit path.
+3. Learn what each major area of the main window is responsible for.
+4. Make small, deliberate changes while watching the display and meters.
+
+## Before You Start
+
+Make sure:
+
+1. The radio is powered on.
+2. Your computer and radio are on the same LAN for local operation, or SmartLink is already configured for remote use.
+3. Speakers, headphones, or your normal station audio path are ready.
+4. You know whether you want local LAN operation, SmartLink remote operation, or multiFLEX shared operation.
+
+## Connect to a Radio
+
+### Local LAN connection
+
+1. Start AetherSDR.
+2. Wait for the Connection panel to show discovered radios.
+3. If the panel is not visible, open `Settings -> Choose Radio / SmartLink Setup...`.
+4. Select the radio you want.
+5. Leave `Low Bandwidth` off for normal local use unless you are intentionally reducing display traffic.
+6. Click `Connect`.
+
+If nothing appears in the discovered list:
+
+1. Confirm the radio and computer are on the same network segment.
+2. Check that guest Wi-Fi isolation, VPN software, or firewall rules are not blocking discovery.
+3. Try the manual IP field in the `Manual Connection` section if you know the radio's address.
+4. Open `Settings -> Network...` for diagnostics if discovery still fails.
+
+### SmartLink remote connection
+
+1. Open `Settings -> Choose Radio / SmartLink Setup...`.
+2. Use the SmartLink section to sign in.
+3. Select the WAN radio or station entry you want to use.
+4. Click `Connect`.
+5. Give the audio and panadapter streams a few extra seconds to settle, especially on slower links.
+
+Remote operation depends more heavily on Internet quality, latency, and firewall setup than LAN operation. If the display or audio feels rough, simplify the session first by using fewer panadapters and avoiding unnecessary visual load.
+
+## Learn the Main Window
+
+The AetherSDR main window has four areas that matter immediately.
+
+### Title bar
+
+The title bar is more than a cosmetic header. It holds:
+
+- The menu bar
+- The heartbeat indicator for discovery activity
+- The `multiFLEX` indicator when another station is involved
+- The other-client transmit warning
+- The `PC Audio` toggle
+- Master speaker volume
+- Headphone volume
+- The `Minimal Mode` button
+- The lightbulb button for feature requests and AI-assisted reporting
+
+This area answers an important question quickly: "Am I hearing the radio locally, and who owns transmit right now?"
+
+### Center workspace
+
+The center of the window is where operating actually happens:
+
+- The `PanadapterStack` shows one or more panadapters vertically.
+- Each panadapter contains a spectrum and waterfall display.
+- Each active slice has a VFO overlay with frequency, mode, filter width, and quick controls.
+- The left-side spectrum overlay opens fast controls for `Band`, `ANT`, `DSP`, `Display`, and `DAX`.
+
+If you are watching signals, tuning, or comparing activity across a band, this is your primary work area.
+
+### Right-side applet panel
+
+The right side is the applet panel. Think of applets as focused control modules rather than separate operating modes. The panel can be shown or hidden from `View -> Applet Panel`, and the applets can be reordered to match your workflow.
+
+Common applets include:
+
+- `VU`: analog-style receive and transmit metering
+- `RX`: slice-focused receive controls
+- `TUN`: tuner controls when supported hardware is present
+- `AMP`: amplifier controls when supported hardware is present
+- `TX`: transmit power, profiles, ATU, TUNE, and MOX
+- `PHNE`: voice-specific transmit shaping
+- `P/CW`: microphone controls in phone modes and keyer controls in CW modes
+- `EQ`: transmit and receive equalization
+- `DIGI`: CAT, DAX, TTY, and TCI controls for software integration
+- `MTR`: additional metering
+- `AG`: Antenna Genius controls when present
+
+### Status bar
+
+The bottom status bar is the fast "station sanity check" row. It includes quick actions and live status such as:
+
+- Add panadapter
+- Show or hide the applet panel
+- TNF, CWX, DVK, and FDX controls
+- The station label in the center
+- GPS, temperature, voltage, network quality, tuner or amplifier status, transmit state, grid, date, and time on the right
+
+When something feels wrong, the status bar is often the quickest place to confirm whether the issue is connection health, accessory state, or transmit ownership.
+
+## How the Window Works During Real Operation
+
+The layout makes more sense when you read it as a workflow:
+
+1. The Connection panel gets you attached to a radio.
+2. The center workspace lets you see signals and choose where to operate.
+3. The VFO and slice overlays tell you exactly which slice is active and whether it is the transmit slice.
+4. The applet panel exposes deeper controls without covering the panadapter.
+5. The title bar and status bar keep the global station state visible while you work.
+
+That is why the help guides open in separate non-modal windows: you can keep them beside the radio view while continuing to operate.
+
+## First Safe Operating Session
+
+Use this checklist for the first session on a new station:
+
+1. Connect to the radio.
+2. Verify that `PC Audio` is in the state you expect.
+3. Turn speaker and headphone levels down before enabling monitor audio.
+4. Identify the active slice letter and current mode.
+5. Confirm whether the `TX` badge is on the slice you intend to transmit on.
+6. Check the transmit antenna, RF power, tune power, and tuner state before keying.
+7. Make one change at a time and watch the panadapter, meters, and status bar for the result.
+
+## Global Controls vs Slice Controls
+
+One of the biggest early learning curves in Flex-style software is understanding which settings affect everything and which settings only affect one slice.
+
+### App-wide and station-wide controls
+
+These usually change the client, the station workflow, or the presentation of the UI:
+
+- `View -> UI Scale`
+- `View -> Band Plan`
+- `View -> Applet Panel`
+- `View -> Minimal Mode`
+- Keyboard shortcut enablement and shortcut configuration
+- `PC Audio` and local output device choices
+- SmartLink login state
+- Station name
+- Autostart settings for rigctld, CAT, TCI, and DAX
+
+### Radio-wide controls
+
+These affect the connected radio or the whole client session more broadly:
+
+- `Settings -> Radio Setup...`
+- `Settings -> TX Band Settings...`
+- `Settings -> USB Cables...`
+- multiFLEX enablement
+- network and remote-operation behavior
+
+### Slice-specific controls
+
+These belong to one receive or transmit slice:
+
+- Frequency
+- Mode
+- Filter width and passband
+- RX and TX antenna selection
+- AGC and many DSP choices
+- RIT and XIT
+- DAX channel assignment
+- diversity and related receive features
+
+If a change follows only slice `A`, `B`, `C`, or `D`, it is probably slice-specific. If the whole client or radio behaves differently, it is probably global or radio-wide.
+
+## A Good Next Step
+
+Once you are comfortable getting connected and identifying the main window areas:
+
+- Open `Help -> AetherSDR Help...` for a deeper window-by-window reference.
+- Open `Help -> Understanding Data Modes...` before setting up WSJT-X, Winlink, fldigi, JS8Call, VARA, or IQ software.
+- Open `Help -> Contributing to AetherSDR...` if you want to report confusing behavior, request workflow improvements, or help improve the documentation itself.

--- a/resources/help/understanding-data-modes.md
+++ b/resources/help/understanding-data-modes.md
@@ -1,0 +1,276 @@
+# Understanding Data Modes
+
+## Why Digital Operation Feels More Complicated
+
+Voice operation can often be understood as "microphone in, speaker out." Digital operation adds more moving parts:
+
+- a radio-control path
+- a receive-audio path
+- a transmit-audio path
+- sometimes an IQ path
+- sometimes a single integrated control protocol such as TCI
+
+The goal is not to memorize every acronym. The goal is to keep each path visible and predictable.
+
+## The Digital Signal Paths Inside AetherSDR
+
+### Control path
+
+This is how outside software reads frequency, mode, PTT, and other radio state. In AetherSDR that path is usually one of these:
+
+- CAT over TCP
+- CAT over virtual TTY or PTY
+- TCI over WebSocket
+
+### Receive audio path
+
+This is how digital software hears the radio. In AetherSDR that is usually DAX receive audio.
+
+### Transmit audio path
+
+This is how digital software sends audio back into the radio path. In AetherSDR that is usually the DAX transmit path.
+
+### IQ path
+
+This is for applications that need raw IQ instead of demodulated audio. AetherSDR supports DAX IQ streaming with selectable rates.
+
+## The Windows and Controls That Matter Most
+
+### Slice or VFO area
+
+The slice tells you which frequency, mode, and filter you are actually working on. If your digital program is talking to the wrong slice, everything else will feel wrong even if CAT appears to be working.
+
+For digital work, pay special attention to:
+
+- active slice letter
+- mode
+- transmit assignment
+- digital offset
+- DAX channel
+
+### DIGI applet
+
+This is the control center for external-software integration. It exposes:
+
+- `Enable TCP`
+- `Enable TTY`
+- CAT base port
+- per-channel CAT status for channels `A` through `D`
+- TCI enable and port
+- DAX enable
+- DAX receive and transmit level controls
+
+Keep this applet visible during setup. It answers the question, "What endpoints is AetherSDR offering to the rest of the station?"
+
+### Spectrum `DAX` overlay
+
+The panadapter overlay also has a `DAX` panel. This is where you manage DAX and IQ channel choices in the same visual area where you are choosing slices and frequency. For IQ-based applications, this is an important bridge between the display and the external software.
+
+### `Radio Setup...`
+
+For digital workflows, the most relevant setup tabs are:
+
+- `Audio`
+- `Phone/CW`
+- `Filters`
+- `Serial`
+
+Those tabs affect routing, compression, digital behavior, and external control integration more than casual receive-only operation does.
+
+## Important Terms
+
+### DIGU and DIGL
+
+These are digital sideband modes. In practice, they give digital software a predictable transmit and receive environment without the voice-processing assumptions of SSB phone modes.
+
+### DAX
+
+DAX is the digital audio exchange between AetherSDR and outside applications. Think of it as the software patch cable between the radio session and your digital program.
+
+### CAT
+
+CAT is rig control. A digital program uses it to follow frequency changes, key the transmitter, read mode, or command changes back to AetherSDR.
+
+### TTY or PTY
+
+This is the serial-style version of CAT. Some older or more rigid software expects a serial-looking endpoint instead of a TCP socket.
+
+### TCI
+
+TCI is a more integrated network protocol that can carry control, audio, IQ, CW, and spot information through one server connection when the client application supports it.
+
+### DAX IQ
+
+DAX IQ is raw IQ streaming rather than demodulated audio. Use it when the external program needs baseband data rather than normal receive audio.
+
+## How AetherSDR Maps Channels
+
+The DIGI applet is designed around four CAT channels, labeled `A`, `B`, `C`, and `D`. They track the common four-slice workflow and line up naturally with slice letters.
+
+### CAT over TCP
+
+When `Enable TCP` is on:
+
+- AetherSDR starts four rigctld-style TCP servers.
+- The base port defaults to `4532`.
+- The four channels use the base port and the next three ports.
+
+That means a default setup typically looks like:
+
+- channel `A`: `4532`
+- channel `B`: `4533`
+- channel `C`: `4534`
+- channel `D`: `4535`
+
+### CAT over TTY or PTY
+
+When `Enable TTY` is on, AetherSDR exposes serial-style endpoints for the same channel model. The DIGI applet shows the actual path names, which are useful when an external application can talk only to a serial-looking device.
+
+### TCI
+
+TCI is separate from the four-channel CAT model. It is one server, with a default port of `50001`.
+
+### DAX audio
+
+The DIGI applet exposes four receive DAX channels and one transmit path. Keep your channel numbering consistent with your slice usage so you do not have to rediscover the routing every time you operate.
+
+## First Digital Setup
+
+Use this sequence the first time you integrate a new digital application:
+
+1. Connect to the radio.
+2. Create or select the slice you want for digital work.
+3. Set the slice to the correct digital mode, usually `DIGU` or `DIGL`.
+4. Confirm that the correct slice owns transmit.
+5. Open the `DIGI` applet and place it where you can see it continuously.
+6. Turn on `Enable TCP` or `Enable TTY` depending on what the external application expects.
+7. If the application supports TCI, decide whether you want TCI instead of separate CAT and audio routing.
+8. Enable DAX if your workflow uses digital audio channels.
+9. Set or confirm the DAX channel for the slice you are using.
+10. Open the external digital application and match its radio-control and audio settings to the endpoints shown by AetherSDR.
+11. Test receive first.
+12. Test transmit only after receive, frequency tracking, and slice assignment all make sense.
+
+## Practical Workflow by Application Type
+
+### CAT plus audio applications
+
+Programs such as WSJT-X, fldigi, JS8Call, Winlink, and VARA often want:
+
+- one CAT endpoint
+- one receive audio device
+- one transmit audio device
+
+In that workflow:
+
+1. pick the correct CAT port or TTY path
+2. pick the correct DAX receive audio source
+3. pick the correct DAX transmit audio destination
+4. confirm that frequency changes follow in both directions
+
+### TCI-capable applications
+
+Some applications can use TCI and avoid the split between CAT and separate audio routing. In that workflow:
+
+1. enable the TCI server
+2. use the TCI port shown in the DIGI applet
+3. confirm the application is truly using TCI rather than a second fallback CAT path
+
+### IQ-driven applications
+
+If the external application needs raw IQ:
+
+1. open the panadapter `DAX` overlay
+2. select the IQ channel and rate you want
+3. point the external application at the matching IQ source
+
+## Keep the Window Readable During Digital Sessions
+
+Digital problems are easier to solve when the right controls stay visible. A good digital layout usually keeps these items on screen:
+
+- the active slice and its mode
+- the DIGI applet
+- the TX applet
+- the status bar network and TX indicators
+- at least one visible panadapter
+
+If you collapse too much into `Minimal Mode` too early, you may hide the clues you need to diagnose a routing problem.
+
+## Gain Staging
+
+Bad gain staging creates many fake "protocol" problems. If decode quality is poor or your transmitted signal looks dirty:
+
+1. reduce the problem to one slice and one digital application
+2. set moderate DAX levels
+3. avoid clipping in the digital program
+4. avoid excessive transmit processing in the voice path
+5. test again with a short transmission
+
+Digital software is often much less tolerant of overdriven audio than casual voice monitoring.
+
+## Common Mistakes
+
+### The software connects, but the wrong slice moves
+
+Cause:
+
+- the external program is attached to a different CAT channel than the slice you are watching
+
+Fix:
+
+- match the CAT channel, slice letter, and DAX channel intentionally instead of assuming they were paired automatically
+
+### Receive works, but transmit goes nowhere
+
+Cause:
+
+- wrong transmit slice
+- wrong DAX transmit path
+- wrong audio device selected in the external program
+
+Fix:
+
+- confirm TX ownership first, then confirm the application's transmit-audio destination
+
+### CAT works, but there is no decode audio
+
+Cause:
+
+- the radio-control path is correct but the DAX receive audio path is not
+
+Fix:
+
+- leave CAT alone and correct only the receive-audio source
+
+### Audio is present, but the application does not tune the radio
+
+Cause:
+
+- the DAX path is right, but CAT, TTY, or TCI is wrong or blocked
+
+Fix:
+
+- leave audio alone and fix only the control path
+
+### Everything works locally, but remote digital operation is choppy
+
+Cause:
+
+- WAN latency, audio compression, or too much visual and streaming load
+
+Fix:
+
+- simplify the session, reduce extra panadapters, and re-check audio and network quality before changing every digital setting
+
+## A Safe Troubleshooting Order
+
+When a digital setup fails, isolate one layer at a time:
+
+1. verify the slice and mode
+2. verify CAT, TTY, or TCI control
+3. verify receive audio
+4. verify transmit audio
+5. verify transmit ownership
+6. verify IQ only if the workflow actually needs it
+
+This order is faster than changing ports, channels, modes, and audio devices all at once.

--- a/src/gui/HelpDialog.cpp
+++ b/src/gui/HelpDialog.cpp
@@ -1,0 +1,171 @@
+#include "HelpDialog.h"
+
+#include <QDialogButtonBox>
+#include <QFile>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QTextBrowser>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+HelpDialog::HelpDialog(const QString& windowTitle,
+                       const QString& resourcePath,
+                       QWidget* parent)
+    : QDialog(parent)
+{
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    setWindowTitle(windowTitle);
+    buildUI(resourcePath);
+}
+
+void HelpDialog::buildUI(const QString& resourcePath)
+{
+    resize(760, 680);
+    setMinimumSize(520, 420);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+
+    auto* header = new QWidget(this);
+    header->setStyleSheet("background: #0a0a14;");
+    auto* headerLayout = new QVBoxLayout(header);
+    headerLayout->setContentsMargins(20, 18, 20, 14);
+    headerLayout->setSpacing(6);
+
+    auto* eyebrow = new QLabel("AETHERSDR OFFLINE HELP", header);
+    eyebrow->setStyleSheet("color: #00b4d8; font-size: 11px; letter-spacing: 2px;");
+    headerLayout->addWidget(eyebrow);
+
+    auto* title = new QLabel(windowTitle(), header);
+    title->setWordWrap(true);
+    title->setStyleSheet("color: #c8d8e8; font-size: 22px; font-weight: 700;");
+    headerLayout->addWidget(title);
+
+    auto* subtitle = new QLabel(
+        "Bundled help is available even when your station computer is offline.",
+        header);
+    subtitle->setWordWrap(true);
+    subtitle->setStyleSheet("color: #8aa8c0; font-size: 12px;");
+    headerLayout->addWidget(subtitle);
+
+    layout->addWidget(header);
+
+    auto* separator = new QWidget(this);
+    separator->setFixedHeight(1);
+    separator->setStyleSheet("background: #203040;");
+    layout->addWidget(separator);
+
+    auto* browser = new QTextBrowser(this);
+    browser->setReadOnly(true);
+    browser->setOpenExternalLinks(true);
+    browser->setOpenLinks(true);
+    browser->document()->setDocumentMargin(18);
+    browser->document()->setDefaultStyleSheet(
+        "body { color: #c8d8e8; font-size: 12px; font-family: sans-serif; }"
+        "h1 { color: #00b4d8; font-size: 22px; font-weight: 700; margin: 0 0 16px 0; }"
+        "h2 { color: #c8d8e8; font-size: 18px; font-weight: 700; margin: 18px 0 8px 0; }"
+        "h3 { color: #8898a8; font-size: 14px; font-weight: 700; margin: 14px 0 6px 0; }"
+        "h4 { color: #8898a8; font-size: 12px; font-weight: 700; margin: 12px 0 4px 0; }"
+        "p { color: #c8d8e8; font-size: 12px; line-height: 1.5; margin: 0 0 10px 0; }"
+        "ul, ol { margin: 0 0 12px 20px; }"
+        "li { color: #c8d8e8; font-size: 12px; line-height: 1.55; margin: 3px 0; }"
+        "ol li::marker { color: #00b4d8; font-weight: 700; }"
+        "ul li::marker { color: #40c060; }"
+        "strong { color: #dfeaf3; font-weight: 700; }"
+        "em { color: #8898a8; font-style: italic; }"
+        "code { color: #d8e4ee; background-color: #152230; }"
+        "a { color: #00b4d8; text-decoration: none; }");
+    browser->setMarkdown(loadMarkdown(resourcePath));
+    browser->setStyleSheet(
+        "QTextBrowser {"
+        "  background: #0f0f1a;"
+        "  color: #d8e4ee;"
+        "  border: none;"
+        "  padding: 10px;"
+        "  selection-background-color: #245a7a;"
+        "  font-size: 14px;"
+        "  line-height: 1.5;"
+        "}"
+        "QScrollBar:vertical {"
+        "  background: #0a0a14;"
+        "  width: 10px;"
+        "  margin: 8px 2px 8px 2px;"
+        "}"
+        "QScrollBar::handle:vertical {"
+        "  background: #304050;"
+        "  min-height: 28px;"
+        "  border-radius: 5px;"
+        "}"
+        "QScrollBar::handle:vertical:hover {"
+        "  background: #3f5870;"
+        "}"
+        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {"
+        "  height: 0px;"
+        "}"
+        "QScrollBar:horizontal {"
+        "  background: #0a0a14;"
+        "  height: 10px;"
+        "  margin: 2px 8px 2px 8px;"
+        "}"
+        "QScrollBar::handle:horizontal {"
+        "  background: #304050;"
+        "  min-width: 28px;"
+        "  border-radius: 5px;"
+        "}"
+        "QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {"
+        "  width: 0px;"
+        "}");
+    layout->addWidget(browser, 1);
+
+    auto* footer = new QWidget(this);
+    footer->setStyleSheet("background: #0a0a14;");
+    auto* footerLayout = new QHBoxLayout(footer);
+    footerLayout->setContentsMargins(16, 12, 16, 16);
+
+    auto* hint = new QLabel(
+        "Tip: The Help menu keeps each guide separate so you can reopen just the topic you need.",
+        footer);
+    hint->setWordWrap(true);
+    hint->setStyleSheet("color: #7f93a7; font-size: 11px;");
+    footerLayout->addWidget(hint, 1);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Close, footer);
+    auto* closeButton = buttons->button(QDialogButtonBox::Close);
+    closeButton->setCursor(Qt::PointingHandCursor);
+    closeButton->setStyleSheet(
+        "QPushButton {"
+        "  background: #00b4d8;"
+        "  color: #0f0f1a;"
+        "  font-weight: 700;"
+        "  border: none;"
+        "  border-radius: 16px;"
+        "  min-width: 96px;"
+        "  min-height: 32px;"
+        "  padding: 0 18px;"
+        "}"
+        "QPushButton:hover { background: #18c8ea; }");
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::close);
+    footerLayout->addWidget(buttons, 0, Qt::AlignRight);
+
+    layout->addWidget(footer);
+
+    setStyleSheet("HelpDialog { background: #0f0f1a; }");
+}
+
+QString HelpDialog::loadMarkdown(const QString& resourcePath) const
+{
+    QFile file(resourcePath);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return QStringLiteral(
+            "# Help file not available\n\n"
+            "AetherSDR could not open this bundled help topic.\n\n"
+            "Please reinstall the application or report the missing help asset.");
+    }
+
+    return QString::fromUtf8(file.readAll());
+}
+
+} // namespace AetherSDR

--- a/src/gui/HelpDialog.h
+++ b/src/gui/HelpDialog.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QDialog>
+
+class QString;
+
+namespace AetherSDR {
+
+class HelpDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit HelpDialog(const QString& windowTitle,
+                        const QString& resourcePath,
+                        QWidget* parent = nullptr);
+
+private:
+    void buildUI(const QString& resourcePath);
+    QString loadMarkdown(const QString& resourcePath) const;
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -37,6 +37,7 @@
 #include "SliceTroubleshootingDialog.h"
 #include "ShortcutDialog.h"
 #include "MultiFlexDialog.h"
+#include "HelpDialog.h"
 #include "WhatsNewDialog.h"
 #include "models/SliceModel.h"
 #include "models/MeterModel.h"
@@ -3139,6 +3140,39 @@ void MainWindow::buildMenuBar()
     });
 
     auto* helpMenu = menuBar()->addMenu("&Help");
+    helpMenu->addAction("Getting Started...", this, [this]() {
+        auto* dlg = new HelpDialog("Getting Started", ":/help/getting-started.md", this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        dlg->setModal(false);
+        dlg->show();
+        dlg->raise();
+        dlg->activateWindow();
+    });
+    helpMenu->addAction("AetherSDR Help...", this, [this]() {
+        auto* dlg = new HelpDialog("AetherSDR Help", ":/help/aethersdr-help.md", this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        dlg->setModal(false);
+        dlg->show();
+        dlg->raise();
+        dlg->activateWindow();
+    });
+    helpMenu->addAction("Understanding Data Modes...", this, [this]() {
+        auto* dlg = new HelpDialog("Understanding Data Modes", ":/help/understanding-data-modes.md", this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        dlg->setModal(false);
+        dlg->show();
+        dlg->raise();
+        dlg->activateWindow();
+    });
+    helpMenu->addAction("Contributing to AetherSDR...", this, [this]() {
+        auto* dlg = new HelpDialog("Contributing to AetherSDR", ":/help/contributing-to-aethersdr.md", this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        dlg->setModal(false);
+        dlg->show();
+        dlg->raise();
+        dlg->activateWindow();
+    });
+    helpMenu->addSeparator();
     helpMenu->addAction("Support...", this, [this]() {
         SupportDialog dlg(this);
         dlg.setRadioModel(&m_radioModel);


### PR DESCRIPTION

<img width="872" height="824" alt="Screenshot 2026-04-05 at 2 59 50 PM" src="https://github.com/user-attachments/assets/16a78ac7-557d-4640-9887-089e7b132988" />

## What changed

- Added a new offline Help system with four bundled Markdown guides
- Wired the new Help entries into the Help menu
- Added a reusable non-modal `HelpDialog` so operators can keep help open beside the radio UI
- Expanded the help content into deeper operator-facing guidance for layout, menus, setup dialogs, panadapters, applets, and digital workflows

## Why

- Give users built-in guidance even when the station computer is offline
- Make the app easier to learn without leaving the operating screen
- Provide more practical context around window layout, control purpose, and radio workflow

## User impact

- Users can open Getting Started, AetherSDR Help, Understanding Data Modes, and Contributing directly from the Help menu
- Help windows stay open while the radio is being operated
- The docs now explain the actual UI structure and workflows in much more depth

## Validation

- `cmake --build build`
- manually opened the app and iterated on the Help windows in the UI
