### PR TITLE
Fix setup-fftw.ps1 early exit not checking for fftw3f.lib

### DIFF
--- a/setup-fftw.ps1
+++ b/setup-fftw.ps1
@@ -28,8 +28,8 @@ if (-not (Test-Path $VsVars)) {
 }
 
 # ── Check if already set up ──────────────────────────────────────────────
-if (Test-Path "$OutDir\lib\fftw3.lib") {
-    Write-Host "FFTW3 already set up in $OutDir" -ForegroundColor Green
+if ((Test-Path "$OutDir\lib\fftw3.lib") -and (Test-Path "$OutDir\lib\fftw3f.lib")) {
+    Write-Host "FFTW3 already set up in $OutDir (double + float)" -ForegroundColor Green
     exit 0
 }
 


### PR DESCRIPTION
Script exited at the fftw3.lib check without generating fftw3f.lib
(float precision) needed by NR4/libspecbleach.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
