### PR TITLE
Add sidebar controls lock toggle (#745)

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -363,6 +363,26 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         return {id, wrapper, titleBar, btn};
     };
 
+    // Controls lock toggle — disables wheel/mouse on sidebar sliders (#745)
+    {
+        m_lockBtn = new QPushButton("\U0001F513", btnRow1);  // 🔓
+        m_lockBtn->setCheckable(true);
+        m_lockBtn->setToolTip("Lock sidebar controls — prevent accidental\n"
+                              "value changes while scrolling");
+        m_lockBtn->setStyleSheet(
+            "QPushButton { font-size: 13px; padding: 2px 4px; "
+            "background: #1a2a3a; border: 1px solid #203040; border-radius: 3px; }"
+            "QPushButton:checked { background: #c04040; border: 1px solid #e06060; }");
+        bool locked = settings.value("ControlsLocked", "False").toString() == "True";
+        m_lockBtn->setChecked(locked);
+        ControlsLock::setLocked(locked);
+        if (locked) m_lockBtn->setText("\U0001F512");  // 🔒
+        btnLayout1->addWidget(m_lockBtn);
+        connect(m_lockBtn, &QPushButton::toggled, this, [this](bool on) {
+            setControlsLocked(on);
+        });
+    }
+
     // ANLG / VU button — toggles the S-Meter section (not in the reorderable stack)
     {
         auto* anlgBtn = new QPushButton("VU", btnRow1);
@@ -572,6 +592,19 @@ void AppletPanel::setAgVisible(bool visible)
         m_agBtn->setChecked(false);
         m_agBtn->hide();
     }
+}
+
+bool AppletPanel::controlsLocked() const
+{
+    return ControlsLock::isLocked();
+}
+
+void AppletPanel::setControlsLocked(bool locked)
+{
+    ControlsLock::setLocked(locked);
+    m_lockBtn->setText(locked ? "\U0001F512" : "\U0001F513");  // 🔒 / 🔓
+    m_lockBtn->setChecked(locked);
+    AppSettings::instance().setValue("ControlsLocked", locked ? "True" : "False");
 }
 
 void AppletPanel::setSlice(SliceModel* slice)

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -61,6 +61,10 @@ public:
     // Reset applet order to default
     void resetOrder();
 
+    // Global controls lock — disables wheel/mouse on sidebar sliders (#745)
+    bool controlsLocked() const;
+    void setControlsLocked(bool locked);
+
     // Ordered applet entry for drag-reorder support
     struct AppletEntry {
         QString id;
@@ -96,6 +100,7 @@ private:
     QVBoxLayout* m_stack{nullptr};
     QScrollArea* m_scrollArea{nullptr};
     QWidget*     m_dropIndicator{nullptr};
+    QPushButton* m_lockBtn{nullptr};   // controls-lock toggle (#745)
 
     // Ordered list of applets (drag-reorderable)
     QVector<AppletEntry> m_appletOrder;

--- a/src/gui/GuardedSlider.h
+++ b/src/gui/GuardedSlider.h
@@ -6,13 +6,30 @@
 #include <QLabel>
 #include <QWheelEvent>
 
+// Global lock for sidebar controls — when locked, sliders, combo boxes,
+// and scrollable labels ignore wheel/mouse events so the user can scroll
+// the applet panel without accidentally changing values. (#745)
+class ControlsLock {
+public:
+    static bool isLocked() { return s_locked; }
+    static void setLocked(bool locked) { s_locked = locked; }
+private:
+    static inline bool s_locked = false;
+};
+
 // QSlider subclass that always consumes wheel events, even at min/max
 // boundaries. Prevents scroll from propagating to parent widgets (e.g.
 // SpectrumWidget tuning the VFO when a slider bottoms out). (#570)
+// When controls are locked (#745), ignores wheel events and lets the
+// parent scroll area handle them.
 class GuardedSlider : public QSlider {
 public:
     using QSlider::QSlider;
     void wheelEvent(QWheelEvent* ev) override {
+        if (ControlsLock::isLocked()) {
+            ev->ignore();
+            return;
+        }
         QSlider::wheelEvent(ev);
         ev->accept();
     }
@@ -22,24 +39,42 @@ public:
 // popup is open. Prevents accidental value changes when scrolling the applet
 // panel, but allows normal wheel scrolling through the list when the user
 // has clicked to open the dropdown. (#570, #676)
+// When controls are locked (#745), also blocks mouse press to prevent
+// opening the dropdown.
 class GuardedComboBox : public QComboBox {
 public:
     using QComboBox::QComboBox;
     void wheelEvent(QWheelEvent* ev) override {
+        if (ControlsLock::isLocked()) {
+            ev->ignore();
+            return;
+        }
         if (view() && view()->isVisible())
             QComboBox::wheelEvent(ev);  // popup open — scroll the list
         else
             ev->ignore();  // popup closed — let parent handle scroll
     }
+    void mousePressEvent(QMouseEvent* ev) override {
+        if (ControlsLock::isLocked()) {
+            ev->ignore();
+            return;
+        }
+        QComboBox::mousePressEvent(ev);
+    }
 };
 
 // QLabel subclass that emits scrolled(int steps) on wheel events and
 // always consumes them. Used for RIT/XIT/pitch numeric displays. (#619)
+// When controls are locked (#745), ignores wheel events.
 class ScrollableLabel : public QLabel {
     Q_OBJECT
 public:
     using QLabel::QLabel;
     void wheelEvent(QWheelEvent* ev) override {
+        if (ControlsLock::isLocked()) {
+            ev->ignore();
+            return;
+        }
         int delta = ev->angleDelta().y();
         if (delta > 0) emit scrolled(1);
         else if (delta < 0) emit scrolled(-1);

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -26,10 +26,11 @@
 #include <cmath>
 
 // Slider that resets to a default value on double-click.
-class ResetSlider : public QSlider {
+// Extends GuardedSlider for controls-lock support (#745).
+class ResetSlider : public GuardedSlider {
 public:
     explicit ResetSlider(int resetVal, Qt::Orientation o, QWidget* parent = nullptr)
-        : QSlider(o, parent), m_resetVal(resetVal) {}
+        : GuardedSlider(o, parent), m_resetVal(resetVal) {}
 protected:
     void mouseDoubleClickEvent(QMouseEvent*) override { setValue(m_resetVal); }
 private:

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -64,10 +64,11 @@ private:
 };
 
 // Slider that resets to a default value on double-click.
-class ResetSlider : public QSlider {
+// Extends GuardedSlider for controls-lock support (#745).
+class ResetSlider : public GuardedSlider {
 public:
     explicit ResetSlider(int resetVal, Qt::Orientation o, QWidget* parent = nullptr)
-        : QSlider(o, parent), m_resetVal(resetVal) {}
+        : GuardedSlider(o, parent), m_resetVal(resetVal) {}
 protected:
     void mouseDoubleClickEvent(QMouseEvent*) override { setValue(m_resetVal); }
 private:


### PR DESCRIPTION
## Summary

Fixes #745

- Adds a 🔒 lock toggle button in the AppletPanel header (button row 1) that globally disables wheel events and combo-box opening on all `GuardedSlider`, `GuardedComboBox`, and `ScrollableLabel` widgets
- When locked, wheel events are **ignored** (not consumed), so they propagate to the scroll area — the user can still scroll the panel without accidentally changing slider/combo values
- Lock state persists across sessions via `AppSettings` (`ControlsLocked` key)
- `ResetSlider`/`CenterMarkSlider` (pan sliders) now extend `GuardedSlider` instead of `QSlider` to inherit lock behavior

### Design

A static `ControlsLock` class in `GuardedSlider.h` holds a global boolean. All guarded widget subclasses check `ControlsLock::isLocked()` at the top of their `wheelEvent()` (and `mousePressEvent()` for `GuardedComboBox`). This is zero-cost when unlocked and requires no signal wiring.

### Files changed

| File | Change |
|------|--------|
| `GuardedSlider.h` | Add `ControlsLock` class; add lock checks to all three widget classes |
| `AppletPanel.h/cpp` | Add lock button, `controlsLocked()`, `setControlsLocked()` |
| `RxApplet.cpp` | `ResetSlider` extends `GuardedSlider` |
| `VfoWidget.cpp` | `ResetSlider` extends `GuardedSlider` |

## Test plan

- [ ] Click the 🔓 button in the applet panel header — it should toggle to 🔒 with red background
- [ ] While locked, scroll wheel over any slider (AF gain, RF power, squelch, etc.) — value should not change, panel should scroll
- [ ] While locked, click a `GuardedComboBox` (AGC mode, antenna select) — dropdown should not open
- [ ] While locked, scroll over RIT/XIT labels — offset should not change
- [ ] Unlock — all controls respond normally again
- [ ] Restart the app — lock state should be restored from settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)