### PR TITLE
Persist CW decoder sensitivity across restarts (#804)

### DIFF
--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -1,6 +1,7 @@
 #include "PanadapterApplet.h"
 #include "GuardedSlider.h"
 #include "SpectrumWidget.h"
+#include "core/AppSettings.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -87,15 +88,18 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     cwBar->addWidget(sensLabel);
     m_cwSensSlider = new GuardedSlider(Qt::Horizontal);
     m_cwSensSlider->setRange(0, 100);  // 0=show everything, 100=only high confidence
-    m_cwSensSlider->setValue(30);      // default: moderate filtering
+    int savedSens = AppSettings::instance().value("CwDecoderSensitivity", "30").toString().toInt();
+    m_cwSensSlider->setValue(savedSens);
     m_cwSensSlider->setFixedWidth(60);
     m_cwSensSlider->setStyleSheet(
         "QSlider::groove:horizontal { background: #1a2a3a; height: 4px; border-radius: 2px; }"
         "QSlider::handle:horizontal { background: #00b4d8; width: 10px; margin: -3px 0; border-radius: 5px; }");
-    m_cwCostThreshold = 0.70f;  // default threshold
+    m_cwCostThreshold = 1.0f - (savedSens / 100.0f) * 0.9f;
     connect(m_cwSensSlider, &QSlider::valueChanged, this, [this](int v) {
         // Map 0-100 slider to 1.0-0.1 cost threshold (inverted: higher sens = lower threshold)
         m_cwCostThreshold = 1.0f - (v / 100.0f) * 0.9f;
+        AppSettings::instance().setValue("CwDecoderSensitivity", QString::number(v));
+        AppSettings::instance().save();
     });
     cwBar->addWidget(m_cwSensSlider);
 


### PR DESCRIPTION
## Summary

- Save/restore the CW reader sensitivity slider value via `AppSettings` so the user's preferred decode threshold persists between sessions
- On startup, reads `CwDecoderSensitivity` from settings (defaults to `30` if unset)
- On slider change, writes the new value immediately to `AppSettings`
- Initializes `m_cwCostThreshold` from the restored value so decoding uses the correct threshold from first audio frame

Fixes #804

## Test plan

- [ ] Launch AetherSDR, switch to CW mode, adjust the sensitivity slider to a non-default value (e.g. 70)
- [ ] Close and relaunch — verify slider is at 70 and decoded text filtering matches the restored threshold
- [ ] Verify `~/.config/AetherSDR/AetherSDR.settings` contains `CwDecoderSensitivity` key with correct value
- [ ] Verify default behavior (fresh install with no saved setting) still starts at 30

🤖 Generated with [Claude Code](https://claude.com/claude-code)