### PR TITLE
Immediately start/stop CAT, DAX, and rigctld when autostart toggled (#863)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3014,20 +3014,45 @@ void MainWindow::buildMenuBar()
     autoRigctlAction->setCheckable(true);
     autoRigctlAction->setChecked(
         AppSettings::instance().value("AutoStartRigctld", "False").toString() == "True");
-    connect(autoRigctlAction, &QAction::toggled, this, [](bool on) {
+    connect(autoRigctlAction, &QAction::toggled, this, [this](bool on) {
         auto& s = AppSettings::instance();
         s.setValue("AutoStartRigctld", on ? "True" : "False");
         s.save();
+        if (m_radioModel.isConnected()) {
+            const int basePort = s.value("CatTcpPort", "4532").toInt();
+            for (int i = 0; i < kCatChannels; ++i) {
+                if (on && m_rigctlServers[i] && !m_rigctlServers[i]->isRunning())
+                    m_rigctlServers[i]->start(static_cast<quint16>(basePort + i));
+                else if (!on && m_rigctlServers[i] && m_rigctlServers[i]->isRunning())
+                    m_rigctlServers[i]->stop();
+            }
+            if (m_appletPanel && m_appletPanel->catApplet())
+                m_appletPanel->catApplet()->setTcpEnabled(on);
+        }
     });
 
     auto* autoCatAction = settingsMenu->addAction("Autostart CAT with AetherSDR");
     autoCatAction->setCheckable(true);
     autoCatAction->setChecked(
         AppSettings::instance().value("AutoStartCAT", "False").toString() == "True");
-    connect(autoCatAction, &QAction::toggled, this, [](bool on) {
+#ifdef _WIN32
+    autoCatAction->setEnabled(false);
+    autoCatAction->setToolTip("CAT virtual serial ports require macOS or Linux");
+#endif
+    connect(autoCatAction, &QAction::toggled, this, [this](bool on) {
         auto& s = AppSettings::instance();
         s.setValue("AutoStartCAT", on ? "True" : "False");
         s.save();
+        if (m_radioModel.isConnected()) {
+            for (int i = 0; i < kCatChannels; ++i) {
+                if (on && m_rigctlPtys[i] && !m_rigctlPtys[i]->isRunning())
+                    m_rigctlPtys[i]->start();
+                else if (!on && m_rigctlPtys[i] && m_rigctlPtys[i]->isRunning())
+                    m_rigctlPtys[i]->stop();
+            }
+            if (m_appletPanel && m_appletPanel->catApplet())
+                m_appletPanel->catApplet()->setPtyEnabled(on);
+        }
     });
 
     auto* autoTciAction = settingsMenu->addAction("Autostart TCI with AetherSDR");
@@ -3056,10 +3081,27 @@ void MainWindow::buildMenuBar()
     autoDaxAction->setCheckable(true);
     autoDaxAction->setChecked(
         AppSettings::instance().value("AutoStartDAX", "False").toString() == "True");
-    connect(autoDaxAction, &QAction::toggled, this, [](bool on) {
+#if !defined(Q_OS_MAC) && !defined(HAVE_PIPEWIRE)
+    autoDaxAction->setEnabled(false);
+    autoDaxAction->setToolTip("DAX audio bridge requires macOS or Linux with PipeWire");
+#endif
+    connect(autoDaxAction, &QAction::toggled, this, [this](bool on) {
         auto& s = AppSettings::instance();
         s.setValue("AutoStartDAX", on ? "True" : "False");
         s.save();
+#if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
+        if (m_radioModel.isConnected()) {
+            if (on) {
+                startDax();
+                if (m_appletPanel && m_appletPanel->catApplet())
+                    m_appletPanel->catApplet()->setDaxEnabled(true);
+            } else {
+                stopDax();
+                if (m_appletPanel && m_appletPanel->catApplet())
+                    m_appletPanel->catApplet()->setDaxEnabled(false);
+            }
+        }
+#endif
     });
 
     auto* lowLatencyDaxTxAction =


### PR DESCRIPTION
## Summary
- Autostart CAT/DAX/rigctld toggles now immediately start or stop the service when toggled while connected to the radio, matching existing TCI autostart behavior
- Previously these checkboxes only saved the setting — the service wouldn't start until the next radio connection, which confused users (#863)
- Disables the CAT (PTY) checkbox on Windows and the DAX checkbox on platforms without macOS/PipeWire, since those features are unavailable on those platforms

Fixes #863

## Test plan
- [ ] Toggle "Autostart rigctld" while connected — verify rigctld TCP servers start/stop immediately
- [ ] Toggle "Autostart CAT" while connected on macOS/Linux — verify PTY channels start/stop immediately
- [ ] Toggle "Autostart DAX" while connected on macOS/PipeWire Linux — verify DAX bridge starts/stops immediately
- [ ] On Windows, verify CAT (PTY) and DAX checkboxes are greyed out with tooltip
- [ ] Verify autostart-on-connect still works: enable checkboxes, disconnect, reconnect — services should auto-start

🤖 Generated with [Claude Code](https://claude.com/claude-code)