### PR TITLE
Improve waterfall auto-black noise floor estimation (#788)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -662,24 +662,31 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
     // the black threshold to sit just above it. This replaces the radio's
     // auto_black which targets SmartSDR's different rendering engine.
     if (m_wfAutoBlack && !m_transmitting) {
-        // Estimate noise floor from incoming tiles.
+        // Estimate noise floor from incoming tiles using a two-pass trimmed mean.
         // Freeze during TX; threshold is restored to pre-TX value on TX→RX transition.
-        // Cheaper than full sort: sample every 8th bin.
+        // Pass 1: compute overall mean (sampled every 8th bin for speed).
         float sum = 0;
-        float minVal = 1e9f, maxVal = -1e9f;
         int count = 0;
         for (int i = 0; i < binsIntensity.size(); i += 8) {
-            float v = binsIntensity[i];
-            sum += v;
-            if (v < minVal) minVal = v;
-            if (v > maxVal) maxVal = v;
+            sum += binsIntensity[i];
             count++;
         }
         if (count > 0) {
-            float mean = sum / count;
-            // Use mean as noise floor estimate (most bins are noise)
-            // Set threshold below mean so noise shows as faint dark blue
-            float target = mean - 3.0f;
+            const float mean = sum / count;
+            // Pass 2: mean of bins at or below overall mean — filters out
+            // strong signals that would pull the noise floor estimate upward.
+            float noiseSum = 0;
+            int noiseCount = 0;
+            for (int i = 0; i < binsIntensity.size(); i += 8) {
+                if (binsIntensity[i] <= mean) {
+                    noiseSum += binsIntensity[i];
+                    noiseCount++;
+                }
+            }
+            const float noiseFloor = (noiseCount > 0) ? (noiseSum / noiseCount) : mean;
+            // Use noise floor directly as threshold — noise maps to black,
+            // signals above stand out with better contrast.
+            const float target = noiseFloor;
             // Smooth to prevent jitter
             m_autoBlackThresh = 0.95f * m_autoBlackThresh + 0.05f * target;
         }


### PR DESCRIPTION
## Summary

Fixes #788

- **Replaces single-pass mean with two-pass trimmed mean** for auto-black noise floor estimation. The previous `mean - 3.0f` approach was pulled upward by strong signals, causing poor contrast (noise appeared as faint color instead of clean black).
- Pass 1 computes the overall mean of sampled bins; Pass 2 computes the mean of only bins at or below that mean, effectively filtering out signals and isolating the true noise floor.
- Uses the noise floor directly as the black threshold — noise maps to black, signals above stand out with better contrast.

**No rendering pipeline changes** — keeps bilinear texture sampling, smooth row interpolation, and single-row-per-tile scroll. This addresses the maintainer feedback on PR #792 that nearest-neighbor sampling and row count changes caused visible banding.

## Test plan

- [ ] Connect to a FLEX radio on a busy HF band (14 MHz, 40 m, 80 m)
- [ ] Verify waterfall contrast is improved — noise floor should appear darker/blacker, signals should stand out more clearly
- [ ] Verify no banding, scan-lines, or interlaced artifacts (bilinear sampling is preserved)
- [ ] Verify Gain and Black Level sliders in overlay menu still work as expected
- [ ] Toggle auto-black off/on and confirm smooth transition
- [ ] Compare before/after on CW, PSK31, or FT8 signals for visible sharpness improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)