### PR TITLE
Fix Space bar triggering Tune when shortcuts disabled (#928)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2275,16 +2275,18 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
     if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease) {
         auto* ke = static_cast<QKeyEvent*>(event);
         if (ke->key() == Qt::Key_Space && !ke->isAutoRepeat()
-            && m_keyboardShortcutsEnabled && !isTextInputFocused()
+            && !isTextInputFocused()
             && m_radioModel.isConnected()) {
-            if (event->type() == QEvent::KeyPress && !m_spacePttActive) {
-                m_spacePttActive = true;
-                m_radioModel.setTransmit(true);
-            } else if (event->type() == QEvent::KeyRelease && m_spacePttActive) {
-                m_spacePttActive = false;
-                m_radioModel.setTransmit(false);
+            if (m_keyboardShortcutsEnabled) {
+                if (event->type() == QEvent::KeyPress && !m_spacePttActive) {
+                    m_spacePttActive = true;
+                    m_radioModel.setTransmit(true);
+                } else if (event->type() == QEvent::KeyRelease && m_spacePttActive) {
+                    m_spacePttActive = false;
+                    m_radioModel.setTransmit(false);
+                }
             }
-            return true;  // consume — don't let buttons activate
+            return true;  // always consume Space to prevent button activation
         }
     }
 


### PR DESCRIPTION
## Summary

- **Fixes #928** — Space bar triggered TUNE when keyboard shortcuts were disabled via View menu
- The `eventFilter` guard for `m_keyboardShortcutsEnabled` was on the outer condition, so when shortcuts were off, Space was not consumed and fell through to Qt's default QPushButton activation (clicking the focused TUNE button)
- Fix moves the shortcuts check to an inner guard while always consuming Space outside text inputs, preventing unintended button activation

## Test plan

- [ ] Disable keyboard shortcuts via View → Keyboard Shortcuts
- [ ] Press Space with main window focused — verify no radio action fires (no Tune, no PTT)
- [ ] Enable keyboard shortcuts — verify Space triggers PTT (Hold) as configured
- [ ] Verify Space still works normally in text input fields (QLineEdit, QTextEdit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)