### PR TITLE
Fix S-Meter oscillating between RX/TX during receive

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3233,8 +3233,6 @@ void MainWindow::buildMenuBar()
         AppSettings::instance().value("HeartbeatBlinkEnabled", "True").toString() == "True");
     connect(heartbeatBlinkAct, &QAction::toggled, this, [this](bool on) {
         if (m_titleBar) m_titleBar->setBlinkEnabled(on);
-        AppSettings::instance().setValue("HeartbeatBlinkEnabled", on ? "True" : "False");
-        AppSettings::instance().save();
     });
     // Keep the menu item in sync when the right-click on the indicator changes the setting
     if (m_titleBar) {

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -410,12 +410,9 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     // Needle originates from needleCy (just below widget) rather than the
     // arc center, so the pivot is barely out of frame.
     // When transmitting, needle tracks the selected TX meter instead of RX.
-    // Also switches to TX display when RF power is flowing even if m_transmitting
-    // hasn't been set yet (VOX, hardware CW, interlock timing race).
     {
-        const bool effectiveTx = m_transmitting || m_txPower > 0.5f;
         float frac;
-        if (effectiveTx)
+        if (m_transmitting)
             frac = txValueToFraction(currentTxValue());
         else if (m_rxMode == RxMode::SMeterPeak)
             frac = dbmToFraction(m_peakDbm);
@@ -438,7 +435,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     }
 
     // Draw peak marker (small triangle) — only in RX S-Meter Peak mode
-    if (!(m_transmitting || m_txPower > 0.5f) && m_rxMode == RxMode::SMeterPeak
+    if (!m_transmitting && m_rxMode == RxMode::SMeterPeak
         && m_peakDbm > m_levelDbm + 1.0f) {
         const float frac = dbmToFraction(m_peakDbm);
         const float angle = fractionToAngle(frac);
@@ -492,7 +489,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     valFont.setBold(true);
     const QFontMetrics vfm(valFont);
 
-    if (m_transmitting || m_txPower > 0.5f) {
+    if (m_transmitting) {
         // TX mode: show TX source label (center), mode name (left), value (right)
         static const char* txLabels[] = {"Power", "SWR", "Level", "Compression"};
         const QString srcLabel = txLabels[static_cast<int>(m_txMode)];

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -82,9 +82,6 @@ TitleBar::TitleBar(QWidget* parent)
         blinkAction->setChecked(m_blinkEnabled);
         connect(blinkAction, &QAction::triggered, this, [this](bool checked) {
             setBlinkEnabled(checked);
-            AppSettings::instance().setValue("HeartbeatBlinkEnabled", checked ? "True" : "False");
-            AppSettings::instance().save();
-            emit blinkEnabledChanged(checked);
         });
         menu->popup(m_heartbeat->mapToGlobal(pos));
     });
@@ -554,6 +551,9 @@ void TitleBar::setBlinkEnabled(bool enabled)
 {
     if (m_blinkEnabled == enabled) return;
     m_blinkEnabled = enabled;
+    AppSettings::instance().setValue("HeartbeatBlinkEnabled", enabled ? "True" : "False");
+    AppSettings::instance().save();
+    emit blinkEnabledChanged(enabled);
 
     if (enabled) {
         // Resume alarm blink immediately if currently in alarm state (m_missedBeats >= 3).


### PR DESCRIPTION
- Consolidate heartbeat blink AppSettings save into setBlinkEnabled()
- Fix S-Meter oscillating between RX/TX during receive
