### PR TITLE
Fix Intel Mac DMG crash on macOS 13 (Ventura)

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - runner: macos-15
             label: apple-silicon
-          - runner: macos-15-intel
+          - runner: macos-13
             label: intel
     runs-on: ${{ matrix.runner }}
 

--- a/src/gui/AetherDspDialog.cpp
+++ b/src/gui/AetherDspDialog.cpp
@@ -90,12 +90,8 @@ void AetherDspDialog::buildNr2Tab(QTabWidget* tabs)
     m_nr2GainGroup->button(2)->setToolTip("Gamma distribution model matching typical speech amplitude patterns.");
     m_nr2GainGroup->button(3)->setToolTip("Noise reduction model trained on real speech and noise samples.");
     m_nr2GainGroup->button(2)->setChecked(true);  // Gamma default
-    connect(m_nr2GainGroup, &QButtonGroup::idClicked, this, [this](int id) {
-        auto& s = AppSettings::instance();
-        s.setValue("NR2GainMethod", QString::number(id));
-        s.save();
-        emit nr2GainMethodChanged(id);
-    });
+    gainGroup->setEnabled(false);
+    gainGroup->setToolTip("Not yet wired to SpectralNR — reserved for future use.");
     vbox->addWidget(gainGroup);
 
     // NPE Method
@@ -112,24 +108,16 @@ void AetherDspDialog::buildNr2Tab(QTabWidget* tabs)
     m_nr2NpeGroup->button(1)->setToolTip("Minimum Mean Squared Error \u2014 minimizes the expected noise estimation error.");
     m_nr2NpeGroup->button(2)->setToolTip("Non-Stationary estimation \u2014 adapts to noise that changes over time.");
     m_nr2NpeGroup->button(0)->setChecked(true);  // OSMS default
-    connect(m_nr2NpeGroup, &QButtonGroup::idClicked, this, [this](int id) {
-        auto& s = AppSettings::instance();
-        s.setValue("NR2NpeMethod", QString::number(id));
-        s.save();
-        emit nr2NpeMethodChanged(id);
-    });
+    npeGroup->setEnabled(false);
+    npeGroup->setToolTip("Not yet wired to SpectralNR — reserved for future use.");
     vbox->addWidget(npeGroup);
 
     // AE Filter
     m_nr2AeCheck = new QCheckBox("AE Filter (artifact elimination)");
     m_nr2AeCheck->setToolTip("Reduces ringing and musical artifacts typical of frequency-domain noise reduction.");
     m_nr2AeCheck->setChecked(true);
-    connect(m_nr2AeCheck, &QCheckBox::toggled, this, [this](bool on) {
-        auto& s = AppSettings::instance();
-        s.setValue("NR2AeFilter", on ? "True" : "False");
-        s.save();
-        emit nr2AeFilterChanged(on);
-    });
+    m_nr2AeCheck->setEnabled(false);
+    m_nr2AeCheck->setToolTip("Not yet wired to SpectralNR — reserved for future use.");
     vbox->addWidget(m_nr2AeCheck);
 
     // Sliders: GainMax, GainSmooth, Q_SPP

--- a/src/gui/AetherDspDialog.h
+++ b/src/gui/AetherDspDialog.h
@@ -27,10 +27,7 @@ public:
     void syncFromEngine();
 
 signals:
-    // NR2 parameter changes
-    void nr2GainMethodChanged(int method);
-    void nr2NpeMethodChanged(int method);
-    void nr2AeFilterChanged(bool on);
+    // NR2 parameter changes (GainMethod, NpeMethod, AeFilter not yet wired to SpectralNR)
     void nr2GainMaxChanged(float value);
     void nr2GainSmoothChanged(float value);
     void nr2QsppChanged(float value);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6032,14 +6032,6 @@ void MainWindow::showNr2ParamPopup(const QPoint& globalPos)
     auto& s = AppSettings::instance();
     auto* popup = new DspParamPopup(this);
 
-    popup->addRadioGroup("Gain:", {"Lin", "Log", "Gam"},
-        s.value("NR2GainMethod", "2").toInt(),
-        [this](int id) {
-            auto& s = AppSettings::instance();
-            s.setValue("NR2GainMethod", QString::number(id));
-            s.save();
-        });
-
     popup->addSlider("Smoothing",  50, 98,
         static_cast<int>(s.value("NR2GainSmooth", "0.85").toFloat() * 100),
         [](int v) { return QString::number(v / 100.0f, 'f', 2); },
@@ -6049,14 +6041,6 @@ void MainWindow::showNr2ParamPopup(const QPoint& globalPos)
             s.setValue("NR2GainSmooth", QString::number(val, 'f', 2));
             s.save();
             QMetaObject::invokeMethod(m_audio, [this, val]() { m_audio->setNr2GainSmooth(val); });
-        });
-
-    popup->addCheckbox("AE Filter",
-        s.value("NR2AeFilter", "True").toString() == "True",
-        [](bool on) {
-            auto& s = AppSettings::instance();
-            s.setValue("NR2AeFilter", on ? "True" : "False");
-            s.save();
         });
 
     popup->finalize(


### PR DESCRIPTION
- Disable unwired NR2 controls in AetherDSP dialog
- Fix Intel Mac DMG crash on macOS 13 (Ventura)
