### PR TITLE
[codex] Fix SmartLink teardown crash on macOS Intel

### DIFF
--- a/src/core/SmartLinkClient.cpp
+++ b/src/core/SmartLinkClient.cpp
@@ -31,6 +31,7 @@ SmartLinkClient::SmartLinkClient(QObject* parent)
 
 SmartLinkClient::~SmartLinkClient()
 {
+    QObject::disconnect(&m_socket, nullptr, this, nullptr);
     disconnect();
 }
 

--- a/src/core/SmartLinkClient.h
+++ b/src/core/SmartLinkClient.h
@@ -114,10 +114,13 @@ private:
     bool    m_authenticated{false};
 
     // SmartLink server TLS connection
-    QSslSocket m_socket;
-    QByteArray m_readBuffer;
+    // Keep the timer/connection state alive longer than the socket so a
+    // destructor-driven QSslSocket::disconnected emission cannot touch
+    // already-destroyed state.
     QTimer     m_pingTimer;
     bool       m_serverConnected{false};
+    QSslSocket m_socket;
+    QByteArray m_readBuffer;
 
     // User info from server
     QString m_publicIp;


### PR DESCRIPTION
## Summary
- fix SmartLinkClient teardown ordering so timer/state outlive the SSL socket
- disconnect socket-to-client signals in the destructor before shutdown proceeds
- prevent destructor-time `QSslSocket::disconnected` from reaching partially destroyed state

## Root cause
On the reported Intel macOS path, `QSslSocket::~QSslSocket()` can emit `disconnected` while `SmartLinkClient` is being destroyed. `onSslDisconnected()` then called `m_pingTimer.stop()` after timer/state teardown had begun, leading to the observed `EXC_BAD_ACCESS`.

## Impact
- prevents a shutdown/disconnect crash on macOS Intel
- keeps normal runtime disconnect behavior unchanged
- limits the fix to a narrow SmartLink lifetime bug

## Validation
- crash stack analysis matched the teardown path
- `git diff --check`
- targeted code inspection
- parallel architect / code review / security review approvals
- full Qt/CMake runtime verification remains to be done on the affected Intel Mac environment

Closes #842.
