### PR TITLE
Fix CW filter low-cut drag and VFO line thickness (#764)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1086,14 +1086,22 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
         const int hiX = mhzToX(ao->freqMhz + ao->filterHighHz / 1.0e6);
         constexpr int GRAB = 5;
 
-        if (std::abs(mx - loX) <= GRAB) {
-            m_draggingFilter = FilterEdge::Low;
-            setCursor(Qt::SizeHorCursor);
-            ev->accept();
-            return;
-        }
-        if (std::abs(mx - hiX) <= GRAB) {
-            m_draggingFilter = FilterEdge::High;
+        const bool loHit = std::abs(mx - loX) <= GRAB;
+        const bool hiHit = std::abs(mx - hiX) <= GRAB;
+        if (loHit || hiHit) {
+            // When both edges are within grab range, pick the closer one (#764)
+            if (loHit && hiHit)
+                m_draggingFilter = (std::abs(mx - loX) <= std::abs(mx - hiX))
+                    ? FilterEdge::Low : FilterEdge::High;
+            else
+                m_draggingFilter = loHit ? FilterEdge::Low : FilterEdge::High;
+
+            // Store anchor offset so the edge doesn't snap to cursor (#764)
+            const double mhz = xToMhz(mx);
+            const int mouseHz = static_cast<int>(std::round((mhz - ao->freqMhz) * 1.0e6));
+            const int edgeHz = (m_draggingFilter == FilterEdge::Low) ? ao->filterLowHz : ao->filterHighHz;
+            m_filterDragOffsetHz = edgeHz - mouseHz;
+
             setCursor(Qt::SizeHorCursor);
             ev->accept();
             return;
@@ -1197,6 +1205,7 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         const int mx = static_cast<int>(ev->position().x());
         const double mhz = xToMhz(mx);
         int hz = static_cast<int>(std::round((mhz - ao->freqMhz) * 1.0e6));
+        hz += m_filterDragOffsetHz; // apply anchor offset (#764)
 
         if (m_draggingFilter == FilterEdge::Low) {
             hz = std::clamp(hz, m_filterMinHz, ao->filterHighHz - 10);
@@ -3268,7 +3277,9 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
             // ── Standard VFO center line ─────────────────────────────────
             int markerX = vfoX;
 
-            p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 220), 2.0));
+            // Reduce line width when a filter edge is very close (e.g. CW mode) (#764)
+            const qreal vfoLineW = (std::abs(vfoX - fX1) <= 4 || std::abs(vfoX - fX2) <= 4) ? 1.0 : 2.0;
+            p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 220), vfoLineW));
             p.drawLine(markerX, specRect.top(), markerX, wfRect.bottom());
 
             // ── Triangle marker at top ───────────────────────────────────

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -427,6 +427,7 @@ private:
     // Filter edge drag state
     enum class FilterEdge { None, Low, High };
     FilterEdge m_draggingFilter{FilterEdge::None};
+    int m_filterDragOffsetHz{0}; // anchor offset to prevent snap-to-cursor (#764)
     // VFO passband drag state (#404)
     bool m_draggingVfo{false};
     // dBm scale strip drag state


### PR DESCRIPTION
## Summary
Fixes #764

- **Delta-based filter edge dragging**: Store an anchor offset when the user grabs a filter edge, so the edge tracks mouse movement rather than snapping to the absolute cursor position. This prevents the CW low-cut from jumping to 0 Hz on the first drag event.
- **Overlapping grab zone disambiguation**: When both filter edges are within the 5px grab zone (common in CW's narrow filters), pick the closer edge instead of always defaulting to the low edge.
- **VFO center line width**: Reduce the VFO center line from 2px to 1px when a filter edge is within 4px, preventing the visual "thick line" overlap in CW mode.

## Test plan
- [ ] In CW mode, grab the low-cut filter edge on the panadapter and drag — it should track smoothly without snapping to the carrier
- [ ] In CW mode at narrow zoom, verify that clicking near overlapping filter edges grabs the intended (closer) edge
- [ ] Verify the VFO center line appears thinner in CW mode where it overlaps with filter edges
- [ ] Verify SSB/AM filter edge dragging still works normally (no regression)
- [ ] Verify the VFO center line remains 2px wide in SSB/AM modes where filter edges are far from carrier

🤖 Generated with [Claude Code](https://claude.com/claude-code)