### PR TITLE
Enable NR4 on Windows CI: install LLVM, setup fftw3f

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -27,11 +27,14 @@ jobs:
           arch: 'win64_msvc2019_64'
           modules: 'qtmultimedia qtserialport qtwebsockets qtshadertools'
 
-      - name: Install Ninja and Inno Setup
-        run: choco install ninja innosetup -y
+      - name: Install Ninja, Inno Setup, and LLVM
+        run: choco install ninja innosetup llvm -y
 
       - name: Setup Opus (SmartLink audio codec)
         run: .\setup-opus.ps1
+
+      - name: Setup FFTW3 float (NR4 dependency)
+        run: .\setup-fftw.ps1
 
       - name: Configure
         run: |
@@ -47,6 +50,9 @@ jobs:
           windeployqt deploy\AetherSDR.exe --release --no-translations --no-system-d3d-compiler
           if (Test-Path "third_party\fftw3\bin\libfftw3-3.dll") {
             copy third_party\fftw3\bin\libfftw3-3.dll deploy\
+          }
+          if (Test-Path "third_party\fftw3\bin\libfftw3f-3.dll") {
+            copy third_party\fftw3\bin\libfftw3f-3.dll deploy\
           }
 
       - name: Create portable ZIP

--- a/setup-fftw.ps1
+++ b/setup-fftw.ps1
@@ -19,6 +19,13 @@ $FftwUrl   = "https://fftw.org/pub/fftw/fftw-3.3.5-dll64.zip"
 $OutDir    = "third_party\fftw3"
 $ZipFile   = "third_party\fftw3-dll64.zip"
 $VsVars    = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+# Also try Enterprise (GitHub CI) and BuildTools (winget)
+if (-not (Test-Path $VsVars)) {
+    $VsVars = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+}
+if (-not (Test-Path $VsVars)) {
+    $VsVars = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+}
 
 # ── Check if already set up ──────────────────────────────────────────────
 if (Test-Path "$OutDir\lib\fftw3.lib") {
@@ -49,6 +56,9 @@ Expand-Archive -Path $ZipFile -DestinationPath $tempDir -Force
 Copy-Item "$tempDir\fftw3.h" "$OutDir\include\"
 Copy-Item "$tempDir\libfftw3-3.dll" "$OutDir\bin\"
 Copy-Item "$tempDir\libfftw3-3.def" "$OutDir\lib\"
+# Float precision (fftw3f) — needed by libspecbleach (NR4)
+Copy-Item "$tempDir\libfftw3f-3.dll" "$OutDir\bin\" -ErrorAction SilentlyContinue
+Copy-Item "$tempDir\libfftw3f-3.def" "$OutDir\lib\" -ErrorAction SilentlyContinue
 
 # ── Import MSVC environment and generate .lib ────────────────────────────
 Write-Host "Generating MSVC import library..." -ForegroundColor Cyan
@@ -66,9 +76,12 @@ foreach ($line in $envVars) {
     }
 }
 
-# Generate .lib from .def
+# Generate .lib from .def (double and float precision)
 Push-Location "$OutDir\lib"
 & lib.exe /machine:x64 /def:libfftw3-3.def /out:fftw3.lib 2>&1 | Out-Null
+if (Test-Path "libfftw3f-3.def") {
+    & lib.exe /machine:x64 /def:libfftw3f-3.def /out:fftw3f.lib 2>&1 | Out-Null
+}
 Pop-Location
 
 if (-not (Test-Path "$OutDir\lib\fftw3.lib")) {


### PR DESCRIPTION
- Add choco install llvm to Windows workflow for clang-cl
- Update setup-fftw.ps1 to extract and generate fftw3f (float precision)
- Deploy libfftw3f-3.dll alongside libfftw3-3.dll
- Add VS Enterprise and BuildTools detection to setup-fftw.ps1
- RADE still disabled pending separate CI validation

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
