### PR TITLE
Add fftw3, hidapi, portaudio to x86_64 AppImage system deps

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -37,7 +37,8 @@ jobs:
             gstreamer1.0-pulseaudio gstreamer1.0-gl \
             libgstreamer-gl1.0-0 libgstreamer-plugins-base1.0-0 \
             libfuse2 file desktop-file-utils imagemagick \
-            python3-pip autoconf automake libtool libasound2-dev
+            python3-pip autoconf automake libtool libasound2-dev \
+            libfftw3-dev libhidapi-dev portaudio19-dev
 
       - name: Install system Qt (ARM only)
         if: matrix.use_aqt == false


### PR DESCRIPTION
These were only installed for ARM builds. x86_64 (aqtinstall) needs
them too for NR4 (libspecbleach/fftw3.h), FlexControl, and PortAudio.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
