### PR TITLE
Fix SmartLinkClient crash during SSL disconnect teardown (#842)

### DIFF
--- a/src/core/SmartLinkClient.cpp
+++ b/src/core/SmartLinkClient.cpp
@@ -31,6 +31,10 @@ SmartLinkClient::SmartLinkClient(QObject* parent)
 
 SmartLinkClient::~SmartLinkClient()
 {
+    // Prevent QSslSocket destructor from delivering signals into partially
+    // destroyed state (e.g. disconnected → onSslDisconnected → m_pingTimer.stop
+    // on a dead timer). See issue #842.
+    QObject::disconnect(&m_socket, nullptr, this, nullptr);
     disconnect();
 }
 

--- a/src/core/SmartLinkClient.h
+++ b/src/core/SmartLinkClient.h
@@ -114,10 +114,13 @@ private:
     bool    m_authenticated{false};
 
     // SmartLink server TLS connection
-    QSslSocket m_socket;
-    QByteArray m_readBuffer;
+    // NOTE: m_pingTimer and m_serverConnected must be declared before m_socket
+    // so they outlive it during destruction. QSslSocket's destructor can emit
+    // disconnected(), which invokes onSslDisconnected() → m_pingTimer.stop().
     QTimer     m_pingTimer;
     bool       m_serverConnected{false};
+    QSslSocket m_socket;
+    QByteArray m_readBuffer;
 
     // User info from server
     QString m_publicIp;


### PR DESCRIPTION
## Summary

Fixes #842

`SmartLinkClient` can crash with `EXC_BAD_ACCESS` on macOS Intel during shutdown because `QSslSocket`'s destructor emits `disconnected`, which calls `onSslDisconnected()` → `m_pingTimer.stop()` on an already-destroyed timer.

**Two changes (belt-and-suspenders):**

- **Reorder members** in `SmartLinkClient.h` so `m_pingTimer` and `m_serverConnected` are declared before `m_socket`, ensuring they outlive it during C++ reverse-order destruction
- **Disconnect signals** in `~SmartLinkClient()` with `QObject::disconnect(&m_socket, nullptr, this, nullptr)` to prevent any destructor-time signal delivery

## Test plan

- [ ] Verify patched build compiles on all platforms (CI)
- [ ] Ideally verify on Intel Mac with SmartLink connect/disconnect cycle
- [ ] Confirm normal SmartLink disconnect behavior is unchanged (signals still fire during runtime)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)