### PR TITLE
Persist VU meter TX/RX Select combo box selections (#809)

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -262,10 +262,28 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     selectLayout->addLayout(rxCol, 1);
     sMeterLayout->addWidget(selectRow);
 
+    // Restore saved TX/RX meter selections (#809)
+    int txIdx = settings.value("SMeter_TxSelect", 0).toInt();
+    int rxIdx = settings.value("SMeter_RxSelect", 0).toInt();
+    if (txIdx >= 0 && txIdx < m_txSelect->count())
+        m_txSelect->setCurrentIndex(txIdx);
+    if (rxIdx >= 0 && rxIdx < m_rxSelect->count())
+        m_rxSelect->setCurrentIndex(rxIdx);
+
     connect(m_txSelect, &QComboBox::currentTextChanged,
             m_sMeter, &SMeterWidget::setTxMode);
     connect(m_rxSelect, &QComboBox::currentTextChanged,
             m_sMeter, &SMeterWidget::setRxMode);
+
+    // Persist TX/RX meter selections on change (#809)
+    connect(m_txSelect, &QComboBox::currentIndexChanged,
+            this, [](int idx) {
+        AppSettings::instance().setValue("SMeter_TxSelect", idx);
+    });
+    connect(m_rxSelect, &QComboBox::currentIndexChanged,
+            this, [](int idx) {
+        AppSettings::instance().setValue("SMeter_RxSelect", idx);
+    });
 
     root->addWidget(m_sMeterSection);
 


### PR DESCRIPTION
## Summary
- **Fixes #809** — TX Select and RX Select combo boxes in the S-Meter section now persist across restarts
- Saves selections to `AppSettings` on change (`SMeter_TxSelect`, `SMeter_RxSelect`)
- Restores saved selections on startup with bounds checking

## Details
The combo boxes (Power/SWR/Level/Compression and S-Meter/S-Meter Peak) were created and connected to `SMeterWidget` but never hooked into `AppSettings`. They always reset to index 0 on restart.

The fix adds restore-on-startup and save-on-change, following the same pattern used for applet visibility toggles elsewhere in `AppletPanel.cpp`.

## Test plan
- [ ] Launch AetherSDR, change TX Select to "SWR" and RX Select to "S-Meter Peak"
- [ ] Restart AetherSDR — verify both selections are restored
- [ ] Verify the S-Meter display reflects the restored selections immediately
- [ ] Verify fresh install (no saved settings) defaults to Power / S-Meter

🤖 Generated with [Claude Code](https://claude.ai/claude-code)