### PR TITLE
Add manual IP entry for Antenna Genius remote connections (#873)

### DIFF
--- a/src/gui/AntennaGeniusApplet.cpp
+++ b/src/gui/AntennaGeniusApplet.cpp
@@ -5,11 +5,14 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QComboBox>
+#include <QLineEdit>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QGridLayout>
 #include <QSignalBlocker>
+#include <QHostAddress>
 #include <QDebug>
+#include "core/AppSettings.h"
 
 namespace AetherSDR {
 
@@ -95,6 +98,34 @@ void AntennaGeniusApplet::buildUI()
     m_statusLabel->setStyleSheet("color: #606878; font-size: 10px;");
     m_statusLabel->setAlignment(Qt::AlignCenter);
     vbox->addWidget(m_statusLabel);
+
+    // ── Manual IP entry (for remote connections) ───────────────────────────
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(4);
+
+        auto* label = new QLabel("Manual IP:");
+        label->setStyleSheet(kLabelStyle);
+        row->addWidget(label);
+
+        m_manualIpEdit = new QLineEdit;
+        m_manualIpEdit->setStyleSheet(
+            "QLineEdit { background: #1a2a3a; border: 1px solid #203040; "
+            "border-radius: 3px; padding: 2px 4px; color: #c8d8e8; font-size: 10px; }");
+        m_manualIpEdit->setPlaceholderText("IP address");
+        m_manualIpEdit->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+        m_manualIpEdit->setMinimumWidth(0);
+
+        // Restore last-used manual IP from settings.
+        auto& settings = AppSettings::instance();
+        QString savedIp = settings.value("AG_ManualIp", "").toString();
+        if (!savedIp.isEmpty())
+            m_manualIpEdit->setText(savedIp);
+
+        row->addWidget(m_manualIpEdit, 1);
+
+        vbox->addLayout(row);
+    }
 
     // ── Port A section ──────────────────────────────────────────────────────
     m_portASection = new QWidget;
@@ -201,7 +232,24 @@ void AntennaGeniusApplet::buildUI()
             auto devices = m_model->discoveredDevices();
             if (idx >= 0 && idx < devices.size()) {
                 m_model->connectToDevice(devices[idx]);
+            } else {
+                // No discovered device selected — try manual IP.
+                QString ip = m_manualIpEdit->text().trimmed();
+                if (!ip.isEmpty()) {
+                    AppSettings::instance().setValue("AG_ManualIp", ip);
+                    m_model->connectToAddress(QHostAddress(ip), 9007);
+                }
             }
+        }
+    });
+
+    // Manual IP: pressing Enter triggers connect.
+    connect(m_manualIpEdit, &QLineEdit::returnPressed, this, [this]() {
+        if (!m_model || m_model->isConnected()) return;
+        QString ip = m_manualIpEdit->text().trimmed();
+        if (!ip.isEmpty()) {
+            AppSettings::instance().setValue("AG_ManualIp", ip);
+            m_model->connectToAddress(QHostAddress(ip), 9007);
         }
     });
 

--- a/src/gui/AntennaGeniusApplet.h
+++ b/src/gui/AntennaGeniusApplet.h
@@ -6,6 +6,7 @@
 class QPushButton;
 class QLabel;
 class QComboBox;
+class QLineEdit;
 
 namespace AetherSDR {
 
@@ -41,6 +42,9 @@ private:
     QComboBox*   m_deviceCombo{nullptr};
     QPushButton* m_connectBtn{nullptr};
     QLabel*      m_statusLabel{nullptr};
+
+    // Manual IP entry (for remote connections without UDP discovery)
+    QLineEdit*   m_manualIpEdit{nullptr};
 
     // Port A widgets
     QLabel*      m_portABandLabel{nullptr};

--- a/src/models/AntennaGeniusModel.cpp
+++ b/src/models/AntennaGeniusModel.cpp
@@ -166,6 +166,16 @@ void AntennaGeniusModel::connectToDevice(const AgDeviceInfo& info)
     m_tcpSocket->connectToHost(info.ip, info.port);
 }
 
+void AntennaGeniusModel::connectToAddress(const QHostAddress& ip, quint16 port)
+{
+    AgDeviceInfo info;
+    info.ip   = ip;
+    info.port = port;
+    info.name = ip.toString();
+    info.serial = QString("manual-%1").arg(ip.toString());
+    connectToDevice(info);
+}
+
 void AntennaGeniusModel::disconnectFromDevice()
 {
     if (m_keepAlive) {

--- a/src/models/AntennaGeniusModel.h
+++ b/src/models/AntennaGeniusModel.h
@@ -85,6 +85,8 @@ public:
 
     // Connect to a specific device (by IP:port from discovery).
     void connectToDevice(const AgDeviceInfo& info);
+    // Connect directly by IP address (for remote/manual connections).
+    void connectToAddress(const QHostAddress& ip, quint16 port);
     void disconnectFromDevice();
 
     // Getters


### PR DESCRIPTION
## Summary
Fixes #873

- Adds a **Manual IP** text field to the Antenna Genius applet, allowing users to connect to their AG device by IP address when UDP broadcast discovery doesn't reach (e.g., remote/WAN connections with port forwarding)
- Adds `AntennaGeniusModel::connectToAddress()` convenience method that constructs an `AgDeviceInfo` from a raw IP+port and delegates to `connectToDevice()`
- Persists the manual IP in AppSettings (`AG_ManualIp`) so the user doesn't need to re-enter it each session

## Test plan
- [ ] Verify discovered AG devices still appear in the combo box and auto-connect works as before
- [ ] Enter a valid AG IP in the manual field and press Enter or click Connect — should connect over TCP
- [ ] Verify the manual IP is restored on next launch
- [ ] Confirm antenna selection, band tracking, and port status all work normally after a manual-IP connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)