### PR TITLE
Add Peripherals tab in Radio Setup for manual IP connect (#914)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2514,7 +2514,7 @@ void MainWindow::buildMenuBar()
         // Snapshot compression setting before dialog opens
         QString prevComp = m_radioModel.audioCompressionParam();
 
-        auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, this);
+        auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, &m_tgxlConn, &m_pgxlConn, &m_antennaGenius, this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
         m_radioSetupDialog = dlg;
         connect(dlg, &RadioSetupDialog::txBandSettingsRequested,
@@ -2570,7 +2570,7 @@ void MainWindow::buildMenuBar()
 #ifdef HAVE_SERIALPORT
     auto* flexControlAction = settingsMenu->addAction("FlexControl...");
     connect(flexControlAction, &QAction::triggered, this, [this] {
-        auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, this);
+        auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, &m_tgxlConn, &m_pgxlConn, &m_antennaGenius, this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
         connect(dlg, &RadioSetupDialog::txBandSettingsRequested,
                 m_txBandAction, &QAction::trigger);
@@ -2604,7 +2604,7 @@ void MainWindow::buildMenuBar()
     });
     auto* usbCablesAction = settingsMenu->addAction("USB Cables...");
     connect(usbCablesAction, &QAction::triggered, this, [this] {
-        auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, this);
+        auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, &m_tgxlConn, &m_pgxlConn, &m_antennaGenius, this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
         connect(dlg, &RadioSetupDialog::txBandSettingsRequested,
                 m_txBandAction, &QAction::trigger);
@@ -4025,6 +4025,22 @@ void MainWindow::onConnectionStateChanged(bool connected)
                     QMetaObject::invokeMethod(m_freedvClient, [this] { m_freedvClient->startConnection(); });
             }
 #endif
+            // Auto-connect peripherals with manual IPs (#914)
+            QString tgxlIp = cs.value("TGXL_ManualIp", "").toString();
+            if (!tgxlIp.isEmpty() && !m_tgxlConn.isConnected()) {
+                quint16 tgxlPort = static_cast<quint16>(cs.value("TGXL_ManualPort", "9010").toInt());
+                m_tgxlConn.connectToTgxl(tgxlIp, tgxlPort);
+            }
+            QString pgxlIp = cs.value("PGXL_ManualIp", "").toString();
+            if (!pgxlIp.isEmpty() && !m_pgxlConn.isConnected()) {
+                quint16 pgxlPort = static_cast<quint16>(cs.value("PGXL_ManualPort", "9008").toInt());
+                m_pgxlConn.connectToPgxl(pgxlIp, pgxlPort);
+            }
+            QString agIp = cs.value("AG_ManualIp", "").toString();
+            if (!agIp.isEmpty() && !m_antennaGenius.isConnected()) {
+                quint16 agPort = static_cast<quint16>(cs.value("AG_ManualPort", "9007").toInt());
+                m_antennaGenius.connectToAddress(QHostAddress(agIp), agPort);
+            }
         }
     } else {
         QMetaObject::invokeMethod(m_dxCluster, [=] { m_dxCluster->disconnect(); });
@@ -5464,7 +5480,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     disconnect(menu, &SpectrumOverlayMenu::xvtrSetupRequested, this, nullptr);
     connect(menu, &SpectrumOverlayMenu::xvtrSetupRequested,
             this, [this]() {
-        auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, this);
+        auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, &m_tgxlConn, &m_pgxlConn, &m_antennaGenius, this);
         connect(dlg, &RadioSetupDialog::txBandSettingsRequested,
                 m_txBandAction, &QAction::trigger);
         dlg->selectTab("XVTR");

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -11,6 +11,9 @@
 #endif
 #include "core/FirmwareUploader.h"
 #include "core/FirmwareStager.h"
+#include "core/TgxlConnection.h"
+#include "core/PgxlConnection.h"
+#include "models/AntennaGeniusModel.h"
 
 #include <QTabWidget>
 #include <QVBoxLayout>
@@ -37,6 +40,7 @@
 #include <QStackedWidget>
 #include <QPlainTextEdit>
 #include <QSplitter>
+#include <QHostAddress>
 
 namespace AetherSDR {
 
@@ -56,8 +60,11 @@ static const QString kEditStyle =
     "QLineEdit { background: #1a2a3a; border: 1px solid #304050; "
     "border-radius: 3px; color: #c8d8e8; font-size: 12px; padding: 2px 4px; }";
 
-RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio, QWidget* parent)
-    : QDialog(parent), m_model(model), m_audio(audio)
+RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
+                                   TgxlConnection* tgxl, PgxlConnection* pgxl,
+                                   AntennaGeniusModel* ag, QWidget* parent)
+    : QDialog(parent), m_model(model), m_audio(audio),
+      m_tgxl(tgxl), m_pgxl(pgxl), m_ag(ag)
 {
     setWindowTitle("Radio Setup");
     setMinimumSize(820, 520);
@@ -84,6 +91,7 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio, QWidge
     tabs->addTab(buildFiltersTab(), "Filters");
     tabs->addTab(buildXvtrTab(), "XVTR");
     tabs->addTab(buildUsbCablesTab(), "USB Cables");
+    tabs->addTab(buildPeripheralsTab(), "Peripherals");
 #ifdef HAVE_SERIALPORT
     tabs->addTab(buildSerialTab(), "Serial");
 #endif
@@ -2790,6 +2798,156 @@ QWidget* RadioSetupDialog::buildSerialTab()
     return page;
 }
 #endif
+
+// ─── Peripherals tab — manual IP connect for TGXL, PGXL, AG (#914) ───────────
+
+QWidget* RadioSetupDialog::buildPeripheralsTab()
+{
+    auto* page = new QWidget;
+    auto* vbox = new QVBoxLayout(page);
+    vbox->setSpacing(8);
+
+    auto* group = new QGroupBox("External Devices — Manual IP Connection");
+    group->setStyleSheet(kGroupStyle);
+    auto* grid = new QGridLayout(group);
+    grid->setSpacing(6);
+
+    // Column headers
+    auto addHeader = [&](int col, const QString& text) {
+        auto* lbl = new QLabel(text);
+        lbl->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; font-weight: bold; }");
+        grid->addWidget(lbl, 0, col);
+    };
+    addHeader(0, "Device");
+    addHeader(1, "IP Address");
+    addHeader(2, "Port");
+    addHeader(3, "");
+    addHeader(4, "Status");
+
+    auto& settings = AppSettings::instance();
+
+    static const QString kBtnStyle =
+        "QPushButton { background: #1a2a3a; border: 1px solid #304050; "
+        "border-radius: 3px; color: #c8d8e8; font-size: 11px; font-weight: bold; "
+        "padding: 3px 10px; }"
+        "QPushButton:hover { background: #203040; }";
+
+    // Helper to build one peripheral row
+    auto buildRow = [&](int row, const QString& label, const QString& ipKey,
+                        const QString& portKey, int defaultPort,
+                        auto connectFn, auto disconnectFn, auto isConnectedFn) {
+        // Device label
+        auto* devLbl = new QLabel(label);
+        devLbl->setStyleSheet(kLabelStyle);
+        grid->addWidget(devLbl, row, 0);
+
+        // IP field
+        auto* ipEdit = new QLineEdit;
+        ipEdit->setPlaceholderText("e.g. 192.168.1.100");
+        ipEdit->setStyleSheet(kEditStyle);
+        ipEdit->setMinimumWidth(140);
+        ipEdit->setText(settings.value(ipKey, "").toString());
+        grid->addWidget(ipEdit, row, 1);
+
+        // Port field
+        auto* portSpin = new QSpinBox;
+        portSpin->setRange(1, 65535);
+        portSpin->setValue(settings.value(portKey, QString::number(defaultPort)).toInt());
+        portSpin->setStyleSheet(
+            "QSpinBox { background: #1a2a3a; border: 1px solid #304050; "
+            "border-radius: 3px; color: #c8d8e8; font-size: 12px; padding: 2px; }");
+        grid->addWidget(portSpin, row, 2);
+
+        // Status label
+        auto* statusLbl = new QLabel(isConnectedFn() ? "Connected" : "Not connected");
+        statusLbl->setStyleSheet(isConnectedFn()
+            ? "QLabel { color: #00e060; font-size: 11px; }"
+            : "QLabel { color: #8aa8c0; font-size: 11px; }");
+        grid->addWidget(statusLbl, row, 4);
+
+        // Connect/Disconnect button
+        auto* btn = new QPushButton(isConnectedFn() ? "Disconnect" : "Connect");
+        btn->setStyleSheet(kBtnStyle);
+        grid->addWidget(btn, row, 3);
+
+        connect(btn, &QPushButton::clicked, this,
+                [=, &settings]() {
+            if (isConnectedFn()) {
+                disconnectFn();
+            } else {
+                QString ip = ipEdit->text().trimmed();
+                if (ip.isEmpty()) return;
+                int port = portSpin->value();
+                // Save to settings
+                settings.setValue(ipKey, ip);
+                settings.setValue(portKey, QString::number(port));
+                settings.save();
+                connectFn(ip, static_cast<quint16>(port));
+            }
+        });
+
+        // Update UI on connection state changes
+        auto updateState = [btn, statusLbl, isConnectedFn]() {
+            bool conn = isConnectedFn();
+            btn->setText(conn ? "Disconnect" : "Connect");
+            statusLbl->setText(conn ? "Connected" : "Not connected");
+            statusLbl->setStyleSheet(conn
+                ? "QLabel { color: #00e060; font-size: 11px; }"
+                : "QLabel { color: #8aa8c0; font-size: 11px; }");
+        };
+
+        return updateState;
+    };
+
+    // Row 1: Tuner Genius XL (TGXL)
+    if (m_tgxl) {
+        auto updateTgxl = buildRow(1, "Tuner Genius XL (TGXL)", "TGXL_ManualIp", "TGXL_ManualPort", 9010,
+            [this](const QString& ip, quint16 port) { m_tgxl->connectToTgxl(ip, port); },
+            [this]() { m_tgxl->disconnect(); },
+            [this]() { return m_tgxl->isConnected(); });
+        connect(m_tgxl, &TgxlConnection::connected, this, updateTgxl);
+        connect(m_tgxl, &TgxlConnection::disconnected, this, updateTgxl);
+    }
+
+    // Row 2: Power Genius XL (PGXL)
+    if (m_pgxl) {
+        auto updatePgxl = buildRow(2, "Power Genius XL (PGXL)", "PGXL_ManualIp", "PGXL_ManualPort", 9008,
+            [this](const QString& ip, quint16 port) { m_pgxl->connectToPgxl(ip, port); },
+            [this]() { m_pgxl->disconnect(); },
+            [this]() { return m_pgxl->isConnected(); });
+        connect(m_pgxl, &PgxlConnection::connected, this, updatePgxl);
+        connect(m_pgxl, &PgxlConnection::disconnected, this, updatePgxl);
+    }
+
+    // Row 3: Antenna Genius (AG)
+    if (m_ag) {
+        auto updateAg = buildRow(3, "Antenna Genius (AG)", "AG_ManualIp", "AG_ManualPort", 9007,
+            [this](const QString& ip, quint16 port) {
+                m_ag->connectToAddress(QHostAddress(ip), port);
+            },
+            [this]() { m_ag->disconnectFromDevice(); },
+            [this]() { return m_ag->isConnected(); });
+        connect(m_ag, &AntennaGeniusModel::connected, this, updateAg);
+        connect(m_ag, &AntennaGeniusModel::disconnected, this, updateAg);
+    }
+
+    for (auto* lbl : group->findChildren<QLabel*>())
+        if (lbl->styleSheet().isEmpty()) lbl->setStyleSheet(kLabelStyle);
+
+    vbox->addWidget(group);
+
+    // Info note
+    auto* note = new QLabel(
+        "Configure manual IP addresses for peripherals that cannot be discovered via UDP broadcast.\n"
+        "This is needed for remote, VPN, and SmartLink connections. "
+        "Configured devices auto-connect when the radio connects.");
+    note->setWordWrap(true);
+    note->setStyleSheet("QLabel { color: #607080; font-size: 11px; padding: 8px; }");
+    vbox->addWidget(note);
+
+    vbox->addStretch();
+    return page;
+}
 
 void RadioSetupDialog::selectTab(const QString& tabName)
 {

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -15,6 +15,9 @@ class RadioModel;
 class AudioEngine;
 class FirmwareUploader;
 class FirmwareStager;
+class TgxlConnection;
+class PgxlConnection;
+class AntennaGeniusModel;
 
 // Radio Setup dialog — tabbed configuration window matching SmartSDR's
 // Settings → Radio Setup. Shows radio info, GPS, TX, RX, filters, etc.
@@ -23,6 +26,9 @@ class RadioSetupDialog : public QDialog {
 
 public:
     explicit RadioSetupDialog(RadioModel* model, AudioEngine* audio = nullptr,
+                              TgxlConnection* tgxl = nullptr,
+                              PgxlConnection* pgxl = nullptr,
+                              AntennaGeniusModel* ag = nullptr,
                               QWidget* parent = nullptr);
     void selectTab(const QString& tabName);
 
@@ -41,12 +47,16 @@ private:
     QWidget* buildFiltersTab();
     QWidget* buildXvtrTab();
     QWidget* buildUsbCablesTab();
+    QWidget* buildPeripheralsTab();
 #ifdef HAVE_SERIALPORT
     QWidget* buildSerialTab();
 #endif
 
     RadioModel*  m_model;
     AudioEngine* m_audio{nullptr};
+    TgxlConnection*    m_tgxl{nullptr};
+    PgxlConnection*    m_pgxl{nullptr};
+    AntennaGeniusModel* m_ag{nullptr};
     QTabWidget*  m_tabs{nullptr};
 
     // Radio tab fields


### PR DESCRIPTION
## Summary

Fixes #914

- Add a **Peripherals** tab to `RadioSetupDialog` with manual IP/port entry rows for TGXL (default 9010), PGXL (default 9008), and AG (default 9007)
- Each row has IP field, port spinner, Connect/Disconnect button, and live status label
- Settings persisted via `AppSettings` (keys: `TGXL_ManualIp`, `TGXL_ManualPort`, `PGXL_ManualIp`, `PGXL_ManualPort`, `AG_ManualIp`, `AG_ManualPort`)
- Configured peripherals auto-connect when the radio connects, solving the chicken-and-egg problem for remote/VPN/SmartLink operators

## Files changed

- `src/gui/RadioSetupDialog.h` — Add peripheral pointers and `buildPeripheralsTab()` declaration
- `src/gui/RadioSetupDialog.cpp` — Implement Peripherals tab with three device rows
- `src/gui/MainWindow.cpp` — Pass peripheral objects to dialog; add auto-connect on radio connect

## Test plan

- [ ] Open Radio Setup → verify "Peripherals" tab appears between USB Cables and Serial
- [ ] Enter a TGXL/PGXL/AG IP and click Connect → verify connection and status label updates
- [ ] Click Disconnect → verify status reverts to "Not connected"
- [ ] Close and reopen dialog → verify saved IPs/ports are restored
- [ ] Configure a peripheral IP, disconnect radio, reconnect → verify peripheral auto-connects
- [ ] Verify existing AG manual IP in the AG applet still works and shares the `AG_ManualIp` setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)