### PR TITLE
Fix S-Meter TX power not showing during transmit

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1129,12 +1129,7 @@ MainWindow::MainWindow(QWidget* parent)
             m_appletPanel->sMeterWidget()->setLevel(dbm);
     });
     connect(&m_radioModel.meterModel(), &MeterModel::txMetersChanged,
-            this, [this](float fwdPwr, float swr) {
-        // When amplifier is present, ampMetersChanged feeds the S-Meter
-        // with amplifier output power. Skip exciter meters to avoid overwriting.
-        if (!m_radioModel.hasAmplifier())
-            m_appletPanel->sMeterWidget()->setTxMeters(fwdPwr, swr);
-    });
+            m_appletPanel->sMeterWidget(), &SMeterWidget::setTxMeters);
     connect(&m_radioModel.meterModel(), &MeterModel::micMetersChanged,
             m_appletPanel->sMeterWidget(), &SMeterWidget::setMicMeters);
     connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -58,7 +58,10 @@ void SMeterWidget::setTxMeters(float fwdPower, float swr)
     m_txPower = m_txPower + SMOOTH_ALPHA * (fwdPower - m_txPower);
     m_txSwr   = m_txSwr   + SMOOTH_ALPHA * (swr - m_txSwr);
 
-    if (m_transmitting && (m_txMode == TxMode::Power || m_txMode == TxMode::SWR))
+    // Repaint whenever TX power data arrives — either because moxChanged set
+    // m_transmitting, or because RF power is flowing regardless (e.g. VOX,
+    // hardware-keyed CW, or interlock race where setTransmitting arrives late).
+    if (m_transmitting || m_txPower > 0.5f)
         update();
 }
 
@@ -78,6 +81,12 @@ void SMeterWidget::setMicMeters(float micLevel, float compLevel, float micPeak, 
 void SMeterWidget::setTransmitting(bool tx)
 {
     m_transmitting = tx;
+    if (!tx) {
+        // Clear TX values immediately on un-key so the needle snaps back to RX
+        // rather than decaying slowly through the smoothing filter.
+        m_txPower = 0.0f;
+        m_txSwr   = 1.0f;
+    }
     update();
 }
 
@@ -385,9 +394,12 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     // Needle originates from needleCy (just below widget) rather than the
     // arc center, so the pivot is barely out of frame.
     // When transmitting, needle tracks the selected TX meter instead of RX.
+    // Also switches to TX display when RF power is flowing even if m_transmitting
+    // hasn't been set yet (VOX, hardware CW, interlock timing race).
     {
+        const bool effectiveTx = m_transmitting || m_txPower > 0.5f;
         float frac;
-        if (m_transmitting)
+        if (effectiveTx)
             frac = txValueToFraction(currentTxValue());
         else if (m_rxMode == RxMode::SMeterPeak)
             frac = dbmToFraction(m_peakDbm);
@@ -410,7 +422,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     }
 
     // ── Draw peak marker (small triangle) — only in RX S-Meter Peak mode ─
-    if (!m_transmitting && m_rxMode == RxMode::SMeterPeak
+    if (!(m_transmitting || m_txPower > 0.5f) && m_rxMode == RxMode::SMeterPeak
         && m_peakDbm > m_levelDbm + 1.0f) {
         const float frac = dbmToFraction(m_peakDbm);
         const float angle = fractionToAngle(frac);
@@ -447,7 +459,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     valFont.setBold(true);
     const QFontMetrics vfm(valFont);
 
-    if (m_transmitting) {
+    if (m_transmitting || m_txPower > 0.5f) {
         // TX mode: show TX source label (center), mode name (left), value (right)
         static const char* txLabels[] = {"Power", "SWR", "Level", "Compression"};
         const QString srcLabel = txLabels[static_cast<int>(m_txMode)];


### PR DESCRIPTION
## Summary

- **`MainWindow.cpp`**: `txMetersChanged` was wrapped in a `hasAmplifier()` guard, which blocked exciter forward power from reaching `SMeterWidget` whenever the radio sent any amplifier status message — including internal ATU reports or non-PGXL devices that happen to use the amplifier API. The guard was redundant: the `ampMetersChanged` path already feeds the S-Meter separately when a real PGXL is present. Replaced the lambda with a direct signal connection.

- **`SMeterWidget.cpp`**: `setTxMeters()` only called `update()` when `m_transmitting` was already `true`. However, `m_transmitting` can arrive late or be reset by competing interlock state updates (VOX, hardware-keyed CW, interlock race condition). The widget was receiving power data correctly but never repainting the needle.

  Fix: also trigger repaint when `m_txPower > 0.5W` regardless of `m_transmitting`, so RF power flowing is self-sufficient to drive the display. The same `effectiveTx` condition is applied consistently to the needle, peak marker, and text readout in `paintEvent`. On un-key, `setTransmitting(false)` now zeroes `m_txPower`/`m_txSwr` immediately so the needle snaps back to RX instantly rather than decaying slowly through the smoothing filter.

## Root cause detail

`RadioModel::handleStatus()` sets `m_hasAmplifier = true` for any `amplifier` status message with a non-empty, non-TGXL model string. Some FLEX radios report internal hardware via the amplifier API even with no physical PGXL connected. Once `hasAmplifier()` became true, the `txMetersChanged` guard suppressed all exciter power updates to the S-Meter, while the PGXL-specific `ampMetersChanged` signal never fired — leaving the needle completely dead during TX. The TxApplet forward power bar was unaffected because it has no such guard.

## Test plan

- [ ] TX on SSB/CW with no PGXL — S-Meter needle moves with RF power
- [ ] TX mode selector (Power / SWR / Level / Compression) all update correctly during TX
- [ ] Needle snaps back to RX level immediately on un-key
- [ ] RX signal level still works normally between transmissions
- [ ] PGXL users unaffected — `ampMetersChanged` continues to feed S-Meter with amplifier output power

Verified on macOS 15 with FLEX-6600 (no PGXL). The `hasAmplifier()` guard was introduced in 0.8.2 and was present through 0.8.4, so all users on these versions without a PGXL were affected.