### PR TITLE
Add hidapi to Windows build for USB HID device support (#878)

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Setup FFTW3 float (NR4 dependency)
         run: .\setup-fftw.ps1
 
+      - name: Setup hidapi (USB HID device support)
+        run: .\setup-hidapi.ps1
+
       - name: Configure
         run: |
           cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DENABLE_RADE=OFF
@@ -53,6 +56,9 @@ jobs:
           }
           if (Test-Path "third_party\fftw3\bin\libfftw3f-3.dll") {
             copy third_party\fftw3\bin\libfftw3f-3.dll deploy\
+          }
+          if (Test-Path "third_party\hidapi\bin\hidapi.dll") {
+            copy third_party\hidapi\bin\hidapi.dll deploy\
           }
 
       - name: Create portable ZIP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,14 +562,30 @@ else()
     target_link_libraries(AetherSDR PRIVATE asound)
 endif()
 
-# hidapi — USB HID encoder support (Icom RC-28, Griffin PowerMate, Contour Shuttle)
-if(PkgConfig_FOUND)
-    pkg_check_modules(HIDAPI hidapi-hidraw)
-    if(NOT HIDAPI_FOUND)
-        pkg_check_modules(HIDAPI hidapi-libusb)
+# hidapi — USB HID encoder support (Stream Deck, Icom RC-28, Griffin PowerMate, Contour Shuttle)
+# Windows: run setup-hidapi.ps1 first to download and build hidapi
+# Linux:   apt install libhidapi-dev
+# macOS:   brew install hidapi
+if(WIN32)
+    set(HIDAPI_ROOT "${CMAKE_SOURCE_DIR}/third_party/hidapi")
+    if(EXISTS "${HIDAPI_ROOT}/include/hidapi/hidapi.h")
+        set(HIDAPI_FOUND TRUE)
+        set(HIDAPI_INCLUDE_DIRS "${HIDAPI_ROOT}/include")
+        set(HIDAPI_LIBRARIES "${HIDAPI_ROOT}/lib/hidapi.lib")
+        set(HIDAPI_DLL "${HIDAPI_ROOT}/bin/hidapi.dll")
+    else()
+        message(WARNING "hidapi not found. Run setup-hidapi.ps1 to download it. "
+                        "USB HID device support (Stream Deck, etc.) will be disabled.")
     endif()
-    if(NOT HIDAPI_FOUND)
-        pkg_check_modules(HIDAPI hidapi)
+else()
+    if(PkgConfig_FOUND)
+        pkg_check_modules(HIDAPI hidapi-hidraw)
+        if(NOT HIDAPI_FOUND)
+            pkg_check_modules(HIDAPI hidapi-libusb)
+        endif()
+        if(NOT HIDAPI_FOUND)
+            pkg_check_modules(HIDAPI hidapi)
+        endif()
     endif()
 endif()
 if(HIDAPI_FOUND)
@@ -595,6 +611,14 @@ if(HIDAPI_FOUND)
     list(REMOVE_DUPLICATES HIDAPI_NORMALIZED_INCLUDE_DIRS)
     target_include_directories(AetherSDR PRIVATE ${HIDAPI_NORMALIZED_INCLUDE_DIRS})
     target_link_libraries(AetherSDR PRIVATE ${HIDAPI_LIBRARIES})
+    # Copy DLL to build dir on Windows
+    if(WIN32 AND HIDAPI_DLL)
+        add_custom_command(TARGET AetherSDR POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${HIDAPI_DLL}" "$<TARGET_FILE_DIR:AetherSDR>"
+            COMMENT "Copying hidapi.dll to build directory"
+        )
+    endif()
 else()
     message(STATUS "hidapi not found — USB HID encoder support disabled")
 endif()

--- a/setup-hidapi.ps1
+++ b/setup-hidapi.ps1
@@ -1,0 +1,91 @@
+<#
+.SYNOPSIS
+    Download and build hidapi for Windows x64.
+
+.DESCRIPTION
+    Downloads hidapi 0.14.0 source from GitHub, builds it with CMake + MSVC,
+    and places headers/lib/dll in third_party/hidapi/ ready for CMake.
+
+    Required for USB HID device support (Stream Deck, Icom RC-28,
+    Griffin PowerMate, Contour Shuttle, etc.).
+
+.EXAMPLE
+    .\setup-hidapi.ps1
+#>
+
+$ErrorActionPreference = "Stop"
+
+$HidapiVersion = "0.14.0"
+$HidapiUrl     = "https://github.com/libusb/hidapi/archive/refs/tags/hidapi-${HidapiVersion}.tar.gz"
+$OutDir        = "third_party\hidapi"
+$TarFile       = "third_party\hidapi-${HidapiVersion}.tar.gz"
+
+# ── Check if already set up ──────────────────────────────────────────────
+if (Test-Path "$OutDir\lib\hidapi.lib") {
+    Write-Host "hidapi already set up in $OutDir" -ForegroundColor Green
+    exit 0
+}
+
+# ── Create directories ───────────────────────────────────────────────────
+New-Item -ItemType Directory -Force -Path "third_party" | Out-Null
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+New-Item -ItemType Directory -Force -Path "$OutDir\lib" | Out-Null
+New-Item -ItemType Directory -Force -Path "$OutDir\include\hidapi" | Out-Null
+New-Item -ItemType Directory -Force -Path "$OutDir\bin" | Out-Null
+
+# ── Download source ─────────────────────────────────────────────────────
+if (-not (Test-Path $TarFile)) {
+    Write-Host "Downloading hidapi ${HidapiVersion} source..." -ForegroundColor Cyan
+    Invoke-WebRequest -Uri $HidapiUrl -OutFile $TarFile
+}
+
+# ── Extract ──────────────────────────────────────────────────────────────
+Write-Host "Extracting..." -ForegroundColor Cyan
+$tempDir = "third_party\hidapi-temp"
+if (Test-Path $tempDir) { Remove-Item -Recurse -Force $tempDir }
+New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
+tar -xzf $TarFile -C $tempDir 2>$null
+
+$srcDir = Get-ChildItem "$tempDir\hidapi-hidapi-*" -Directory | Select-Object -First 1
+if (-not $srcDir) {
+    $srcDir = Get-ChildItem "$tempDir\hidapi-*" -Directory | Select-Object -First 1
+}
+
+# ── Copy headers ─────────────────────────────────────────────────────────
+Copy-Item "$($srcDir.FullName)\hidapi\hidapi.h" "$OutDir\include\hidapi\"
+
+# ── Build with CMake + MSVC ──────────────────────────────────────────────
+Write-Host "Building hidapi from source with MSVC..." -ForegroundColor Cyan
+
+$buildDir = "$($srcDir.FullName)\build"
+cmake -B $buildDir -S $srcDir.FullName -G "Ninja" `
+    -DCMAKE_BUILD_TYPE=Release `
+    -DBUILD_SHARED_LIBS=ON
+
+cmake --build $buildDir --config Release -j $env:NUMBER_OF_PROCESSORS
+
+# ── Find and copy built artifacts ────────────────────────────────────────
+# hidapi builds hidapi.dll + hidapi.lib (import lib) on Windows
+$dllFile = Get-ChildItem "$buildDir" -Recurse -Filter "hidapi.dll" | Select-Object -First 1
+$libFile = Get-ChildItem "$buildDir" -Recurse -Filter "hidapi.lib" | Select-Object -First 1
+
+if (-not $libFile) {
+    Write-Error "Failed to build hidapi.lib"
+    exit 1
+}
+
+Copy-Item $libFile.FullName "$OutDir\lib\hidapi.lib"
+if ($dllFile) {
+    Copy-Item $dllFile.FullName "$OutDir\bin\hidapi.dll"
+}
+
+# ── Cleanup ──────────────────────────────────────────────────────────────
+Remove-Item -Recurse -Force $tempDir
+Remove-Item -Force $TarFile
+
+Write-Host "hidapi ready in $OutDir" -ForegroundColor Green
+Write-Host "  Header: $OutDir\include\hidapi\hidapi.h"
+Write-Host "  Lib:    $OutDir\lib\hidapi.lib"
+if ($dllFile) {
+    Write-Host "  DLL:    $OutDir\bin\hidapi.dll"
+}


### PR DESCRIPTION
## Summary

Fixes #878

The Windows CI build was missing `hidapi`, so the entire Stream Deck and USB HID encoder subsystem (`StreamDeckManager`, `StreamDeckDevice`, `HidEncoderManager`, etc.) was silently compiled out via `#ifdef HAVE_HIDAPI` guards. This meant **all HID device support was disabled on Windows**: Stream Deck (all models including XL), Icom RC-28, Griffin PowerMate, Contour Shuttle, etc.

### Changes

- **`setup-hidapi.ps1`** — New setup script (follows the existing `setup-opus.ps1`/`setup-fftw.ps1` pattern) that downloads hidapi 0.14.0 source from GitHub, builds it with CMake + MSVC, and places the header/lib/dll in `third_party/hidapi/`
- **`CMakeLists.txt`** — Added Windows-specific `third_party/hidapi` detection (matching the FFTW3 pattern) before the existing PkgConfig-based detection for Linux/macOS. Also adds a post-build step to copy `hidapi.dll` to the build directory
- **`.github/workflows/windows-installer.yml`** — Added `setup-hidapi.ps1` build step and `hidapi.dll` deploy copy

## Test plan

- [ ] Windows CI build completes with `hidapi found — USB HID encoder support enabled` in CMake output
- [ ] `hidapi.dll` is present in the deployed installer/portable ZIP
- [ ] Stream Deck XL (and other HID devices) are detected when plugged into the computer running AetherSDR on Windows
- [ ] Linux and macOS builds are unaffected (they continue using PkgConfig detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)