### PR TITLE
Show AMP OPERATE/STANDBY button during remote/VPN operation (#874)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1275,6 +1275,14 @@ MainWindow::MainWindow(QWidget* parent)
     };
     connect(&m_radioModel, &RadioModel::ampStateChanged, this, updatePgxlStyle);
 
+    // Fallback: update AmpApplet OPERATE/STANDBY button from the radio API state
+    // so the button appears even when the direct PGXL TCP connection is unavailable
+    // (e.g. remote/VPN operation where the PGXL LAN IP is not routable).
+    connect(&m_radioModel, &RadioModel::ampStateChanged, this, [this]() {
+        m_appletPanel->ampApplet()->setState(
+            m_radioModel.ampOperate() ? "OPERATE" : "STANDBY");
+    });
+
     connect(&m_radioModel, &RadioModel::amplifierChanged, this, [this, updatePgxlStyle](bool present) {
         m_pgxlIndicator->setVisible(present);
         m_appletPanel->setAmpVisible(present);


### PR DESCRIPTION
## Summary

- Wire `RadioModel::ampStateChanged` to update the AMP applet's OPERATE/STANDBY button state via the radio API, so the button appears even when the direct PGXL TCP connection is unavailable (remote/VPN operation where the PGXL LAN IP is not routable)

Fixes #874

## Test plan

- [ ] Connect to radio with PGXL amplifier over local LAN — verify OPERATE/STANDBY button still works as before (direct PGXL connection provides granular states)
- [ ] Connect to radio with PGXL amplifier over VPN/SmartLink — verify OPERATE/STANDBY button now appears and reflects correct state
- [ ] Toggle OPERATE/STANDBY via the button in remote mode — verify the command is sent through the radio API successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)