### PR TITLE
Fix background image distortion during window resize (#737)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2541,7 +2541,11 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         } else {
             // Cache scaled image to avoid per-frame scaling
             if (m_bgScaledSize != specRect.size()) {
-                m_bgScaled = m_bgImage.scaled(specRect.size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+                // Scale to cover (keep aspect ratio, expand to fill) then crop to fit
+                QImage expanded = m_bgImage.scaled(specRect.size(), Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
+                int cx = (expanded.width()  - specRect.width())  / 2;
+                int cy = (expanded.height() - specRect.height()) / 2;
+                m_bgScaled = expanded.copy(cx, cy, specRect.width(), specRect.height());
                 m_bgScaledSize = specRect.size();
             }
             p.drawImage(specRect.topLeft(), m_bgScaled);


### PR DESCRIPTION
## Summary
- Fix background image stretching/distortion when the spectrum widget resizes or UI scale changes
- Changed from `Qt::IgnoreAspectRatio` to `Qt::KeepAspectRatioByExpanding` with center crop — equivalent to CSS `background-size: cover`
- Image maintains its original aspect ratio at any widget size or UI scale factor

Fixes #737

## Test plan
- [ ] Set a background image via Display overlay panel
- [ ] Resize the window to various aspect ratios — image should not distort
- [ ] Change UI Scale (View → UI Scale) and restart — image should remain undistorted
- [ ] Verify the image fills the entire spectrum area (no black bars)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)