### PR TITLE
Fix S-Meter Level/Compression modes during VOX/hardware CW (#877)

### DIFF
--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -90,7 +90,11 @@ void SMeterWidget::setMicMeters(float micLevel, float compLevel, float micPeak, 
     float comp = (compPeak < -30.0f || compPeak >= 0.0f) ? 0.0f : compPeak;
     m_compLevel = m_compLevel + SMOOTH_ALPHA * (comp - m_compLevel);
 
-    if (m_transmitting && (m_txMode == TxMode::Level || m_txMode == TxMode::Compression))
+    // Repaint when TX mic data arrives — use the same effectiveTx logic as
+    // setTxMeters so Level/Compression modes work during VOX/hardware CW
+    // when setTransmitting(true) arrives late (#877).
+    if ((m_transmitting || m_txPower > 0.5f)
+        && (m_txMode == TxMode::Level || m_txMode == TxMode::Compression))
         update();
 }
 


### PR DESCRIPTION
## Summary

Fixes #877

PR #872 fixed the S-Meter Power and SWR modes to repaint when `m_txPower > 0.5f` (detecting effective TX during VOX/hardware CW where `setTransmitting(true)` arrives late). However, `setMicMeters()` — which drives the **Level** and **Compression** TX modes — still only checked `m_transmitting`, so those two modes remained blank during VOX/hardware CW.

This applies the same `effectiveTx` pattern (`m_transmitting || m_txPower > 0.5f`) to the `setMicMeters()` repaint guard, completing the fix for all four TX meter modes.

## Changes

- `src/gui/SMeterWidget.cpp`: Update `setMicMeters()` repaint condition to use `m_transmitting || m_txPower > 0.5f` instead of just `m_transmitting`

## Test plan

- [ ] Connect to radio, select **Level** in TX Select dropdown, key TX via VOX or hardware CW — needle should deflect
- [ ] Repeat with **Compression** selected — needle should deflect
- [ ] Verify **Power** and **SWR** modes still work (unchanged path)
- [ ] Verify RX S-Meter is unaffected when not transmitting