### PR TITLE
Guard against empty mode list clearing mode dropdown (#891)

### DIFF
--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1074,6 +1074,7 @@ void RxApplet::connectSlice(SliceModel* s)
         if (idx >= 0) m_modeCombo->setCurrentIndex(idx);
     }
     connect(s, &SliceModel::modeListChanged, this, [this](const QStringList& modes) {
+        if (modes.isEmpty()) return;          // keep static fallback list (#891)
         QSignalBlocker b(m_modeCombo);
         QString cur = m_modeCombo->currentText();
         m_modeCombo->clear();

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1880,6 +1880,7 @@ void VfoWidget::setSlice(SliceModel* slice)
     connect(m_slice, &SliceModel::frequencyChanged, this, [this](double) { updateFreqLabel(); });
     // Mode list (dynamic from radio)
     connect(m_slice, &SliceModel::modeListChanged, this, [this](const QStringList& modes) {
+        if (modes.isEmpty()) return;          // keep static fallback list (#891)
         QSignalBlocker sb(m_modeCombo);
         QString cur = m_modeCombo->currentText();
         m_modeCombo->clear();


### PR DESCRIPTION
## Summary

Fixes #891

When the radio sends an empty `mode_list` value in a slice status message, the `modeListChanged` signal handler in both `RxApplet` and `VfoWidget` was calling `clear()` followed by `addItems({})`, permanently emptying the mode dropdown. This made it impossible to change the slice mode via the GUI.

- Add an early return in both `modeListChanged` handlers when the incoming mode list is empty, preserving the existing static fallback modes (USB, LSB, AM, SAM, FM, NFM, DFM, CW, DIGU, DIGL, RTTY)

## Changed files

- `src/gui/RxApplet.cpp` — guard empty mode list in `modeListChanged` handler
- `src/gui/VfoWidget.cpp` — same guard

## Test plan

- [ ] Connect to radio, verify mode dropdown in RX applet shows all standard modes
- [ ] Verify mode dropdown in VfoWidget shows all standard modes
- [ ] Changing mode via either dropdown sends correct `slice set` command
- [ ] No spurious mode-change command sent during sync (QSignalBlocker coverage unchanged)