### PR TITLE
Widen VFO frequency display for transverter/SHF bands (#844)

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -427,11 +427,11 @@ void VfoWidget::buildUI()
         " border-radius: 3px; color: #00e5ff; font-size: 22px;"
         " font-weight: bold; padding: 0 2px 0 0; }");
     m_freqEdit->setAlignment(Qt::AlignRight);
-    // Size to fit "000.000.000" at the label font size
+    // Size to fit "0000.000.000" at the label font size (4-digit MHz for XVTR/SHF)
     QFont labelFont;
     labelFont.setPixelSize(26);
     labelFont.setBold(true);
-    const int stackW = QFontMetrics(labelFont).horizontalAdvance("000.000.000") + 8;
+    const int stackW = QFontMetrics(labelFont).horizontalAdvance("0000.000.000") + 8;
     m_freqStack->setFixedWidth(stackW);
     m_freqEdit->setPlaceholderText("MHz (e.g. 14.225)");
     m_freqStack->addWidget(m_freqEdit);


### PR DESCRIPTION
## Summary
- Fixes #844 — VFO frequency display truncates leading digit(s) for frequencies above 999 MHz (e.g. 1296.090.000 displayed as 296.090.000)
- Widens the `QStackedWidget` sizing template from `"000.000.000"` to `"0000.000.000"` to accommodate 4-digit MHz values used with transverters through SHF bands

## Root cause
The frequency label widget was sized using `QFontMetrics::horizontalAdvance("000.000.000")`, which only fits 3-digit MHz values (max 999 MHz). Transverter frequencies like 1296 MHz have a 4-digit MHz part that overflows the fixed width, causing Qt to clip the leftmost digit(s).

## Change
One-line change in `src/gui/VfoWidget.cpp` — the sizing template and comment.

## Test plan
- [ ] Verify VFO displays correctly for frequencies below 999 MHz (no regression)
- [ ] Verify VFO displays correctly for transverter frequencies above 999 MHz (e.g. 1296.090.000)
- [ ] Confirm no layout overflow or visual artifacts at various window sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)