### PR TITLE
Add accessible names to all interactive controls for VoiceOver (#870)

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -222,6 +222,8 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     sMeterLayout->addWidget(sMeterTitle);
 
     m_sMeter = new SMeterWidget(m_sMeterSection);
+    m_sMeter->setAccessibleName("S-Meter");
+    m_sMeter->setAccessibleDescription("Signal strength meter, shows S-units or TX power");
     sMeterLayout->addWidget(m_sMeter);
 
     // ── TX / RX meter select row ──────────────────────────────────────────
@@ -238,6 +240,8 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     txLabel->setAlignment(Qt::AlignCenter);
     m_txSelect = new GuardedComboBox(selectRow);
     m_txSelect->addItems({"Power", "SWR", "Level", "Compression"});
+    m_txSelect->setAccessibleName("TX meter mode");
+    m_txSelect->setAccessibleDescription("Select which TX parameter the S-meter displays");
     AetherSDR::applyComboStyle(m_txSelect);
 
     auto* txCol = new QVBoxLayout;
@@ -251,6 +255,8 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_rxSelect = new GuardedComboBox(selectRow);
     m_rxSelect->addItems({"S-Meter", "S-Meter Peak"});
     m_rxSelect->setCurrentIndex(0);
+    m_rxSelect->setAccessibleName("RX meter mode");
+    m_rxSelect->setAccessibleDescription("Select which RX parameter the S-meter displays");
     AetherSDR::applyComboStyle(m_rxSelect);
 
     auto* rxCol = new QVBoxLayout;
@@ -294,6 +300,8 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     auto* peakBtn = new QPushButton("Peak Hold", peakRow);
     peakBtn->setCheckable(true);
     peakBtn->setChecked(AppSettings::instance().value("PeakHoldEnabled", "False") == "True");
+    peakBtn->setAccessibleName("Peak hold");
+    peakBtn->setAccessibleDescription("Toggle peak hold line on S-meter");
     peakBtn->setFixedHeight(20);
     peakBtn->setStyleSheet(
         "QPushButton { background: #1a1a2e; color: #8090a0; border: 1px solid #334; "
@@ -304,6 +312,8 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     decayLabel->setStyleSheet(labelStyle);
     auto* decayCombo = new GuardedComboBox(peakRow);
     decayCombo->addItems({"Fast", "Medium", "Slow"});
+    decayCombo->setAccessibleName("Peak decay rate");
+    decayCombo->setAccessibleDescription("Speed at which peak hold marker decays");
     decayCombo->setCurrentText(
         AppSettings::instance().value("PeakDecayRate", "Medium").toString());
     AetherSDR::applyComboStyle(decayCombo);
@@ -311,6 +321,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     auto* resetBtn = new QPushButton("RST", peakRow);
     resetBtn->setFixedSize(32, 20);
     resetBtn->setToolTip("Reset peak hold");
+    resetBtn->setAccessibleName("Reset peak hold");
     resetBtn->setStyleSheet(
         "QPushButton { background: #1a1a2e; color: #8090a0; border: 1px solid #334; "
         "border-radius: 3px; font-size: 10px; padding: 0 4px; } "
@@ -448,6 +459,8 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         m_lockBtn->setCheckable(true);
         m_lockBtn->setToolTip("Lock sidebar controls — prevent accidental\n"
                               "value changes while scrolling");
+        m_lockBtn->setAccessibleName("Lock controls");
+        m_lockBtn->setAccessibleDescription("Lock sidebar controls to prevent accidental value changes");
         bool locked = settings.value("ControlsLocked", "False").toString() == "True";
         m_lockBtn->setChecked(locked);
         ControlsLock::setLocked(locked);

--- a/src/gui/EqApplet.cpp
+++ b/src/gui/EqApplet.cpp
@@ -108,6 +108,8 @@ void EqApplet::buildUI()
         m_onBtn = new QPushButton("ON");
         m_onBtn->setCheckable(true);
         m_onBtn->setFixedSize(36, 22);
+        m_onBtn->setAccessibleName("Equalizer enable");
+        m_onBtn->setAccessibleDescription("Toggle equalizer on or off");
         m_onBtn->setStyleSheet(kBtnBase + kGreenActive);
         connect(m_onBtn, &QPushButton::toggled, this, [this](bool on) {
             if (!m_updatingFromModel && m_model) {
@@ -138,6 +140,8 @@ void EqApplet::buildUI()
         m_rxBtn = new QPushButton("RX");
         m_rxBtn->setCheckable(true);
         m_rxBtn->setFixedSize(36, 22);
+        m_rxBtn->setAccessibleName("RX equalizer");
+        m_rxBtn->setAccessibleDescription("Show receive equalizer bands");
         m_rxBtn->setStyleSheet(kBtnBase + kBlueActive);
         row->addWidget(m_rxBtn);
 
@@ -145,6 +149,8 @@ void EqApplet::buildUI()
         m_txBtn->setCheckable(true);
         m_txBtn->setChecked(true);  // start on TX view
         m_txBtn->setFixedSize(36, 22);
+        m_txBtn->setAccessibleName("TX equalizer");
+        m_txBtn->setAccessibleDescription("Show transmit equalizer bands");
         m_txBtn->setStyleSheet(kBtnBase + kBlueActive);
         row->addWidget(m_txBtn);
 
@@ -231,6 +237,11 @@ void EqApplet::buildUI()
             slider->setTickPosition(QSlider::NoTicks);
             slider->setStyleSheet(kVSliderStyle);
             slider->setFixedHeight(100);
+            slider->setAccessibleName(
+                QString("EQ %1").arg(EqualizerModel::bandLabel(static_cast<EqualizerModel::Band>(i))));
+            slider->setAccessibleDescription(
+                QString("Equalizer band %1, minus 10 to plus 10 dB").arg(
+                    EqualizerModel::bandLabel(static_cast<EqualizerModel::Band>(i))));
             m_sliders[i] = slider;
 
             col->addWidget(slider, 0, Qt::AlignHCenter);

--- a/src/gui/PhoneApplet.cpp
+++ b/src/gui/PhoneApplet.cpp
@@ -114,6 +114,8 @@ void PhoneApplet::buildUI()
 
         m_amCarrierSlider = new GuardedSlider(Qt::Horizontal);
         m_amCarrierSlider->setRange(0, 100);
+        m_amCarrierSlider->setAccessibleName("AM carrier level");
+        m_amCarrierSlider->setAccessibleDescription("AM carrier power level, 0 to 100 percent");
         m_amCarrierSlider->setStyleSheet(kSliderStyle);
         connect(m_amCarrierSlider, &QSlider::valueChanged, this, [this](int v) {
             if (!m_updatingFromModel && m_model) m_model->setAmCarrierLevel(v);
@@ -141,6 +143,8 @@ void PhoneApplet::buildUI()
         m_voxBtn = new QPushButton("VOX");
         m_voxBtn->setCheckable(true);
         m_voxBtn->setFixedSize(52, 22);
+        m_voxBtn->setAccessibleName("VOX voice-operated transmit");
+        m_voxBtn->setAccessibleDescription("Toggle voice-activated transmit");
         m_voxBtn->setStyleSheet(kBtnBase + kGreenActive);
         connect(m_voxBtn, &QPushButton::toggled, this, [this](bool on) {
             if (!m_updatingFromModel && m_model) m_model->setVoxEnable(on);
@@ -150,6 +154,8 @@ void PhoneApplet::buildUI()
 
         m_voxLevelSlider = new GuardedSlider(Qt::Horizontal);
         m_voxLevelSlider->setRange(0, 100);
+        m_voxLevelSlider->setAccessibleName("VOX level");
+        m_voxLevelSlider->setAccessibleDescription("VOX activation threshold");
         m_voxLevelSlider->setStyleSheet(kSliderStyle);
         connect(m_voxLevelSlider, &QSlider::valueChanged, this, [this](int v) {
             if (!m_updatingFromModel && m_model) m_model->setVoxLevel(v);
@@ -183,6 +189,8 @@ void PhoneApplet::buildUI()
 
         m_voxDelaySlider = new GuardedSlider(Qt::Horizontal);
         m_voxDelaySlider->setRange(0, 100);
+        m_voxDelaySlider->setAccessibleName("VOX delay");
+        m_voxDelaySlider->setAccessibleDescription("VOX hang time before returning to receive");
         m_voxDelaySlider->setStyleSheet(kSliderStyle);
         connect(m_voxDelaySlider, &QSlider::valueChanged, this, [this](int v) {
             if (!m_updatingFromModel && m_model) m_model->setVoxDelay(v);
@@ -213,6 +221,8 @@ void PhoneApplet::buildUI()
         m_dexpBtn = new QPushButton("DEXP");
         m_dexpBtn->setCheckable(true);
         m_dexpBtn->setFixedSize(52, 22);
+        m_dexpBtn->setAccessibleName("Downward expander");
+        m_dexpBtn->setAccessibleDescription("Toggle downward expander noise gate");
         m_dexpBtn->setStyleSheet(kBtnBase + kBlueActive);
         connect(m_dexpBtn, &QPushButton::toggled, this, [this](bool on) {
             if (!m_updatingFromModel && m_model) m_model->setDexp(on);
@@ -222,6 +232,8 @@ void PhoneApplet::buildUI()
 
         m_dexpSlider = new GuardedSlider(Qt::Horizontal);
         m_dexpSlider->setRange(0, 100);
+        m_dexpSlider->setAccessibleName("DEXP threshold");
+        m_dexpSlider->setAccessibleDescription("Downward expander gate threshold");
         m_dexpSlider->setStyleSheet(kSliderStyle);
         connect(m_dexpSlider, &QSlider::valueChanged, this, [this](int v) {
             if (!m_updatingFromModel && m_model) m_model->setDexpLevel(v);
@@ -263,6 +275,7 @@ void PhoneApplet::buildUI()
         lowRow->addWidget(txLbl);
 
         m_lowCutDown = new PhoneTriBtn(PhoneTriBtn::Left);
+        m_lowCutDown->setAccessibleName("TX low cut decrease");
         auto lowCutDown = [this]() {
             if (m_model) m_model->setTxFilterLow(qMax(0, m_model->txFilterLow() - 50));
         };
@@ -274,6 +287,7 @@ void PhoneApplet::buildUI()
         lowRow->addWidget(m_lowCutDown);
 
         m_lowCutLabel = new ScrollableLabel("50");
+        m_lowCutLabel->setAccessibleName("TX low cut frequency");
         m_lowCutLabel->setFixedWidth(46);
         m_lowCutLabel->setAlignment(Qt::AlignCenter);
         m_lowCutLabel->setStyleSheet(
@@ -286,6 +300,7 @@ void PhoneApplet::buildUI()
         lowRow->addWidget(m_lowCutLabel);
 
         m_lowCutUp = new PhoneTriBtn(PhoneTriBtn::Right);
+        m_lowCutUp->setAccessibleName("TX low cut increase");
         connect(m_lowCutUp, &QPushButton::clicked, this, lowCutUp);
         lowRow->addWidget(m_lowCutUp);
 
@@ -307,6 +322,7 @@ void PhoneApplet::buildUI()
         highRow->setSpacing(2);
 
         m_highCutDown = new PhoneTriBtn(PhoneTriBtn::Left);
+        m_highCutDown->setAccessibleName("TX high cut decrease");
         auto highCutDown = [this]() {
             if (m_model) m_model->setTxFilterHigh(
                 qMax(m_model->txFilterLow() + 50, m_model->txFilterHigh() - 50));
@@ -319,6 +335,7 @@ void PhoneApplet::buildUI()
         highRow->addWidget(m_highCutDown);
 
         m_highCutLabel = new ScrollableLabel("3300");
+        m_highCutLabel->setAccessibleName("TX high cut frequency");
         m_highCutLabel->setFixedWidth(46);
         m_highCutLabel->setAlignment(Qt::AlignCenter);
         m_highCutLabel->setStyleSheet(
@@ -331,6 +348,7 @@ void PhoneApplet::buildUI()
         highRow->addWidget(m_highCutLabel);
 
         m_highCutUp = new PhoneTriBtn(PhoneTriBtn::Right);
+        m_highCutUp->setAccessibleName("TX high cut increase");
         connect(m_highCutUp, &QPushButton::clicked, this, highCutUp);
         highRow->addWidget(m_highCutUp);
 

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -128,18 +128,24 @@ void PhoneCwApplet::buildPhonePanel()
     m_levelGauge = new HGauge(-40.0f, 10.0f, 0.0f, "Level", "dB",
         {{-40, "-40dB"}, {-30, "-30"}, {-20, "-20"}, {-10, "-10"}, {0, "0"}, {5, "+5"}, {10, "+10"}},
         nullptr, -10.0f);
+    m_levelGauge->setAccessibleName("Microphone level gauge");
+    m_levelGauge->setAccessibleDescription("Microphone input level in dBFS");
     vbox->addWidget(m_levelGauge);
 
     // ── Compression gauge (dB: -25 to 0, fills right-to-left) ───────────
     m_compGauge = new HGauge(-25.0f, 0.0f, 1.0f, "Compression", "",
         {{-25, "-25dB"}, {-20, "-20"}, {-15, "-15"}, {-10, "-10"}, {-5, "-5"}, {0, "0"}});
     m_compGauge->setReversed(true);
+    m_compGauge->setAccessibleName("Compression gauge");
+    m_compGauge->setAccessibleDescription("Speech compression amount in dB");
     vbox->addWidget(m_compGauge);
     vbox->addSpacing(4);
 
     // ── Mic profile dropdown ─────────────────────────────────────────────
     m_micProfileCombo = new GuardedComboBox;
     m_micProfileCombo->setFixedHeight(22);
+    m_micProfileCombo->setAccessibleName("Microphone profile");
+    m_micProfileCombo->setAccessibleDescription("Select microphone processing profile");
     AetherSDR::applyComboStyle(m_micProfileCombo);
     connect(m_micProfileCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
             this, [this](int) {
@@ -159,6 +165,8 @@ void PhoneCwApplet::buildPhonePanel()
         m_micSourceCombo = new GuardedComboBox;
         m_micSourceCombo->setFixedWidth(55);
         m_micSourceCombo->setFixedHeight(22);
+        m_micSourceCombo->setAccessibleName("Microphone source");
+        m_micSourceCombo->setAccessibleDescription("Select microphone input source");
         AetherSDR::applyComboStyle(m_micSourceCombo);
         m_micSourceCombo->addItems({"MIC", "BAL", "LINE", "ACC", "PC"});
         connect(m_micSourceCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
@@ -172,6 +180,8 @@ void PhoneCwApplet::buildPhonePanel()
         m_micLevelSlider = new GuardedSlider(Qt::Horizontal);
         m_micLevelSlider->setRange(0, 100);
         m_micLevelSlider->setStyleSheet(kSliderStyle);
+        m_micLevelSlider->setAccessibleName("Microphone gain");
+        m_micLevelSlider->setAccessibleDescription("Microphone input level, 0 to 100");
         row->addWidget(m_micLevelSlider, 1);
 
         m_micLevelLabel = new QLabel("50");
@@ -184,6 +194,8 @@ void PhoneCwApplet::buildPhonePanel()
         m_accBtn->setCheckable(true);
         m_accBtn->setFixedHeight(22);
         m_accBtn->setFixedWidth(48);
+        m_accBtn->setAccessibleName("Accessory mic input");
+        m_accBtn->setAccessibleDescription("Enable accessory microphone input");
         m_accBtn->setStyleSheet(QString(kButtonBase) + kGreenActive);
         row->addWidget(m_accBtn);
 
@@ -211,6 +223,8 @@ void PhoneCwApplet::buildPhonePanel()
         m_procBtn->setCheckable(true);
         m_procBtn->setFixedHeight(22);
         m_procBtn->setFixedWidth(48);
+        m_procBtn->setAccessibleName("Speech processor");
+        m_procBtn->setAccessibleDescription("Toggle speech processor for compression");
         m_procBtn->setStyleSheet(QString(kButtonBase) + kGreenActive);
         row->addWidget(m_procBtn);
 
@@ -243,6 +257,8 @@ void PhoneCwApplet::buildPhonePanel()
         m_procSlider->setTickPosition(QSlider::NoTicks);
         m_procSlider->setPageStep(1);
         m_procSlider->setFixedHeight(14);
+        m_procSlider->setAccessibleName("Processor level");
+        m_procSlider->setAccessibleDescription("Speech processor level: Normal, DX, or DX+");
         m_procSlider->setStyleSheet(kSliderStyle);
         procVbox->addWidget(m_procSlider);
 
@@ -252,6 +268,8 @@ void PhoneCwApplet::buildPhonePanel()
         m_daxBtn->setCheckable(true);
         m_daxBtn->setFixedHeight(22);
         m_daxBtn->setFixedWidth(48);
+        m_daxBtn->setAccessibleName("DAX digital audio");
+        m_daxBtn->setAccessibleDescription("Toggle DAX digital audio exchange");
         m_daxBtn->setStyleSheet(QString(kButtonBase) + kBlueActive);
         row->addWidget(m_daxBtn);
 
@@ -284,12 +302,16 @@ void PhoneCwApplet::buildPhonePanel()
         m_monBtn->setCheckable(true);
         m_monBtn->setFixedHeight(22);
         m_monBtn->setFixedWidth(48);
+        m_monBtn->setAccessibleName("TX monitor");
+        m_monBtn->setAccessibleDescription("Toggle sidetone monitor of transmitted audio");
         m_monBtn->setStyleSheet(QString(kButtonBase) + kGreenActive);
         row->addWidget(m_monBtn);
 
         m_monSlider = new GuardedSlider(Qt::Horizontal);
         m_monSlider->setRange(0, 100);
         m_monSlider->setStyleSheet(kSliderStyle);
+        m_monSlider->setAccessibleName("Monitor volume");
+        m_monSlider->setAccessibleDescription("TX sidetone monitor volume");
         row->addWidget(m_monSlider, 1);
 
         m_monLabel = new QLabel("50");
@@ -325,6 +347,8 @@ void PhoneCwApplet::buildCwPanel()
     // ── ALC gauge (0–100) ────────────────────────────────────────────────
     m_alcGauge = new HGauge(0.0f, 100.0f, 80.0f, "ALC", "",
         {{0, "0"}, {25, "25"}, {50, "50"}, {75, "75"}, {100, "100"}});
+    m_alcGauge->setAccessibleName("ALC gauge");
+    m_alcGauge->setAccessibleDescription("Automatic level control meter");
     vbox->addWidget(m_alcGauge);
     vbox->addSpacing(2);
 
@@ -349,6 +373,8 @@ void PhoneCwApplet::buildCwPanel()
         m_delaySlider->setRange(0, 2000);
         m_delaySlider->setSingleStep(10);
         m_delaySlider->setPageStep(100);
+        m_delaySlider->setAccessibleName("CW delay");
+        m_delaySlider->setAccessibleDescription("CW break-in delay in milliseconds");
         m_delaySlider->setStyleSheet(kSliderStyle);
         row->addWidget(m_delaySlider, 1);
 
@@ -381,6 +407,8 @@ void PhoneCwApplet::buildCwPanel()
 
         m_speedSlider = new GuardedSlider(Qt::Horizontal);
         m_speedSlider->setRange(5, 100);
+        m_speedSlider->setAccessibleName("CW speed");
+        m_speedSlider->setAccessibleDescription("CW keying speed in words per minute");
         m_speedSlider->setStyleSheet(kSliderStyle);
         row->addWidget(m_speedSlider, 1);
 
@@ -408,6 +436,8 @@ void PhoneCwApplet::buildCwPanel()
         m_sidetoneBtn->setCheckable(true);
         m_sidetoneBtn->setFixedHeight(22);
         m_sidetoneBtn->setFixedWidth(kLeftColW);
+        m_sidetoneBtn->setAccessibleName("CW sidetone");
+        m_sidetoneBtn->setAccessibleDescription("Toggle CW sidetone monitor");
         m_sidetoneBtn->setStyleSheet(QString(kButtonBase) + kGreenActive);
         row->addWidget(m_sidetoneBtn);
 
@@ -415,6 +445,8 @@ void PhoneCwApplet::buildCwPanel()
 
         m_sidetoneSlider = new GuardedSlider(Qt::Horizontal);
         m_sidetoneSlider->setRange(0, 100);
+        m_sidetoneSlider->setAccessibleName("Sidetone volume");
+        m_sidetoneSlider->setAccessibleDescription("CW sidetone monitor volume");
         m_sidetoneSlider->setStyleSheet(kSliderStyle);
         row->addWidget(m_sidetoneSlider, 1);
 
@@ -451,6 +483,8 @@ void PhoneCwApplet::buildCwPanel()
         m_cwPanSlider = new GuardedSlider(Qt::Horizontal);
         m_cwPanSlider->setRange(0, 100);
         m_cwPanSlider->setValue(50);
+        m_cwPanSlider->setAccessibleName("CW audio pan");
+        m_cwPanSlider->setAccessibleDescription("CW monitor audio pan, left to right");
         m_cwPanSlider->setStyleSheet(kSliderStyle);
         row->addWidget(m_cwPanSlider, 1);
 
@@ -472,12 +506,16 @@ void PhoneCwApplet::buildCwPanel()
         m_breakinBtn = new QPushButton("Breakin");
         m_breakinBtn->setCheckable(true);
         m_breakinBtn->setFixedHeight(22);
+        m_breakinBtn->setAccessibleName("CW break-in");
+        m_breakinBtn->setAccessibleDescription("Toggle full break-in QSK mode");
         m_breakinBtn->setStyleSheet(QString(kButtonBase) + kGreenActive);
         row->addWidget(m_breakinBtn);
 
         m_iambicBtn = new QPushButton("Iambic");
         m_iambicBtn->setCheckable(true);
         m_iambicBtn->setFixedHeight(22);
+        m_iambicBtn->setAccessibleName("Iambic keyer");
+        m_iambicBtn->setAccessibleDescription("Toggle iambic paddle keyer mode");
         m_iambicBtn->setStyleSheet(QString(kButtonBase) + kBlueActive);
         row->addWidget(m_iambicBtn);
 
@@ -489,17 +527,20 @@ void PhoneCwApplet::buildCwPanel()
         row->addWidget(pitchLbl);
 
         m_pitchDown = new CwTriBtn(CwTriBtn::Left);
+        m_pitchDown->setAccessibleName("CW pitch down");
         row->addWidget(m_pitchDown);
 
         m_pitchLabel = new QLabel("600");
         m_pitchLabel->setAlignment(Qt::AlignCenter);
         m_pitchLabel->setFixedWidth(48);
+        m_pitchLabel->setAccessibleName("CW pitch frequency");
         m_pitchLabel->setStyleSheet(
             "QLabel { font-size: 11px; background: #0a0a18; border: 1px solid #1e2e3e; "
             "border-radius: 3px; padding: 1px 3px; color: #c8d8e8; }");
         row->addWidget(m_pitchLabel);
 
         m_pitchUp = new CwTriBtn(CwTriBtn::Right);
+        m_pitchUp->setAccessibleName("CW pitch up");
         row->addWidget(m_pitchUp);
 
         connect(m_breakinBtn, &QPushButton::toggled, this, [this](bool on) {

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -896,6 +896,62 @@ void RxApplet::buildUI()
     m_xitOnBtn->setToolTip("Transmit Incremental Tuning \u2014 offsets the transmit frequency without moving receive.");
     m_xitZero->setToolTip("Resets the XIT offset to zero.");
 
+    // Accessible names for VoiceOver / screen reader support (#870)
+    m_sliceBadge->setAccessibleName("Slice letter");
+    m_lockBtn->setAccessibleName("VFO lock");
+    m_lockBtn->setAccessibleDescription("Lock VFO frequency to prevent accidental tuning");
+    m_rxAntBtn->setAccessibleName("RX antenna");
+    m_rxAntBtn->setAccessibleDescription("Select receive antenna port");
+    m_txAntBtn->setAccessibleName("TX antenna");
+    m_txAntBtn->setAccessibleDescription("Select transmit antenna port");
+    m_filterWidthLbl->setAccessibleName("Filter width");
+    m_qskBtn->setAccessibleName("QSK indicator");
+    m_qskBtn->setAccessibleDescription("Full break-in CW indicator");
+    m_txBadge->setAccessibleName("TX slice selector");
+    m_txBadge->setAccessibleDescription("Click to set this slice as the transmit slice");
+    m_modeCombo->setAccessibleName("Operating mode");
+    m_modeCombo->setAccessibleDescription("Select operating mode such as USB, LSB, CW, AM, FM");
+    m_freqLabel->setAccessibleName("Frequency display");
+    m_freqEdit->setAccessibleName("Frequency entry");
+    m_freqEdit->setAccessibleDescription("Type a frequency in MHz and press Enter");
+    m_stepDown->setAccessibleName("Step size down");
+    m_stepLabel->setAccessibleName("Tuning step size");
+    m_stepUp->setAccessibleName("Step size up");
+    m_filterPassband->setAccessibleName("Filter passband");
+    m_filterPassband->setAccessibleDescription("Visual filter passband with draggable edges");
+    m_muteBtn->setAccessibleName("Slice audio mute");
+    m_afSlider->setAccessibleName("AF gain");
+    m_afSlider->setAccessibleDescription("Audio output volume for this slice");
+    m_panSlider->setAccessibleName("Audio pan");
+    m_panSlider->setAccessibleDescription("Stereo audio pan, left to right");
+    m_sqlBtn->setAccessibleName("Squelch");
+    m_sqlBtn->setAccessibleDescription("Toggle squelch gate");
+    m_sqlSlider->setAccessibleName("Squelch threshold");
+    m_sqlSlider->setAccessibleDescription("Signal level below which audio is muted");
+    m_agcCombo->setAccessibleName("AGC mode");
+    m_agcCombo->setAccessibleDescription("Automatic gain control speed");
+    m_agcTSlider->setAccessibleName("AGC threshold");
+    m_agcTSlider->setAccessibleDescription("Maximum gain applied to weak signals");
+    m_ritOnBtn->setAccessibleName("RIT toggle");
+    m_ritOnBtn->setAccessibleDescription("Receive incremental tuning");
+    m_ritZero->setAccessibleName("RIT zero");
+    m_ritMinus->setAccessibleName("RIT decrease");
+    m_ritLabel->setAccessibleName("RIT offset");
+    m_ritPlus->setAccessibleName("RIT increase");
+    m_xitOnBtn->setAccessibleName("XIT toggle");
+    m_xitOnBtn->setAccessibleDescription("Transmit incremental tuning");
+    m_xitZero->setAccessibleName("XIT zero");
+    m_xitMinus->setAccessibleName("XIT decrease");
+    m_xitLabel->setAccessibleName("XIT offset");
+    m_xitPlus->setAccessibleName("XIT increase");
+    m_toneModeCmb->setAccessibleName("FM tone mode");
+    m_toneValueCmb->setAccessibleName("CTCSS tone frequency");
+    m_offsetSpin->setAccessibleName("Repeater offset frequency");
+    m_offsetDown->setAccessibleName("Offset down");
+    m_simplexBtn->setAccessibleName("Simplex");
+    m_offsetUp->setAccessibleName("Offset up");
+    m_revBtn->setAccessibleName("Reverse offset");
+
     root->addStretch();
 }
 

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -42,6 +42,8 @@ TitleBar::TitleBar(QWidget* parent)
     m_heartbeat->setStyleSheet(
         "QLabel { background: #404858; border-radius: 5px; }");
     m_heartbeat->setToolTip("Radio discovery heartbeat");
+    m_heartbeat->setAccessibleName("Radio heartbeat");
+    m_heartbeat->setAccessibleDescription("Flashes green when radio discovery packets are received");
 
     // 100ms timer to return green flash back to grey
     m_heartbeatOffTimer = new QTimer(this);
@@ -86,6 +88,7 @@ TitleBar::TitleBar(QWidget* parent)
         "QPushButton:hover { background: rgba(32, 192, 96, 30); }");
     m_mfBtn->setVisible(false);
     m_mfBtn->setCursor(Qt::PointingHandCursor);
+    m_mfBtn->setAccessibleName("multiFLEX status");
     connect(m_mfBtn, &QPushButton::clicked, this, &TitleBar::multiFlexClicked);
     m_hbox->addWidget(m_mfBtn);
 
@@ -116,6 +119,8 @@ TitleBar::TitleBar(QWidget* parent)
 
     bool pcOn = s.value("PcAudioEnabled", "True").toString() == "True";
     m_pcBtn->setChecked(pcOn);
+    m_pcBtn->setAccessibleName("PC Audio");
+    m_pcBtn->setAccessibleDescription("Toggle PC audio input for microphone");
 
     auto updatePcStyle = [this]() {
         m_pcBtn->setStyleSheet(m_pcBtn->isChecked()
@@ -147,6 +152,8 @@ TitleBar::TitleBar(QWidget* parent)
         "QPushButton { background: transparent; border: none; font-size: 14px; padding: 0; }"
         "QPushButton:checked { opacity: 0.4; }");
     m_speakerBtn->setToolTip("Click to mute/unmute line out");
+    m_speakerBtn->setAccessibleName("Line out mute");
+    m_speakerBtn->setAccessibleDescription("Mute or unmute line out speaker audio");
     connect(m_speakerBtn, &QPushButton::toggled, this, [this](bool muted) {
         m_speakerBtn->setText(muted ? "\xF0\x9F\x94\x87" : "\xF0\x9F\x94\x8A");  // 🔇 / 🔊
         emit lineoutMuteChanged(muted);
@@ -159,6 +166,8 @@ TitleBar::TitleBar(QWidget* parent)
     m_masterSlider->setValue(savedVol);
     m_masterSlider->setFixedWidth(80);
     m_masterSlider->setFixedHeight(16);
+    m_masterSlider->setAccessibleName("Master volume");
+    m_masterSlider->setAccessibleDescription("Line out volume level, 0 to 100 percent");
     m_masterSlider->setStyleSheet(
         "QSlider::groove:horizontal { background: #1a2a3a; height: 4px; border-radius: 2px; }"
         "QSlider::handle:horizontal { background: #00b4d8; width: 10px; margin: -3px 0; border-radius: 5px; }"
@@ -186,6 +195,8 @@ TitleBar::TitleBar(QWidget* parent)
         "QPushButton { background: transparent; border: none; font-size: 14px; padding: 0; }"
         "QPushButton:checked { opacity: 0.4; }");
     m_headphoneBtn->setToolTip("Click to mute/unmute headphones");
+    m_headphoneBtn->setAccessibleName("Headphone mute");
+    m_headphoneBtn->setAccessibleDescription("Mute or unmute headphone audio");
     connect(m_headphoneBtn, &QPushButton::toggled, this, [this](bool muted) {
         m_headphoneBtn->setText(muted ? "\xF0\x9F\x94\x87" : "\xF0\x9F\x8E\xA7");  // 🔇 / 🎧
         emit headphoneMuteChanged(muted);
@@ -197,6 +208,8 @@ TitleBar::TitleBar(QWidget* parent)
     m_hpSlider->setValue(50);
     m_hpSlider->setFixedWidth(80);
     m_hpSlider->setFixedHeight(16);
+    m_hpSlider->setAccessibleName("Headphone volume");
+    m_hpSlider->setAccessibleDescription("Headphone volume level, 0 to 100 percent");
     m_hpSlider->setStyleSheet(
         "QSlider::groove:horizontal { background: #1a2a3a; height: 4px; border-radius: 2px; }"
         "QSlider::handle:horizontal { background: #00b4d8; width: 10px; margin: -3px 0; border-radius: 5px; }"
@@ -220,6 +233,7 @@ TitleBar::TitleBar(QWidget* parent)
     m_minimalBtn = new QPushButton("\xe2\x86\x99");  // ↙ U+2199
     m_minimalBtn->setFixedSize(28, 28);
     m_minimalBtn->setToolTip("Minimal Mode (Ctrl+M)");
+    m_minimalBtn->setAccessibleName("Minimal mode");
     m_minimalBtn->setStyleSheet(
         "QPushButton { background: #1a2a3a; color: #c8d8e8; border: 1px solid #304050; "
         "border-radius: 4px; font-size: 18px; padding: 0; }"
@@ -232,6 +246,7 @@ TitleBar::TitleBar(QWidget* parent)
     auto* featureBtn = m_featureBtn;
     featureBtn->setFixedSize(28, 28);
     featureBtn->setToolTip("Submit a feature request");
+    featureBtn->setAccessibleName("Feature request");
     featureBtn->setStyleSheet(
         "QPushButton { background: #3a2a00; color: #ffd060; border: 1px solid #806020; "
         "border-radius: 4px; font-size: 20px; padding: 0; }"

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -69,11 +69,15 @@ void TxApplet::buildUI()
     // ── Forward Power gauge (0–120 W, red > 100 W) ─────────────────────────
     m_fwdGauge = new HGauge(0.0f, 120.0f, 100.0f, "RF Pwr", "W",
         {{0, "0"}, {40, "40"}, {80, "80"}, {100, "100"}, {120, "120"}});
+    m_fwdGauge->setAccessibleName("Forward power gauge");
+    m_fwdGauge->setAccessibleDescription("RF forward power in watts");
     vbox->addWidget(m_fwdGauge);
 
     // ── SWR gauge (1.0–3.0, red > 2.5) ─────────────────────────────────────
     m_swrGauge = new HGauge(1.0f, 3.0f, 2.5f, "SWR", "",
         {{1.0f, "1"}, {1.5f, "1.5"}, {2.5f, "2.5"}, {3.0f, "3"}});
+    m_swrGauge->setAccessibleName("SWR gauge");
+    m_swrGauge->setAccessibleDescription("Standing wave ratio");
     vbox->addWidget(m_swrGauge);
 
     // ── RF Power slider ─────────────────────────────────────────────────────
@@ -88,6 +92,8 @@ void TxApplet::buildUI()
         m_rfPowerSlider = new GuardedSlider(Qt::Horizontal);
         m_rfPowerSlider->setRange(0, 100);
         m_rfPowerSlider->setStyleSheet(kSliderStyle);
+        m_rfPowerSlider->setAccessibleName("RF power");
+        m_rfPowerSlider->setAccessibleDescription("Transmit RF power level, 0 to 100 watts");
         row->addWidget(m_rfPowerSlider, 1);
 
         m_rfPowerLabel = new QLabel("100");
@@ -110,6 +116,8 @@ void TxApplet::buildUI()
         m_tunePowerSlider = new GuardedSlider(Qt::Horizontal);
         m_tunePowerSlider->setRange(0, 100);
         m_tunePowerSlider->setStyleSheet(kSliderStyle);
+        m_tunePowerSlider->setAccessibleName("Tune power");
+        m_tunePowerSlider->setAccessibleDescription("Tune carrier power level, 0 to 100 watts");
         row->addWidget(m_tunePowerSlider, 1);
 
         m_tunePowerLabel = new QLabel("10");
@@ -128,6 +136,8 @@ void TxApplet::buildUI()
         m_profileCombo = new GuardedComboBox;
         AetherSDR::applyComboStyle(m_profileCombo);
         m_profileCombo->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+        m_profileCombo->setAccessibleName("TX profile");
+        m_profileCombo->setAccessibleDescription("Select transmit profile");
         row->addWidget(m_profileCombo, 1);  // 1 out of 2 = 50%
 
         m_successInd = makeIndicator("Success");
@@ -159,6 +169,8 @@ void TxApplet::buildUI()
         m_tuneBtn->setStyleSheet(btnStyle);
         m_tuneBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         m_tuneBtn->setFixedHeight(22);
+        m_tuneBtn->setAccessibleName("Tune");
+        m_tuneBtn->setAccessibleDescription("Start or stop tune carrier");
         row->addWidget(m_tuneBtn);
 
         m_moxBtn = new QPushButton("MOX");
@@ -166,12 +178,16 @@ void TxApplet::buildUI()
         m_moxBtn->setCheckable(true);
         m_moxBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         m_moxBtn->setFixedHeight(22);
+        m_moxBtn->setAccessibleName("MOX transmit");
+        m_moxBtn->setAccessibleDescription("Toggle manual transmit on or off");
         row->addWidget(m_moxBtn);
 
         m_atuBtn = new QPushButton("ATU");
         m_atuBtn->setStyleSheet(btnStyle);
         m_atuBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         m_atuBtn->setFixedHeight(22);
+        m_atuBtn->setAccessibleName("ATU tune");
+        m_atuBtn->setAccessibleDescription("Start automatic antenna tuner");
         row->addWidget(m_atuBtn);
 
         m_memBtn = new QPushButton("MEM");
@@ -179,6 +195,8 @@ void TxApplet::buildUI()
         m_memBtn->setCheckable(true);
         m_memBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         m_memBtn->setFixedHeight(22);
+        m_memBtn->setAccessibleName("ATU memories");
+        m_memBtn->setAccessibleDescription("Toggle ATU memory recall");
         row->addWidget(m_memBtn);
 
         vbox->addLayout(row);
@@ -192,6 +210,8 @@ void TxApplet::buildUI()
         m_apdBtn = new QPushButton("APD");
         m_apdBtn->setCheckable(true);
         m_apdBtn->setFixedHeight(22);
+        m_apdBtn->setAccessibleName("APD pre-distortion");
+        m_apdBtn->setAccessibleDescription("Toggle adaptive pre-distortion");
         m_apdBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         m_apdBtn->setStyleSheet(
             "QPushButton { background: #1a3a5a; border: 1px solid #205070; "

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -546,6 +546,23 @@ void VfoWidget::buildUI()
     buildTabContent();
     root->addWidget(m_tabStack);
 
+    // Accessible names for VoiceOver / screen reader support (#870)
+    m_rxAntBtn->setAccessibleName("RX antenna");
+    m_txAntBtn->setAccessibleName("TX antenna");
+    m_filterWidthLbl->setAccessibleName("Filter width");
+    m_splitBadge->setAccessibleName("Split mode");
+    m_splitBadge->setAccessibleDescription("Toggle split transmit frequency");
+    m_txBadge->setAccessibleName("TX slice selector");
+    m_sliceBadge->setAccessibleName("Slice letter");
+    m_freqLabel->setAccessibleName("Frequency display");
+    m_freqEdit->setAccessibleName("Frequency entry");
+    m_freqEdit->setAccessibleDescription("Type a frequency in MHz and press Enter");
+    m_closeSliceBtn->setAccessibleName("Close slice");
+    m_lockVfoBtn->setAccessibleName("VFO lock");
+    m_recordBtn->setAccessibleName("Record slice audio");
+    m_playBtn->setAccessibleName("Play recorded audio");
+    m_dbmLabel->setAccessibleName("Signal level dBm");
+
     adjustSize();
 }
 
@@ -662,6 +679,21 @@ void VfoWidget::buildTabContent()
         m_agcCmb->setToolTip("AGC speed. Slow resists pumping on quiet bands; Fast tracks rapid signal changes.");
         m_agcTSlider->setToolTip("AGC threshold. Higher values reduce the maximum gain applied to weak signals.");
         m_panSlider->setToolTip("Pans audio between left and right channels.");
+
+        // Audio tab accessible names (#870)
+        m_muteBtn->setAccessibleName("Slice audio mute");
+        m_afGainSlider->setAccessibleName("AF gain");
+        m_afGainSlider->setAccessibleDescription("Audio output volume for this slice");
+        m_sqlBtn->setAccessibleName("Squelch");
+        m_sqlSlider->setAccessibleName("Squelch threshold");
+        m_agcCmb->setAccessibleName("AGC mode");
+        m_agcTSlider->setAccessibleName("AGC threshold");
+        m_panSlider->setAccessibleName("Audio pan");
+        m_panSlider->setAccessibleDescription("Stereo audio pan, left to right");
+        m_divBtn->setAccessibleName("Diversity receive");
+        m_escBtn->setAccessibleName("Enhanced signal clarity");
+        m_escPhaseSlider->setAccessibleName("ESC phase");
+        m_escGainSlider->setAccessibleName("ESC gain");
 
         // ESC (Enhanced Signal Clarity) panel — visible only when DIV is active
         m_escPanel = new QWidget;
@@ -887,6 +919,24 @@ void VfoWidget::buildTabContent()
         m_anftBtn->setToolTip("FFT-based notch filter \u2014 removes up to five persistent tones from transformers or power supplies.");
         m_bnrBtn->setToolTip("NVIDIA GPU-accelerated neural audio denoising. Requires NVIDIA RTX 4000+ with Docker.");
         m_nr4Btn->setToolTip("Client-side spectral bleach noise reduction (libspecbleach). Right-click for NR4 settings.");
+
+        // DSP button accessible names (#870)
+        m_nrBtn->setAccessibleName("Noise reduction");
+        m_nr2Btn->setAccessibleName("NR2 spectral noise reduction");
+        m_nbBtn->setAccessibleName("Noise blanker");
+        m_anfBtn->setAccessibleName("Auto notch filter");
+        m_apfBtn->setAccessibleName("CW audio peaking filter");
+        m_nrlBtn->setAccessibleName("Leaky LMS noise reduction");
+        m_nrsBtn->setAccessibleName("Spectral subtraction");
+        m_rnnBtn->setAccessibleName("RNN noise reduction");
+        m_rn2Btn->setAccessibleName("RNNoise noise suppression");
+        m_nrfBtn->setAccessibleName("Spectral noise filter");
+        m_anflBtn->setAccessibleName("LMS notch filter");
+        m_anftBtn->setAccessibleName("FFT notch filter");
+        m_bnrBtn->setAccessibleName("GPU neural denoising");
+        m_nr4Btn->setAccessibleName("Spectral bleach noise reduction");
+        m_apfSlider->setAccessibleName("APF bandwidth");
+        m_apfSlider->setAccessibleDescription("CW audio peaking filter bandwidth");
 
         // APF level slider (hidden unless CW mode)
         {


### PR DESCRIPTION
## Summary

Fixes #870

- Add `setAccessibleName()` and `setAccessibleDescription()` to every interactive widget across 8 GUI files: TitleBar, RxApplet, TxApplet, VfoWidget, AppletPanel, PhoneCwApplet, PhoneApplet, and EqApplet
- Covers all controls critical for operating the radio: frequency, mode, filter, AGC, AF gain, squelch, RIT/XIT, TX/MOX/TUNE/ATU, RF power, SWR gauge, S-meter, CW speed/delay/pitch, VOX, EQ bands, mic controls, and more
- Purely additive metadata — zero visual impact, no layout changes, no new visible elements
- Qt6 bridges `QAccessible` properties to `NSAccessibility` automatically on macOS, so VoiceOver will now announce control names and descriptions

This is **Phase 1** of the accessibility work outlined in #870. Future phases will add `QAccessibleInterface` subclasses for custom-painted widgets (panadapter, waterfall, meters) and live announcements for state changes.

## Test plan

- [ ] Build passes on Linux, macOS, and Windows CI
- [ ] Visual regression: no visible UI changes (all changes are metadata-only)
- [ ] On macOS with VoiceOver enabled, Tab/VO+arrow through the main window and verify controls announce their names
- [ ] Verify slice controls (mode, frequency, filter, AGC, AF gain) are announced by VoiceOver
- [ ] Verify TX controls (MOX, TUNE, ATU, RF power, SWR gauge) are announced
- [ ] Verify CW controls (speed, delay, pitch, break-in, sidetone) are announced
- [ ] Verify title bar controls (master volume, headphone volume, mute buttons) are announced

🤖 Generated with [Claude Code](https://claude.com/claude-code)