### PR TITLE
Fix RX filter flag showing 0.1 kHz less than selected preset (#794)

### DIFF
--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -985,7 +985,7 @@ void RxApplet::connectSlice(SliceModel* s)
     });
 
     // Filter width label
-    m_filterWidthLbl->setText(formatFilterWidth(s->filterLow(), s->filterHigh()));
+    m_filterWidthLbl->setText(formatFilterWidth(s->filterLow(), s->filterHigh(), s->mode()));
 
     // QSK
     {
@@ -1073,11 +1073,13 @@ void RxApplet::connectSlice(SliceModel* s)
     m_filterPassband->setMode(s->mode());
     connect(s, &SliceModel::filterChanged, this, [this](int lo, int hi) {
         updateFilterButtons();
-        m_filterWidthLbl->setText(formatFilterWidth(lo, hi));
+        m_filterWidthLbl->setText(formatFilterWidth(lo, hi, m_slice ? m_slice->mode() : QString()));
         m_filterPassband->setFilter(lo, hi);
     });
     connect(s, &SliceModel::modeChanged, this, [this](const QString& mode) {
         m_filterPassband->setMode(mode);
+        if (m_slice)
+            m_filterWidthLbl->setText(formatFilterWidth(m_slice->filterLow(), m_slice->filterHigh(), mode));
     });
 
     // AGC mode
@@ -1246,9 +1248,15 @@ QString RxApplet::formatHz(int hz)
     return (hz >= 0 ? "+" : "") + QString::number(hz) + " Hz";
 }
 
-QString RxApplet::formatFilterWidth(int lo, int hi)
+QString RxApplet::formatFilterWidth(int lo, int hi, const QString& mode)
 {
-    const int w = hi - lo;
+    int w;
+    if (mode == "USB" || mode == "DIGU" || mode == "FDV")
+        w = hi;
+    else if (mode == "LSB" || mode == "DIGL")
+        w = std::abs(lo);
+    else
+        w = hi - lo;
     if (w <= 0) return "?";
     if (w >= 1000) return QString::number(w / 1000.0, 'f', 1) + "K";
     return QString::number(w);

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -83,7 +83,7 @@ private:
     void updateOffsetDirButtons();
     void applyOffsetDir(const QString& dir);
     static QString formatHz(int hz);
-    static QString formatFilterWidth(int lo, int hi);
+    static QString formatFilterWidth(int lo, int hi, const QString& mode = QString());
     static QString formatStepLabel(int hz);
 
     SliceModel* m_slice{nullptr};

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1856,6 +1856,7 @@ void VfoWidget::setSlice(SliceModel* slice)
 #endif
         m_nrfBtn->setVisible(!isFm);
         relayoutDspGrid();
+        updateFilterLabel();
         if (m_tabStack->isVisible()) adjustSize();
     });
     // Filter
@@ -2355,7 +2356,14 @@ void VfoWidget::updateFreqLabel()
 void VfoWidget::updateFilterLabel()
 {
     if (!m_slice) return;
-    int w = m_slice->filterHigh() - m_slice->filterLow();
+    const QString& mode = m_slice->mode();
+    int w;
+    if (mode == "USB" || mode == "DIGU" || mode == "FDV")
+        w = m_slice->filterHigh();
+    else if (mode == "LSB" || mode == "DIGL")
+        w = std::abs(m_slice->filterLow());
+    else
+        w = m_slice->filterHigh() - m_slice->filterLow();
     if (w >= 1000)
         m_filterWidthLbl->setText(QString("%1K").arg(w / 1000.0, 0, 'f', 1));
     else


### PR DESCRIPTION
## Summary

Fixes #794

- For SSB-like modes (USB/LSB/DIGU/DIGL/FDV), the filter width label now shows the **nominal filter edge value** (hi-cut for USB-like, abs(lo-cut) for LSB-like) instead of `hi - lo`, which was 95 Hz less due to the intentional 95 Hz low-cut offset
- Updated both `VfoWidget::updateFilterLabel()` and `RxApplet::formatFilterWidth()` with mode-aware width calculation
- Filter label now also refreshes on mode change so the display stays correct when switching modes

## Details

When selecting a preset RX filter (e.g. 2.7K), the radio sets `lo=95, hi=2700` (USB) or `lo=-2700, hi=-95` (LSB). The old code displayed `hi - lo = 2605`, which rounds to "2.6K" — 0.1 kHz less than the selected "2.7K" preset. The fix displays the filter edge value directly (2700 → "2.7K"), matching SmartSDR behavior.

CW/AM/SAM/DSB/RTTY modes are unaffected (symmetric filters where `hi - lo` is already correct).

## Files changed

| File | Change |
|---|---|
| `src/gui/VfoWidget.cpp` | Mode-aware `updateFilterLabel()`, refresh on mode change |
| `src/gui/RxApplet.cpp` | Mode-aware `formatFilterWidth()`, pass mode to callers, refresh on mode change |
| `src/gui/RxApplet.h` | Add optional `mode` parameter to `formatFilterWidth()` |

## Test plan

- [ ] Select USB mode, choose 2.7K/2.9K/3.3K preset filters — flag should show 2.7K/2.9K/3.3K (not 2.6K/2.8K/3.2K)
- [ ] Same test in LSB/DIGU/DIGL modes
- [ ] Manually drag filter edges — label should still update correctly
- [ ] CW/AM modes — verify symmetric filter display unchanged
- [ ] Switch modes (e.g. USB→LSB→CW) — filter label updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)