### PR TITLE
Fix serial PTT/CW non-functional on macOS (#884)

### DIFF
--- a/src/core/FlexControlManager.cpp
+++ b/src/core/FlexControlManager.cpp
@@ -10,6 +10,10 @@ namespace AetherSDR {
 FlexControlManager::FlexControlManager(QObject* parent)
     : QObject(parent)
 {
+    // Set this as parent so moveToThread() moves m_port with us.
+    // Without this, m_port stays on the creating thread, causing
+    // cross-thread QObject access that silently fails on macOS.
+    m_port.setParent(this);
     connect(&m_port, &QSerialPort::readyRead, this, &FlexControlManager::onReadyRead);
 }
 

--- a/src/core/SerialPortController.cpp
+++ b/src/core/SerialPortController.cpp
@@ -12,6 +12,11 @@ SerialPortController::SerialPortController(QObject* parent)
     : QObject(parent)
 {
 #ifdef HAVE_SERIALPORT
+    // Set this as parent so moveToThread() moves them with us.
+    // Without this, m_port and m_pollTimer stay on the creating thread,
+    // causing cross-thread QObject access that silently fails on macOS.
+    m_port.setParent(this);
+    m_pollTimer.setParent(this);
     connect(&m_pollTimer, &QTimer::timeout, this, &SerialPortController::pollInputPins);
 #endif
 }


### PR DESCRIPTION
## Summary

Fixes #884

- **Root cause:** When `SerialPortController` and `FlexControlManager` are moved to the worker thread via `moveToThread()`, their member `QSerialPort` and `QTimer` objects were not moved because they had no parent set. This caused cross-thread QObject access that silently fails on macOS (Linux worked by accident because its ioctl path is thread-safe).
- **Fix:** Call `setParent(this)` on `m_port` and `m_pollTimer` in both constructors, so `moveToThread()` moves all child QObjects together to the worker thread.
- Regression introduced in commit `35c2b82` ("Move external controllers to dedicated worker thread", PR #502/#525).

## Test plan

- [ ] On macOS: configure Serial PTT (DTR or RTS) with a USB-serial adapter, verify DTR/RTS line transitions on MOX/TX
- [ ] On macOS: configure CTS/DSR input for foot switch, verify input polling responds to line state changes
- [ ] On Linux: verify serial PTT still works (no regression)
- [ ] On Windows: verify serial PTT still works (no regression)
- [ ] Verify FlexControl USB knob still functions after the same `setParent(this)` fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)