### PR TITLE
Fix CW filter low-edge drag snapping to zero (#764)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4279,7 +4279,11 @@ void MainWindow::onSliceAdded(SliceModel* s)
         m_antennaGenius.setRadioFrequency(s->frequency());
 
     connect(s, &SliceModel::filterChanged, this, [this, s](int lo, int hi) {
-        spectrumForSlice(s)->setSliceOverlay(s->sliceId(), s->frequency(),
+        auto* sw = spectrumForSlice(s);
+        // Skip overlay update while user is dragging a filter edge — the radio's
+        // status echo would overwrite the drag position, causing snap-to-zero (#764)
+        if (sw->isDraggingFilter()) return;
+        sw->setSliceOverlay(s->sliceId(), s->frequency(),
             lo, hi, s->isTxSlice(), s->sliceId() == m_activeSliceId,
             s->mode(), s->rttyMark(), s->rttyShift(),
             s->ritOn(), s->ritFreq(), s->xitOn(), s->xitFreq());

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1100,7 +1100,8 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
             const double mhz = xToMhz(mx);
             const int mouseHz = static_cast<int>(std::round((mhz - ao->freqMhz) * 1.0e6));
             const int edgeHz = (m_draggingFilter == FilterEdge::Low) ? ao->filterLowHz : ao->filterHighHz;
-            m_filterDragOffsetHz = edgeHz - mouseHz;
+            m_filterDragStartX = mx;
+            m_filterDragStartHz = edgeHz;
 
             setCursor(Qt::SizeHorCursor);
             ev->accept();
@@ -1203,15 +1204,13 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         auto* ao = const_cast<SliceOverlay*>(activeOverlay());
         if (!ao) { m_draggingFilter = FilterEdge::None; return; }
         const int mx = static_cast<int>(ev->position().x());
-        const double mhz = xToMhz(mx);
-        int hz = static_cast<int>(std::round((mhz - ao->freqMhz) * 1.0e6));
-        hz += m_filterDragOffsetHz; // apply anchor offset (#764)
+        // Compute Hz delta from pixel delta — immune to freq/overlay changes (#764)
+        const double hzPerPx = (m_bandwidthMhz * 1.0e6) / width();
+        int hz = m_filterDragStartHz + static_cast<int>(std::round((mx - m_filterDragStartX) * hzPerPx));
 
         if (m_draggingFilter == FilterEdge::Low) {
-            hz = std::clamp(hz, m_filterMinHz, ao->filterHighHz - 10);
             ao->filterLowHz = hz;
         } else {
-            hz = std::clamp(hz, ao->filterLowHz + 10, m_filterMaxHz);
             ao->filterHighHz = hz;
         }
         markOverlayDirty();

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -203,6 +203,7 @@ public:
     };
 
     // Add or update a slice overlay (called per-slice on any state change).
+    bool isDraggingFilter() const { return m_draggingFilter != FilterEdge::None; }
     void setSliceOverlay(int sliceId, double freq, int fLow, int fHigh,
                          bool tx, bool active, const QString& mode = {},
                          int rttyMark = 2125, int rttyShift = 170,
@@ -427,7 +428,8 @@ private:
     // Filter edge drag state
     enum class FilterEdge { None, Low, High };
     FilterEdge m_draggingFilter{FilterEdge::None};
-    int m_filterDragOffsetHz{0}; // anchor offset to prevent snap-to-cursor (#764)
+    int m_filterDragStartX{0};      // pixel X at grab time (#764)
+    int m_filterDragStartHz{0};     // filter edge Hz at grab time (#764)
     // VFO passband drag state (#404)
     bool m_draggingVfo{false};
     // dBm scale strip drag state


### PR DESCRIPTION
Three issues combined to cause the snap:
1. Status echo from radio overwrote overlay during drag — added
   isDraggingFilter() guard on setSliceOverlay calls
2. Frequency-based Hz calculation drifted between press and move —
   switched to pixel-delta approach (startHz + pixelDelta * hzPerPx)
3. Client-side clamp was fighting the radio's own limits — removed
   all client clamping, let the radio enforce filter boundaries

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
