### PR TITLE
Fix FlexControl VFO jitter: track absolute target frequency (#693)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1362,22 +1362,25 @@ MainWindow::MainWindow(QWidget* parent)
     m_flexCoalesceTimer.setSingleShot(true);
     m_flexCoalesceTimer.setInterval(20);
     connect(&m_flexCoalesceTimer, &QTimer::timeout, this, [this]() {
-        if (m_flexPendingSteps == 0) return;
+        if (m_flexTargetMhz < 0.0) return;
         auto* s = activeSlice();
-        if (!s || s->isLocked()) { m_flexPendingSteps = 0; return; }
-        int stepHz = spectrum() ? spectrum()->stepSize() : 100;
-        double newMhz = s->frequency() + m_flexPendingSteps * stepHz / 1e6;
-        m_flexPendingSteps = 0;
-        QString panId = m_panStack ? m_panStack->activePanId() : m_radioModel.panId();
-        if (!panId.isEmpty())
-            m_radioModel.sendCommand(
-                QString("slice m %1 pan=%2").arg(newMhz, 0, 'f', 6).arg(panId));
-        if (spectrum()) spectrum()->setVfoFrequency(newMhz);
+        if (!s || s->isLocked()) { m_flexTargetMhz = -1.0; return; }
+        double target = m_flexTargetMhz;
+        // Use slice tune (not slice m) — doesn't recenter pan, correct for encoder
+        s->setFrequency(target);
     });
     // FlexControl signals (auto-queued from worker → main)
     connect(m_flexControl, &FlexControlManager::tuneSteps,
             this, [this](int steps) {
-        m_flexPendingSteps += steps;
+        auto* s = activeSlice();
+        if (!s || s->isLocked()) return;
+        int stepHz = spectrum() ? spectrum()->stepSize() : 100;
+        // Initialize target from slice on first step or after external QSY
+        if (m_flexTargetMhz < 0.0)
+            m_flexTargetMhz = s->frequency();
+        m_flexTargetMhz += steps * stepHz / 1e6;
+        // Optimistic VFO display update — immediate visual feedback
+        if (spectrum()) spectrum()->setVfoFrequency(m_flexTargetMhz);
         if (!m_flexCoalesceTimer.isActive())
             m_flexCoalesceTimer.start();
     });

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -180,7 +180,7 @@ private:
     SerialPortController* m_serialPort{nullptr};
     FlexControlManager*   m_flexControl{nullptr};
     QTimer               m_flexCoalesceTimer;
-    int                  m_flexPendingSteps{0};
+    double               m_flexTargetMhz{-1.0};
 #endif
 #ifdef HAVE_HIDAPI
     HidEncoderManager*   m_hidEncoder{nullptr};


### PR DESCRIPTION
Replaced relative step accumulator with absolute target frequency
to prevent echo-drift jitter. Previous approach re-read slice
frequency each coalesce cycle, but radio echoes from prior commands
shifted the base causing the VFO to bounce.

Now: first encoder step initializes target from slice, subsequent
steps accumulate on the target. Optimistic VFO display update on
each step for immediate feedback. Uses slice tune (not slice m)
which is correct for encoder tuning.

Inspired by PR #972 from @RiskAndReward1337 but without modifying
SliceModel's applyStatus() echo handling.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
