### PR TITLE
Fix WNB/RF gain overlay: same font, horizontal layout, right-aligned

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -365,19 +365,14 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
     // Controls lock toggle — disables wheel/mouse on sidebar sliders (#745)
     {
-        m_lockBtn = new QPushButton("\U0001F513", btnRow1);  // 🔓
+        m_lockBtn = new QPushButton("LCK", btnRow2);
         m_lockBtn->setCheckable(true);
         m_lockBtn->setToolTip("Lock sidebar controls — prevent accidental\n"
                               "value changes while scrolling");
-        m_lockBtn->setStyleSheet(
-            "QPushButton { font-size: 13px; padding: 2px 4px; "
-            "background: #1a2a3a; border: 1px solid #203040; border-radius: 3px; }"
-            "QPushButton:checked { background: #c04040; border: 1px solid #e06060; }");
         bool locked = settings.value("ControlsLocked", "False").toString() == "True";
         m_lockBtn->setChecked(locked);
         ControlsLock::setLocked(locked);
-        if (locked) m_lockBtn->setText("\U0001F512");  // 🔒
-        btnLayout1->addWidget(m_lockBtn);
+        btnLayout2->addWidget(m_lockBtn);
         connect(m_lockBtn, &QPushButton::toggled, this, [this](bool on) {
             setControlsLocked(on);
         });
@@ -602,7 +597,7 @@ bool AppletPanel::controlsLocked() const
 void AppletPanel::setControlsLocked(bool locked)
 {
     ControlsLock::setLocked(locked);
-    m_lockBtn->setText(locked ? "\U0001F512" : "\U0001F513");  // 🔒 / 🔓
+    m_lockBtn->setText("LCK");
     m_lockBtn->setChecked(locked);
     AppSettings::instance().setValue("ControlsLocked", locked ? "True" : "False");
 }

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2141,8 +2141,12 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             // Background image
             if (!m_bgImage.isNull()) {
                 if (m_bgScaledSize != specRect.size()) {
-                    m_bgScaled = m_bgImage.scaled(specRect.size(),
-                        Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+                    // Scale to cover (keep aspect ratio, expand to fill) then center crop
+                    QImage expanded = m_bgImage.scaled(specRect.size(),
+                        Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
+                    int cx = (expanded.width()  - specRect.width())  / 2;
+                    int cy = (expanded.height() - specRect.height()) / 2;
+                    m_bgScaled = expanded.copy(cx, cy, specRect.width(), specRect.height());
                     m_bgScaledSize = specRect.size();
                 }
                 p.setOpacity(1.0 - m_bgOpacity / 100.0);
@@ -2166,22 +2170,24 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             drawSliceMarkers(p, specRect, wfRect);
             drawOffScreenSlices(p, specRect);
 
-            // WNB / RF gain indicators
-            if (m_wnbActive) {
-                p.setFont(QFont(p.font().family(), 14, QFont::Bold));
+            // WNB / RF gain indicators (horizontal, top-left of spectrum)
+            if (m_wnbActive || m_rfGainValue != 0) {
+                QFont indFont(p.font().family(), 14, QFont::Bold);
+                p.setFont(indFont);
                 p.setPen(QColor(0xc8, 0xd8, 0xe8, 180));
-                p.drawText(specRect.right() - 130, specRect.top() + 20,
-                           QStringLiteral("WNB"));
-            }
-            if (m_rfGainValue != 0) {
-                QFont f = p.font();
-                f.setPixelSize(12);
-                p.setFont(f);
-                p.setPen(QColor(0xc8, 0xd8, 0xe8, 140));
-                QString label = QStringLiteral("RF %1%2 dB")
-                    .arg(m_rfGainValue > 0 ? "+" : "").arg(m_rfGainValue);
-                p.drawText(specRect.right() - 80,
-                           specRect.top() + (m_wnbActive ? 38 : 20), label);
+                const QFontMetrics fm(indFont);
+                int y = specRect.top() + fm.ascent() + 4;
+                // Build combined label, measure, and right-align
+                QString label;
+                if (m_wnbActive)
+                    label += QStringLiteral("WNB");
+                if (m_rfGainValue != 0) {
+                    if (!label.isEmpty()) label += QStringLiteral("   ");
+                    label += QStringLiteral("%1%2 dB")
+                        .arg(m_rfGainValue > 0 ? "+" : "").arg(m_rfGainValue);
+                }
+                int x = specRect.right() - DBM_STRIP_W - 8 - fm.horizontalAdvance(label);
+                p.drawText(x, y, label);
             }
 
             // Cursor frequency label (#726)

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -309,17 +309,12 @@ void VfoWidget::buildUI()
     });
     hdr->addWidget(m_txBadge);
 
-    m_sliceBadge = new QPushButton("A");
+    m_sliceBadge = new QLabel("A");
     m_sliceBadge->setFixedSize(20, 20);
-    m_sliceBadge->setFlat(true);
-    m_sliceBadge->setCursor(Qt::PointingHandCursor);
-    m_sliceBadge->setToolTip("Click to collapse/expand VFO flag");
+    m_sliceBadge->setAlignment(Qt::AlignCenter);
     m_sliceBadge->setStyleSheet(
-        "QPushButton { background: #0070c0; color: #ffffff; "
-        "border-radius: 3px; font-weight: bold; font-size: 11px; border: none; }");
-    connect(m_sliceBadge, &QPushButton::clicked, this, [this] {
-        setCollapsed(!m_collapsed);
-    });
+        "QLabel { background: #0070c0; color: #ffffff; "
+        "border-radius: 3px; font-weight: bold; font-size: 11px; }");
     hdr->addWidget(m_sliceBadge);
 
     root->addLayout(hdr);
@@ -498,12 +493,8 @@ void VfoWidget::buildUI()
 
     // ── S-meter + dBm row (75/25 split) ────────────────────────────────────
     // S-meter bar is painted in paintEvent; spacer reserves its space.
-    // dBm label sits to the right. Wrapped in a widget for collapse toggle.
-    m_meterWidget = new QWidget;
-    m_meterWidget->setAttribute(Qt::WA_TranslucentBackground);
-    m_meterWidget->setStyleSheet("QWidget { background: transparent; }");
-    auto* meterRow = new QHBoxLayout(m_meterWidget);
-    meterRow->setContentsMargins(0, 0, 0, 0);
+    // dBm label sits to the right.
+    auto* meterRow = new QHBoxLayout;
     meterRow->setSpacing(4);
 
     auto* sMeterSpacer = new QWidget;
@@ -518,7 +509,7 @@ void VfoWidget::buildUI()
     m_dbmLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     meterRow->addWidget(m_dbmLabel, 1);    // 25%
 
-    root->addWidget(m_meterWidget);
+    root->addLayout(meterRow);
 
     // ── Tab bar ────────────────────────────────────────────────────────────
     m_tabBar = new QWidget;
@@ -1626,53 +1617,6 @@ void VfoWidget::updatePosition(int vfoX, int specTop, FlagDir dir)
     }
 }
 
-// ── Collapse / expand VFO flag (#761) ─────────────────────────────────────────
-
-void VfoWidget::setCollapsed(bool collapsed)
-{
-    if (m_collapsed == collapsed) return;
-    m_collapsed = collapsed;
-
-    // Hide/show header controls (antenna buttons, filter width, split/tx badges)
-    m_rxAntBtn->setVisible(!collapsed);
-    m_txAntBtn->setVisible(!collapsed);
-    m_filterWidthLbl->setVisible(!collapsed);
-    m_splitBadge->setVisible(!collapsed);
-    m_txBadge->setVisible(!collapsed);
-
-    // Hide/show meter row, tab bar, tab content
-    m_meterWidget->setVisible(!collapsed);
-    m_tabBar->setVisible(!collapsed);
-    m_tabStack->setVisible(!collapsed);
-
-#ifdef HAVE_RADE
-    if (m_radeStatusLabel && collapsed)
-        m_radeStatusLabel->hide();
-#endif
-
-    // Adjust fixed width: collapsed shows only badge + frequency
-    if (collapsed) {
-        // Badge (20) + spacing + frequency label width
-        QFont labelFont;
-        labelFont.setPixelSize(26);
-        labelFont.setBold(true);
-        const int freqW = QFontMetrics(labelFont).horizontalAdvance("000.000.000") + 8;
-        setFixedWidth(20 + 6 + freqW + 12);  // badge + gap + freq + margins
-    } else {
-        setFixedWidth(WIDGET_W);
-    }
-
-    // Force re-layout and repaint
-    adjustSize();
-    update();
-
-    // Persist per-slice
-    if (m_slice) {
-        const QString key = QString("VfoFlag/Collapsed/%1").arg(m_slice->sliceId());
-        AppSettings::instance().setValue(key, collapsed);
-    }
-}
-
 // ── S-Meter bar (custom paint) ────────────────────────────────────────────────
 
 void VfoWidget::paintEvent(QPaintEvent* event)
@@ -1691,9 +1635,6 @@ void VfoWidget::paintEvent(QPaintEvent* event)
     p.setPen(QColor(255, 255, 255, 13));
     p.setBrush(QColor(255, 255, 255, 13));
     p.drawRoundedRect(rect().adjusted(0, 0, -1, -1), 3, 3);
-
-    // Skip S-meter painting when collapsed (#761)
-    if (m_collapsed) return;
 
     p.setRenderHint(QPainter::Antialiasing, false);
 
@@ -2121,12 +2062,6 @@ void VfoWidget::setSlice(SliceModel* slice)
     });
 
     syncFromSlice();
-
-    // Restore per-slice collapsed state (#761)
-    const QString key = QString("VfoFlag/Collapsed/%1").arg(slice->sliceId());
-    bool collapsed = AppSettings::instance().value(key, false).toBool();
-    if (collapsed != m_collapsed)
-        setCollapsed(collapsed);
 }
 
 void VfoWidget::updateTxBadgeStyle(bool isTx)
@@ -2244,8 +2179,8 @@ void VfoWidget::syncFromSlice()
     const char* badgeColor = (id >= 0 && id < kSliceColorCount)
         ? kSliceColors[id].hexActive : "#0070c0";
     m_sliceBadge->setStyleSheet(
-        QString("QPushButton { background: %1; color: #000000; "
-                "border-radius: 3px; font-weight: bold; font-size: 11px; border: none; }").arg(badgeColor));
+        QString("QLabel { background: %1; color: #000000; "
+                "border-radius: 3px; font-weight: bold; font-size: 11px; }").arg(badgeColor));
     updateFreqLabel();
     updateFilterLabel();
 

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -63,10 +63,6 @@ public:
     void beginDirectEntry();
     QLabel* freqLabel() const { return m_freqLabel; }
 
-    // Collapse the VFO flag to show only slice badge + frequency (like SmartSDR).
-    void setCollapsed(bool collapsed);
-    bool isCollapsed() const { return m_collapsed; }
-
 #ifdef HAVE_RADE
     void setRadeActive(bool on);
     void setRadeSynced(bool synced);
@@ -120,7 +116,6 @@ private:
     QStringList    m_antList;
     bool           m_updatingFromModel{false};
     bool           m_lastOnLeft{true};
-    bool           m_collapsed{false};
     float          m_signalDbm{-130.0f};
 
     // Header row
@@ -129,7 +124,7 @@ private:
     QLabel*      m_filterWidthLbl{nullptr};
     QPushButton* m_splitBadge{nullptr};
     QPushButton* m_txBadge{nullptr};
-    QPushButton* m_sliceBadge{nullptr};
+    QLabel*      m_sliceBadge{nullptr};
     QPointer<QPushButton> m_lockVfoBtn;
     QPointer<QPushButton> m_closeSliceBtn;
     QPointer<QPushButton> m_recordBtn;
@@ -137,7 +132,6 @@ private:
     QTimer* m_recordPulse{nullptr};
 
     // Frequency / meter
-    QWidget* m_meterWidget{nullptr};
     QLabel* m_freqLabel{nullptr};
     QLineEdit* m_freqEdit{nullptr};
     QStackedWidget* m_freqStack{nullptr};


### PR DESCRIPTION
- Move LCK button to row 2 and use text label instead of emoji
- Revert "Add click-to-collapse VFO flag via slice badge toggle (#761) (#805)"
- Fix background image aspect ratio in GPU rendering path (#737)
- Fix WNB/RF gain overlay: same font, horizontal layout, right-aligned
