### PR TITLE
Fix FLEX-6500 capped at 2 panadapters instead of 4 (#953)

### DIFF
--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -132,13 +132,13 @@ public:
 
     // Max panadapters supported by this radio model.
     // FLEX-6700: 8 (dual SCU, high-capacity)
-    // FLEX-6600 / FLEX-8600 / AU-520: 4 (dual SCU)
-    // All single-SCU models: 2
+    // FLEX-6600 / FLEX-6500 / FLEX-8600 / AU-520: 4 (dual SCU)
+    // All single-SCU models (6300, 6400, etc.): 2
     int maxPanadapters() const {
         if (m_model.contains("6700"))
             return 8;
-        if (m_model.contains("6600") || m_model.contains("8600")
-                || m_model.contains("AU-520"))
+        if (m_model.contains("6600") || m_model.contains("6500")
+                || m_model.contains("8600") || m_model.contains("AU-520"))
             return 4;
         return 2;
     }


### PR DESCRIPTION
The FLEX-6500 has a dual-SCU architecture and supports 4 panadapters, the same as the FLEX-6600/8600 and AU-520. It was missing from the explicit model list in maxPanadapters() and fell through to the 2-pan catch-all for single-SCU models (6300, 6400, etc.).

The pre-refactor dualScu chain in MainWindow.cpp (before issue #53) did not include the 6500 either — this is a pre-existing bug now surfaced by a 6500 user on firmware 4.1.5.39794.

Fix: add "6500" to the 4-panadapter branch in RadioModel::maxPanadapters().

No changes needed in PanLayoutDialog — it already gates layout tiles with `layout.panCount <= maxPans`, so the 2x2 and 4v layouts will become selectable for 6500 users automatically with this fix.

Fixes #953