### PR TITLE
Build out StreamController plugin full action set (#838)

### DIFF
--- a/plugins/streamcontroller-aethersdr/actions/Audio/MuteToggle/MuteToggle.py
+++ b/plugins/streamcontroller-aethersdr/actions/Audio/MuteToggle/MuteToggle.py
@@ -1,0 +1,24 @@
+"""
+MuteToggle action — toggle master audio mute.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class MuteToggle(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._muted = False
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "mute.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._muted = not self._muted
+        self.plugin_base.tci.send(f"mute:{str(self._muted).lower()};")

--- a/plugins/streamcontroller-aethersdr/actions/Audio/VolumeDown/VolumeDown.py
+++ b/plugins/streamcontroller-aethersdr/actions/Audio/VolumeDown/VolumeDown.py
@@ -1,0 +1,24 @@
+"""
+VolumeDown action — decrease master volume by 5.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class VolumeDown(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._volume = 50
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "volume_down.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._volume = max(0, self._volume - 5)
+        self.plugin_base.tci.send(f"volume:{self._volume};")

--- a/plugins/streamcontroller-aethersdr/actions/Audio/VolumeUp/VolumeUp.py
+++ b/plugins/streamcontroller-aethersdr/actions/Audio/VolumeUp/VolumeUp.py
@@ -1,0 +1,24 @@
+"""
+VolumeUp action — increase master volume by 5.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class VolumeUp(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._volume = 50
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "volume_up.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._volume = min(100, self._volume + 5)
+        self.plugin_base.tci.send(f"volume:{self._volume};")

--- a/plugins/streamcontroller-aethersdr/actions/DSP/ANFToggle/ANFToggle.py
+++ b/plugins/streamcontroller-aethersdr/actions/DSP/ANFToggle/ANFToggle.py
@@ -1,0 +1,24 @@
+"""
+ANFToggle action — toggle auto notch filter.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class ANFToggle(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._enabled = False
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "anf.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._enabled = not self._enabled
+        self.plugin_base.tci.send(f"rx_anf_enable:0,{str(self._enabled).lower()};")

--- a/plugins/streamcontroller-aethersdr/actions/DSP/APFToggle/APFToggle.py
+++ b/plugins/streamcontroller-aethersdr/actions/DSP/APFToggle/APFToggle.py
@@ -1,0 +1,24 @@
+"""
+APFToggle action — toggle audio peaking filter.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class APFToggle(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._enabled = False
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "apf.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._enabled = not self._enabled
+        self.plugin_base.tci.send(f"rx_apf_enable:0,{str(self._enabled).lower()};")

--- a/plugins/streamcontroller-aethersdr/actions/DSP/NBToggle/NBToggle.py
+++ b/plugins/streamcontroller-aethersdr/actions/DSP/NBToggle/NBToggle.py
@@ -1,0 +1,24 @@
+"""
+NBToggle action — toggle noise blanker.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class NBToggle(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._enabled = False
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "nb.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._enabled = not self._enabled
+        self.plugin_base.tci.send(f"rx_nb_enable:0,{str(self._enabled).lower()};")

--- a/plugins/streamcontroller-aethersdr/actions/DSP/NRToggle/NRToggle.py
+++ b/plugins/streamcontroller-aethersdr/actions/DSP/NRToggle/NRToggle.py
@@ -1,0 +1,24 @@
+"""
+NRToggle action — toggle noise reduction.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class NRToggle(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._enabled = False
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "nr.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._enabled = not self._enabled
+        self.plugin_base.tci.send(f"rx_nr_enable:0,{str(self._enabled).lower()};")

--- a/plugins/streamcontroller-aethersdr/actions/DSP/SQLToggle/SQLToggle.py
+++ b/plugins/streamcontroller-aethersdr/actions/DSP/SQLToggle/SQLToggle.py
@@ -1,0 +1,24 @@
+"""
+SQLToggle action — toggle squelch.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class SQLToggle(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._enabled = False
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "sql.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._enabled = not self._enabled
+        self.plugin_base.tci.send(f"sql_enable:0,{str(self._enabled).lower()};")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/Band10m/Band10m.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/Band10m/Band10m.py
@@ -1,0 +1,22 @@
+"""
+Band10m action — tune to 10m band (28.400 MHz).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class Band10m(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "band_10m.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("vfo:0,0,28400000;")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/Band12m/Band12m.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/Band12m/Band12m.py
@@ -1,0 +1,22 @@
+"""
+Band12m action — tune to 12m band (24.950 MHz).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class Band12m(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "band_12m.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("vfo:0,0,24950000;")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/Band15m/Band15m.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/Band15m/Band15m.py
@@ -1,0 +1,22 @@
+"""
+Band15m action — tune to 15m band (21.300 MHz).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class Band15m(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "band_15m.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("vfo:0,0,21300000;")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/Band160m/Band160m.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/Band160m/Band160m.py
@@ -1,0 +1,22 @@
+"""
+Band160m action — tune to 160m band (1.900 MHz).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class Band160m(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "band_160m.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("vfo:0,0,1900000;")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/Band17m/Band17m.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/Band17m/Band17m.py
@@ -1,0 +1,22 @@
+"""
+Band17m action — tune to 17m band (18.130 MHz).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class Band17m(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "band_17m.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("vfo:0,0,18130000;")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/Band20m/Band20m.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/Band20m/Band20m.py
@@ -1,0 +1,22 @@
+"""
+Band20m action — tune to 20m band (14.225 MHz).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class Band20m(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "band_20m.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("vfo:0,0,14225000;")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/Band30m/Band30m.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/Band30m/Band30m.py
@@ -1,0 +1,22 @@
+"""
+Band30m action — tune to 30m band (10.125 MHz).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class Band30m(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "band_30m.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("vfo:0,0,10125000;")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/Band40m/Band40m.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/Band40m/Band40m.py
@@ -1,0 +1,22 @@
+"""
+Band40m action — tune to 40m band (7.200 MHz).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class Band40m(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "band_40m.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("vfo:0,0,7200000;")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/Band60m/Band60m.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/Band60m/Band60m.py
@@ -1,0 +1,22 @@
+"""
+Band60m action — tune to 60m band (5.357 MHz).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class Band60m(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "band_60m.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("vfo:0,0,5357000;")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/Band6m/Band6m.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/Band6m/Band6m.py
@@ -1,0 +1,22 @@
+"""
+Band6m action — tune to 6m band (50.150 MHz).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class Band6m(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "band_6m.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("vfo:0,0,50150000;")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/Band80m/Band80m.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/Band80m/Band80m.py
@@ -1,0 +1,22 @@
+"""
+Band80m action — tune to 80m band (3.800 MHz).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class Band80m(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "band_80m.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("vfo:0,0,3800000;")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/BandDown/BandDown.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/BandDown/BandDown.py
@@ -1,0 +1,41 @@
+"""
+BandDown action — cycle to the next lower amateur band.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+# Band defaults from BandDefs.h (name, freq_hz)
+_BANDS = [
+    ("160m",  1_900_000),
+    ("80m",   3_800_000),
+    ("60m",   5_357_000),
+    ("40m",   7_200_000),
+    ("30m",  10_125_000),
+    ("20m",  14_225_000),
+    ("17m",  18_130_000),
+    ("15m",  21_300_000),
+    ("12m",  24_950_000),
+    ("10m",  28_400_000),
+    ("6m",   50_150_000),
+]
+
+
+class BandDown(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "band_down.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        if not hasattr(self.plugin_base, "_band_index"):
+            self.plugin_base._band_index = 5  # default 20m
+        self.plugin_base._band_index = (self.plugin_base._band_index - 1) % len(_BANDS)
+        _, freq_hz = _BANDS[self.plugin_base._band_index]
+        self.plugin_base.tci.send(f"vfo:0,0,{freq_hz};")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/BandUp/BandUp.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/BandUp/BandUp.py
@@ -1,0 +1,41 @@
+"""
+BandUp action — cycle to the next higher amateur band.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+# Band defaults from BandDefs.h (name, freq_hz)
+_BANDS = [
+    ("160m",  1_900_000),
+    ("80m",   3_800_000),
+    ("60m",   5_357_000),
+    ("40m",   7_200_000),
+    ("30m",  10_125_000),
+    ("20m",  14_225_000),
+    ("17m",  18_130_000),
+    ("15m",  21_300_000),
+    ("12m",  24_950_000),
+    ("10m",  28_400_000),
+    ("6m",   50_150_000),
+]
+
+
+class BandUp(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "band_up.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        if not hasattr(self.plugin_base, "_band_index"):
+            self.plugin_base._band_index = 5  # default 20m
+        self.plugin_base._band_index = (self.plugin_base._band_index + 1) % len(_BANDS)
+        _, freq_hz = _BANDS[self.plugin_base._band_index]
+        self.plugin_base.tci.send(f"vfo:0,0,{freq_hz};")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/TuneDown/TuneDown.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/TuneDown/TuneDown.py
@@ -1,0 +1,26 @@
+"""
+TuneDown action — decrease VFO frequency by one step.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class TuneDown(ActionBase):
+    TUNE_STEP_HZ = 1000  # 1 kHz default step
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._freq_hz = 14_225_000  # default 20m
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "tune_down.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._freq_hz = max(0, self._freq_hz - self.TUNE_STEP_HZ)
+        self.plugin_base.tci.send(f"vfo:0,0,{self._freq_hz};")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/TuneUp/TuneUp.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/TuneUp/TuneUp.py
@@ -1,0 +1,26 @@
+"""
+TuneUp action — increase VFO frequency by one step.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class TuneUp(ActionBase):
+    TUNE_STEP_HZ = 1000  # 1 kHz default step
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._freq_hz = 14_225_000  # default 20m
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "tune_up.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._freq_hz += self.TUNE_STEP_HZ
+        self.plugin_base.tci.send(f"vfo:0,0,{self._freq_hz};")

--- a/plugins/streamcontroller-aethersdr/actions/Frequency/_bands.py
+++ b/plugins/streamcontroller-aethersdr/actions/Frequency/_bands.py
@@ -1,0 +1,25 @@
+"""
+Shared band definitions for AetherSDR StreamController plugin.
+Frequencies from BandDefs.h (defaultFreqMhz converted to Hz).
+"""
+
+# (name, default_freq_hz, default_mode)
+BANDS = [
+    ("160m",  1_900_000, "LSB"),
+    ("80m",   3_800_000, "LSB"),
+    ("60m",   5_357_000, "USB"),
+    ("40m",   7_200_000, "LSB"),
+    ("30m",  10_125_000, "DIGU"),
+    ("20m",  14_225_000, "USB"),
+    ("17m",  18_130_000, "USB"),
+    ("15m",  21_300_000, "USB"),
+    ("12m",  24_950_000, "USB"),
+    ("10m",  28_400_000, "USB"),
+    ("6m",   50_150_000, "USB"),
+]
+
+BAND_NAMES = [b[0] for b in BANDS]
+BAND_FREQS = {b[0]: b[1] for b in BANDS}
+
+# Shared band index for BandUp/BandDown cycling
+_band_index = 5  # default to 20m

--- a/plugins/streamcontroller-aethersdr/actions/Mode/ModeAM/ModeAM.py
+++ b/plugins/streamcontroller-aethersdr/actions/Mode/ModeAM/ModeAM.py
@@ -1,0 +1,22 @@
+"""
+ModeAM action — switch to AM mode.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class ModeAM(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "mode_am.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("modulation:0,AM;")

--- a/plugins/streamcontroller-aethersdr/actions/Mode/ModeCW/ModeCW.py
+++ b/plugins/streamcontroller-aethersdr/actions/Mode/ModeCW/ModeCW.py
@@ -1,0 +1,22 @@
+"""
+ModeCW action — switch to CW mode.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class ModeCW(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "mode_cw.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("modulation:0,CW;")

--- a/plugins/streamcontroller-aethersdr/actions/Mode/ModeDIGL/ModeDIGL.py
+++ b/plugins/streamcontroller-aethersdr/actions/Mode/ModeDIGL/ModeDIGL.py
@@ -1,0 +1,22 @@
+"""
+ModeDIGL action — switch to Digital Lower Sideband mode.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class ModeDIGL(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "mode_digl.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("modulation:0,DIGL;")

--- a/plugins/streamcontroller-aethersdr/actions/Mode/ModeDIGU/ModeDIGU.py
+++ b/plugins/streamcontroller-aethersdr/actions/Mode/ModeDIGU/ModeDIGU.py
@@ -1,0 +1,22 @@
+"""
+ModeDIGU action — switch to Digital Upper Sideband mode.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class ModeDIGU(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "mode_digu.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("modulation:0,DIGU;")

--- a/plugins/streamcontroller-aethersdr/actions/Mode/ModeFM/ModeFM.py
+++ b/plugins/streamcontroller-aethersdr/actions/Mode/ModeFM/ModeFM.py
@@ -1,0 +1,22 @@
+"""
+ModeFM action — switch to FM mode.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class ModeFM(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "mode_fm.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("modulation:0,FM;")

--- a/plugins/streamcontroller-aethersdr/actions/Mode/ModeFT8/ModeFT8.py
+++ b/plugins/streamcontroller-aethersdr/actions/Mode/ModeFT8/ModeFT8.py
@@ -1,0 +1,26 @@
+"""
+ModeFT8 action — switch to DIGU mode and tune to 20m FT8 frequency (14.074 MHz).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class ModeFT8(ActionBase):
+    FT8_FREQ_HZ = 14_074_000  # 20m FT8 dial frequency
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "mode_ft8.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        tci = self.plugin_base.tci
+        tci.send("modulation:0,DIGU;")
+        tci.send(f"vfo:0,0,{self.FT8_FREQ_HZ};")

--- a/plugins/streamcontroller-aethersdr/actions/Mode/ModeLSB/ModeLSB.py
+++ b/plugins/streamcontroller-aethersdr/actions/Mode/ModeLSB/ModeLSB.py
@@ -1,0 +1,22 @@
+"""
+ModeLSB action — switch to Lower Sideband mode.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class ModeLSB(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "mode_lsb.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("modulation:0,LSB;")

--- a/plugins/streamcontroller-aethersdr/actions/Mode/ModeUSB/ModeUSB.py
+++ b/plugins/streamcontroller-aethersdr/actions/Mode/ModeUSB/ModeUSB.py
@@ -1,0 +1,22 @@
+"""
+ModeUSB action — switch to Upper Sideband mode.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class ModeUSB(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "mode_usb.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self.plugin_base.tci.send("modulation:0,USB;")

--- a/plugins/streamcontroller-aethersdr/actions/Slice/LockToggle/LockToggle.py
+++ b/plugins/streamcontroller-aethersdr/actions/Slice/LockToggle/LockToggle.py
@@ -1,0 +1,24 @@
+"""
+LockToggle action — toggle tune lock.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class LockToggle(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._locked = False
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "lock.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._locked = not self._locked
+        self.plugin_base.tci.send(f"lock:0,{str(self._locked).lower()};")

--- a/plugins/streamcontroller-aethersdr/actions/Slice/RITToggle/RITToggle.py
+++ b/plugins/streamcontroller-aethersdr/actions/Slice/RITToggle/RITToggle.py
@@ -1,0 +1,24 @@
+"""
+RITToggle action — toggle Receiver Incremental Tuning.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class RITToggle(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._enabled = False
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "rit.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._enabled = not self._enabled
+        self.plugin_base.tci.send(f"rit_enable:0,{str(self._enabled).lower()};")

--- a/plugins/streamcontroller-aethersdr/actions/Slice/SplitToggle/SplitToggle.py
+++ b/plugins/streamcontroller-aethersdr/actions/Slice/SplitToggle/SplitToggle.py
@@ -1,0 +1,24 @@
+"""
+SplitToggle action — toggle split (separate TX/RX frequencies).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class SplitToggle(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._enabled = False
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "split.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._enabled = not self._enabled
+        self.plugin_base.tci.send(f"split_enable:0,{str(self._enabled).lower()};")

--- a/plugins/streamcontroller-aethersdr/actions/Slice/XITToggle/XITToggle.py
+++ b/plugins/streamcontroller-aethersdr/actions/Slice/XITToggle/XITToggle.py
@@ -1,0 +1,24 @@
+"""
+XITToggle action — toggle Transmitter Incremental Tuning.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class XITToggle(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._enabled = False
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "xit.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._enabled = not self._enabled
+        self.plugin_base.tci.send(f"xit_enable:0,{str(self._enabled).lower()};")

--- a/plugins/streamcontroller-aethersdr/actions/TX/MOXToggle/MOXToggle.py
+++ b/plugins/streamcontroller-aethersdr/actions/TX/MOXToggle/MOXToggle.py
@@ -1,0 +1,24 @@
+"""
+MOXToggle action — toggle transmit on/off (unlike PTT which is hold-to-talk).
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class MOXToggle(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._transmitting = False
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "mox.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._transmitting = not self._transmitting
+        self.plugin_base.tci.send(f"trx:0,{str(self._transmitting).lower()};")

--- a/plugins/streamcontroller-aethersdr/actions/TX/RFPower/RFPower.py
+++ b/plugins/streamcontroller-aethersdr/actions/TX/RFPower/RFPower.py
@@ -1,0 +1,33 @@
+"""
+RFPower action — adjust RF drive power.
+Supports both key press (step +/-5) and dial rotation on StreamDeck+.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class RFPower(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._power = 50  # percent
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "rf_power.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event == Input.Dial.Events.TURN_CW:
+            self._power = min(100, self._power + 5)
+            self.plugin_base.tci.send(f"drive:{self._power};")
+        elif event == Input.Dial.Events.TURN_CCW:
+            self._power = max(0, self._power - 5)
+            self.plugin_base.tci.send(f"drive:{self._power};")
+        elif event == Input.Key.Events.DOWN:
+            # Key press cycles: 25 → 50 → 75 → 100 → 25
+            self._power = (self._power + 25) % 125
+            if self._power == 0:
+                self._power = 25
+            self.plugin_base.tci.send(f"drive:{self._power};")

--- a/plugins/streamcontroller-aethersdr/actions/TX/TUNEToggle/TUNEToggle.py
+++ b/plugins/streamcontroller-aethersdr/actions/TX/TUNEToggle/TUNEToggle.py
@@ -1,0 +1,24 @@
+"""
+TUNEToggle action — toggle antenna tuner transmit.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class TUNEToggle(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._tuning = False
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "tune.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event != Input.Key.Events.DOWN:
+            return
+        self._tuning = not self._tuning
+        self.plugin_base.tci.send(f"tune:0,{str(self._tuning).lower()};")

--- a/plugins/streamcontroller-aethersdr/actions/TX/TunePower/TunePower.py
+++ b/plugins/streamcontroller-aethersdr/actions/TX/TunePower/TunePower.py
@@ -1,0 +1,32 @@
+"""
+TunePower action — adjust tune drive power.
+Supports both key press (step +/-5) and dial rotation on StreamDeck+.
+"""
+
+import os
+from src.backend.PluginManager.ActionBase import ActionBase
+from src.backend.DeckManagement.InputIdentifier import Input
+
+
+class TunePower(ActionBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._power = 10  # percent (tune usually lower)
+
+    def on_ready(self):
+        icon = os.path.join(self.plugin_base.PATH, "assets", "tune_power.png")
+        if os.path.exists(icon):
+            self.set_media(media_path=icon)
+
+    def event_callback(self, event, data):
+        if event == Input.Dial.Events.TURN_CW:
+            self._power = min(100, self._power + 5)
+            self.plugin_base.tci.send(f"tune_drive:{self._power};")
+        elif event == Input.Dial.Events.TURN_CCW:
+            self._power = max(0, self._power - 5)
+            self.plugin_base.tci.send(f"tune_drive:{self._power};")
+        elif event == Input.Key.Events.DOWN:
+            self._power = (self._power + 10) % 110
+            if self._power == 0:
+                self._power = 10
+            self.plugin_base.tci.send(f"tune_drive:{self._power};")

--- a/plugins/streamcontroller-aethersdr/gen_icons.py
+++ b/plugins/streamcontroller-aethersdr/gen_icons.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Generate PNG icon assets for AetherSDR StreamController plugin.
+Renders text-on-dark-background icons at 72x72 for StreamDeck LCD displays.
+
+Usage: python gen_icons.py
+Output: assets/*.png
+"""
+
+import os
+import sys
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError:
+    print("Pillow required: pip install Pillow")
+    sys.exit(1)
+
+SIZE = 72
+BG_COLOR = (15, 15, 26)       # #0f0f1a — AetherSDR theme
+TEXT_COLOR = (255, 255, 255)   # white
+ACCENT_COLOR = (0, 220, 255)  # cyan accent
+
+ASSETS_DIR = os.path.join(os.path.dirname(__file__), "assets")
+
+# (filename, label_lines, use_accent)
+ICONS = [
+    # TX
+    ("ptt.png",        ["PTT"],        True),
+    ("mox.png",        ["MOX"],        True),
+    ("tune.png",       ["TUNE"],       True),
+    ("rf_power.png",   ["RF", "PWR"],  False),
+    ("tune_power.png", ["TUNE", "PWR"], False),
+    # Frequency
+    ("tune_up.png",    ["\u25b2", "FREQ"], False),
+    ("tune_down.png",  ["\u25bc", "FREQ"], False),
+    ("band_up.png",    ["BAND", "\u25b2"], False),
+    ("band_down.png",  ["BAND", "\u25bc"], False),
+    # Band buttons
+    ("band_160m.png",  ["160m"],       False),
+    ("band_80m.png",   ["80m"],        False),
+    ("band_60m.png",   ["60m"],        False),
+    ("band_40m.png",   ["40m"],        False),
+    ("band_30m.png",   ["30m"],        False),
+    ("band_20m.png",   ["20m"],        False),
+    ("band_17m.png",   ["17m"],        False),
+    ("band_15m.png",   ["15m"],        False),
+    ("band_12m.png",   ["12m"],        False),
+    ("band_10m.png",   ["10m"],        False),
+    ("band_6m.png",    ["6m"],         False),
+    # Mode buttons
+    ("mode_usb.png",   ["USB"],        False),
+    ("mode_lsb.png",   ["LSB"],        False),
+    ("mode_cw.png",    ["CW"],         True),
+    ("mode_am.png",    ["AM"],         False),
+    ("mode_fm.png",    ["FM"],         False),
+    ("mode_digu.png",  ["DIGU"],       False),
+    ("mode_digl.png",  ["DIGL"],       False),
+    ("mode_ft8.png",   ["FT8"],        True),
+    # Audio
+    ("mute.png",       ["MUTE"],       True),
+    ("volume_up.png",  ["VOL", "\u25b2"], False),
+    ("volume_down.png",["VOL", "\u25bc"], False),
+    # DSP
+    ("nb.png",         ["NB"],         False),
+    ("nr.png",         ["NR"],         False),
+    ("anf.png",        ["ANF"],        False),
+    ("apf.png",        ["APF"],        False),
+    ("sql.png",        ["SQL"],        False),
+    # Slice
+    ("split.png",      ["SPLIT"],      False),
+    ("lock.png",       ["LOCK"],       False),
+    ("rit.png",        ["RIT"],        False),
+    ("xit.png",        ["XIT"],        False),
+    # DVK
+    ("record.png",     ["\u25cf", "REC"], True),
+    ("play.png",       ["\u25b6", "PLAY"], False),
+]
+
+
+def make_icon(filename, lines, use_accent):
+    img = Image.new("RGB", (SIZE, SIZE), BG_COLOR)
+    draw = ImageDraw.Draw(img)
+    color = ACCENT_COLOR if use_accent else TEXT_COLOR
+
+    # Try to use a built-in font; fall back to default
+    try:
+        if len(lines) == 1 and len(lines[0]) <= 3:
+            font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 24)
+        else:
+            font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 16)
+    except (OSError, IOError):
+        font = ImageFont.load_default()
+
+    total_height = sum(draw.textbbox((0, 0), line, font=font)[3] - draw.textbbox((0, 0), line, font=font)[1] for line in lines)
+    spacing = 2
+    total_height += spacing * (len(lines) - 1)
+    y = (SIZE - total_height) // 2
+
+    for line in lines:
+        bbox = draw.textbbox((0, 0), line, font=font)
+        w = bbox[2] - bbox[0]
+        h = bbox[3] - bbox[1]
+        x = (SIZE - w) // 2
+        draw.text((x, y), line, fill=color, font=font)
+        y += h + spacing
+
+    img.save(os.path.join(ASSETS_DIR, filename))
+
+
+def main():
+    os.makedirs(ASSETS_DIR, exist_ok=True)
+    for filename, lines, accent in ICONS:
+        make_icon(filename, lines, accent)
+        print(f"  {filename}")
+    print(f"\nGenerated {len(ICONS)} icons in {ASSETS_DIR}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/streamcontroller-aethersdr/main.py
+++ b/plugins/streamcontroller-aethersdr/main.py
@@ -3,9 +3,13 @@ AetherSDR StreamController Plugin
 Controls FlexRadio via AetherSDR's TCI WebSocket server.
 
 Actions:
-  - PTT: Hold-to-transmit (ideal for pedal)
-  - Play: Toggle slice recording playback
-  - Record: Toggle slice recording
+  TX:        PTT (hold), MOXToggle, TUNEToggle, RFPower, TunePower
+  Frequency: TuneUp, TuneDown, BandUp, BandDown, Band160m..Band6m
+  Mode:      ModeUSB, ModeLSB, ModeCW, ModeAM, ModeFM, ModeDIGU, ModeDIGL, ModeFT8
+  Audio:     MuteToggle, VolumeUp, VolumeDown
+  DSP:       NBToggle, NRToggle, ANFToggle, APFToggle, SQLToggle
+  Slice:     SplitToggle, LockToggle, RITToggle, XITToggle
+  DVK:       Play, Record
 """
 
 import os
@@ -17,11 +21,89 @@ from src.backend.DeckManagement.InputIdentifier import Input
 from src.backend.PluginManager.ActionInputSupport import ActionInputSupport
 
 from .tci_client import TciClient
+
+# --- Existing actions ---
 from .actions.PTT.PTT import PTT
 from .actions.Play.Play import Play
 from .actions.Record.Record import Record
 
+# --- Frequency ---
+from .actions.Frequency.TuneUp.TuneUp import TuneUp
+from .actions.Frequency.TuneDown.TuneDown import TuneDown
+from .actions.Frequency.BandUp.BandUp import BandUp
+from .actions.Frequency.BandDown.BandDown import BandDown
+from .actions.Frequency.Band160m.Band160m import Band160m
+from .actions.Frequency.Band80m.Band80m import Band80m
+from .actions.Frequency.Band60m.Band60m import Band60m
+from .actions.Frequency.Band40m.Band40m import Band40m
+from .actions.Frequency.Band30m.Band30m import Band30m
+from .actions.Frequency.Band20m.Band20m import Band20m
+from .actions.Frequency.Band17m.Band17m import Band17m
+from .actions.Frequency.Band15m.Band15m import Band15m
+from .actions.Frequency.Band12m.Band12m import Band12m
+from .actions.Frequency.Band10m.Band10m import Band10m
+from .actions.Frequency.Band6m.Band6m import Band6m
+
+# --- Mode ---
+from .actions.Mode.ModeUSB.ModeUSB import ModeUSB
+from .actions.Mode.ModeLSB.ModeLSB import ModeLSB
+from .actions.Mode.ModeCW.ModeCW import ModeCW
+from .actions.Mode.ModeAM.ModeAM import ModeAM
+from .actions.Mode.ModeFM.ModeFM import ModeFM
+from .actions.Mode.ModeDIGU.ModeDIGU import ModeDIGU
+from .actions.Mode.ModeDIGL.ModeDIGL import ModeDIGL
+from .actions.Mode.ModeFT8.ModeFT8 import ModeFT8
+
+# --- TX ---
+from .actions.TX.MOXToggle.MOXToggle import MOXToggle
+from .actions.TX.TUNEToggle.TUNEToggle import TUNEToggle
+from .actions.TX.RFPower.RFPower import RFPower
+from .actions.TX.TunePower.TunePower import TunePower
+
+# --- Audio ---
+from .actions.Audio.MuteToggle.MuteToggle import MuteToggle
+from .actions.Audio.VolumeUp.VolumeUp import VolumeUp
+from .actions.Audio.VolumeDown.VolumeDown import VolumeDown
+
+# --- DSP ---
+from .actions.DSP.NBToggle.NBToggle import NBToggle
+from .actions.DSP.NRToggle.NRToggle import NRToggle
+from .actions.DSP.ANFToggle.ANFToggle import ANFToggle
+from .actions.DSP.APFToggle.APFToggle import APFToggle
+from .actions.DSP.SQLToggle.SQLToggle import SQLToggle
+
+# --- Slice ---
+from .actions.Slice.SplitToggle.SplitToggle import SplitToggle
+from .actions.Slice.LockToggle.LockToggle import LockToggle
+from .actions.Slice.RITToggle.RITToggle import RITToggle
+from .actions.Slice.XITToggle.XITToggle import XITToggle
+
 sys.path.append(os.path.dirname(__file__))
+
+# Key-only support (most actions)
+_KEY_ONLY = {
+    Input.Key: ActionInputSupport.SUPPORTED,
+    Input.Dial: ActionInputSupport.UNSUPPORTED,
+    Input.Touchscreen: ActionInputSupport.UNSUPPORTED,
+}
+
+# Key + dial support (power sliders)
+_KEY_AND_DIAL = {
+    Input.Key: ActionInputSupport.SUPPORTED,
+    Input.Dial: ActionInputSupport.SUPPORTED,
+    Input.Touchscreen: ActionInputSupport.UNSUPPORTED,
+}
+
+
+def _add(plugin, cls, suffix, name, support=None):
+    """Helper to register an action with less boilerplate."""
+    plugin.add_action_holder(ActionHolder(
+        plugin_base=plugin,
+        action_base=cls,
+        action_id_suffix=suffix,
+        action_name=name,
+        action_support=support or _KEY_ONLY,
+    ))
 
 
 class AetherSDRPlugin(PluginBase):
@@ -34,44 +116,61 @@ class AetherSDRPlugin(PluginBase):
         self.tci = TciClient()
         self.tci.connect("localhost", 50001)
 
-        # PTT — hold to transmit, release to receive
-        self.add_action_holder(ActionHolder(
-            plugin_base=self,
-            action_base=PTT,
-            action_id_suffix="PTT",
-            action_name="PTT (Push-to-Talk)",
-            action_support={
-                Input.Key: ActionInputSupport.SUPPORTED,
-                Input.Dial: ActionInputSupport.UNSUPPORTED,
-                Input.Touchscreen: ActionInputSupport.UNSUPPORTED,
-            },
-        ))
+        # ── TX ──
+        _add(self, PTT,        "PTT",        "PTT (Push-to-Talk)")
+        _add(self, MOXToggle,  "MOXToggle",  "MOX Toggle")
+        _add(self, TUNEToggle, "TUNEToggle", "TUNE Toggle")
+        _add(self, RFPower,    "RFPower",    "RF Power",    _KEY_AND_DIAL)
+        _add(self, TunePower,  "TunePower",  "Tune Power",  _KEY_AND_DIAL)
 
-        # Play — toggle slice playback
-        self.add_action_holder(ActionHolder(
-            plugin_base=self,
-            action_base=Play,
-            action_id_suffix="Play",
-            action_name="Play Recording",
-            action_support={
-                Input.Key: ActionInputSupport.SUPPORTED,
-                Input.Dial: ActionInputSupport.UNSUPPORTED,
-                Input.Touchscreen: ActionInputSupport.UNSUPPORTED,
-            },
-        ))
+        # ── Frequency ──
+        _add(self, TuneUp,   "TuneUp",   "Tune Up (+1 kHz)")
+        _add(self, TuneDown, "TuneDown", "Tune Down (-1 kHz)")
+        _add(self, BandUp,   "BandUp",   "Band Up")
+        _add(self, BandDown, "BandDown", "Band Down")
+        _add(self, Band160m, "Band160m", "160m Band")
+        _add(self, Band80m,  "Band80m",  "80m Band")
+        _add(self, Band60m,  "Band60m",  "60m Band")
+        _add(self, Band40m,  "Band40m",  "40m Band")
+        _add(self, Band30m,  "Band30m",  "30m Band")
+        _add(self, Band20m,  "Band20m",  "20m Band")
+        _add(self, Band17m,  "Band17m",  "17m Band")
+        _add(self, Band15m,  "Band15m",  "15m Band")
+        _add(self, Band12m,  "Band12m",  "12m Band")
+        _add(self, Band10m,  "Band10m",  "10m Band")
+        _add(self, Band6m,   "Band6m",   "6m Band")
 
-        # Record — toggle slice recording
-        self.add_action_holder(ActionHolder(
-            plugin_base=self,
-            action_base=Record,
-            action_id_suffix="Record",
-            action_name="Record",
-            action_support={
-                Input.Key: ActionInputSupport.SUPPORTED,
-                Input.Dial: ActionInputSupport.UNSUPPORTED,
-                Input.Touchscreen: ActionInputSupport.UNSUPPORTED,
-            },
-        ))
+        # ── Mode ──
+        _add(self, ModeUSB,  "ModeUSB",  "Mode: USB")
+        _add(self, ModeLSB,  "ModeLSB",  "Mode: LSB")
+        _add(self, ModeCW,   "ModeCW",   "Mode: CW")
+        _add(self, ModeAM,   "ModeAM",   "Mode: AM")
+        _add(self, ModeFM,   "ModeFM",   "Mode: FM")
+        _add(self, ModeDIGU, "ModeDIGU", "Mode: DIGU")
+        _add(self, ModeDIGL, "ModeDIGL", "Mode: DIGL")
+        _add(self, ModeFT8,  "ModeFT8",  "Mode: FT8 (20m)")
+
+        # ── Audio ──
+        _add(self, MuteToggle, "MuteToggle", "Mute Toggle")
+        _add(self, VolumeUp,   "VolumeUp",   "Volume Up")
+        _add(self, VolumeDown, "VolumeDown", "Volume Down")
+
+        # ── DSP ──
+        _add(self, NBToggle,  "NBToggle",  "Noise Blanker Toggle")
+        _add(self, NRToggle,  "NRToggle",  "Noise Reduction Toggle")
+        _add(self, ANFToggle, "ANFToggle", "Auto Notch Filter Toggle")
+        _add(self, APFToggle, "APFToggle", "Audio Peaking Filter Toggle")
+        _add(self, SQLToggle, "SQLToggle", "Squelch Toggle")
+
+        # ── Slice ──
+        _add(self, SplitToggle, "SplitToggle", "Split Toggle")
+        _add(self, LockToggle,  "LockToggle",  "Lock Toggle")
+        _add(self, RITToggle,   "RITToggle",   "RIT Toggle")
+        _add(self, XITToggle,   "XITToggle",   "XIT Toggle")
+
+        # ── DVK ──
+        _add(self, Play,   "Play",   "Play Recording")
+        _add(self, Record, "Record", "Record")
 
         self.register(
             plugin_name="AetherSDR",

--- a/plugins/streamcontroller-aethersdr/manifest.json
+++ b/plugins/streamcontroller-aethersdr/manifest.json
@@ -3,7 +3,7 @@
     "id": "com_aethersdr_radio",
     "name": "AetherSDR",
     "descriptions": {
-        "en_US": "Control AetherSDR via TCI — PTT, Record, Play for FlexRadio."
+        "en_US": "Full AetherSDR radio control via TCI — 40+ actions for TX, bands, modes, DSP, audio, and DVK."
     },
     "short-descriptions": {
         "en_US": "AetherSDR radio control"


### PR DESCRIPTION
## Summary

Fixes #838

Builds out the StreamController plugin from 3 actions to 43 actions covering full radio control via TCI WebSocket:

- **TX (5):** PTT (existing), MOXToggle, TUNEToggle, RFPower (dial+key), TunePower (dial+key)
- **Frequency (15):** TuneUp, TuneDown, BandUp, BandDown, Band160m through Band6m (11 bands)
- **Mode (8):** ModeUSB, ModeLSB, ModeCW, ModeAM, ModeFM, ModeDIGU, ModeDIGL, ModeFT8
- **Audio (3):** MuteToggle, VolumeUp, VolumeDown
- **DSP (5):** NBToggle, NRToggle, ANFToggle, APFToggle, SQLToggle
- **Slice (4):** SplitToggle, LockToggle, RITToggle, XITToggle
- **DVK (2):** Play (existing), Record (existing)

### Implementation details

- Each action is a separate `.py` file in a category subdirectory under `actions/`
- Toggle actions track state locally and flip on each DOWN press
- Hold actions (PTT) use DOWN/UP events
- RFPower and TunePower support `Input.Dial` for StreamDeck+ rotary encoders
- Band frequencies match `BandDefs.h` defaults (160m=1.900 MHz through 6m=50.150 MHz)
- BandUp/BandDown cycle through bands using shared state on `plugin_base`
- ModeFT8 sets DIGU mode and tunes to 14.074 MHz (20m FT8 dial frequency)
- `gen_icons.py` generates 72×72 PNG icons (text-on-dark-background) for StreamDeck LCD displays
- All 40 new actions registered in `main.py` with `_add()` helper to reduce boilerplate
- `_bands.py` provides shared band definitions as reference data

## Test plan

- [ ] Verify plugin loads in StreamController without import errors
- [ ] Test PTT hold behavior (DOWN=TX, UP=RX) with StreamDeck Pedal
- [ ] Test toggle actions (MOX, TUNE, NB, NR, etc.) cycle state on each press
- [ ] Test band buttons send correct VFO frequencies via `wscat -c ws://localhost:50001`
- [ ] Test mode buttons send correct `modulation:0,<mode>;` commands
- [ ] Test RFPower/TunePower dial rotation on StreamDeck+ (if available)
- [ ] Run `python gen_icons.py` to generate icon assets for LCD-equipped StreamDecks
- [ ] Verify `.gitignore` excludes `__pycache__/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)