### PR TITLE
Fix crash on VPN connect by checking UDP stream setup result (#894)

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -797,15 +797,37 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
 
         // Always (re)start on connect — re-binds socket and re-registers
         // UDP port with the radio. start() calls stop() internally if needed. (#561)
+        bool streamOk = false;
         if (m_wanConn) {
-            QMetaObject::invokeMethod(m_panStream, [this]() {
-                m_panStream->startWan(QHostAddress(m_wanPublicIp), m_wanUdpPort);
+            QMetaObject::invokeMethod(m_panStream, [this, &streamOk]() {
+                streamOk = m_panStream->startWan(QHostAddress(m_wanPublicIp), m_wanUdpPort);
             }, Qt::BlockingQueuedConnection);
         } else {
-            QMetaObject::invokeMethod(m_panStream, [this]() {
-                m_panStream->start(m_connection);
+            QMetaObject::invokeMethod(m_panStream, [this, &streamOk]() {
+                streamOk = m_panStream->start(m_connection);
             }, Qt::BlockingQueuedConnection);
         }
+
+        if (!streamOk) {
+            qCWarning(lcProtocol) << "RadioModel: UDP stream setup failed — disconnecting gracefully (#894)";
+            emit connectionError(tr("UDP stream setup failed. If connecting over VPN, "
+                                    "ensure UDP port 4991 is routable."));
+            QTimer::singleShot(0, this, &RadioModel::disconnectFromRadio);
+            return;
+        }
+
+        // Schedule a UDP stream health check: if no VITA-49 data arrives
+        // within 10 seconds (e.g. VPN blocks UDP), warn the user. (#894)
+        QTimer::singleShot(10000, this, [this]() {
+            if (!isConnected()) return;
+            if (m_panStream->totalRxBytes() == 0) {
+                qCWarning(lcProtocol) << "RadioModel: no VITA-49 UDP data received after 10s"
+                             << "— possible VPN/firewall blocking UDP (#894)";
+                emit connectionError(tr("No spectrum data received. UDP traffic from the "
+                                        "radio may be blocked by a VPN or firewall. "
+                                        "Ensure UDP port 4991 is routable."));
+            }
+        });
 
         // On WAN: use "client udp_register" via UDP (not TCP "client udpport").
         // The radio only accepts udp_register on WAN connections.


### PR DESCRIPTION
## Summary

Fixes #894

- **Check `PanadapterStream::start()` return value** in `RadioModel::onConnected()` — if UDP socket binding fails, emit a user-visible error and disconnect gracefully instead of continuing into a broken state that crashes
- **Add 10-second UDP health check** after connection: if no VITA-49 data arrives (common when VPN blocks UDP port 4991), warn the user with an actionable error message

## Context

When connecting to a routed Flex radio over VPN, the TCP control connection (port 4992) succeeds, but UDP VITA-49 stream data (port 4991) may not be routable back through the VPN. Previously, AetherSDR ignored the `start()` return value and proceeded with the full subscription chain, leading to a crash ~2 seconds after launch. The crash loop persisted across reinstalls because `LastRoutedRadioIp` in settings triggered auto-reconnect.

## Test plan

- [ ] Connect to a local Flex radio — verify normal operation is unaffected
- [ ] Connect to a routed radio over VPN where UDP is blocked — verify error dialog appears instead of crash
- [ ] Verify the 10-second health check fires and warns when no VITA-49 data arrives
- [ ] Verify `disconnectFromRadio()` is called cleanly on stream setup failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)