### PR TITLE
Fix RADE selecting DIGL instead of DIGU on 60m (#875)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -41,6 +41,7 @@
 #include "WhatsNewDialog.h"
 #include "models/SliceModel.h"
 #include "models/MeterModel.h"
+#include "models/BandDefs.h"
 #include "models/BandPlanManager.h"
 #include "models/TunerModel.h"
 #include "models/TransmitModel.h"
@@ -6575,9 +6576,17 @@ void MainWindow::activateRADE(int sliceId)
     if (!s->isTxSlice())
         s->setTxSlice(true);
 
-    // Set radio mode to DIGU/DIGL (passthrough for OFDM modem)
+    // Set radio mode to DIGU/DIGL (passthrough for OFDM modem).
+    // Use band convention from BandDefs to pick sideband — 60m is USB
+    // despite being below 10 MHz (#875).
     double freqMhz = s->frequency();
-    QString mode = (freqMhz < 10.0) ? "DIGL" : "DIGU";
+    QString mode = "DIGU";
+    for (const auto& band : AetherSDR::kBands) {
+        if (freqMhz >= band.lowMhz && freqMhz <= band.highMhz) {
+            mode = (QString(band.defaultMode) == "LSB") ? "DIGL" : "DIGU";
+            break;
+        }
+    }
     s->setMode(mode);
     if (mode == "DIGL")
         s->setFilterWidth(-3500, 0);


### PR DESCRIPTION
## Summary

Fixes #875

- RADE's `activateRADE()` used a simple `frequency < 10 MHz` threshold to choose between DIGL and DIGU, but 60m (5.330–5.405 MHz) uses USB by convention
- Replaced the frequency threshold with a lookup against the existing `kBands` table in `BandDefs.h`, so the band's actual default sideband is respected
- This correctly handles 60m (USB → DIGU), all other sub-10 MHz bands that use LSB (160m, 80m, 40m → DIGL), and any future band edge cases

## Test plan

- [ ] Activate RADE on 60m — verify mode is set to DIGU (not DIGL) and filter is (0, 3500)
- [ ] Activate RADE on 40m — verify mode is set to DIGL and filter is (-3500, 0)
- [ ] Activate RADE on 20m — verify mode is set to DIGU and filter is (0, 3500)
- [ ] Verify RADE audio works correctly on 60m after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)