### PR TITLE
Fix/issue 53 slice pan limit notifications

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -581,6 +581,12 @@ MainWindow::MainWindow(QWidget* parent)
             QString("%1 supports a maximum of %2 panadapters")
                 .arg(model).arg(limit), 4000);
     });
+    connect(&m_radioModel, &RadioModel::sliceCreateFailed,
+            this, [this](int limit, const QString& model) {
+        statusBar()->showMessage(
+            QString("%1 supports a maximum of %2 slices across all connected clients")
+                .arg(model).arg(limit), 4000);
+    });
     connect(&m_radioModel.spotModel(), &SpotModel::spotsCleared,
             this, &MainWindow::rebuildMemorySpotFeed);
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -491,12 +491,14 @@ void RadioModel::addSlice()
     const QString cmd = QString("slice create pan=%1 freq=%2").arg(m_activePanId, freq);
 
     qCDebug(lcProtocol) << "RadioModel::addSlice:" << cmd;
-    sendCmd(cmd, [](int code, const QString& body) {
-        if (code != 0)
+    sendCmd(cmd, [this](int code, const QString& body) {
+        if (code != 0) {
             qCWarning(lcProtocol) << "RadioModel: slice create failed, code"
                        << Qt::hex << code << "body:" << body;
-        else
+            emit sliceCreateFailed(maxSlices(), m_model);
+        } else {
             qCDebug(lcProtocol) << "RadioModel: new slice created, index =" << body;
+        }
     });
 }
 
@@ -517,12 +519,14 @@ void RadioModel::addSliceOnPan(const QString& panId)
     const QString cmd = QString("slice create pan=%1 freq=%2").arg(panId, freq);
 
     qCDebug(lcProtocol) << "RadioModel::addSliceOnPan:" << cmd;
-    sendCmd(cmd, [](int code, const QString& body) {
-        if (code != 0)
+    sendCmd(cmd, [this](int code, const QString& body) {
+        if (code != 0) {
             qCWarning(lcProtocol) << "RadioModel: slice create failed, code"
                        << Qt::hex << code << "body:" << body;
-        else
+            emit sliceCreateFailed(maxSlices(), m_model);
+        } else {
             qCDebug(lcProtocol) << "RadioModel: new slice created, index =" << body;
+        }
     });
 }
 

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -271,6 +271,9 @@ signals:
     void panadapterRemoved(const QString& panId);
     // Emitted when createPanadapter() is blocked because the radio's pan limit is reached.
     void panadapterLimitReached(int limit, const QString& model);
+    // Emitted when the radio rejects a slice create command (e.g. limit reached across
+    // all Multi-Flex clients — our local slice count may be below maxSlices()).
+    void sliceCreateFailed(int limit, const QString& model);
     // Emitted when a pan needs xpixels/ypixels pushed (after profile change, reconnect, etc.)
     void panDimensionsNeeded(const QString& panId);
     // Emitted when the radio reports its antenna list (e.g. "ANT1,ANT2,RX_A,RX_B").


### PR DESCRIPTION
## Slice and panadapter limit notifications (#53)

### Problem

When a user hit the slice or panadapter limit, the app either silently
ignored the action or let the command reach the radio only to discard
the error response. There was no feedback to the user explaining why
nothing happened.

This was especially broken in Multi-Flex sessions: the +RX button only
counted slices owned by the local client, so if other connected clients
were holding slices the guard would pass, the `slice create` command
would fire, and the radio's rejection (`0x50000003`) was logged but
never surfaced to the UI.

---

### Changes

**`src/models/RadioModel.h`**
- Added `maxPanadapters()` — centralizes per-model panadapter capacity
  that was previously duplicated inline in `MainWindow.cpp`:
  - FLEX-6700: 8 (dual SCU, high-capacity)
  - FLEX-6600 / FLEX-8600 / AU-520: 4 (dual SCU)
  - All single-SCU models: 2
- Added `panadapterLimitReached(int limit, QString model)` signal —
  emitted by `createPanadapter()` when the pan limit is reached;
  keeps UI concerns out of the model layer
- Added `sliceCreateFailed(int limit, QString model)` signal — emitted
  when the radio rejects a `slice create` command, covering Multi-Flex
  cases where the local slice count is below `maxSlices()` but the
  combined count across all clients is not

**`src/models/RadioModel.cpp`**
- `createPanadapter()`: checks `m_panadapters.size() >= maxPanadapters()`
  before sending the command; emits `panadapterLimitReached` and returns
  early if the limit is hit
- `addSlice()` and `addSliceOnPan()`: callbacks now capture `this` and
  emit `sliceCreateFailed` on any non-zero radio response

**`src/gui/MainWindow.cpp`**
- `+RX` handler: added `else` branch showing e.g.
  `"FLEX-8600 supports a maximum of 4 slices"` for 4 seconds (fast-path
  for single-client case)
- `+PAN` label handler: replaced the duplicated `dualScu` boolean and
  `model.contains()` chain with `m_radioModel.maxPanadapters()`
- Wired `panadapterLimitReached` → `statusBar()->showMessage()`:
  `"FLEX-6700 supports a maximum of 8 panadapters"`
- Wired `sliceCreateFailed` → `statusBar()->showMessage()`:
  `"FLEX-8600 supports a maximum of 4 slices across all connected clients"`

---

### How to test

**Single client — slice limit:**
1. Connect to a FLEX-6600 or FLEX-8600 (4-slice radio)
2. Create slices until at the limit (4 slices)
3. Click +RX — status bar should show
   `"FLEX-8600 supports a maximum of 4 slices"`

**Single client — panadapter limit:**
1. Connect to a FLEX-6600 or FLEX-8600
2. Open the +PAN layout picker and expand to the max layout (4 pans)
3. Attempt to call `createPanadapter()` directly — status bar should
   show `"FLEX-8600 supports a maximum of 4 panadapters"`

**Multi-Flex — slice limit across clients:**
1. Connect Client A (SmartSDR or a second AetherSDR instance) and
   create 2 slices
2. Connect Client B (AetherSDR) and create 2 more slices — combined
   total is now 4 (the limit on most radios)
3. On Client B, click +RX — the command will reach the radio, be
   rejected with `0x50000003`, and the status bar should show
   `"FLEX-8600 supports a maximum of 4 slices across all connected clients"`

**FLEX-6700 — higher limits:**
1. Connect to a FLEX-6700
2. Verify the +RX guard allows up to 8 slices before triggering

---

### Notes

`applyPanLayout()`'s `kPanCounts` map currently defines no layouts
beyond 4 pans (`"2x2"` / `"4v"`), so the FLEX-6700's 8-pan capacity
is not yet reachable through the layout picker. `maxPanadapters()`
returns the correct value of 8 and the limit guard in
`createPanadapter()` is in place — 8-pan layout entries are a
follow-up task.

Closes #53