### PR TITLE
Fix SmartLink TX audio artifacts: add compression param to remote_audio_tx (#869)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -613,6 +613,8 @@ MainWindow::MainWindow(QWidget* parent)
     connect(&m_radioModel, &RadioModel::remoteTxStreamReady,
             this, [this](quint32 streamId) {
         m_audio->setRemoteTxStreamId(streamId);
+        // Enable Opus TX encoding when compression is active (SmartLink/WAN)
+        m_audio->setOpusTxEnabled(m_radioModel.audioCompressionParam() == "opus");
         // Restore PC mic gain from client-side settings (radio has no
         // hardware gain stage for PC input — client-authoritative)
         if (m_radioModel.transmitModel().micSelection() == "PC") {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -963,7 +963,7 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
                             });
 
                         sendCmd(
-                            "stream create type=remote_audio_tx",
+                            QString("stream create type=remote_audio_tx compression=%1").arg(audioCompressionParam()),
                             [this](int code, const QString& body) {
                                 if (code == 0) {
                                     quint32 id = body.trimmed().toUInt(nullptr, 16);


### PR DESCRIPTION
## Summary

Fixes #869

- Add `compression=` parameter to `remote_audio_tx` stream creation, matching what `remote_audio_rx` already does — without this, the radio firmware on SmartLink/WAN may misinterpret Opus frames as raw PCM, producing digital artifacts
- Gate Opus TX encoding on the actual compression setting (`audioCompressionParam()`) in the `remoteTxStreamReady` handler, so Opus is only enabled when the connection actually uses it

## Details

The `remote_audio_rx` stream was correctly created with `compression=%1` using `audioCompressionParam()`, but the `remote_audio_tx` stream was created bare (`stream create type=remote_audio_tx`). Meanwhile, the Opus encoder was enabled unconditionally for DAX TX but not wired at all for the remote TX path. This mismatch between what the radio expects and what AetherSDR sends is the most likely cause of the reported digital artifacts on SmartLink connections.

## Test plan

- [ ] Connect via SmartLink (WAN) and transmit voice — verify no digital artifacts
- [ ] Connect via LAN and transmit — verify audio works normally (compression=none path)
- [ ] With AudioCompression set to "Auto", verify Opus is used on WAN and uncompressed on LAN
- [ ] With AudioCompression set to "Opus", verify Opus TX works on both LAN and WAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)