### PR TITLE
Persist VU meter selections + S-Meter peak hold line (#809, #840)

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -262,10 +262,71 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     selectLayout->addLayout(rxCol, 1);
     sMeterLayout->addWidget(selectRow);
 
+    // Restore saved TX/RX meter selections (#809)
+    int txIdx = AppSettings::instance().value("SMeter_TxSelect", 0).toInt();
+    int rxIdx = AppSettings::instance().value("SMeter_RxSelect", 0).toInt();
+    if (txIdx >= 0 && txIdx < m_txSelect->count())
+        m_txSelect->setCurrentIndex(txIdx);
+    if (rxIdx >= 0 && rxIdx < m_rxSelect->count())
+        m_rxSelect->setCurrentIndex(rxIdx);
+
     connect(m_txSelect, &QComboBox::currentTextChanged,
             m_sMeter, &SMeterWidget::setTxMode);
     connect(m_rxSelect, &QComboBox::currentTextChanged,
             m_sMeter, &SMeterWidget::setRxMode);
+
+    // Persist TX/RX meter selections on change (#809)
+    connect(m_txSelect, &QComboBox::currentIndexChanged,
+            this, [](int idx) {
+        AppSettings::instance().setValue("SMeter_TxSelect", idx);
+    });
+    connect(m_rxSelect, &QComboBox::currentIndexChanged,
+            this, [](int idx) {
+        AppSettings::instance().setValue("SMeter_RxSelect", idx);
+    });
+
+    // ── Peak hold line controls (#840) ────────────────────────────────────
+    auto* peakRow = new QWidget(m_sMeterSection);
+    auto* peakLayout = new QHBoxLayout(peakRow);
+    peakLayout->setContentsMargins(4, 2, 4, 2);
+    peakLayout->setSpacing(6);
+
+    auto* peakBtn = new QPushButton("Peak Hold", peakRow);
+    peakBtn->setCheckable(true);
+    peakBtn->setChecked(AppSettings::instance().value("PeakHoldEnabled", "False") == "True");
+    peakBtn->setFixedHeight(20);
+    peakBtn->setStyleSheet(
+        "QPushButton { background: #1a1a2e; color: #8090a0; border: 1px solid #334; "
+        "border-radius: 3px; font-size: 10px; padding: 0 6px; } "
+        "QPushButton:checked { background: #0a3060; color: #00b4d8; border-color: #00b4d8; }");
+
+    auto* decayLabel = new QLabel("Decay", peakRow);
+    decayLabel->setStyleSheet(labelStyle);
+    auto* decayCombo = new GuardedComboBox(peakRow);
+    decayCombo->addItems({"Fast", "Medium", "Slow"});
+    decayCombo->setCurrentText(
+        AppSettings::instance().value("PeakDecayRate", "Medium").toString());
+    AetherSDR::applyComboStyle(decayCombo);
+
+    peakLayout->addWidget(peakBtn);
+    peakLayout->addWidget(decayLabel);
+    peakLayout->addWidget(decayCombo, 1);
+    sMeterLayout->addWidget(peakRow);
+
+    m_sMeter->setPeakHoldEnabled(peakBtn->isChecked());
+    m_sMeter->setPeakDecayRate(decayCombo->currentText());
+
+    connect(peakBtn, &QPushButton::toggled, this, [this](bool on) {
+        m_sMeter->setPeakHoldEnabled(on);
+        AppSettings::instance().setValue("PeakHoldEnabled", on ? "True" : "False");
+        AppSettings::instance().save();
+    });
+    connect(decayCombo, &QComboBox::currentTextChanged,
+            this, [this](const QString& rate) {
+        m_sMeter->setPeakDecayRate(rate);
+        AppSettings::instance().setValue("PeakDecayRate", rate);
+        AppSettings::instance().save();
+    });
 
     root->addWidget(m_sMeterSection);
 

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -8,7 +8,7 @@
 
 namespace AetherSDR {
 
-// ─── Construction ────────────────────────────────────────────────────────────
+// --- Construction ------------------------------------------------------------
 
 SMeterWidget::SMeterWidget(QWidget* parent)
     : QWidget(parent)
@@ -36,17 +36,33 @@ SMeterWidget::SMeterWidget(QWidget* parent)
     });
 }
 
-// ─── Public interface ────────────────────────────────────────────────────────
+// --- Public interface --------------------------------------------------------
 
 void SMeterWidget::setLevel(float dbm)
 {
     // Exponential smoothing for needle movement
     m_levelDbm = m_levelDbm + SMOOTH_ALPHA * (dbm - m_levelDbm);
 
-    // Peak hold
+    // Peak hold (existing needle/triangle behavior)
     if (dbm > m_peakDbm) {
         m_peakDbm = dbm;
         m_peakDecay.start();
+    }
+
+    // Configurable peak hold line
+    if (m_peakHoldEnabled) {
+        if (dbm > m_peakHoldDbm) {
+            m_peakHoldDbm = dbm;
+            m_peakHoldTimer.start();
+            m_peakHoldTimerRunning = true;
+        } else if (m_peakHoldTimerRunning
+                   && m_peakHoldTimer.elapsed() > m_peakHoldTimeMs) {
+            // Decay phase: meter refresh is ~50ms (from m_peakDecay interval)
+            const float dt = 0.05f;
+            m_peakHoldDbm -= m_peakDecayDbPerSec * dt;
+            if (m_peakHoldDbm < m_levelDbm)
+                m_peakHoldDbm = m_levelDbm;
+        }
     }
 
     if (!m_transmitting)
@@ -113,7 +129,7 @@ QString SMeterWidget::sUnitsText() const
     return QString("S9+%1").arg(over);
 }
 
-// ─── Mapping ─────────────────────────────────────────────────────────────────
+// --- Mapping -----------------------------------------------------------------
 
 float SMeterWidget::dbmToFraction(float dbm) const
 {
@@ -122,10 +138,10 @@ float SMeterWidget::dbmToFraction(float dbm) const
     const float clamped = qBound(S0_DBM, dbm, MAX_DBM);
 
     if (clamped <= S9_DBM) {
-        // Linear within S0..S9 → 0.0..0.6
+        // Linear within S0..S9 -> 0.0..0.6
         return 0.6f * (clamped - S0_DBM) / (S9_DBM - S0_DBM);
     }
-    // Linear within S9..S9+60 → 0.6..1.0
+    // Linear within S9..S9+60 -> 0.6..1.0
     return 0.6f + 0.4f * (clamped - S9_DBM) / (MAX_DBM - S9_DBM);
 }
 
@@ -135,7 +151,7 @@ float SMeterWidget::txValueToFraction(float value) const
     case TxMode::Power:
         return qBound(0.0f, value / m_powerScaleMax, 1.0f);
     case TxMode::SWR:
-        // 1.0–3.0
+        // 1.0-3.0
         return qBound(0.0f, (value - 1.0f) / 2.0f, 1.0f);
     case TxMode::Level:
         // -40 to +5
@@ -158,7 +174,7 @@ float SMeterWidget::currentTxValue() const
     return 0.0f;
 }
 
-// ─── Paint ───────────────────────────────────────────────────────────────────
+// --- Paint -------------------------------------------------------------------
 
 void SMeterWidget::paintEvent(QPaintEvent*)
 {
@@ -171,8 +187,8 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     // Background
     p.fillRect(rect(), QColor(0x0f, 0x0f, 0x1a));
 
-    // ── Arc geometry ─────────────────────────────────────────────────────
-    // Large radius with center far below widget → shallow ~70° arc segment
+    // -- Arc geometry ---------------------------------------------------------
+    // Large radius with center far below widget -> shallow ~70 deg arc segment
     const float cx = w * 0.5f;
     const float radius = w * 0.85f;
     const float cy = h + radius - h * 0.65f;  // arc center well below widget
@@ -183,12 +199,12 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     const float arcEndRad   = qDegreesToRadians(ARC_END_DEG);
     const float arcSpanRad  = arcEndRad - arcStartRad;
 
-    // fraction 0.0 → left end (ARC_END_DEG), fraction 1.0 → right end (ARC_START_DEG)
+    // fraction 0.0 -> left end (ARC_END_DEG), fraction 1.0 -> right end (ARC_START_DEG)
     auto fractionToAngle = [&](float frac) -> float {
         return arcEndRad - frac * arcSpanRad;  // radians
     };
 
-    // ── Draw colored outer arc (RX scale) ───────────────────────────────
+    // -- Draw colored outer arc (RX scale) ------------------------------------
     // White from S0 to S9, red from S9+
     {
         const QRectF outerArc(cx - radius, cy - radius, radius * 2, radius * 2);
@@ -207,7 +223,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
                   static_cast<int>((s9Deg - ARC_START_DEG) * 16));
     }
 
-    // ── Draw colored inner arc (TX scale) — 6px gap ──────────────────────
+    // -- Draw colored inner arc (TX scale) -- 6px gap -------------------------
     const float arcGap = 6.0f;
     const QColor blueColor(0x00, 0x80, 0xd0);
     const QColor redColor(0xff, 0x44, 0x44);
@@ -243,7 +259,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
         }
     }
 
-    // ── Tick drawing helpers ──────────────────────────────────────────────
+    // -- Tick drawing helpers -------------------------------------------------
     QFont tickFont = font();
     tickFont.setPixelSize(qMax(10, h / 10));
     tickFont.setBold(true);
@@ -311,7 +327,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
 
     const QColor whiteColor(0xc8, 0xd8, 0xe8);
 
-    // ── Outside ticks (RX): S-meter scale — odd S-units only ──────────
+    // -- Outside ticks (RX): S-meter scale -- odd S-units only ----------------
     for (int s = 1; s <= 9; s += 2) {
         const float dbm = S0_DBM + s * DB_PER_S;
         drawOutsideTick(dbmToFraction(dbm), QString::number(s), whiteColor, true);
@@ -321,7 +337,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
         drawOutsideTick(dbmToFraction(dbm), QString("+%1").arg(over), redColor, true);
     }
 
-    // ── Inside ticks (TX): scale depends on TX mode ──────────────────────
+    // -- Inside ticks (TX): scale depends on TX mode --------------------------
     switch (m_txMode) {
     case TxMode::Power: {
         // Dynamic scale based on m_powerScaleMax
@@ -347,7 +363,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
         break;
     }
     case TxMode::SWR: {
-        // 1.0–3.0, ticks at 1, 1.5, 2, 2.5, 3.  Red starting at 2.5.
+        // 1.0-3.0, ticks at 1, 1.5, 2, 2.5, 3.  Red starting at 2.5.
         for (float s : {1.0f, 1.5f, 2.0f, 2.5f, 3.0f}) {
             const float frac = (s - 1.0f) / 2.0f;
             const bool red = (s >= 2.5f);
@@ -381,7 +397,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     }
     }
 
-    // ── Draw needle ──────────────────────────────────────────────────────
+    // -- Draw needle ----------------------------------------------------------
     // Needle originates from needleCy (just below widget) rather than the
     // arc center, so the pivot is barely out of frame.
     // When transmitting, needle tracks the selected TX meter instead of RX.
@@ -409,7 +425,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
         p.drawLine(QPointF(cx, needleCy), QPointF(tipX, tipY));
     }
 
-    // ── Draw peak marker (small triangle) — only in RX S-Meter Peak mode ─
+    // -- Draw peak marker (small triangle) -- only in RX S-Meter Peak mode ----
     if (!m_transmitting && m_rxMode == RxMode::SMeterPeak
         && m_peakDbm > m_levelDbm + 1.0f) {
         const float frac = dbmToFraction(m_peakDbm);
@@ -436,7 +452,24 @@ void SMeterWidget::paintEvent(QPaintEvent*)
         p.drawPath(tri);
     }
 
-    // ── Text readout — all top-aligned on the same baseline ─────────────
+    // -- Draw peak hold line (configurable overlay, independent of RX mode) ---
+    if (m_peakHoldEnabled && !m_transmitting
+        && m_peakHoldDbm > S0_DBM + 1.0f) {
+        const float frac = dbmToFraction(m_peakHoldDbm);
+        const float angle = fractionToAngle(frac);
+
+        const float cosA = std::cos(angle);
+        const float sinA = std::sin(angle);
+        const QPointF inner(cx + (radius - 4) * cosA,
+                            cy - (radius - 4) * sinA);
+        const QPointF outer(cx + (radius + 10) * cosA,
+                            cy - (radius + 10) * sinA);
+
+        p.setPen(QPen(QColor(0xff, 0x44, 0x44, 0xcc), 2));
+        p.drawLine(inner, outer);
+    }
+
+    // -- Text readout -- all top-aligned on the same baseline -----------------
     QFont srcFont = font();
     srcFont.setPixelSize(qMax(9, h / 14));
     const QFontMetrics sfm(srcFont);
@@ -508,6 +541,44 @@ void SMeterWidget::setPowerScale(int maxWatts, bool hasAmplifier)
         m_powerScaleMax = 120.0f;
         m_powerRedStart = 100.0f;
     }
+    update();
+}
+
+// --- Peak hold configuration -------------------------------------------------
+
+void SMeterWidget::setPeakHoldEnabled(bool enabled)
+{
+    m_peakHoldEnabled = enabled;
+    if (!enabled)
+        m_peakHoldDbm = m_levelDbm;
+    update();
+}
+
+void SMeterWidget::setPeakHoldTimeMs(int ms)
+{
+    m_peakHoldTimeMs = qBound(100, ms, 2000);
+}
+
+void SMeterWidget::setPeakDecayRate(DecayRate rate)
+{
+    switch (rate) {
+    case DecayRate::Fast:   m_peakDecayDbPerSec = 20.0f; break;
+    case DecayRate::Medium: m_peakDecayDbPerSec = 10.0f; break;
+    case DecayRate::Slow:   m_peakDecayDbPerSec = 5.0f;  break;
+    }
+}
+
+void SMeterWidget::setPeakDecayRate(const QString& rate)
+{
+    if (rate == "Fast")        setPeakDecayRate(DecayRate::Fast);
+    else if (rate == "Slow")   setPeakDecayRate(DecayRate::Slow);
+    else                       setPeakDecayRate(DecayRate::Medium);
+}
+
+void SMeterWidget::resetPeak()
+{
+    m_peakHoldDbm = m_levelDbm;
+    m_peakHoldTimerRunning = false;
     update();
 }
 

--- a/src/gui/SMeterWidget.h
+++ b/src/gui/SMeterWidget.h
@@ -2,6 +2,7 @@
 
 #include <QWidget>
 #include <QTimer>
+#include <QElapsedTimer>
 
 namespace AetherSDR {
 
@@ -30,6 +31,7 @@ public:
 
     enum class TxMode { Power, SWR, Level, Compression };
     enum class RxMode { SMeter, SMeterPeak };
+    enum class DecayRate { Fast, Medium, Slow };
 
 public slots:
     // Update the displayed RX level (S-meter dBm).
@@ -50,6 +52,13 @@ public slots:
 
     // Set TX power gauge scale: barefoot (120W), Aurora (600W), amplifier (2000W).
     void setPowerScale(int maxWatts, bool hasAmplifier);
+
+    // Peak hold configuration.
+    void setPeakHoldEnabled(bool enabled);
+    void setPeakHoldTimeMs(int ms);
+    void setPeakDecayRate(DecayRate rate);
+    void setPeakDecayRate(const QString& rate);
+    void resetPeak();
 
 protected:
     void paintEvent(QPaintEvent* event) override;
@@ -82,6 +91,14 @@ private:
 
     QTimer  m_peakDecay;
     QTimer  m_peakReset;    // hard reset peak hold every 10 seconds
+
+    // Peak hold line state
+    bool           m_peakHoldEnabled{false};
+    float          m_peakHoldDbm{-127.0f};
+    int            m_peakHoldTimeMs{1000};
+    float          m_peakDecayDbPerSec{10.0f};  // Medium default
+    QElapsedTimer  m_peakHoldTimer;
+    bool           m_peakHoldTimerRunning{false};
 
     // S-unit reference: S0 = -127 dBm, each S-unit = 6 dB
     static constexpr float S0_DBM  = -127.0f;


### PR DESCRIPTION
Cherry-picked and merged from pi-claude PRs #847 and #850 (stale
branches had CI failures). Resolved merge conflict in AppletPanel.

- TX/RX Select combos persist via AppSettings (#809)
- Configurable peak hold line with Fast/Medium/Slow decay (#840)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
