### PR TITLE
Require serial port support in AppImage builds (#755)

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -68,6 +68,7 @@ jobs:
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=/usr \
+            -DREQUIRE_SERIALPORT=ON \
             $CMAKE_EXTRA
 
       - name: Build Opus (RADE dependency)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,12 @@ find_package(Qt6 REQUIRED COMPONENTS
     Network
     Multimedia
 )
-find_package(Qt6 QUIET COMPONENTS SerialPort)
+option(REQUIRE_SERIALPORT "Fail if Qt6 SerialPort is not found (use for release builds)" OFF)
+if(REQUIRE_SERIALPORT)
+    find_package(Qt6 REQUIRED COMPONENTS SerialPort)
+else()
+    find_package(Qt6 QUIET COMPONENTS SerialPort)
+endif()
 if(Qt6SerialPort_FOUND)
     message(STATUS "Qt6::SerialPort found — serial PTT/CW support enabled")
 else()


### PR DESCRIPTION
## Summary

Fixes #755

The AppImage release was shipping without the Serial tab in Radio Settings. The root cause: `find_package(Qt6 QUIET COMPONENTS SerialPort)` silently continues if SerialPort isn't found, so the build succeeds without `HAVE_SERIALPORT` defined.

- Add `REQUIRE_SERIALPORT` CMake option — when ON, uses `REQUIRED` instead of `QUIET` so the build fails fast
- Enable `-DREQUIRE_SERIALPORT=ON` in the AppImage workflow so release builds can never ship without serial support
- Default is OFF so local/dev builds aren't affected

## Test plan

- [ ] Verify AppImage CI passes with `-DREQUIRE_SERIALPORT=ON` (SerialPort is already listed in aqt modules and ARM system packages)
- [ ] Verify local builds without `-DREQUIRE_SERIALPORT` still work with or without SerialPort installed
- [ ] Confirm the built AppImage includes the Serial tab in Radio Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)