### PR TITLE
Fix DIGU/DIGL filter offset centering to match SmartSDR behavior

### DIFF
--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1269,7 +1269,25 @@ void RxApplet::applyFilterPreset(int widthHz)
     int lo, hi;
     const QString& mode = m_slice->mode();
 
-    if (mode == "LSB" || mode == "DIGL") {
+    if (mode == "DIGU") {
+        if (widthHz < 3000) {
+            int offset = m_slice->diguOffset();
+            lo = offset - widthHz / 2;
+            hi = offset + widthHz / 2;
+            if (lo < 95) { hi += (95 - lo); lo = 95; }
+        } else {
+            lo = 95; hi = widthHz;
+        }
+    } else if (mode == "DIGL") {
+        if (widthHz < 3000) {
+            int offset = m_slice->diglOffset();
+            hi = -offset + widthHz / 2;
+            lo = -offset - widthHz / 2;
+            if (hi > -95) { lo -= (hi + 95); hi = -95; }
+        } else {
+            lo = -widthHz; hi = -95;
+        }
+    } else if (mode == "LSB") {
         lo = -widthHz;
         hi = -95;
     } else if (mode == "RTTY") {
@@ -1290,7 +1308,7 @@ void RxApplet::applyFilterPreset(int widthHz)
         lo = -(widthHz / 2);
         hi =  (widthHz / 2);
     } else {
-        // USB, DIGU, FDV, etc. — low cut at 95 Hz to reject carrier/hum
+        // USB, FDV, etc. — low cut at 95 Hz to reject carrier/hum
         lo = 95;
         hi = widthHz;
     }

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1071,6 +1071,18 @@ void VfoWidget::buildTabContent()
                     m_slice->setDiglOffset(hz);
                 else
                     m_slice->setDiguOffset(hz);
+                // Re-apply the current filter so the passband repositions
+                // immediately around the new offset without requiring a preset click.
+                // In wide mode (>=3000 Hz) lo/hi are anchored at ±95, so recover
+                // the preset width from the anchored edge, not the span.
+                int curLo = m_slice->filterLow();
+                int curHi = m_slice->filterHigh();
+                int width;
+                if (m_slice->mode() == "DIGL")
+                    width = (curHi == -95 && curLo <= -3000) ? -curLo : curHi - curLo;
+                else
+                    width = (curLo == 95 && curHi >= 3000) ? curHi : curHi - curLo;
+                applyFilterPreset(width);
             };
 
             static constexpr int DIG_STEP = 10;

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1109,8 +1109,11 @@ void VfoWidget::buildTabContent()
             // Double-click label → switch to inline edit
             m_digOffsetLabel->installEventFilter(this);
 
-            // Commit edit on Enter or focus loss
+            // Commit edit on Enter or focus loss.
+            // Guard against double-fire: returnPressed switches stack to index 0,
+            // which removes focus and triggers editingFinished a second time.
             auto commitEdit = [this, applyOffset] {
+                if (m_digOffsetStack->currentIndex() != 1) return;
                 m_digOffsetStack->setCurrentIndex(0);
                 bool ok;
                 int hz = m_digOffsetEdit->text().toInt(&ok);

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1011,6 +1011,9 @@ void VfoWidget::buildTabContent()
         }
 
         // DIG offset control (hidden unless DIGL/DIGU mode)
+        // The offset centers the filter passband for widths < 3000 Hz.
+        // Double-click the value to enter directly; arrows step by 10 Hz;
+        // scroll wheel also steps. (fw v1.4.0.0)
         {
             static const QString kStepLabelStyle2 =
                 "QLabel { font-size: 10px; background: #0a0a18; border: 1px solid #1e2e3e; "
@@ -1032,31 +1035,77 @@ void VfoWidget::buildTabContent()
             auto* row = new QHBoxLayout;
             row->setContentsMargins(0, 0, 0, 0);
             row->setSpacing(0);
+
             auto* minus = new TriBtn(TriBtn::Left);
             row->addWidget(minus);
-            m_digOffsetLabel = new QLabel("2210");
+
+            // Stacked widget: label (normal) / line edit (direct entry)
+            m_digOffsetStack = new QStackedWidget;
+            m_digOffsetStack->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+
+            m_digOffsetLabel = new ScrollableLabel("2210");
             m_digOffsetLabel->setAlignment(Qt::AlignCenter);
             m_digOffsetLabel->setStyleSheet(kStepLabelStyle2);
-            row->addWidget(m_digOffsetLabel, 1);
+            m_digOffsetLabel->setCursor(Qt::PointingHandCursor);
+            m_digOffsetLabel->setToolTip("Double-click to enter offset directly");
+            m_digOffsetStack->addWidget(m_digOffsetLabel);  // index 0
+
+            m_digOffsetEdit = new QLineEdit;
+            m_digOffsetEdit->setAlignment(Qt::AlignCenter);
+            m_digOffsetEdit->setStyleSheet(
+                "QLineEdit { font-size: 10px; background: #0a0a18; border: 1px solid #00b4d8; "
+                "border-radius: 3px; padding: 0px 2px; color: #00e5ff; }");
+            m_digOffsetStack->addWidget(m_digOffsetEdit);   // index 1
+
+            row->addWidget(m_digOffsetStack, 1);
+
             auto* plus = new TriBtn(TriBtn::Right);
             row->addWidget(plus);
             dvb->addLayout(row);
 
+            // Helper to apply a validated offset value
+            auto applyOffset = [this](int hz) {
+                if (!m_slice) return;
+                hz = qBound(0, hz, 10000);
+                if (m_slice->mode() == "DIGL")
+                    m_slice->setDiglOffset(hz);
+                else
+                    m_slice->setDiguOffset(hz);
+            };
+
             static constexpr int DIG_STEP = 10;
-            connect(minus, &QPushButton::clicked, this, [this] {
+            connect(minus, &QPushButton::clicked, this, [this, applyOffset] {
                 if (!m_slice) return;
-                if (m_slice->mode() == "DIGL")
-                    m_slice->setDiglOffset(m_slice->diglOffset() - DIG_STEP);
-                else
-                    m_slice->setDiguOffset(m_slice->diguOffset() - DIG_STEP);
+                int cur = (m_slice->mode() == "DIGL")
+                    ? m_slice->diglOffset() : m_slice->diguOffset();
+                applyOffset(cur - DIG_STEP);
             });
-            connect(plus, &QPushButton::clicked, this, [this] {
+            connect(plus, &QPushButton::clicked, this, [this, applyOffset] {
                 if (!m_slice) return;
-                if (m_slice->mode() == "DIGL")
-                    m_slice->setDiglOffset(m_slice->diglOffset() + DIG_STEP);
-                else
-                    m_slice->setDiguOffset(m_slice->diguOffset() + DIG_STEP);
+                int cur = (m_slice->mode() == "DIGL")
+                    ? m_slice->diglOffset() : m_slice->diguOffset();
+                applyOffset(cur + DIG_STEP);
             });
+            connect(m_digOffsetLabel, &ScrollableLabel::scrolled, this,
+                    [this, applyOffset](int dir) {
+                if (!m_slice) return;
+                int cur = (m_slice->mode() == "DIGL")
+                    ? m_slice->diglOffset() : m_slice->diguOffset();
+                applyOffset(cur + dir * DIG_STEP);
+            });
+
+            // Double-click label → switch to inline edit
+            m_digOffsetLabel->installEventFilter(this);
+
+            // Commit edit on Enter or focus loss
+            auto commitEdit = [this, applyOffset] {
+                m_digOffsetStack->setCurrentIndex(0);
+                bool ok;
+                int hz = m_digOffsetEdit->text().toInt(&ok);
+                if (ok) applyOffset(hz);
+            };
+            connect(m_digOffsetEdit, &QLineEdit::returnPressed, this, commitEdit);
+            connect(m_digOffsetEdit, &QLineEdit::editingFinished, this, commitEdit);
 
             m_digContainer->hide();
             dspVb->addWidget(m_digContainer);
@@ -2611,7 +2660,42 @@ void VfoWidget::applyFilterPreset(int widthHz)
     int lo, hi;
     const QString& mode = m_slice->mode();
 
-    if (mode == "LSB" || mode == "DIGL") {
+    if (mode == "DIGU") {
+        // For widths < 3000 Hz, center the filter on the stored digu_offset.
+        // SmartSDR behavior (fw v1.4.0.0): offset is the audio center frequency;
+        // filter spans [offset - width/2, offset + width/2], clamped so lo >= 95.
+        // For widths >= 3000 Hz, SmartSDR ignores the offset and runs from 95 Hz
+        // upward — preserve that behavior unchanged.
+        if (widthHz < 3000) {
+            int offset = m_slice->diguOffset();
+            lo = offset - widthHz / 2;
+            hi = offset + widthHz / 2;
+            if (lo < 95) {
+                // Clamp: don't let lo drop below 95 Hz (carrier rejection)
+                hi += (95 - lo);
+                lo = 95;
+            }
+        } else {
+            lo = 95;
+            hi = widthHz;
+        }
+    } else if (mode == "DIGL") {
+        // Mirror of DIGU: offset is negative (below carrier). For widths < 3000 Hz,
+        // center on -digl_offset, clamped so hi <= -95.
+        // For widths >= 3000 Hz, run from -95 downward.
+        if (widthHz < 3000) {
+            int offset = m_slice->diglOffset();
+            hi = -offset + widthHz / 2;
+            lo = -offset - widthHz / 2;
+            if (hi > -95) {
+                lo -= (hi + 95);
+                hi = -95;
+            }
+        } else {
+            lo = -widthHz;
+            hi = -95;
+        }
+    } else if (mode == "LSB") {
         lo = -widthHz; hi = -95;
     } else if (mode == "RTTY") {
         // RTTY: RF_frequency = mark. Filter is relative to mark.
@@ -2628,7 +2712,7 @@ void VfoWidget::applyFilterPreset(int widthHz)
     } else if (mode == "AM" || mode == "SAM" || mode == "DSB") {
         lo = -(widthHz / 2); hi = (widthHz / 2);
     } else {
-        // USB/DIGU/FDV: low cut at 95 Hz to reject carrier/hum
+        // USB/FDV/etc: low cut at 95 Hz to reject carrier/hum
         lo = 95; hi = widthHz;
     }
     m_slice->setFilterWidth(lo, hi);
@@ -2658,6 +2742,19 @@ void VfoWidget::setTransmitModel(TransmitModel* txModel)
 
 bool VfoWidget::eventFilter(QObject* obj, QEvent* event)
 {
+    // Double-click on DIG offset label → switch to inline edit
+    if (obj == m_digOffsetLabel && event->type() == QEvent::MouseButtonDblClick) {
+        if (m_digOffsetStack && m_digOffsetEdit) {
+            int cur = m_slice ? ((m_slice->mode() == "DIGL")
+                ? m_slice->diglOffset() : m_slice->diguOffset()) : 0;
+            m_digOffsetEdit->setText(QString::number(cur));
+            m_digOffsetStack->setCurrentIndex(1);
+            m_digOffsetEdit->selectAll();
+            m_digOffsetEdit->setFocus();
+        }
+        return true;
+    }
+
     // Double-click on frequency label → open inline edit
     if (obj == m_freqLabel && event->type() == QEvent::MouseButtonDblClick) {
         beginDirectEntry();

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -193,8 +193,10 @@ private:
     // RTTY Mark/Shift (shown only in RTTY mode)
     QWidget* m_rttyContainer{nullptr};
     // DIG offset (shown only in DIGL/DIGU mode)
-    QWidget* m_digContainer{nullptr};
-    QLabel*  m_digOffsetLabel{nullptr};
+    QWidget*        m_digContainer{nullptr};
+    ScrollableLabel* m_digOffsetLabel{nullptr};   // read-only display, scroll-wheel steps
+    QLineEdit*       m_digOffsetEdit{nullptr};     // inline direct-entry (double-click)
+    QStackedWidget*  m_digOffsetStack{nullptr};    // switches between label and edit
     // FM OPT controls (shown only in FM/NFM mode)
     QWidget*       m_fmContainer{nullptr};
     QComboBox*     m_fmToneModeCmb{nullptr};


### PR DESCRIPTION
## Summary

- For filter widths < 3000 Hz, center the DSP passband on the stored `digu_offset` / `digl_offset` value, matching SmartSDR behavior documented in the SSDR manual
- For filter widths ≥ 3000 Hz, fall back to `lo=95/hi=widthHz` (DIGU) or `lo=-widthHz/hi=-95` (DIGL) — the wide-filter behavior SmartSDR uses
- Changing the offset (via arrows, scroll wheel, or direct entry) now immediately repositions the filter without requiring a preset re-click
- Adds direct-entry support to the DIG offset control in the VFO widget DSP tab: double-click the value to open an inline text field; commit with Enter or focus loss
- Applied consistently to both `VfoWidget::applyFilterPreset()` and `RxApplet::applyFilterPreset()`

## Reference

SmartSDR Software User Guide, **Section 35.6 — Digi Mode Audio Offsets** documents this behavior as intentional and operator-configurable. The default offsets (DIGU=1500 Hz, DIGL=2210 Hz) match the values already initialized in `SliceModel.h`.

> *"This control allows the operator to set the audio offset in Hertz of the center of the receiver's bandpass preset filters... This feature allows the operator to configure a narrow filter in DIGU or DIGL mode, then conveniently drop it over a signal of interest by simply double clicking on the signal."*

## Use Case — RADE/FreeDV

RADE (the FreeDV 2020B waveform used by AetherSDR) places its transmitted signal approximately 1500 Hz above the indicated carrier frequency. With this fix, an operator running RADE on DIGU can set the offset to 1500 Hz and select a narrow receive filter (e.g. 2000 Hz) — the passband will be correctly centered on the RADE waveform without requiring a change to the transmit frequency.

Previously, the same narrow filter would be anchored at lo=95 Hz, placing most of the passband below the actual signal and degrading receive performance.

**AetherSDR with 2K filter and 1500 Hz offset applied (500–2500 Hz passband):**

![AetherSDR spectrum showing 2K filter centered at 1500 Hz offset](https://github.com/user-attachments/assets/591c87e8-028a-46f3-89f4-4eca1ed19f46)

**RADE waveform spectral footprint (FreeDV waterfall) — signal occupies 500–2500 Hz:**

![FreeDV waterfall showing RADE waveform from 500 to 2500 Hz](https://github.com/user-attachments/assets/e8202c24-5256-490e-afcc-159d60a41604)

## Test Plan

- [x] Switch slice to DIGU, set a narrow preset (≤ 2000 Hz), verify passband centers on offset value
- [x] Switch slice to DIGL, same verification
- [x] Set a wide preset (≥ 3000 Hz), verify offset is ignored and filter anchors at lo=95 / hi=widthHz
- [x] Change offset via arrows, scroll wheel, and direct entry — verify filter repositions immediately each time
- [x] Double-click offset value, enter a number, press Enter — verify field closes and filter updates
- [x] Verify RTTY mode filter behavior is unchanged
- [x] RADE/FreeDV: with DIGU offset=1500 Hz and a 2000 Hz filter, confirm passband spans 500–2500 Hz and covers the RADE waveform

🤖 Generated with [Claude Code](https://claude.com/claude-code)