### PR TITLE
Fix SmartLink SSB TX audio requiring DAX ON (#932)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -611,8 +611,6 @@ MainWindow::MainWindow(QWidget* parent)
     connect(&m_radioModel, &RadioModel::txAudioStreamReady,
             this, [this](quint32 streamId) {
         m_audio->setTxStreamId(streamId);
-        // TX audio on remote_audio_tx always requires Opus (radio enforces compression=OPUS)
-        m_audio->setOpusTxEnabled(true);
         qDebug() << "MainWindow: DAX TX stream ID set to" << Qt::hex << streamId;
         // Start PC audio TX if mic_selection is PC
         if (m_radioModel.transmitModel().micSelection() == "PC") {

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1345,7 +1345,7 @@ QWidget* RadioSetupDialog::buildAudioTab()
         auto* compLayout = new QHBoxLayout(compGroup);
         compLayout->setSpacing(4);
 
-        QString current = AppSettings::instance().value("AudioCompression", "None").toString();
+        QString current = AppSettings::instance().value("AudioCompression", "Auto").toString();
 
         const QString btnStyle =
             "QPushButton { background: #1a2a3a; color: #c8d8e8; border: 1px solid #304050; "

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -364,7 +364,7 @@ void RadioModel::setTransmit(bool tx)
 
 QString RadioModel::audioCompressionParam() const
 {
-    QString setting = AppSettings::instance().value("AudioCompression", "None").toString();
+    QString setting = AppSettings::instance().value("AudioCompression", "Auto").toString();
     if (setting == "Opus") return "opus";
     if (setting == "None") return "none";
     // Auto: use Opus on WAN, uncompressed on LAN


### PR DESCRIPTION
## Summary
Fixes #932

- Change `AudioCompression` default from `"None"` to `"Auto"` so SmartLink/WAN connections automatically select Opus encoding (the `"None"` default short-circuited before the WAN auto-detection logic)
- Remove erroneous unconditional `setOpusTxEnabled(true)` from the `dax_tx` stream handler — it was immediately overridden by the `remote_audio_tx` handler, which set it to `false` under the default `"None"` compression setting

## Root cause
Commit `b8bf700` added a compression parameter to `remote_audio_tx` and gated Opus TX encoding on the `AudioCompression` setting. With the default `"None"`, Opus was disabled on SmartLink, routing TX audio to the wrong stream. The radio only processes that stream when DAX is ON.

## Test plan
- [ ] SmartLink connection with default settings: verify SSB TX audio works without DAX ON
- [ ] LAN connection: verify TX audio still works (Auto selects uncompressed on LAN)
- [ ] SmartLink with explicit "Opus" setting: verify TX audio works
- [ ] SmartLink with explicit "Uncompressed" setting: verify behavior matches prior default (DAX required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)