### PR TITLE
Add click-to-collapse VFO flag via slice badge toggle (#761)

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -308,12 +308,17 @@ void VfoWidget::buildUI()
     });
     hdr->addWidget(m_txBadge);
 
-    m_sliceBadge = new QLabel("A");
+    m_sliceBadge = new QPushButton("A");
     m_sliceBadge->setFixedSize(20, 20);
-    m_sliceBadge->setAlignment(Qt::AlignCenter);
+    m_sliceBadge->setFlat(true);
+    m_sliceBadge->setCursor(Qt::PointingHandCursor);
+    m_sliceBadge->setToolTip("Click to collapse/expand VFO flag");
     m_sliceBadge->setStyleSheet(
-        "QLabel { background: #0070c0; color: #ffffff; "
-        "border-radius: 3px; font-weight: bold; font-size: 11px; }");
+        "QPushButton { background: #0070c0; color: #ffffff; "
+        "border-radius: 3px; font-weight: bold; font-size: 11px; border: none; }");
+    connect(m_sliceBadge, &QPushButton::clicked, this, [this] {
+        setCollapsed(!m_collapsed);
+    });
     hdr->addWidget(m_sliceBadge);
 
     root->addLayout(hdr);
@@ -492,8 +497,12 @@ void VfoWidget::buildUI()
 
     // ── S-meter + dBm row (75/25 split) ────────────────────────────────────
     // S-meter bar is painted in paintEvent; spacer reserves its space.
-    // dBm label sits to the right.
-    auto* meterRow = new QHBoxLayout;
+    // dBm label sits to the right. Wrapped in a widget for collapse toggle.
+    m_meterWidget = new QWidget;
+    m_meterWidget->setAttribute(Qt::WA_TranslucentBackground);
+    m_meterWidget->setStyleSheet("QWidget { background: transparent; }");
+    auto* meterRow = new QHBoxLayout(m_meterWidget);
+    meterRow->setContentsMargins(0, 0, 0, 0);
     meterRow->setSpacing(4);
 
     auto* sMeterSpacer = new QWidget;
@@ -508,7 +517,7 @@ void VfoWidget::buildUI()
     m_dbmLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     meterRow->addWidget(m_dbmLabel, 1);    // 25%
 
-    root->addLayout(meterRow);
+    root->addWidget(m_meterWidget);
 
     // ── Tab bar ────────────────────────────────────────────────────────────
     m_tabBar = new QWidget;
@@ -1616,6 +1625,53 @@ void VfoWidget::updatePosition(int vfoX, int specTop, FlagDir dir)
     }
 }
 
+// ── Collapse / expand VFO flag (#761) ─────────────────────────────────────────
+
+void VfoWidget::setCollapsed(bool collapsed)
+{
+    if (m_collapsed == collapsed) return;
+    m_collapsed = collapsed;
+
+    // Hide/show header controls (antenna buttons, filter width, split/tx badges)
+    m_rxAntBtn->setVisible(!collapsed);
+    m_txAntBtn->setVisible(!collapsed);
+    m_filterWidthLbl->setVisible(!collapsed);
+    m_splitBadge->setVisible(!collapsed);
+    m_txBadge->setVisible(!collapsed);
+
+    // Hide/show meter row, tab bar, tab content
+    m_meterWidget->setVisible(!collapsed);
+    m_tabBar->setVisible(!collapsed);
+    m_tabStack->setVisible(!collapsed);
+
+#ifdef HAVE_RADE
+    if (m_radeStatusLabel && collapsed)
+        m_radeStatusLabel->hide();
+#endif
+
+    // Adjust fixed width: collapsed shows only badge + frequency
+    if (collapsed) {
+        // Badge (20) + spacing + frequency label width
+        QFont labelFont;
+        labelFont.setPixelSize(26);
+        labelFont.setBold(true);
+        const int freqW = QFontMetrics(labelFont).horizontalAdvance("000.000.000") + 8;
+        setFixedWidth(20 + 6 + freqW + 12);  // badge + gap + freq + margins
+    } else {
+        setFixedWidth(WIDGET_W);
+    }
+
+    // Force re-layout and repaint
+    adjustSize();
+    update();
+
+    // Persist per-slice
+    if (m_slice) {
+        const QString key = QString("VfoFlag/Collapsed/%1").arg(m_slice->sliceId());
+        AppSettings::instance().setValue(key, collapsed);
+    }
+}
+
 // ── S-Meter bar (custom paint) ────────────────────────────────────────────────
 
 void VfoWidget::paintEvent(QPaintEvent* event)
@@ -1634,6 +1690,9 @@ void VfoWidget::paintEvent(QPaintEvent* event)
     p.setPen(QColor(255, 255, 255, 13));
     p.setBrush(QColor(255, 255, 255, 13));
     p.drawRoundedRect(rect().adjusted(0, 0, -1, -1), 3, 3);
+
+    // Skip S-meter painting when collapsed (#761)
+    if (m_collapsed) return;
 
     p.setRenderHint(QPainter::Antialiasing, false);
 
@@ -2061,6 +2120,12 @@ void VfoWidget::setSlice(SliceModel* slice)
     });
 
     syncFromSlice();
+
+    // Restore per-slice collapsed state (#761)
+    const QString key = QString("VfoFlag/Collapsed/%1").arg(slice->sliceId());
+    bool collapsed = AppSettings::instance().value(key, false).toBool();
+    if (collapsed != m_collapsed)
+        setCollapsed(collapsed);
 }
 
 void VfoWidget::updateTxBadgeStyle(bool isTx)
@@ -2178,8 +2243,8 @@ void VfoWidget::syncFromSlice()
     const char* badgeColor = (id >= 0 && id < kSliceColorCount)
         ? kSliceColors[id].hexActive : "#0070c0";
     m_sliceBadge->setStyleSheet(
-        QString("QLabel { background: %1; color: #000000; "
-                "border-radius: 3px; font-weight: bold; font-size: 11px; }").arg(badgeColor));
+        QString("QPushButton { background: %1; color: #000000; "
+                "border-radius: 3px; font-weight: bold; font-size: 11px; border: none; }").arg(badgeColor));
     updateFreqLabel();
     updateFilterLabel();
 

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -63,6 +63,10 @@ public:
     void beginDirectEntry();
     QLabel* freqLabel() const { return m_freqLabel; }
 
+    // Collapse the VFO flag to show only slice badge + frequency (like SmartSDR).
+    void setCollapsed(bool collapsed);
+    bool isCollapsed() const { return m_collapsed; }
+
 #ifdef HAVE_RADE
     void setRadeActive(bool on);
     void setRadeSynced(bool synced);
@@ -116,6 +120,7 @@ private:
     QStringList    m_antList;
     bool           m_updatingFromModel{false};
     bool           m_lastOnLeft{true};
+    bool           m_collapsed{false};
     float          m_signalDbm{-130.0f};
 
     // Header row
@@ -124,7 +129,7 @@ private:
     QLabel*      m_filterWidthLbl{nullptr};
     QPushButton* m_splitBadge{nullptr};
     QPushButton* m_txBadge{nullptr};
-    QLabel*      m_sliceBadge{nullptr};
+    QPushButton* m_sliceBadge{nullptr};
     QPointer<QPushButton> m_lockVfoBtn;
     QPointer<QPushButton> m_closeSliceBtn;
     QPointer<QPushButton> m_recordBtn;
@@ -132,6 +137,7 @@ private:
     QTimer* m_recordPulse{nullptr};
 
     // Frequency / meter
+    QWidget* m_meterWidget{nullptr};
     QLabel* m_freqLabel{nullptr};
     QLineEdit* m_freqEdit{nullptr};
     QStackedWidget* m_freqStack{nullptr};


### PR DESCRIPTION
## Summary

- Clicking the slice letter badge (A/B/C/D) on the VFO flag toggles between **expanded** (full controls) and **collapsed** (badge + frequency only) modes, matching SmartSDR behavior
- Collapsed state persists per-slice via AppSettings (`VfoFlag/Collapsed/<sliceId>`)
- S-meter custom painting is skipped in collapsed mode to avoid rendering artifacts

Fixes #761

## Changes

- `VfoWidget.h`: Changed `m_sliceBadge` from `QLabel*` to `QPushButton*`, added `m_collapsed` bool, `m_meterWidget` pointer, `setCollapsed()`/`isCollapsed()` public API
- `VfoWidget.cpp`:
  - Slice badge is now a clickable `QPushButton` that toggles collapsed state
  - `setCollapsed()` hides/shows header controls (antennas, filter width, SPLIT, TX), meter row, tab bar, and tab content; adjusts widget width
  - Meter row wrapped in `m_meterWidget` container for clean show/hide
  - `paintEvent()` skips S-meter bar painting when collapsed
  - `setSlice()` restores per-slice collapsed state from AppSettings

## Test plan

- [ ] Click slice badge (A/B/C/D) — flag collapses to show only badge + frequency
- [ ] Click badge again — flag expands back to full controls
- [ ] Collapsed state persists across slice switches and app restarts
- [ ] Frequency display remains functional (click-to-tune, direct entry) in collapsed mode
- [ ] Multiple slices can have independent collapsed states
- [ ] Side buttons (close, lock, record, play) remain accessible in collapsed mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)