### PR TITLE
Fix panadapter FFT spectrum and waterfall horizontal misalignment (#845)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -414,6 +414,26 @@ void SpectrumWidget::setFrequencyRange(double centerMhz, double bandwidthMhz)
              << QString::number(centerMhz, 'f', 6)
              << "bw=" << QString::number(bandwidthMhz, 'f', 6)
              << "bins=" << m_smoothed.size();
+
+    // (#845) Waterfall rows have their frequency-to-pixel mapping baked in at
+    // write time using the current m_centerMhz / m_bandwidthMhz.  When the
+    // frequency range changes, stale rows would be drawn against the new range,
+    // causing the FFT spectrum and waterfall to be horizontally misaligned.
+    // Clear the waterfall buffer when the change exceeds ~1% of the bandwidth
+    // to avoid black flashes during tiny panning increments.
+    if (m_bandwidthMhz > 0.0) {
+        const double delta = std::abs(centerMhz - m_centerMhz) / m_bandwidthMhz
+                           + std::abs(bandwidthMhz - m_bandwidthMhz) / m_bandwidthMhz;
+        if (delta > 0.01) {
+            if (!m_waterfall.isNull()) {
+                m_waterfall.fill(Qt::black);
+                m_wfWriteRow = 0;
+            }
+            m_smoothed.clear();
+            m_bins.clear();
+        }
+    }
+
     m_centerMhz    = centerMhz;
     m_bandwidthMhz = bandwidthMhz;
     markOverlayDirty();


### PR DESCRIPTION
## Summary

Fixes #845

- Waterfall rows have their frequency-to-pixel mapping baked in at write time using `m_centerMhz` / `m_bandwidthMhz`. When the centre frequency or bandwidth changes (band switch, zoom, pan), stale rows are drawn against the new frequency range, causing the FFT spectrum and waterfall to be horizontally misaligned.
- Clear the waterfall buffer (`m_waterfall.fill(Qt::black)`) and FFT bins (`m_smoothed` / `m_bins`) in `setFrequencyRange()` when the range changes by more than ~1% of bandwidth.
- The 1% dead-zone prevents black flashes during smooth micro-panning increments.

## Test plan

- [ ] Connect to radio, observe a known signal — spectrum and waterfall should align
- [ ] Switch bands — waterfall clears and new rows align with the FFT spectrum
- [ ] Zoom in/out — waterfall resets cleanly, no persistent misalignment
- [ ] Smooth pan (drag) — small increments below 1% threshold should not cause black flashes
- [ ] Verify no regression in waterfall scrolling, auto-black, or blanker behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)