### PR TITLE
Add poppable panadapters — float/dock spectrum windows (#920)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -938,6 +938,15 @@ MainWindow::MainWindow(QWidget* parent)
                         if (pan->panStreamId())
                             m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
                     }
+                    // Restore previously-floating pans (#920)
+                    auto& s = AppSettings::instance();
+                    for (auto* applet : m_panStack->allApplets()) {
+                        const QString key = QStringLiteral("FloatingPan_%1_IsFloating").arg(applet->panId());
+                        if (s.value(key, "False").toString() == "True")
+                            QTimer::singleShot(0, this, [this, id = applet->panId()]() {
+                                m_panStack->floatPanadapter(id);
+                            });
+                    }
                 });
             });
         }
@@ -4814,6 +4823,12 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         if (m_panStack->count() <= 1) return;
         m_radioModel.sendCommand(QString("display pan remove %1").arg(panId));
     });
+
+    // ── Pop out / dock: float pan into its own window or dock back ───────
+    connect(applet, &PanadapterApplet::popOutRequested,
+            m_panStack, &PanadapterStack::floatPanadapter);
+    connect(applet, &PanadapterApplet::dockRequested,
+            m_panStack, &PanadapterStack::dockPanadapter);
 
     // ── User drag actions from spectrum → radio (per-pan) ──────────────────
     connect(sw, &SpectrumWidget::bandwidthChangeRequested,

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -10,6 +10,8 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QTextEdit>
+#include <QMenu>
+#include <QContextMenuEvent>
 
 namespace AetherSDR {
 
@@ -21,14 +23,14 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     layout->setSpacing(0);
 
     // ── Title bar (16px gradient, matching applet style) ─────────────────
-    auto* titleBar = new QWidget;
-    titleBar->setFixedHeight(16);
-    titleBar->setStyleSheet(
+    m_titleBar = new QWidget;
+    m_titleBar->setFixedHeight(16);
+    m_titleBar->setStyleSheet(
         "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
         "stop:0 #3a4a5a, stop:0.5 #2a3a4a, stop:1 #1a2a38); "
         "border-bottom: 1px solid #0a1a28; }");
 
-    auto* barLayout = new QHBoxLayout(titleBar);
+    auto* barLayout = new QHBoxLayout(m_titleBar);
     barLayout->setContentsMargins(6, 1, 4, 1);
     barLayout->setSpacing(2);
 
@@ -43,6 +45,19 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
         "border: none; font-size: 9px; padding: 0; }"
         "QPushButton:hover { color: #c8d8e8; }");
 
+    // Pop-out / dock button (↗ when docked, ↙ when floating)
+    m_popOutBtn = new QPushButton(QStringLiteral("\u2197"));
+    m_popOutBtn->setFixedSize(14, 14);
+    m_popOutBtn->setToolTip("Pop out to floating window");
+    m_popOutBtn->setStyleSheet(btnStyle);
+    connect(m_popOutBtn, &QPushButton::clicked, this, [this]() {
+        if (m_floating)
+            emit dockRequested(m_panId);
+        else
+            emit popOutRequested(m_panId);
+    });
+    barLayout->addWidget(m_popOutBtn);
+
     auto* closeBtn = new QPushButton("\u00D7");
     closeBtn->setFixedSize(14, 14);
     closeBtn->setStyleSheet(btnStyle + "QPushButton:hover { color: #ff4040; }");
@@ -51,7 +66,7 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     });
     barLayout->addWidget(closeBtn);
 
-    layout->addWidget(titleBar);
+    layout->addWidget(m_titleBar);
 
     // ── Spectrum widget (FFT + waterfall) ────────────────────────────────
     m_spectrum = new SpectrumWidget(this);
@@ -271,11 +286,38 @@ void PanadapterApplet::clearCwText()
     m_cwText->clear();
 }
 
+void PanadapterApplet::setFloating(bool floating)
+{
+    m_floating = floating;
+    m_popOutBtn->setText(floating ? QStringLiteral("\u2199") : QStringLiteral("\u2197"));
+    m_popOutBtn->setToolTip(floating ? "Dock back into main window" : "Pop out to floating window");
+}
+
 bool PanadapterApplet::eventFilter(QObject* obj, QEvent* ev)
 {
     if (ev->type() == QEvent::MouseButtonPress)
         emit activated(m_panId);
     return QWidget::eventFilter(obj, ev);
+}
+
+void PanadapterApplet::contextMenuEvent(QContextMenuEvent* ev)
+{
+    // Only show on title bar area
+    if (!m_titleBar->geometry().contains(ev->pos())) {
+        QWidget::contextMenuEvent(ev);
+        return;
+    }
+    auto* menu = new QMenu(this);
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+    QAction* act = menu->addAction(m_floating ? QStringLiteral("\u21a9 Dock")
+                                              : QStringLiteral("\u2197 Pop out"));
+    connect(act, &QAction::triggered, this, [this]() {
+        if (m_floating)
+            emit dockRequested(m_panId);
+        else
+            emit popOutRequested(m_panId);
+    });
+    menu->popup(ev->globalPos());
 }
 
 } // namespace AetherSDR

--- a/src/gui/PanadapterApplet.h
+++ b/src/gui/PanadapterApplet.h
@@ -31,6 +31,10 @@ public:
     void setSliceId(int id);
     void clearSliceTitle();
 
+    // Float/dock state
+    bool isFloating() const { return m_floating; }
+    void setFloating(bool floating);
+
     // CW decode panel
     void setCwPanelVisible(bool visible);
     void appendCwText(const QString& text, float cost = 0.0f);
@@ -44,15 +48,21 @@ public:
 signals:
     void activated(const QString& panId);
     void closeRequested(const QString& panId);
+    void popOutRequested(const QString& panId);
+    void dockRequested(const QString& panId);
     void pitchRangeChanged(int minHz, int maxHz);
 
 protected:
     bool eventFilter(QObject* obj, QEvent* ev) override;
+    void contextMenuEvent(QContextMenuEvent* ev) override;
 
 private:
     QString m_panId;
+    bool m_floating{false};
     SpectrumWidget* m_spectrum{nullptr};
     QLabel*         m_titleLabel{nullptr};
+    QPushButton*    m_popOutBtn{nullptr};
+    QWidget*        m_titleBar{nullptr};
 
     // CW decode
     QWidget*   m_cwPanel{nullptr};

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -1,6 +1,8 @@
 #include "PanadapterStack.h"
+#include "FloatingAppletWindow.h"
 #include "PanadapterApplet.h"
 #include "SpectrumWidget.h"
+#include "core/AppSettings.h"
 
 #include <QVBoxLayout>
 #include <QTimer>
@@ -50,6 +52,10 @@ PanadapterApplet* PanadapterStack::addPanadapter(const QString& panId)
 
 void PanadapterStack::removePanadapter(const QString& panId)
 {
+    // Auto-dock if floating before removing
+    if (m_floatingWindows.contains(panId))
+        dockPanadapter(panId);
+
     auto* applet = m_pans.take(panId);
     if (!applet) return;
 
@@ -133,6 +139,9 @@ void PanadapterStack::equalizeSizes()
 
 void PanadapterStack::rearrangeLayout(const QString& layoutId)
 {
+    // Auto-dock all floating pans before rebuilding the splitter layout
+    dockAll();
+
     // Collect applets in order
     QList<PanadapterApplet*> applets = m_pans.values();
     if (applets.isEmpty()) return;
@@ -215,6 +224,12 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
 
 void PanadapterStack::removeAll()
 {
+    // Close all floating windows first
+    for (auto* win : m_floatingWindows)
+        delete win;
+    m_floatingWindows.clear();
+    m_floatSplitterIndex.clear();
+
     qDeleteAll(m_pans);
     m_pans.clear();
     m_activePanId.clear();
@@ -366,6 +381,85 @@ void PanadapterStack::applyLayout(const QString& layoutId, const QStringList& pa
         addPanadapter(panIds[2]);
         addPanadapter(panIds[3]);
     }
+}
+
+void PanadapterStack::floatPanadapter(const QString& panId)
+{
+    auto* applet = m_pans.value(panId);
+    if (!applet || m_floatingWindows.contains(panId)) return;
+
+    // Save the current splitter index for re-insertion on dock
+    m_floatSplitterIndex[panId] = m_splitter->indexOf(applet);
+
+    // Reparent applet out of the splitter
+    applet->setParent(nullptr);
+
+    // Build a human-readable title from the pan's title label
+    QString title = applet->property("sliceTitle").toString();
+    if (title.isEmpty()) title = QStringLiteral("Panadapter %1").arg(panId);
+
+    // Create floating window (pass 'this' as parent → Qt::Tool window)
+    auto* win = new FloatingAppletWindow(panId, title, applet, this);
+    m_floatingWindows[panId] = win;
+    applet->setFloating(true);
+
+    connect(win, &FloatingAppletWindow::dockRequested,
+            this, &PanadapterStack::dockPanadapter);
+
+    win->show();
+    QTimer::singleShot(50, win, [win]() { win->restoreGeometry(); });
+
+    // Persist floating state
+    auto& s = AppSettings::instance();
+    s.setValue(QStringLiteral("FloatingPan_%1_IsFloating").arg(panId), "True");
+    s.save();
+}
+
+void PanadapterStack::dockPanadapter(const QString& panId)
+{
+    if (!m_floatingWindows.contains(panId)) return;
+
+    auto* applet = m_pans.value(panId);
+    auto* win = m_floatingWindows.value(panId);
+
+    if (applet) {
+        // Reparent back into the splitter
+        applet->setParent(m_splitter);
+
+        // Re-insert at original position or append at end
+        int targetIdx = m_floatSplitterIndex.value(panId, m_splitter->count());
+        if (targetIdx > m_splitter->count()) targetIdx = m_splitter->count();
+        m_splitter->insertWidget(targetIdx, applet);
+        m_splitter->setStretchFactor(m_splitter->indexOf(applet), 1);
+
+        applet->setFloating(false);
+        applet->show();
+    }
+
+    // Clean up the floating window
+    if (win) {
+        win->saveGeometry();
+        win->hide();
+        win->deleteLater();
+    }
+    m_floatingWindows.remove(panId);
+    m_floatSplitterIndex.remove(panId);
+
+    // Persist floating state
+    auto& s = AppSettings::instance();
+    s.setValue(QStringLiteral("FloatingPan_%1_IsFloating").arg(panId), "False");
+    s.save();
+
+    // Re-equalize after docking
+    if (m_splitter->count() > 1)
+        QTimer::singleShot(0, this, [this]() { equalizeSizes(); });
+}
+
+void PanadapterStack::dockAll()
+{
+    const QStringList ids = m_floatingWindows.keys();
+    for (const QString& id : ids)
+        dockPanadapter(id);
 }
 
 } // namespace AetherSDR

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -6,6 +6,7 @@
 
 namespace AetherSDR {
 
+class FloatingAppletWindow;
 class PanadapterApplet;
 class SpectrumWidget;
 
@@ -29,6 +30,12 @@ public:
     // panIds: the pan IDs to place in order (A, B, C, D)
     void applyLayout(const QString& layoutId, const QStringList& panIds);
 
+    // Float/dock panadapters into standalone windows
+    void floatPanadapter(const QString& panId);
+    void dockPanadapter(const QString& panId);
+    void dockAll();  // dock all floating pans (e.g. before layout change)
+    bool isPanFloating(const QString& panId) const { return m_floatingWindows.contains(panId); }
+
     // Accessors
     PanadapterApplet* panadapter(const QString& panId) const;
     SpectrumWidget* spectrum(const QString& panId) const;
@@ -50,6 +57,8 @@ signals:
 private:
     QSplitter* m_splitter{nullptr};
     QMap<QString, PanadapterApplet*> m_pans;
+    QMap<QString, FloatingAppletWindow*> m_floatingWindows;
+    QMap<QString, int> m_floatSplitterIndex;  // saved splitter position at pop-out time
     QString m_activePanId;
 };
 


### PR DESCRIPTION
## Summary

Fixes #920

- Right-click a panadapter title bar → "Pop out" / "Dock" context menu, or click the ↗/↙ arrow button in the title bar (per @ScooterTech's SmartSDR UX suggestion)
- Pop-out reparents the `PanadapterApplet` into a `FloatingAppletWindow` (reused from PR #916); dock returns it to the `PanadapterStack` splitter at its original position
- Layout changes (`rearrangeLayout`) auto-dock all floating pans first; pan removal auto-docks before delete
- Float state + geometry persisted per-pan via `AppSettings`; restored on reconnect
- `PanadapterStack::count()` still counts floating pans (they remain in `m_pans` map)
- Active pan tracking works across floating/docked states via existing `activated()` signal

## Files changed

- `PanadapterApplet.h/.cpp` — new `popOutRequested`/`dockRequested` signals, pop-out button, context menu, `isFloating()` state
- `PanadapterStack.h/.cpp` — new `floatPanadapter()`/`dockPanadapter()`/`dockAll()` methods, floating window management
- `MainWindow.cpp` — signal wiring, floating state restore on startup

## Test plan

- [x] Right-click pan title bar → "Pop out" detaches pan to floating window
- [ ] Click ↗ button on title bar pops out; ↙ button on floating pan docks back
- [ ] Floating window close button (X) docks the pan back
- [ ] GPU-accelerated spectrum + waterfall render correctly in floating window
- [ ] VFO overlays and overlay menu work in floating window
- [ ] Clicking a floating pan activates it (applet column updates)
- [ ] Layout change (e.g. 2v→2h) auto-docks all floating pans first
- [ ] Removing a pan that is floating works without crash
- [ ] Float state persists across reconnect (pan pops out again on restore)
- [ ] Multi-monitor: floating pan remembers per-screen geometry

🤖 Generated with [Claude Code](https://claude.ai/claude-code)