### PR TITLE
Route CW decoder output to correct pan (#864)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -990,8 +990,8 @@ MainWindow::MainWindow(QWidget* parent)
 
     // ── CW decoder: feed audio ──────────────────────────────────────────
     // Audio feed is global (same audio for all pans).
-    // Text/stats output is wired to m_panApplet via setActivePanApplet()
-    // which re-wires on active pan change.
+    // Text/stats output is routed to the pan owning the active slice
+    // via routeCwDecoderOutput(), which re-wires on active slice change (#864).
     connect(m_radioModel.panStream(), &PanadapterStream::audioDataReady,
             &m_cwDecoder, &CwDecoder::feedAudio);
 
@@ -2523,7 +2523,7 @@ void MainWindow::buildMenuBar()
             auto* s = activeSlice();
             if (s) {
                 bool isCw = (s->mode() == "CW" || s->mode() == "CWL");
-                if (m_panApplet) m_panApplet->setCwPanelVisible(isCw && decodeOn);
+                if (m_cwDecoderApplet) m_cwDecoderApplet->setCwPanelVisible(isCw && decodeOn);
             }
 
             // If audio compression changed, recreate the RX audio stream
@@ -3463,7 +3463,7 @@ void MainWindow::buildUI()
             this, [this](const QString& panId) {
         m_radioModel.setActivePanId(panId);
 
-        // Update m_panApplet and CW decoder wiring for the new active pan
+        // Update m_panApplet for the new active pan
         if (auto* applet = m_panStack->panadapter(panId))
             setActivePanApplet(applet);
 
@@ -3472,7 +3472,8 @@ void MainWindow::buildUI()
             if (sl->panId() == panId) {
                 bool isCw = (sl->mode() == "CW" || sl->mode() == "CWL");
                 bool decodeOn = AppSettings::instance().value("CwDecodeOverlay", "True").toString() == "True";
-                if (m_panApplet) m_panApplet->setCwPanelVisible(isCw && decodeOn);
+                if (auto* applet = m_panStack->panadapter(panId))
+                    applet->setCwPanelVisible(isCw && decodeOn);
                 if (isCw && !m_cwDecoder.isRunning())
                     m_cwDecoder.start();
                 else if (!isCw && m_cwDecoder.isRunning())
@@ -4175,7 +4176,7 @@ void MainWindow::onSliceAdded(SliceModel* s)
             if (sl) {
                 bool isCw = (sl->mode() == "CW" || sl->mode() == "CWL");
                 bool decodeOn = settings.value("CwDecodeOverlay", "True").toString() == "True";
-                if (m_panApplet) m_panApplet->setCwPanelVisible(isCw && decodeOn);
+                if (m_cwDecoderApplet) m_cwDecoderApplet->setCwPanelVisible(isCw && decodeOn);
                 if (isCw && !m_cwDecoder.isRunning())
                     m_cwDecoder.start();
             }
@@ -4305,7 +4306,7 @@ void MainWindow::onSliceAdded(SliceModel* s)
         if (s->sliceId() == m_activeSliceId) {
             bool isCw = (mode == "CW" || mode == "CWL");
             bool decodeOn = AppSettings::instance().value("CwDecodeOverlay", "True").toString() == "True";
-            if (m_panApplet) m_panApplet->setCwPanelVisible(isCw && decodeOn);
+            if (m_cwDecoderApplet) m_cwDecoderApplet->setCwPanelVisible(isCw && decodeOn);
             if (isCw && !m_cwDecoder.isRunning())
                 m_cwDecoder.start();
             else if (!isCw && m_cwDecoder.isRunning())
@@ -4566,10 +4567,13 @@ void MainWindow::setActiveSlice(int sliceId)
     // Update filter limits for the active slice's mode
     updateFilterLimitsForMode(s->mode());
 
+    // Route CW decoder output to the pan owning this slice (#864)
+    routeCwDecoderOutput();
+
     // Show/hide CW decode panel for the active slice's current mode
     bool isCw = (s->mode() == "CW" || s->mode() == "CWL");
     bool decodeOn = AppSettings::instance().value("CwDecodeOverlay", "True").toString() == "True";
-    if (m_panApplet) m_panApplet->setCwPanelVisible(isCw && decodeOn);
+    if (m_cwDecoderApplet) m_cwDecoderApplet->setCwPanelVisible(isCw && decodeOn);
     if (isCw && !m_cwDecoder.isRunning())
         m_cwDecoder.start();
     else if (!isCw && m_cwDecoder.isRunning())
@@ -4667,36 +4671,55 @@ void MainWindow::updateSplitState()
 void MainWindow::setActivePanApplet(PanadapterApplet* applet)
 {
     if (applet == m_panApplet) return;
+    m_panApplet = applet;
 
-    // Disconnect CW decoder from old applet (QPointer guards against destroyed widget)
-    if (m_panApplet) {
+    // Re-route CW decoder output: the active slice may now belong to this pan
+    routeCwDecoderOutput();
+}
+
+// Route CW decoder text/stats output to the pan that owns the active slice,
+// so decoded text appears in the correct pan's CW widget (#864).
+void MainWindow::routeCwDecoderOutput()
+{
+    // Determine which applet should receive CW decoder output:
+    // the pan that owns the active audio slice (whose audio feeds the decoder).
+    PanadapterApplet* target = nullptr;
+    if (auto* s = activeSlice(); s && m_panStack && !s->panId().isEmpty())
+        target = m_panStack->panadapter(s->panId());
+    if (!target)
+        target = m_panApplet;  // fallback to active pan
+
+    if (target == m_cwDecoderApplet) return;
+
+    // Disconnect from old applet
+    if (m_cwDecoderApplet) {
         disconnect(&m_cwDecoder, &CwDecoder::textDecoded,
-                   m_panApplet, &PanadapterApplet::appendCwText);
+                   m_cwDecoderApplet, &PanadapterApplet::appendCwText);
         disconnect(&m_cwDecoder, &CwDecoder::statsUpdated,
-                   m_panApplet, &PanadapterApplet::setCwStats);
-        if (auto* pb = m_panApplet->lockPitchButton())
+                   m_cwDecoderApplet, &PanadapterApplet::setCwStats);
+        if (auto* pb = m_cwDecoderApplet->lockPitchButton())
             disconnect(pb, &QPushButton::toggled,
                        &m_cwDecoder, &CwDecoder::lockPitch);
-        if (auto* sb = m_panApplet->lockSpeedButton())
+        if (auto* sb = m_cwDecoderApplet->lockSpeedButton())
             disconnect(sb, &QPushButton::toggled,
                        &m_cwDecoder, &CwDecoder::lockSpeed);
-        disconnect(m_panApplet, &PanadapterApplet::pitchRangeChanged,
+        disconnect(m_cwDecoderApplet, &PanadapterApplet::pitchRangeChanged,
                    &m_cwDecoder, &CwDecoder::setPitchRange);
     }
 
-    m_panApplet = applet;
+    m_cwDecoderApplet = target;
 
-    // Reconnect CW decoder to new applet
-    if (m_panApplet) {
+    // Connect to new applet
+    if (m_cwDecoderApplet) {
         connect(&m_cwDecoder, &CwDecoder::textDecoded,
-                m_panApplet, &PanadapterApplet::appendCwText);
+                m_cwDecoderApplet, &PanadapterApplet::appendCwText);
         connect(&m_cwDecoder, &CwDecoder::statsUpdated,
-                m_panApplet, &PanadapterApplet::setCwStats);
-        connect(m_panApplet->lockPitchButton(), &QPushButton::toggled,
+                m_cwDecoderApplet, &PanadapterApplet::setCwStats);
+        connect(m_cwDecoderApplet->lockPitchButton(), &QPushButton::toggled,
                 &m_cwDecoder, &CwDecoder::lockPitch);
-        connect(m_panApplet->lockSpeedButton(), &QPushButton::toggled,
+        connect(m_cwDecoderApplet->lockSpeedButton(), &QPushButton::toggled,
                 &m_cwDecoder, &CwDecoder::lockSpeed);
-        connect(m_panApplet, &PanadapterApplet::pitchRangeChanged,
+        connect(m_cwDecoderApplet, &PanadapterApplet::pitchRangeChanged,
                 &m_cwDecoder, &CwDecoder::setPitchRange);
     }
 }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -110,6 +110,7 @@ private:
     void disableSplit();
     void wirePanadapter(PanadapterApplet* applet);
     void setActivePanApplet(PanadapterApplet* applet);
+    void routeCwDecoderOutput();  // wire CW decoder to the pan owning the active slice
     SpectrumWidget* spectrumForSlice(SliceModel* s) const;
     void wireVfoWidget(VfoWidget* w, SliceModel* s);
     void enableNr2WithWisdom();  // Wisdom-gated NR2 enable (shared by VFO + overlay)
@@ -209,6 +210,7 @@ private:
     QSplitter*        m_splitter{nullptr};
     PanadapterStack*  m_panStack{nullptr};
     QPointer<PanadapterApplet> m_panApplet;  // backward compat alias to active applet
+    QPointer<PanadapterApplet> m_cwDecoderApplet;  // applet receiving CW decoder output
 
     // GUI — right applet panel
     AppletPanel*     m_appletPanel{nullptr};


### PR DESCRIPTION
## Summary

Fixes #864

The CW decoder is a singleton whose `textDecoded`/`statsUpdated` output was wired to `m_panApplet` (the UI-active pan) via `setActivePanApplet()`. In multi-pan layouts (e.g. two vertical pans), the decoded CW text could appear in the wrong pan's CW widget because the UI-active pan didn't necessarily match the pan owning the slice whose audio was being decoded.

**Changes:**
- Introduce `routeCwDecoderOutput()` which resolves the active slice's `panId()` and wires the CW decoder to that pan's applet, tracked as `m_cwDecoderApplet` (separate from `m_panApplet`)
- Call `routeCwDecoderOutput()` from `setActiveSlice()` so routing updates whenever the active audio slice changes
- Call `routeCwDecoderOutput()` from `setActivePanApplet()` as a fallback path
- Update all `setCwPanelVisible()` calls to use `m_cwDecoderApplet` instead of `m_panApplet`

## Test plan

- [ ] Connect to radio, enable CW decoding, configure two vertical pans with Slice A (top) and Slice B (bottom) both in CW mode
- [ ] Tune Slice A to a CW signal — verify decoded text appears in the **top** pan's CW widget
- [ ] Click on bottom pan to make it UI-active — verify decoded text still appears in the **top** pan (since Slice A's audio is still being decoded)
- [ ] Switch active slice to Slice B — verify CW decoder output moves to the **bottom** pan's widget
- [ ] Single-pan mode continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)