### PR TITLE
Fix mode buttons toggling off on repeated clicks (#813)

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1275,7 +1275,13 @@ void VfoWidget::buildTabContent()
             btn->setStyleSheet(kModeBtn);
             m_quickModeBtns[i] = btn;
 
-            connect(btn, &QPushButton::clicked, this, [this, i] {
+            connect(btn, &QPushButton::clicked, this, [this, i](bool checked) {
+                if (!checked) {
+                    // Don't let the user uncheck the active mode — re-check and bail
+                    QSignalBlocker b(m_quickModeBtns[i]);
+                    m_quickModeBtns[i]->setChecked(true);
+                    return;
+                }
                 if (!m_slice) return;
                 const QString& assign = m_quickModeAssign[i];
 #ifdef HAVE_RADE
@@ -2454,6 +2460,7 @@ void VfoWidget::updateQuickModeButtons()
         }
 
         m_quickModeBtns[i]->setText(label);
+        QSignalBlocker sb(m_quickModeBtns[i]);
         m_quickModeBtns[i]->setChecked(active);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #813

The quick-mode buttons (USB, CW, AM, etc.) in VfoWidget are checkable `QPushButton`s. Clicking an already-checked button caused Qt to uncheck it, but `SliceModel::setMode()` early-returns when the mode hasn't changed — so no `modeChanged` signal fires to re-check the button. The button stays visually unchecked despite the mode being active on the radio.

**Changes (VfoWidget.cpp only):**
- Guard the `clicked` handler with `bool checked` — when the user tries to uncheck the active mode button, immediately re-check it and return
- Block signals in `updateQuickModeButtons()` when programmatically calling `setChecked()` to prevent spurious signal emission

**Note:** The previous PR for this issue was rejected because it included unrelated waterfall rendering changes. This PR is strictly scoped to the mode button fix — one file, 8 lines added, 1 line changed.

## Test plan

- [ ] Click a mode button (e.g. USB) — it should light up
- [ ] Click the same button again — it should stay lit (not toggle off)
- [ ] Click a different mode button — only the new button should be lit
- [ ] Change mode via the combo dropdown — the matching quick button should update
- [ ] Verify waterfall rendering is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)