### PR TITLE
Fix crash with 2+ panadapters: per-stream waterfall frame assembly (#895)

### DIFF
--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -198,6 +198,7 @@ void PanadapterStream::unregisterWfStream(quint32 streamId)
 {
     QMutexLocker lock(&m_streamMutex);
     m_knownWfStreams.remove(streamId);
+    m_wfFrames.remove(streamId);
 }
 
 void PanadapterStream::clearRegisteredStreams()
@@ -206,6 +207,7 @@ void PanadapterStream::clearRegisteredStreams()
     m_knownPanStreams.clear();
     m_knownWfStreams.clear();
     m_frames.clear();
+    m_wfFrames.clear();
     m_dbmRanges.clear();
     qCDebug(lcVita49) << "PanadapterStream: cleared all registered streams";
 }
@@ -532,8 +534,9 @@ void PanadapterStream::decodeWaterfallTile(const uchar* raw, int totalBytes, boo
 
     // ── Waterfall frame assembly ─────────────────────────────────────────
     // Start a new frame if timecode changed
-    if (timecode != m_wfFrame.timecode)
-        m_wfFrame.reset(timecode, totalBinsInFrame, lowFreqMhz, binBwMhz, autoBlack);
+    auto& wfFrame = m_wfFrames[streamId];
+    if (timecode != wfFrame.timecode)
+        wfFrame.reset(timecode, totalBinsInFrame, lowFreqMhz, binBwMhz, autoBlack);
 
     // Copy this fragment's bins into the assembly buffer.
     // Only process the first row (height is typically 1).
@@ -544,16 +547,16 @@ void PanadapterStream::decodeWaterfallTile(const uchar* raw, int totalBytes, boo
 
     for (int i = 0; i < binsToRead; ++i) {
         const auto raw16 = static_cast<qint16>(qFromBigEndian<quint16>(tilePayload + i * 2));
-        m_wfFrame.buf[firstBinIndex + i] = static_cast<float>(raw16) / 128.0f;
+        wfFrame.buf[firstBinIndex + i] = static_cast<float>(raw16) / 128.0f;
     }
-    m_wfFrame.binsReceived += binsToRead;
+    wfFrame.binsReceived += binsToRead;
 
     // Only emit when the full frame is assembled
-    if (!m_wfFrame.isComplete()) return;
+    if (!wfFrame.isComplete()) return;
 
-    const double frameHighMhz = m_wfFrame.lowFreqMhz + m_wfFrame.binBwMhz * m_wfFrame.totalBins;
-    emit waterfallAutoBlackLevel(streamId, m_wfFrame.autoBlack);
-    emit waterfallRowReady(streamId, m_wfFrame.buf, m_wfFrame.lowFreqMhz, frameHighMhz, m_wfFrame.timecode);
+    const double frameHighMhz = wfFrame.lowFreqMhz + wfFrame.binBwMhz * wfFrame.totalBins;
+    emit waterfallAutoBlackLevel(streamId, wfFrame.autoBlack);
+    emit waterfallRowReady(streamId, wfFrame.buf, wfFrame.lowFreqMhz, frameHighMhz, wfFrame.timecode);
 }
 
 // ─── Audio decode ─────────────────────────────────────────────────────────────

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -163,7 +163,7 @@ private:
         bool isComplete() const { return totalBins > 0 && binsReceived >= totalBins; }
     };
 
-    WaterfallFrame m_wfFrame;
+    QMap<quint32, WaterfallFrame> m_wfFrames;  // per-stream waterfall frame assembly
 
     // Per-stream packet sequence tracking (4-bit count in VITA-49 word0 bits 19:16)
     struct StreamStats {


### PR DESCRIPTION
## Summary

Fixes #895. Also fixes #907 (same root cause).

- Replace single shared `m_wfFrame` with per-stream `QMap<quint32, WaterfallFrame> m_wfFrames`, mirroring the existing per-stream FFT frame assembly pattern
- Add cleanup of `m_wfFrames` entries in `unregisterWfStream()` and `clearRegisteredStreams()`

**Root cause:** With 2+ panadapters, two waterfall streams interleaved their VITA-49 tile fragments into one shared buffer, causing timecode thrashing, buffer size mismatches, and out-of-bounds writes leading to heap corruption and crash after ~30-40 seconds.

## Test plan

- [ ] Launch with 2+ panadapters/slices — verify no crash after 60+ seconds
- [ ] Verify waterfall renders correctly on both panadapters simultaneously
- [ ] Verify single-panadapter operation is unaffected
- [ ] Remove a panadapter while running — verify no crash (cleanup path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)