### PR TITLE
Add DXLab SpotCollector UDP listener integration (#795)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ set(CORE_SOURCES
     src/core/WanConnection.cpp
     src/core/DxClusterClient.cpp
     src/core/WsjtxClient.cpp
+    src/core/SpotCollectorClient.cpp
     src/core/PotaClient.cpp
     src/core/RigctlServer.cpp
     src/core/TciServer.cpp

--- a/src/core/SpotCollectorClient.cpp
+++ b/src/core/SpotCollectorClient.cpp
@@ -1,0 +1,129 @@
+#include "SpotCollectorClient.h"
+#include "LogManager.h"
+
+#include <QRegularExpression>
+#include <QStandardPaths>
+#include <QDateTime>
+#include <QDir>
+#include <QFileInfo>
+
+namespace AetherSDR {
+
+SpotCollectorClient::SpotCollectorClient(QObject* parent)
+    : QObject(parent)
+    , m_socket(new QUdpSocket(this))
+{
+    connect(m_socket, &QUdpSocket::readyRead, this, &SpotCollectorClient::onReadyRead);
+}
+
+SpotCollectorClient::~SpotCollectorClient()
+{
+    stopListening();
+    m_logFile.close();
+}
+
+QString SpotCollectorClient::logFilePath() const
+{
+    return QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
+           + "/AetherSDR/spotcollector.log";
+}
+
+void SpotCollectorClient::startListening(quint16 port)
+{
+    if (m_listening) return;
+
+    m_port = port;
+
+    qCDebug(lcDxCluster) << "SpotCollectorClient: binding UDP port" << port;
+
+    if (!m_socket->bind(QHostAddress::AnyIPv4, port,
+                        QAbstractSocket::ShareAddress | QAbstractSocket::ReuseAddressHint)) {
+        qCWarning(lcDxCluster) << "SpotCollectorClient: bind failed:" << m_socket->errorString();
+        return;
+    }
+
+    // Open log file (truncate on each start)
+    m_logFile.close();
+    m_logFile.setFileName(logFilePath());
+    QDir().mkpath(QFileInfo(m_logFile).absolutePath());
+    if (m_logFile.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+        m_logFile.write(QString("--- SpotCollector listener started at %1 on port %2 ---\n")
+            .arg(QDateTime::currentDateTimeUtc().toString("yyyy-MM-dd HH:mm:ss UTC"))
+            .arg(port).toUtf8());
+        m_logFile.flush();
+    }
+
+    m_listening = true;
+    qCDebug(lcDxCluster) << "SpotCollectorClient: listening on port" << port;
+    emit listening();
+}
+
+void SpotCollectorClient::stopListening()
+{
+    if (!m_listening) return;
+    m_socket->close();
+    m_listening = false;
+    emit stopped();
+}
+
+// ── UDP read ────────────────────────────────────────────────────────────────
+
+void SpotCollectorClient::onReadyRead()
+{
+    while (m_socket->hasPendingDatagrams()) {
+        QByteArray data;
+        data.resize(static_cast<int>(m_socket->pendingDatagramSize()));
+        m_socket->readDatagram(data.data(), data.size());
+
+        // SpotCollector sends one or more "DX de" lines per datagram
+        QString payload = QString::fromLatin1(data);
+        const QStringList lines = payload.split('\n', Qt::SkipEmptyParts);
+        for (const QString& raw : lines) {
+            QString line = raw.trimmed();
+            if (line.isEmpty()) continue;
+
+            if (m_logFile.isOpen()) {
+                m_logFile.write((line + "\n").toUtf8());
+                m_logFile.flush();
+            }
+            emit rawLineReceived(line);
+
+            DxSpot spot;
+            if (parseDxSpotLine(line, spot)) {
+                spot.source = "SpotCollector";
+                qCDebug(lcDxCluster) << "SpotCollectorClient: spot" << spot.dxCall
+                         << spot.freqMhz << "MHz de" << spot.spotterCall;
+                emit spotReceived(spot);
+            }
+        }
+    }
+}
+
+// ── DX spot line parser ─────────────────────────────────────────────────────
+
+bool SpotCollectorClient::parseDxSpotLine(const QString& line, DxSpot& spot) const
+{
+    // Standard format: DX de W3LPL:     14025.0  JA1ABC       CW big signal       1824Z
+    static const QRegularExpression rx(
+        R"(^DX\s+de\s+(\S+?):\s+(\d+\.?\d*)\s+(\S+)\s+(.*?)\s+(\d{4})Z)",
+        QRegularExpression::CaseInsensitiveOption);
+
+    auto match = rx.match(line);
+    if (!match.hasMatch())
+        return false;
+
+    spot.spotterCall = match.captured(1);
+    double freqKhz   = match.captured(2).toDouble();
+    spot.freqMhz     = freqKhz / 1000.0;
+    spot.dxCall       = match.captured(3);
+    spot.comment      = match.captured(4).trimmed();
+
+    QString timeStr = match.captured(5);
+    int hh = timeStr.left(2).toInt();
+    int mm = timeStr.mid(2, 2).toInt();
+    spot.utcTime = QTime(hh, mm);
+
+    return spot.freqMhz > 0.0 && !spot.dxCall.isEmpty();
+}
+
+} // namespace AetherSDR

--- a/src/core/SpotCollectorClient.h
+++ b/src/core/SpotCollectorClient.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <QObject>
+#include <QUdpSocket>
+#include <QFile>
+#include <QString>
+#include <atomic>
+#include "DxClusterClient.h"  // for DxSpot
+
+namespace AetherSDR {
+
+// DXLab SpotCollector UDP listener — receives spot push packets
+// in standard "DX de" cluster format on a configurable UDP port (default 9999).
+class SpotCollectorClient : public QObject {
+    Q_OBJECT
+
+public:
+    explicit SpotCollectorClient(QObject* parent = nullptr);
+    ~SpotCollectorClient() override;
+
+    void startListening(quint16 port);
+    void stopListening();
+    bool isListening() const { return m_listening; }
+
+    QString logFilePath() const;
+
+signals:
+    void listening();
+    void stopped();
+    void spotReceived(const DxSpot& spot);
+    void rawLineReceived(const QString& line);
+
+private slots:
+    void onReadyRead();
+
+private:
+    bool parseDxSpotLine(const QString& line, DxSpot& spot) const;
+
+    QUdpSocket* m_socket;
+    QFile       m_logFile;
+    quint16     m_port{9999};
+    std::atomic<bool> m_listening{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -228,7 +228,8 @@ bool BandFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex& sourceP
 // ── DxClusterDialog ─────────────────────────────────────────────────────────
 
 DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient* rbnClient,
-                                   WsjtxClient* wsjtxClient, PotaClient* potaClient,
+                                   WsjtxClient* wsjtxClient, SpotCollectorClient* spotCollectorClient,
+                                   PotaClient* potaClient,
 #ifdef HAVE_WEBSOCKETS
                                    FreeDvClient* freedvClient,
 #endif
@@ -236,7 +237,8 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
                                    DxccColorProvider* dxccProvider,
                                    QWidget* parent)
     : QDialog(parent), m_client(clusterClient), m_rbnClient(rbnClient),
-      m_wsjtxClient(wsjtxClient), m_potaClient(potaClient),
+      m_wsjtxClient(wsjtxClient), m_spotCollectorClient(spotCollectorClient),
+      m_potaClient(potaClient),
 #ifdef HAVE_WEBSOCKETS
       m_freedvClient(freedvClient),
 #endif
@@ -260,6 +262,7 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
     buildClusterTab(tabs);
     buildRbnTab(tabs);
     buildWsjtxTab(tabs);
+    buildSpotCollectorTab(tabs);
     buildPotaTab(tabs);
 #ifdef HAVE_WEBSOCKETS
     buildFreeDvTab(tabs);
@@ -443,6 +446,34 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
     });
 
     // WSJT-X log loaded in deferred loadLogFiles() (#748)
+
+    // ── Live updates from SpotCollector client ───────────────────────
+    connect(spotCollectorClient, &SpotCollectorClient::rawLineReceived, this, [this, isAtBottom](const QString& line) {
+        bool follow = isAtBottom(m_scConsole);
+        m_scConsole->appendPlainText(line);
+        if (follow) {
+            auto* sb = m_scConsole->verticalScrollBar();
+            sb->setValue(sb->maximum());
+        }
+    });
+
+    connect(spotCollectorClient, &SpotCollectorClient::spotReceived, this, [this](DxSpot spot) {
+        spot.source = "SpotCollector";
+        m_spotBatch.append(spot);
+    });
+
+    connect(spotCollectorClient, &SpotCollectorClient::listening, this, [this] {
+        m_scStatusLabel->setText(QString("Listening on port %1").arg(m_scPortSpin->value()));
+        m_scStatusLabel->setStyleSheet("QLabel { color: #00b4d8; font-size: 11px; }");
+        m_scStartBtn->setText("Stop");
+        m_scConsole->appendPlainText("--- Listening ---");
+    });
+    connect(spotCollectorClient, &SpotCollectorClient::stopped, this, [this] {
+        m_scStatusLabel->setText("Stopped");
+        m_scStatusLabel->setStyleSheet("QLabel { color: #808080; font-size: 11px; }");
+        m_scStartBtn->setText("Start");
+        m_scConsole->appendPlainText("--- Stopped ---");
+    });
 
     // ── Live updates from POTA client ─────────────────────────────────
     connect(potaClient, &PotaClient::rawLineReceived, this, [this, isAtBottom](const QString& line) {
@@ -1203,6 +1234,114 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     layout->addWidget(m_wsjtxConsole, 1);
 
     tabs->addTab(page, "WSJT-X");
+}
+
+void DxClusterDialog::buildSpotCollectorTab(QTabWidget* tabs)
+{
+    auto* page = new QWidget;
+    auto* layout = new QVBoxLayout(page);
+    layout->setSpacing(8);
+
+    auto& s = AppSettings::instance();
+
+    // ── Connection settings ─────────────────────────────────────────────
+    auto* connGroup = new QGroupBox("SpotCollector UDP Listener");
+    auto* connLayout = new QVBoxLayout(connGroup);
+    connLayout->setSpacing(4);
+
+    auto* grid = new QGridLayout;
+    grid->setColumnStretch(1, 1);
+
+    grid->addWidget(new QLabel("UDP Port:"), 0, 0);
+    m_scPortSpin = new QSpinBox;
+    m_scPortSpin->setRange(1, 65535);
+    m_scPortSpin->setValue(s.value("SpotCollectorPort", 9999).toInt());
+    m_scPortSpin->setStyleSheet("QSpinBox { background: #1a1a2e; color: #c8d8e8; border: 1px solid #203040; padding: 3px; }");
+    grid->addWidget(m_scPortSpin, 0, 1);
+
+    connLayout->addLayout(grid);
+
+    auto* helpLabel = new QLabel(
+        "Receives DX spots from DXLab SpotCollector via UDP push.\n"
+        "In SpotCollector, enable UDP broadcast to this port (default 9999).\n"
+        "Alternatively, use the DX Cluster tab to connect to SpotCollector's telnet interface.");
+    helpLabel->setWordWrap(true);
+    helpLabel->setStyleSheet("QLabel { color: #607080; font-size: 11px; }");
+    connLayout->addWidget(helpLabel);
+
+    // Button row
+    auto* btnRow = new QHBoxLayout;
+    m_scAutoStartBtn = new QPushButton(
+        s.value("SpotCollectorAutoStart", "False").toString() == "True" ? "Auto-Start: ON" : "Auto-Start: OFF");
+    m_scAutoStartBtn->setCheckable(true);
+    m_scAutoStartBtn->setChecked(s.value("SpotCollectorAutoStart", "False").toString() == "True");
+    m_scAutoStartBtn->setStyleSheet(
+        "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 4px 10px; }"
+        "QPushButton:!checked { background: #603020; }");
+    connect(m_scAutoStartBtn, &QPushButton::toggled, this, [this](bool on) {
+        m_scAutoStartBtn->setText(on ? "Auto-Start: ON" : "Auto-Start: OFF");
+        auto& s = AppSettings::instance();
+        s.setValue("SpotCollectorAutoStart", on ? "True" : "False");
+        s.save();
+    });
+    btnRow->addWidget(m_scAutoStartBtn);
+    btnRow->addStretch();
+
+    m_scStatusLabel = new QLabel("Stopped");
+    m_scStatusLabel->setStyleSheet("QLabel { color: #808080; font-size: 11px; }");
+    btnRow->addWidget(m_scStatusLabel);
+    btnRow->addStretch();
+
+    m_scStartBtn = new QPushButton(m_spotCollectorClient->isListening() ? "Stop" : "Start");
+    m_scStartBtn->setFixedWidth(100);
+    m_scStartBtn->setStyleSheet(
+        "QPushButton { background: #00b4d8; color: #0f0f1a; font-weight: bold; "
+        "border: 1px solid #008ba8; padding: 4px; border-radius: 3px; }"
+        "QPushButton:hover { background: #00c8f0; }"
+        "QPushButton:disabled { background: #404060; color: #808080; }");
+    connect(m_scStartBtn, &QPushButton::clicked, this, [this] {
+        if (m_spotCollectorClient->isListening()) {
+            emit spotCollectorStopRequested();
+            return;
+        }
+        quint16 port = static_cast<quint16>(m_scPortSpin->value());
+        auto& s = AppSettings::instance();
+        s.setValue("SpotCollectorPort", port);
+        s.save();
+        emit spotCollectorStartRequested(port);
+    });
+    btnRow->addWidget(m_scStartBtn);
+    connLayout->addLayout(btnRow);
+
+    layout->addWidget(connGroup);
+
+    // ── Console output ──────────────────────────────────────────────────
+    auto* consoleLabel = new QLabel("SpotCollector Spots");
+    consoleLabel->setStyleSheet("QLabel { color: #00b4d8; font-weight: bold; }");
+    layout->addWidget(consoleLabel);
+
+    m_scConsole = new QPlainTextEdit;
+    m_scConsole->setReadOnly(true);
+    m_scConsole->setMaximumBlockCount(2000);
+    m_scConsole->setStyleSheet(
+        "QPlainTextEdit {"
+        "  background: #0a0a14;"
+        "  color: #a0b0c0;"
+        "  font-family: monospace;"
+        "  font-size: 11px;"
+        "  border: 1px solid #203040;"
+        "  padding: 4px;"
+        "}");
+    layout->addWidget(m_scConsole, 1);
+
+    // Update status if already listening
+    if (m_spotCollectorClient->isListening()) {
+        m_scStatusLabel->setText(QString("Listening on port %1").arg(m_scPortSpin->value()));
+        m_scStatusLabel->setStyleSheet("QLabel { color: #00b4d8; font-size: 11px; }");
+        m_scStartBtn->setText("Stop");
+    }
+
+    tabs->addTab(page, "SpotCollector");
 }
 
 void DxClusterDialog::buildPotaTab(QTabWidget* tabs)

--- a/src/gui/DxClusterDialog.h
+++ b/src/gui/DxClusterDialog.h
@@ -8,6 +8,7 @@
 #include "core/DxClusterClient.h"
 #include "core/DxccColorProvider.h"
 #include "core/WsjtxClient.h"
+#include "core/SpotCollectorClient.h"
 #include "core/PotaClient.h"
 #ifdef HAVE_WEBSOCKETS
 #include "core/FreeDvClient.h"
@@ -80,7 +81,8 @@ class DxClusterDialog : public QDialog {
 
 public:
     explicit DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient* rbnClient,
-                             WsjtxClient* wsjtxClient, PotaClient* potaClient,
+                             WsjtxClient* wsjtxClient, SpotCollectorClient* spotCollectorClient,
+                             PotaClient* potaClient,
 #ifdef HAVE_WEBSOCKETS
                              FreeDvClient* freedvClient,
 #endif
@@ -98,6 +100,8 @@ signals:
     void rbnDisconnectRequested();
     void wsjtxStartRequested(const QString& address, quint16 port);
     void wsjtxStopRequested();
+    void spotCollectorStartRequested(quint16 port);
+    void spotCollectorStopRequested();
     void potaStartRequested(int intervalSec);
     void potaStopRequested();
 #ifdef HAVE_WEBSOCKETS
@@ -113,6 +117,7 @@ private:
     void buildClusterTab(QTabWidget* tabs);
     void buildRbnTab(QTabWidget* tabs);
     void buildWsjtxTab(QTabWidget* tabs);
+    void buildSpotCollectorTab(QTabWidget* tabs);
     void buildPotaTab(QTabWidget* tabs);
 #ifdef HAVE_WEBSOCKETS
     void buildFreeDvTab(QTabWidget* tabs);
@@ -123,10 +128,11 @@ private:
                       const QString& wsjtxLog, const QString& potaLog,
                       const QString& freedvLog = {});
 
-    DxClusterClient* m_client;
-    DxClusterClient* m_rbnClient;
-    WsjtxClient*     m_wsjtxClient;
-    PotaClient*      m_potaClient;
+    DxClusterClient*      m_client;
+    DxClusterClient*      m_rbnClient;
+    WsjtxClient*          m_wsjtxClient;
+    SpotCollectorClient*  m_spotCollectorClient;
+    PotaClient*           m_potaClient;
 #ifdef HAVE_WEBSOCKETS
     FreeDvClient*    m_freedvClient;
 #endif
@@ -164,6 +170,13 @@ private:
     QCheckBox*      m_wsjtxFilterCQ;
     QCheckBox*      m_wsjtxFilterPOTA;
     QCheckBox*      m_wsjtxFilterCallingMe;
+
+    // SpotCollector tab
+    QSpinBox*       m_scPortSpin;
+    QPushButton*    m_scStartBtn;
+    QPushButton*    m_scAutoStartBtn;
+    QLabel*         m_scStatusLabel;
+    QPlainTextEdit* m_scConsole;
 
     // POTA tab
     QSpinBox*       m_potaIntervalSpin;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -373,6 +373,7 @@ MainWindow::MainWindow(QWidget* parent)
     m_rbnClient = new DxClusterClient;
     m_rbnClient->setLogFileName("rbn.log");
     m_wsjtxClient = new WsjtxClient;
+    m_spotCollectorClient = new SpotCollectorClient;
     m_potaClient = new PotaClient;
 #ifdef HAVE_WEBSOCKETS
     m_freedvClient = new FreeDvClient;
@@ -382,6 +383,7 @@ MainWindow::MainWindow(QWidget* parent)
     m_dxCluster->moveToThread(m_spotThread);
     m_rbnClient->moveToThread(m_spotThread);
     m_wsjtxClient->moveToThread(m_spotThread);
+    m_spotCollectorClient->moveToThread(m_spotThread);
     m_potaClient->moveToThread(m_spotThread);
 #ifdef HAVE_WEBSOCKETS
     m_freedvClient->moveToThread(m_spotThread);
@@ -442,6 +444,8 @@ MainWindow::MainWindow(QWidget* parent)
                 spotColor = as.value("DxClusterSpotColor", "#D2B48C").toString();
             else if (source == "RBN")
                 spotColor = as.value("RbnSpotColor", "#4488FF").toString();
+            else if (source == "SpotCollector")
+                spotColor = as.value("SpotCollectorSpotColor", "#FFD700").toString();
             else if (source == "FreeDV")
                 spotColor = as.value("FreeDvSpotColor", "#FF8C00").toString();  // HAVE_WEBSOCKETS
         }
@@ -546,6 +550,11 @@ MainWindow::MainWindow(QWidget* parent)
         if (!colored.color.isEmpty())
             cmd += " color=" + colored.color;
         m_spotCmdBatch.append(cmd);
+    });
+
+    connect(m_spotCollectorClient, &SpotCollectorClient::spotReceived,
+            this, [queueSpotCmd](const DxSpot& spot) {
+        queueSpotCmd(spot, "SpotCollector");
     });
 
     connect(m_potaClient, &PotaClient::spotReceived,
@@ -2229,6 +2238,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
         delete m_dxCluster;  m_dxCluster = nullptr;
         delete m_rbnClient;  m_rbnClient = nullptr;
         delete m_wsjtxClient; m_wsjtxClient = nullptr;
+        delete m_spotCollectorClient; m_spotCollectorClient = nullptr;
         delete m_potaClient;  m_potaClient = nullptr;
 #ifdef HAVE_WEBSOCKETS
         delete m_freedvClient; m_freedvClient = nullptr;
@@ -2634,7 +2644,8 @@ void MainWindow::buildMenuBar()
             m_spotHubDialog->activateWindow();
             return;
         }
-        auto* dlg = new DxClusterDialog(m_dxCluster, m_rbnClient, m_wsjtxClient, m_potaClient,
+        auto* dlg = new DxClusterDialog(m_dxCluster, m_rbnClient, m_wsjtxClient,
+                            m_spotCollectorClient, m_potaClient,
 #ifdef HAVE_WEBSOCKETS
                             m_freedvClient,
 #endif
@@ -2688,6 +2699,12 @@ void MainWindow::buildMenuBar()
         });
         connect(dlg, &DxClusterDialog::wsjtxStopRequested,
                 this, [this] { QMetaObject::invokeMethod(m_wsjtxClient, [=] { m_wsjtxClient->stopListening(); }); });
+        connect(dlg, &DxClusterDialog::spotCollectorStartRequested,
+                this, [this](quint16 port) {
+            QMetaObject::invokeMethod(m_spotCollectorClient, [=] { m_spotCollectorClient->startListening(port); });
+        });
+        connect(dlg, &DxClusterDialog::spotCollectorStopRequested,
+                this, [this] { QMetaObject::invokeMethod(m_spotCollectorClient, [=] { m_spotCollectorClient->stopListening(); }); });
         connect(dlg, &DxClusterDialog::potaStartRequested,
                 this, [this](int interval) {
             QMetaObject::invokeMethod(m_potaClient, [=] { m_potaClient->startPolling(interval); });
@@ -3964,6 +3981,12 @@ void MainWindow::onConnectionStateChanged(bool connected)
                 if (!m_wsjtxClient->isListening())
                     QMetaObject::invokeMethod(m_wsjtxClient, [=] { m_wsjtxClient->startListening(wAddr, wPort); });
             }
+            // Auto-start SpotCollector listener if enabled
+            if (cs.value("SpotCollectorAutoStart", "False").toString() == "True") {
+                quint16 scPort = static_cast<quint16>(cs.value("SpotCollectorPort", 9999).toInt());
+                if (!m_spotCollectorClient->isListening())
+                    QMetaObject::invokeMethod(m_spotCollectorClient, [=] { m_spotCollectorClient->startListening(scPort); });
+            }
             // Auto-start POTA polling if enabled
             if (cs.value("PotaAutoStart", "False").toString() == "True") {
                 int pInterval = cs.value("PotaPollInterval", 30).toInt();
@@ -3982,6 +4005,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
         QMetaObject::invokeMethod(m_dxCluster, [=] { m_dxCluster->disconnect(); });
         QMetaObject::invokeMethod(m_rbnClient, [=] { m_rbnClient->disconnect(); });
         QMetaObject::invokeMethod(m_wsjtxClient, [=] { m_wsjtxClient->stopListening(); });
+        QMetaObject::invokeMethod(m_spotCollectorClient, [=] { m_spotCollectorClient->stopListening(); });
         QMetaObject::invokeMethod(m_potaClient, [=] { m_potaClient->stopPolling(); });
 #ifdef HAVE_WEBSOCKETS
         QMetaObject::invokeMethod(m_freedvClient, [this] { m_freedvClient->stopConnection(); });

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -15,6 +15,7 @@
 #include "core/CwDecoder.h"
 #include "core/DxClusterClient.h"
 #include "core/WsjtxClient.h"
+#include "core/SpotCollectorClient.h"
 #include "core/PotaClient.h"
 #ifdef HAVE_WEBSOCKETS
 #include "core/FreeDvClient.h"
@@ -156,6 +157,7 @@ private:
     DxClusterClient*   m_dxCluster{nullptr};
     DxClusterClient*   m_rbnClient{nullptr};
     WsjtxClient*       m_wsjtxClient{nullptr};
+    SpotCollectorClient* m_spotCollectorClient{nullptr};
     PotaClient*        m_potaClient{nullptr};
 #ifdef HAVE_WEBSOCKETS
     FreeDvClient*      m_freedvClient{nullptr};


### PR DESCRIPTION
## Summary

Fixes #795

- Adds `SpotCollectorClient` — a UDP listener that receives DX spots from DXLab SpotCollector's UDP push interface (default port 9999), parsing the standard `DX de` cluster format
- Adds a "SpotCollector" tab in the SpotHub dialog with start/stop, auto-start on connect, and configurable UDP port
- Spots are forwarded to the radio via `spot add` commands and displayed on the panadapter like all other spot sources (DX Cluster, RBN, WSJT-X, POTA, FreeDV)

This follows the exact same architecture as the existing `WsjtxClient` (UDP listener) and reuses the `DX de` line parser from `DxClusterClient`. No changes to the radio protocol — this is entirely a client-side feature consuming SpotCollector's third-party UDP stream.

**Note:** Users can also connect to SpotCollector's telnet interface today using the existing DX Cluster tab (e.g., `127.0.0.1:7300`). This dedicated UDP listener provides a more direct integration matching SmartSDR's approach.

## Test plan

- [ ] Configure SpotCollector to broadcast UDP spots on port 9999
- [ ] Open SpotHub → SpotCollector tab, click Start — verify "Listening" status
- [ ] Confirm received spots appear in the console and on the panadapter
- [ ] Verify click-to-tune works on SpotCollector spots
- [ ] Test Auto-Start toggle — reconnect to radio and verify listener starts automatically
- [ ] Verify spots are deduplicated and expire correctly
- [ ] Confirm no performance impact on FFT/waterfall rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)