### PR TITLE
Fix TX status bar indicator not lighting up during transmit

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -672,14 +672,8 @@ MainWindow::MainWindow(QWidget* parent)
             m_daxBridge->setTransmitting(tx);
 #endif
 
-        // Update TX status bar indicator
-        if (tx) {
-            m_txIndicator->setText("TX");
-            m_txIndicator->setStyleSheet("QLabel { color: white; background: #c03030; font-weight: bold; font-size: 21px; border-radius: 4px; padding: 0px 1px; }");
-        } else {
-            m_txIndicator->setText("TX");
-            m_txIndicator->setStyleSheet("QLabel { color: rgba(255,255,255,128); font-weight: bold; font-size: 21px; }");
-        }
+        // TX indicator is driven by radioTransmittingChanged (see below) so that
+        // it lights up for external PTT and Multi-Flex TX, not just local MOX.
         // On RX resume, native tiles will restart and m_hasNativeWaterfall
         // will be set again by the first arriving tile.
 #ifdef HAVE_RADE
@@ -709,11 +703,22 @@ MainWindow::MainWindow(QWidget* parent)
         }
     });
 
-    // Raw radio TX state for DAX passthrough — allows DAX TX audio to flow
-    // even when an external app (WSJT-X) triggers PTT (#752).
+    // Raw radio TX state: fired for every interlock state=TRANSMITTING regardless
+    // of TX ownership. Used for DAX passthrough (#752) and the TX status bar
+    // indicator — moxChanged is ownership-gated so it misses external PTT and
+    // Multi-Flex TX from other clients.
     connect(&m_radioModel, &RadioModel::radioTransmittingChanged,
             this, [this](bool tx) {
         m_audio->setRadioTransmitting(tx);
+        if (tx) {
+            m_txIndicator->setStyleSheet(
+                "QLabel { color: white; background: #c03030; font-weight: bold; "
+                "font-size: 21px; border-radius: 4px; padding: 0px 1px; }");
+        } else {
+            m_txIndicator->setStyleSheet(
+                "QLabel { color: rgba(255,255,255,128); font-weight: bold; "
+                "font-size: 21px; }");
+        }
     });
 
     // Sync show-TX-in-waterfall setting to all spectrum widgets


### PR DESCRIPTION
The TX indicator (m_txIndicator) was connected to TransmitModel::moxChanged, which is ownership-gated: the interlock handler only calls setTransmitting(true) — and thus emits moxChanged — when m_txOwnedByUs is true and m_txRequested is set. This means the indicator stayed gray for:

  - External PTT (foot switch, serial port) where the optimistic m_txRequested flag may not be set before the interlock state arrives
  - Multi-Flex sessions where another client holds tx_client_handle, causing !m_txOwnedByUs to force setTransmitting(false) regardless of RF state

RadioModel::radioTransmittingChanged is already emitted unconditionally for every interlock state=TRANSMITTING (line 1981), regardless of ownership. It was previously only used for DAX audio passthrough (#752).

Move the TX indicator styling from the moxChanged lambda into the existing radioTransmittingChanged connection. The moxChanged lambda retains all audio, DAX bridge, waterfall freeze, and RADE mode logic unchanged — those correctly remain ownership-gated for local TX alignment.

Result: indicator turns red whenever the radio reports RF keyed, including external PTT, foot switch, and Multi-Flex TX from other clients.