### PR TITLE
Fix NR4 build on Linux CI and Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,12 +612,22 @@ if(ENABLE_SPECBLEACH)
     target_include_directories(AetherSDR PRIVATE
         ${CMAKE_SOURCE_DIR}/third_party/libspecbleach/include
         ${CMAKE_SOURCE_DIR}/third_party/libspecbleach/src)
+    # libspecbleach C sources include <fftw3.h> directly — add FFTW3 include path
+    if(FFTW3_INCLUDE_DIRS)
+        target_include_directories(AetherSDR PRIVATE ${FFTW3_INCLUDE_DIRS})
+    endif()
     # libspecbleach uses fftwf (float precision FFTW3)
     find_library(FFTW3F_LIB fftw3f HINTS /opt/homebrew/lib /usr/local/lib)
     if(FFTW3F_LIB)
         target_link_libraries(AetherSDR PRIVATE ${FFTW3F_LIB})
     else()
         message(WARNING "fftw3f not found — NR4 will fail to link")
+    endif()
+    # Suppress warnings from third-party C code
+    if(MSVC)
+        set_source_files_properties(${SPECBLEACH_SOURCES} PROPERTIES COMPILE_FLAGS "/w")
+    else()
+        set_source_files_properties(${SPECBLEACH_SOURCES} PROPERTIES COMPILE_FLAGS "-w")
     endif()
 endif()
 

--- a/third_party/libspecbleach/src/shared/configurations.h
+++ b/third_party/libspecbleach/src/shared/configurations.h
@@ -25,6 +25,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <stdbool.h>
 #include <stdint.h>
 
+// MSVC does not support _Static_assert in C mode — map to static_assert
+#if defined(_MSC_VER) && !defined(__cplusplus)
+#define _Static_assert static_assert
+#endif
+
 // Compile-time assertions for configuration validity
 _Static_assert(HANN_WINDOW >= 0 && HANN_WINDOW <= 3,
                "HANN_WINDOW must be between 0 and 3");


### PR DESCRIPTION
- Add FFTW3 include path for libspecbleach C sources (fftw3.h not found)
- Add _Static_assert compat macro for MSVC C mode
- Suppress warnings from third-party C code on all platforms

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
