### PR TITLE
Add FLEX-6500 to dual-SCU diversity/ESC model check

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3889,8 +3889,9 @@ void MainWindow::onConnectionStateChanged(bool connected)
         // Show DIV button on dual-SCU radios
         {
             const QString& model = m_radioModel.model();
-            bool divAllowed = model.contains("6600") || model.contains("6700")
-                           || model.contains("8600") || model.contains("AU-520");
+            bool divAllowed = model.contains("6500") || model.contains("6600")
+                           || model.contains("6700") || model.contains("8600")
+                           || model.contains("AU-520");
             // Set diversity allowed on all existing VFO widgets
             if (auto* vfo = spectrum()->vfoWidget())
                 vfo->setDiversityAllowed(divAllowed);
@@ -4420,8 +4421,9 @@ void MainWindow::onSliceAdded(SliceModel* s)
     // Show DIV button on dual-SCU radios
     {
         const QString& model = m_radioModel.model();
-        bool divAllowed = model.contains("6600") || model.contains("6700")
-                       || model.contains("8600") || model.contains("AU-520");
+        bool divAllowed = model.contains("6500") || model.contains("6600")
+                       || model.contains("6700") || model.contains("8600")
+                       || model.contains("AU-520");
         vfo->setDiversityAllowed(divAllowed);
     }
 


### PR DESCRIPTION
PR #968 added 6500 to maxPanadapters() but the divAllowed check
in two places still excluded it. FLEX-6500 is dual-SCU and supports
diversity/ESC like the 6600/6700/8600.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
