### PR TITLE
Add poppable applets — float/dock with persistent geometry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,7 @@ set(GUI_SOURCES
     src/gui/PanadapterStack.cpp
     src/gui/PanLayoutDialog.cpp
     src/gui/AppletPanel.cpp
+    src/gui/FloatingAppletWindow.cpp
     src/gui/RxApplet.cpp
     src/gui/FilterPassbandWidget.cpp
     src/gui/SMeterWidget.cpp

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -1,4 +1,5 @@
 #include "AppletPanel.h"
+#include "FloatingAppletWindow.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
 #include "RxApplet.h"
@@ -30,6 +31,9 @@
 #include <QScrollBar>
 #include <QPainter>
 #include <QPixmap>
+#include <QMenu>
+#include <QTimer>
+#include <QContextMenuEvent>
 
 namespace AetherSDR {
 
@@ -41,8 +45,9 @@ const QStringList AppletPanel::kDefaultOrder = {
 
 class AppletTitleBar : public QWidget {
 public:
-    AppletTitleBar(const QString& text, const QString& appletId, QWidget* parent = nullptr)
-        : QWidget(parent), m_appletId(appletId)
+    AppletTitleBar(const QString& text, const QString& appletId,
+                   AppletPanel* panel = nullptr, QWidget* parent = nullptr)
+        : QWidget(parent), m_appletId(appletId), m_panel(panel)
     {
         setFixedHeight(16);
         setCursor(Qt::OpenHandCursor);
@@ -98,10 +103,27 @@ protected:
         setCursor(Qt::OpenHandCursor);
     }
 
+    void contextMenuEvent(QContextMenuEvent* ev) override {
+        if (!m_panel) { return; }
+        bool isFloating = m_panel->isAppletFloating(m_appletId);
+        // Use popup() — no nested event loop
+        QMenu* menu = new QMenu(this);
+        menu->setAttribute(Qt::WA_DeleteOnClose);
+        QAction* act = menu->addAction(isFloating ? "\u21a9 Dock" : "\u2197 Pop out");
+        connect(act, &QAction::triggered, this, [this, isFloating]() {
+            if (isFloating)
+                m_panel->dockApplet(m_appletId);
+            else
+                m_panel->floatApplet(m_appletId);
+        });
+        menu->popup(ev->globalPos());
+    }
+
 private:
-    QString m_appletId;
-    QPoint  m_dragStartPos;
-    QLabel* m_label{nullptr};
+    QString      m_appletId;
+    QPoint       m_dragStartPos;
+    QLabel*      m_label{nullptr};
+    AppletPanel* m_panel{nullptr};
 };
 
 // ── Drop-aware scroll area ──────────────────────────────────────────────────
@@ -416,7 +438,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     auto makeEntry = [&](const QString& id, const QString& label,
                          QWidget* applet, bool defaultOn,
                          QWidget* rowParent, QHBoxLayout* rowLayout) -> AppletEntry {
-        auto* titleBar = new AppletTitleBar(label, id);
+        auto* titleBar = new AppletTitleBar(label, id, this);
         auto* wrapper = new QWidget;
         auto* wl = new QVBoxLayout(wrapper);
         wl->setContentsMargins(0, 0, 0, 0);
@@ -434,12 +456,21 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         btn->setChecked(on);
         wrapper->setVisible(on);
 
-        connect(btn, &QPushButton::toggled, wrapper, [wrapper, key](bool checked) {
+        connect(btn, &QPushButton::toggled, this, [this, id, wrapper, key](bool checked) {
+            // If the applet is floating, the toggle button raises/hides the
+            // floating window rather than showing/hiding the docked wrapper.
+            if (m_floatingWindows.contains(id)) {
+                if (checked)
+                    m_floatingWindows[id]->raise();
+                else
+                    m_floatingWindows[id]->hide();
+                return;
+            }
             wrapper->setVisible(checked);
             AppSettings::instance().setValue(key, checked ? "True" : "False");
         });
 
-        return {id, wrapper, titleBar, btn};
+        return {id, wrapper, titleBar, btn, false};
     };
 
     // Controls lock toggle — disables wheel/mouse on sidebar sliders (#745)
@@ -477,7 +508,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
     m_tunerApplet = new TunerApplet;
     {
-        auto* titleBar = new AppletTitleBar("Tuner", "TUN");
+        auto* titleBar = new AppletTitleBar("Tuner", "TUN", this);
         auto* wrapper = new QWidget;
         auto* wl = new QVBoxLayout(wrapper);
         wl->setContentsMargins(0, 0, 0, 0);
@@ -497,7 +528,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
     m_ampApplet = new AmpApplet;
     {
-        auto* titleBar = new AppletTitleBar("Amplifier", "AMP");
+        auto* titleBar = new AppletTitleBar("Amplifier", "AMP", this);
         auto* wrapper = new QWidget;
         auto* wl = new QVBoxLayout(wrapper);
         wl->setContentsMargins(0, 0, 0, 0);
@@ -539,7 +570,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         auto* wl = new QVBoxLayout(wrapper);
         wl->setContentsMargins(0, 0, 0, 0);
         wl->setSpacing(0);
-        auto* titleBar = new AppletTitleBar("Antenna Genius", "AG");
+        auto* titleBar = new AppletTitleBar("Antenna Genius", "AG", this);
         wl->addWidget(titleBar);
         m_agApplet->show();
         wl->addWidget(m_agApplet);
@@ -576,6 +607,16 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     }
 
     rebuildStackOrder();
+
+    // ── Restore floating state ──────────────────────────────────────────────
+    for (auto& entry : m_appletOrder) {
+        const QString floatKey = QStringLiteral("FloatingApplet_%1_IsFloating").arg(entry.id);
+        if (AppSettings::instance().value(floatKey, "False").toString() == "True") {
+            // Use QTimer::singleShot so the window system is ready before showing
+            QTimer::singleShot(0, this, [this, id = entry.id]() { floatApplet(id); });
+        }
+    }
+
 }
 
 void AppletPanel::rebuildStackOrder()
@@ -639,6 +680,7 @@ void AppletPanel::setTunerVisible(bool visible)
         if (!m_tuneBtn->isChecked())
             m_tuneBtn->setChecked(true);
     } else {
+        if (m_floatingWindows.contains("TUN")) { dockApplet("TUN"); }
         m_tuneBtn->setChecked(false);
         m_tuneBtn->hide();
     }
@@ -651,6 +693,7 @@ void AppletPanel::setAmpVisible(bool visible)
         if (!m_ampBtn->isChecked())
             m_ampBtn->setChecked(true);
     } else {
+        if (m_floatingWindows.contains("AMP")) { dockApplet("AMP"); }
         m_ampBtn->setChecked(false);
         m_ampBtn->hide();
     }
@@ -663,9 +706,18 @@ void AppletPanel::setAgVisible(bool visible)
         if (!m_agBtn->isChecked())
             m_agBtn->setChecked(true);
     } else {
+        if (m_floatingWindows.contains("AG")) { dockApplet("AG"); }
         m_agBtn->setChecked(false);
         m_agBtn->hide();
     }
+}
+
+bool AppletPanel::isAppletFloating(const QString& id) const
+{
+    for (const AppletEntry& e : m_appletOrder) {
+        if (e.id == id) { return e.floating; }
+    }
+    return false;
 }
 
 bool AppletPanel::controlsLocked() const
@@ -695,6 +747,121 @@ void AppletPanel::setSlice(SliceModel* slice)
 void AppletPanel::setAntennaList(const QStringList& ants)
 {
     m_rxApplet->setAntennaList(ants);
+}
+
+void AppletPanel::floatApplet(const QString& id)
+{
+    // Find the entry
+    int idx = -1;
+    for (int i = 0; i < m_appletOrder.size(); ++i) {
+        if (m_appletOrder[i].id == id) { idx = i; break; }
+    }
+    if (idx < 0 || m_appletOrder[idx].floating) { return; }
+
+    AppletEntry& entry = m_appletOrder[idx];
+
+    // The actual applet widget is the second item in the wrapper's layout
+    // (index 0 = AppletTitleBar, index 1 = applet content)
+    QWidget* appletWidget = nullptr;
+    if (auto* wl = qobject_cast<QVBoxLayout*>(entry.widget->layout())) {
+        if (wl->count() >= 2) {
+            if (auto* item = wl->itemAt(1)) appletWidget = item->widget();
+        }
+    }
+    if (!appletWidget) { return; }
+
+    // Find the human-readable title from the title bar label
+    QString title = id;
+    if (auto* tb = static_cast<AppletTitleBar*>(entry.titleBar))
+        title = tb->findChild<QLabel*>() ? tb->findChildren<QLabel*>().last()->text() : id;
+
+    // Reparent applet out of wrapper into floating window
+    appletWidget->setParent(nullptr);
+
+    // Pass 'this' as parent so Qt treats the window as a tool window owned
+    // by AppletPanel — Qt's shouldQuit() then correctly ignores tool windows
+    // when deciding whether to keep the event loop alive.
+    auto* win = new FloatingAppletWindow(id, title, appletWidget, this);
+    m_floatingWindows[id] = win;
+    entry.floating = true;
+
+    connect(win, &FloatingAppletWindow::dockRequested,
+            this, &AppletPanel::dockApplet);
+
+    // show() first, then restore geometry after a short delay. The window
+    // manager / compositor must map the window before position hints are
+    // respected. QWidget::restoreGeometry() encodes screen identity so the
+    // window returns to the correct monitor on X11 / XCB.
+    // Note: Wayland compositors control window placement and ignore app-set
+    // positions. On WSL2 (WSLg/Wayland), set QT_QPA_PLATFORM=xcb to get
+    // X11 behaviour via XWayland.
+    win->show();
+    QTimer::singleShot(50, win, [win]() { win->restoreGeometry(); });
+
+    // Hide wrapper in panel (keeps toggle button state as-is)
+    entry.widget->hide();
+
+    // Persist floating state
+    AppSettings::instance().setValue(
+        QStringLiteral("FloatingApplet_%1_IsFloating").arg(id), "True");
+    AppSettings::instance().save();
+}
+
+void AppletPanel::dockApplet(const QString& id)
+{
+    if (!m_floatingWindows.contains(id)) { return; }
+
+    int idx = -1;
+    for (int i = 0; i < m_appletOrder.size(); ++i) {
+        if (m_appletOrder[i].id == id) { idx = i; break; }
+    }
+    if (idx < 0) { return; }
+
+    AppletEntry& entry = m_appletOrder[idx];
+    FloatingAppletWindow* win = m_floatingWindows.value(id);
+
+    // Retrieve the applet widget from the floating window's layout
+    QWidget* appletWidget = nullptr;
+    if (win && win->layout() && win->layout()->count() >= 2) {
+        // root QVBoxLayout: 0=titleBar widget, 1=m_contentLayout (QLayout)
+        if (auto* rootLayout = qobject_cast<QVBoxLayout*>(win->layout())) {
+            if (auto* contentItem = rootLayout->itemAt(1)) {
+                if (auto* contentLayout = contentItem->layout()) {
+                    if (contentLayout->count() > 0) {
+                        if (auto* item = contentLayout->itemAt(0))
+                            appletWidget = item->widget();
+                    }
+                }
+            }
+        }
+    }
+
+    if (appletWidget) {
+        // Re-insert applet widget back into wrapper layout (position 1, after title bar)
+        if (auto* wl = qobject_cast<QVBoxLayout*>(entry.widget->layout())) {
+            appletWidget->setParent(entry.widget);
+            wl->addWidget(appletWidget);
+            appletWidget->show();
+        }
+    }
+
+    // Save geometry before destroying the window
+    if (win) {
+        win->saveGeometry();
+        win->hide();
+        win->deleteLater();
+    }
+    m_floatingWindows.remove(id);
+    entry.floating = false;
+
+    // Show wrapper only if the toggle button is checked
+    if (entry.btn && entry.btn->isChecked())
+        entry.widget->show();
+
+    // Persist floating state
+    AppSettings::instance().setValue(
+        QStringLiteral("FloatingApplet_%1_IsFloating").arg(id), "False");
+    AppSettings::instance().save();
 }
 
 } // namespace AetherSDR

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QWidget>
+#include <QMap>
 #include <QStringList>
 #include <QVector>
 
@@ -8,6 +9,8 @@ class QComboBox;
 class QPushButton;
 class QScrollArea;
 class QVBoxLayout;
+
+namespace AetherSDR { class FloatingAppletWindow; }
 
 namespace AetherSDR {
 
@@ -65,13 +68,21 @@ public:
     bool controlsLocked() const;
     void setControlsLocked(bool locked);
 
-    // Ordered applet entry for drag-reorder support
+    // Ordered applet entry for drag-reorder and float support
     struct AppletEntry {
         QString id;
-        QWidget* widget{nullptr};
-        QWidget* titleBar{nullptr};
-        QPushButton* btn{nullptr};
+        QWidget* widget{nullptr};      // wrapper widget (titleBar + applet)
+        QWidget* titleBar{nullptr};    // draggable AppletTitleBar
+        QPushButton* btn{nullptr};     // toggle button in button row
+        bool floating{false};          // true when applet is in a FloatingAppletWindow
     };
+
+    // Detach an applet into a floating window / re-dock it
+    void floatApplet(const QString& id);
+    void dockApplet(const QString& id);
+
+    // Returns true if the applet with the given id is currently floating
+    bool isAppletFloating(const QString& id) const;
 
     friend class AppletDropArea;
 
@@ -105,6 +116,9 @@ private:
     // Ordered list of applets (drag-reorderable)
     QVector<AppletEntry> m_appletOrder;
     static const QStringList kDefaultOrder;
+
+    // Floating windows keyed by applet ID
+    QMap<QString, FloatingAppletWindow*> m_floatingWindows;
 };
 
 } // namespace AetherSDR

--- a/src/gui/FloatingAppletWindow.cpp
+++ b/src/gui/FloatingAppletWindow.cpp
@@ -1,0 +1,184 @@
+#include "FloatingAppletWindow.h"
+#include "core/AppSettings.h"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QCloseEvent>
+#include <QMoveEvent>
+#include <QResizeEvent>
+#include <QTimer>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QWindow>
+
+namespace AetherSDR {
+
+FloatingAppletWindow::FloatingAppletWindow(const QString& appletId,
+                                           const QString& title,
+                                           QWidget* applet,
+                                           QWidget* parent)
+    : QWidget(parent, Qt::Window | Qt::Tool)
+    , m_appletId(appletId)
+{
+    setWindowTitle(title);
+    setAttribute(Qt::WA_DeleteOnClose, false);  // AppletPanel owns lifecycle
+    setMinimumWidth(260);
+
+    // QWidget selector cascades to children, providing the app's dark background
+    // for applets that relied on AppletPanel's parent stylesheet.
+    setStyleSheet(
+        "FloatingAppletWindow { background: #0f0f1a; "
+        "border: 1px solid #203040; }"
+        "QWidget { background: #0a0a18; }");
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(0, 0, 0, 0);
+    root->setSpacing(0);
+
+    // ── Custom title bar ──────────────────────────────────────────────────────
+    auto* titleBar = new QWidget;
+    titleBar->setFixedHeight(22);
+    titleBar->setStyleSheet(
+        "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
+        "stop:0 #3a4a5a, stop:0.5 #2a3a4a, stop:1 #1a2a38); "
+        "border-bottom: 1px solid #0a1a28; }");
+
+    auto* tbLayout = new QHBoxLayout(titleBar);
+    tbLayout->setContentsMargins(6, 0, 4, 0);
+    tbLayout->setSpacing(4);
+
+    auto* titleLabel = new QLabel(title, titleBar);
+    titleLabel->setStyleSheet(
+        "QLabel { background: transparent; color: #8aa8c0; "
+        "font-size: 10px; font-weight: bold; }");
+    tbLayout->addWidget(titleLabel);
+    tbLayout->addStretch();
+
+    auto* dockBtn = new QPushButton("\u21a9 Dock", titleBar);
+    dockBtn->setFixedHeight(16);
+    dockBtn->setToolTip("Return applet to the panel");
+    dockBtn->setStyleSheet(
+        "QPushButton { background: #1a2a3a; color: #8aa8c0; "
+        "border: 1px solid #304050; border-radius: 3px; "
+        "font-size: 10px; padding: 0 5px; }"
+        "QPushButton:hover { background: #243848; color: #c8d8e8; }");
+    connect(dockBtn, &QPushButton::clicked, this, [this]() {
+        saveGeometry();
+        emit dockRequested(m_appletId);
+    });
+    tbLayout->addWidget(dockBtn);
+
+    root->addWidget(titleBar);
+
+    // ── Applet content area ───────────────────────────────────────────────────
+    m_contentLayout = new QVBoxLayout;
+    m_contentLayout->setContentsMargins(0, 0, 0, 0);
+    m_contentLayout->setSpacing(0);
+    m_contentLayout->addWidget(applet);
+    root->addLayout(m_contentLayout);
+
+    adjustSize();
+
+    // Debounce geometry saves — fire 400 ms after the last resize/move event.
+    m_saveTimer = new QTimer(this);
+    m_saveTimer->setSingleShot(true);
+    m_saveTimer->setInterval(400);
+    connect(m_saveTimer, &QTimer::timeout, this, &FloatingAppletWindow::saveGeometry);
+}
+
+void FloatingAppletWindow::saveGeometry()
+{
+    const QString prefix = QStringLiteral("FloatingApplet_%1").arg(m_appletId);
+    auto& s = AppSettings::instance();
+
+    QScreen* screen = windowHandle() ? windowHandle()->screen() : nullptr;
+    if (!screen) { screen = QGuiApplication::primaryScreen(); }
+    if (!screen) { return; }
+
+    // Store screen name (stable across reboots) and screen-relative position
+    // so that restoreGeometry() can find the right monitor by name rather than
+    // by index, and position the window correctly even if screen order changes.
+    const QRect geo       = geometry();
+    const QRect screenGeo = screen->geometry();
+
+    s.setValue(prefix + "_Screen", screen->name());
+    s.setValue(prefix + "_X",      QString::number(geo.x() - screenGeo.x()));
+    s.setValue(prefix + "_Y",      QString::number(geo.y() - screenGeo.y()));
+    s.setValue(prefix + "_W",      QString::number(geo.width()));
+    s.setValue(prefix + "_H",      QString::number(geo.height()));
+    s.save();
+}
+
+void FloatingAppletWindow::restoreGeometry()
+{
+    const QString prefix = QStringLiteral("FloatingApplet_%1").arg(m_appletId);
+    const auto& s = AppSettings::instance();
+
+    const int w = s.value(prefix + "_W", "0").toInt();
+    const int h = s.value(prefix + "_H", "0").toInt();
+    if (w <= 0 || h <= 0) { return; }  // no saved geometry yet
+
+    // Find the saved screen by name; fall back to primary if disconnected.
+    const QString screenName = s.value(prefix + "_Screen").toString();
+    QScreen* screen = nullptr;
+    for (QScreen* sc : QGuiApplication::screens()) {
+        if (sc->name() == screenName) { screen = sc; break; }
+    }
+    if (!screen) { screen = QGuiApplication::primaryScreen(); }
+    if (!screen) { return; }
+
+    resize(w, h);
+
+    // Wayland compositors own window placement — attempting move() is a no-op
+    // on most compositors. Skip it so we don't fight the compositor.
+    // On X11 (including XWayland / WSL2 with QT_QPA_PLATFORM=xcb) and on
+    // Windows / macOS, move() works correctly.
+    if (QGuiApplication::platformName() == QLatin1String("wayland")) { return; }
+
+    const int     savedX = s.value(prefix + "_X", "0").toInt();
+    const int     savedY = s.value(prefix + "_Y", "0").toInt();
+    const QRect   avail  = screen->availableGeometry();
+    const QRect   sGeo   = screen->geometry();
+
+    // Clamp so the window title bar is always reachable even if the screen
+    // resolution has changed or the window was partially off-screen.
+    const int x = qBound(avail.left(),
+                         sGeo.x() + savedX,
+                         avail.right()  - qMin(w, avail.width()));
+    const int y = qBound(avail.top(),
+                         sGeo.y() + savedY,
+                         avail.bottom() - qMin(h, avail.height()));
+    move(x, y);
+}
+
+void FloatingAppletWindow::resizeEvent(QResizeEvent* ev)
+{
+    QWidget::resizeEvent(ev);
+    m_saveTimer->start();  // restart debounce on every resize step
+}
+
+void FloatingAppletWindow::moveEvent(QMoveEvent* ev)
+{
+    QWidget::moveEvent(ev);
+    m_saveTimer->start();  // restart debounce on every move step
+}
+
+void FloatingAppletWindow::closeEvent(QCloseEvent* ev)
+{
+    // If the parent AppletPanel is hidden the main window is closing — accept
+    // so the window is properly removed from Qt's visible-window count.
+    if (auto* p = qobject_cast<QWidget*>(parent()); !p || !p->isVisible()) {
+        m_saveTimer->stop();
+        saveGeometry();  // capture final size/position before exit
+        ev->accept();
+        return;
+    }
+    // User closed the floating window manually — re-dock instead of discarding.
+    saveGeometry();
+    emit dockRequested(m_appletId);
+    ev->ignore();  // AppletPanel::dockApplet() will hide/destroy this window
+}
+
+} // namespace AetherSDR

--- a/src/gui/FloatingAppletWindow.h
+++ b/src/gui/FloatingAppletWindow.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QWidget>
+
+class QLabel;
+class QTimer;
+class QVBoxLayout;
+
+namespace AetherSDR {
+
+// FloatingAppletWindow — a lightweight top-level window that hosts a single
+// detached applet widget. The window is non-modal and has a thin custom
+// title bar with a "↩ Dock" button. Closing the window (X or Dock button)
+// emits dockRequested() so AppletPanel can re-dock the applet cleanly.
+class FloatingAppletWindow : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit FloatingAppletWindow(const QString& appletId,
+                                  const QString& title,
+                                  QWidget* applet,
+                                  QWidget* parent = nullptr);
+
+    // Restore saved geometry from AppSettings (call after construction)
+    void restoreGeometry();
+
+    // Save current geometry to AppSettings (called before docking)
+    void saveGeometry();
+
+    const QString& appletId() const { return m_appletId; }
+
+signals:
+    void dockRequested(const QString& appletId);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+
+private:
+    QString      m_appletId;
+    QVBoxLayout* m_contentLayout{nullptr};
+    QTimer*      m_saveTimer{nullptr};  // debounce geometry saves on resize/move
+};
+
+} // namespace AetherSDR


### PR DESCRIPTION
Each applet in the AppletPanel can now be detached into its own floating window and re-docked at any time. Position and size persist across sessions and survive dock/undock cycles.

## What's new

**FloatingAppletWindow** (new class, src/gui/FloatingAppletWindow.h/.cpp)
- Qt::Window | Qt::Tool widget hosting a single detached applet
- Custom title bar with "↩ Dock" button; closing the window re-docks rather than losing the applet
- Geometry saved to AppSettings using screen name + screen-relative coordinates (more resilient than QWidget::saveGeometry() binary blob): FloatingApplet_<ID>_Screen  — screen name, stable across reboots
    FloatingApplet_<ID>_X/Y     — screen-relative position
    FloatingApplet_<ID>_W/H     — window size
- 400 ms debounce timer saves geometry on every resize/move without
  hammering AppSettings on each pixel
- Explicit save on dock and on app shutdown (main-window close path)
- Wayland guard: position restore is skipped on Wayland compositors that
  own window placement; size is always restored
- Off-screen clamp: if the saved monitor is disconnected, the window is
  clamped to the nearest available screen geometry

**AppletPanel changes**
- AppletEntry gains a `floating` bool
- floatApplet(id): reparents applet widget into FloatingAppletWindow, hides panel wrapper, persists IsFloating = True
- dockApplet(id): reparents applet widget back into wrapper, destroys floating window, persists IsFloating = False
- isAppletFloating(id): public helper used by AppletTitleBar context menu
- AppletTitleBar: right-click context menu ("Pop out" / "↩ Dock") using QMenu::popup() — no nested event loop
- Toggle button while floating: raises/hides the floating window instead of the docked wrapper
- Floating state restored at startup via QTimer::singleShot(0) so the window system is ready before windows are shown
- setTunerVisible(false), setAmpVisible(false), setAgVisible(false) each call dockApplet() first to prevent orphaned floating windows when a conditional device (TGXL, amp, Antenna Genius) disconnects
- FloatingAppletWindow created with AppletPanel as Qt parent so Qt's shouldQuit() correctly ignores tool windows when the last real window closes — fixes app not exiting when floating windows were open
- show() before restoreGeometry() (with 50 ms singleShot delay) so the window manager maps the window before position hints are applied

**CMakeLists.txt**
- Added src/gui/FloatingAppletWindow.cpp to GUI_SOURCES

## Cross-platform notes
- Windows / macOS / Linux X11: full position + size persistence
- Linux Wayland / WSL2 (WSLg): size persists; position is compositor- controlled. Use QT_QPA_PLATFORM=xcb on WSL2 for full behaviour via XWayland.

This possibly could address #811 - Not the entire panel, but each individual Applet. "Popped-out" applets are still displayed even if the side control panel is visible/not visible.


## Testing Notes — Poppable Applets

### Setup
- Build and launch AetherSDR connected to a supported radio
- Secondary monitor recommended (not required) for multi-monitor tests

---

### Core Float / Dock

| # | Steps | Expected | WT2P Tested (locally) |
|---|-------|----------|-----------------------|
| 1 | Right-click any applet title bar (e.g. RX Controls) | Context menu shows "⬆ Pop out" | ✅  |
| 2 | Click "Pop out" | Applet detaches into its own floating window with a custom title bar and "↩ Dock" button; panel wrapper is hidden | ✅  |
| 3 | Click "↩ Dock" in the floating window | Applet returns to the panel at its original position; floating window is destroyed | ✅  |
| 4 | Float an applet, then right-click its title bar again | Context menu shows "↩ Dock" instead of "Pop out" | ✅  |
| 5 | Float an applet, then click **X** on the floating window | Applet re-docks (does not disappear) — same result as clicking "↩ Dock" | ✅  |
| 6 | Repeat for all 10 applets: RX, TUN, AMP, TX, PHNE, P/CW, EQ, DIGI, MTR, AG | Each floats and docks cleanly | ❌  (VU Meter, will address in later version), ✅ All Other applets |

---

### Toggle Button Behaviour While Floating

| # | Steps | Expected | WT2P Tested (locally) |
|---|-------|----------|-----------------------|
| 7 | Float an applet, then click its toggle button in the panel (button is checked) | Floating window raises to front — does **not** re-dock | N/A |
| 8 | While floating, uncheck the toggle button | Floating window hides |  N/A |
| 9 | Re-check the toggle button | Floating window becomes visible again | N/A |

---

### Geometry Persistence

| # | Steps | Expected | WT2P Tested (locally) |
|---|-------|----------|-----------------------|
| 10 | Pop out RX Controls, drag to a specific position and resize it, wait ~500 ms, close and relaunch | Window restores to the same position and size | ✅  |
| 11 | Pop out two applets to different positions, close app, relaunch | Both restore independently to their saved positions | ✅  |
| 12 | Pop out an applet, dock it, relaunch | Applet appears docked (floating state cleared) | ✅  |
| 13 | **Multi-monitor**: drag a floating applet to a second monitor, close app, relaunch | Window restores on the correct monitor | ⚠️ Not fully tested. There may be issues. |
| 14 | **Disconnected monitor**: save geometry on monitor 2, disconnect it, relaunch | Window appears on the primary screen — not outside visible area | ⚠️  Not Tested |

---

### App Shutdown With Floating Windows

| # | Steps | Expected | WT2P Tested (locally) |
|---|-------|----------|-----------------------|
| 15 | Float one or more applets, close main window via **X** | App exits fully; no zombie windows remain | ✅ |
| 16 | Float one or more applets, use **File → Quit** | Same — clean exit | ✅ |
| 17 | Float applets, close app, relaunch | Applets restore to floating state automatically | ✅ |

---

### Drag Reorder Compatibility

| # | Steps | Expected | WT2P Tested (locally) |
|---|-------|----------|-----------------------|
| 18 | With some applets docked and some floating, drag-reorder a docked applet | Docked applets reorder normally; floating applets are unaffected | ✅ |
| 19 | View → Reset Applet Order | Docked applets reset to default order; floating windows stay where they are | ✅ |

---

### Conditional Applets (TUN / AMP / AG)

| # | Steps | Expected | WT2P Tested (locally) |
|---|-------|----------|-----------------------|
| 20 | Float the **Tuner** applet while a tuner is connected, then disconnect the tuner | Tuner applet auto-docks before the button is hidden; no orphaned floating window | ⚠️ Not Tested |
| 21 | Float the **Amplifier** applet, then disconnect the amp | Same — auto-docks cleanly | ⚠️ Not Tested |
| 22 | Float the **Antenna Genius** applet, then disconnect the AG | Same | ⚠️ Not Tested |

** These were not tested due to WT2P hardware version not supporting it (3.8.19)
---

### RX / TX Functionality While Floating

| # | Steps | Expected | WT2P Tested (locally) |
|---|-------|----------|-----------------------|
| 23 | Float RX Controls, change mode / filter / AGC | Radio responds normally; all controls functional | ✅ |
| 24 | Float TX Controls, key the radio | TX indicator lights; floating applet reflects transmit state | ✅ |
| 25 | Float EQ applet, adjust bands | Audio changes in real time | ✅ |

---

### Edge Cases

| # | Steps | Expected | WT2P Tested (locally) |
|---|-------|----------|-----------------------|
| 26 | Float all 10 reorderable applets simultaneously | All float independently; panel scroll area empties; app remains stable | ⚠️  Not Tested |
| 27 | Float an applet, minimise the main window | Floating window follows OS conventions for `Qt::Tool` windows | ✅ |
| 28 | Float an applet and immediately dock it before the 50 ms restore timer fires | No crash; geometry restored from previous session next launch | ⚠️ Untestable |

---

### Platform Notes

| Platform | Position persistence | Size persistence |
|----------|---------------------|-----------------|
| Windows | ✅ Full | ✅ Full |
| Linux X11 (KDE / GNOME) | ✅ Full | ✅ Full |
| Linux Wayland | ⚠️ Compositor-controlled — position may not restore | ✅ Full |
| WSL2 (WSLg) | ⚠️ Set `QT_QPA_PLATFORM=xcb` for full position restore | ✅ Full |
| macOS | ✅ Full | ✅ Full |

