### PR TITLE
Fix FM tone/repeater UI not updating after memory recall (#879)

### DIFF
--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -741,16 +741,18 @@ void SliceModel::applyStatus(const QMap<QString, QString>& kvs)
     }
 
     // FM duplex/repeater status
+    // Normalize to lowercase / fixed decimal format to match UI combo-box item data
     if (kvs.contains("fm_tone_mode")) {
-        m_fmToneMode = kvs["fm_tone_mode"];
+        m_fmToneMode = kvs["fm_tone_mode"].toLower();
         emit fmToneModeChanged(m_fmToneMode);
     }
     if (kvs.contains("fm_tone_value")) {
-        m_fmToneValue = kvs["fm_tone_value"];
+        double v = kvs["fm_tone_value"].toDouble();
+        m_fmToneValue = QString::number(v, 'f', 1);
         emit fmToneValueChanged(m_fmToneValue);
     }
     if (kvs.contains("repeater_offset_dir")) {
-        m_repeaterOffsetDir = kvs["repeater_offset_dir"];
+        m_repeaterOffsetDir = kvs["repeater_offset_dir"].toLower();
         emit repeaterOffsetDirChanged(m_repeaterOffsetDir);
     }
     if (kvs.contains("fm_repeater_offset_freq")) {


### PR DESCRIPTION
Fixes #879

## Summary

- Normalize `fm_tone_mode` and `repeater_offset_dir` to lowercase in `SliceModel::applyStatus()` to match UI combo box item data
- Normalize `fm_tone_value` to one-decimal format (e.g. `"123"` → `"123.0"`) to match combo item data stored via `QString::number(v, 'f', 1)`

The radio echoes uppercase values (`CTCSS_TX`, `DOWN`) and integer tone values (`123`), but the UI widgets store lowercase (`ctcss_tx`, `down`) and decimal format (`123.0`). This caused `findData()` lookups to return `-1`, silently leaving the combos unchanged after memory recall.

## Test plan

- [ ] Recall an FM memory slot with CTCSS tone and repeater offset configured
- [ ] Verify VfoWidget tone mode combo updates to match recalled value
- [ ] Verify VfoWidget tone value combo updates and is enabled
- [ ] Verify repeater offset direction buttons update in both VfoWidget and RxApplet
- [ ] Verify manual tone/offset changes from UI still send correct commands to radio

🤖 Generated with [Claude Code](https://claude.com/claude-code)