### PR TITLE
[network] Fix first-run network consent race and interface-down discovery failure

### DIFF
--- a/src/core/RadioDiscovery.cpp
+++ b/src/core/RadioDiscovery.cpp
@@ -10,8 +10,22 @@ RadioDiscovery::RadioDiscovery(QObject* parent)
     : QObject(parent)
 {
     connect(&m_socket, &QUdpSocket::readyRead, this, &RadioDiscovery::onReadyRead);
+
     m_staleTimer.setInterval(STALE_TIMEOUT_MS / 2);
     connect(&m_staleTimer, &QTimer::timeout, this, &RadioDiscovery::onStaleCheck);
+
+    m_bindRetryTimer.setInterval(BIND_RETRY_MS);
+    m_bindRetryTimer.setSingleShot(true);
+    connect(&m_bindRetryTimer, &QTimer::timeout, this, &RadioDiscovery::onBindRetry);
+
+    // Periodic re-bind: handles the case where bind() succeeds but the socket
+    // is stale (e.g. no network interface at launch, macOS consent silently
+    // dropping packets).  Stops once the first discovery packet arrives.
+    m_rebindTimer.setInterval(REBIND_INTERVAL_MS);
+    connect(&m_rebindTimer, &QTimer::timeout, this, [this]() {
+        qCDebug(lcDiscovery) << "RadioDiscovery: no packets yet, re-binding socket";
+        startListening();
+    });
 }
 
 RadioDiscovery::~RadioDiscovery()
@@ -21,20 +35,55 @@ RadioDiscovery::~RadioDiscovery()
 
 void RadioDiscovery::startListening()
 {
+    // Close any previous socket state before (re-)binding
+    m_socket.close();
+
     if (!m_socket.bind(QHostAddress::AnyIPv4, DISCOVERY_PORT,
                        QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint)) {
-        qCWarning(lcDiscovery) << "RadioDiscovery: failed to bind UDP port" << DISCOVERY_PORT
-                   << m_socket.errorString();
+        qCWarning(lcDiscovery) << "RadioDiscovery: bind failed on UDP port" << DISCOVERY_PORT
+                               << "–" << m_socket.errorString();
+
+        if (m_bindRetryCount < MAX_BIND_RETRIES) {
+            ++m_bindRetryCount;
+            qCDebug(lcDiscovery) << "RadioDiscovery: scheduling retry"
+                                 << m_bindRetryCount << "/" << MAX_BIND_RETRIES;
+            m_bindRetryTimer.start();
+        } else {
+            qCWarning(lcDiscovery) << "RadioDiscovery: giving up after"
+                                   << MAX_BIND_RETRIES << "retries";
+        }
         return;
     }
+
+    if (m_bindRetryCount > 0) {
+        qCDebug(lcDiscovery) << "RadioDiscovery: bind succeeded after"
+                             << m_bindRetryCount << "retries";
+    }
+    m_bindRetryCount = 0;
     m_staleTimer.start();
+
+    // Keep re-binding periodically until we actually receive a discovery packet.
+    // Covers: no network at launch, macOS consent blocking packets, interface changes.
+    if (!m_receivedAny) {
+        m_rebindTimer.start();
+    }
+
     qCDebug(lcDiscovery) << "RadioDiscovery: listening on UDP" << DISCOVERY_PORT;
 }
 
 void RadioDiscovery::stopListening()
 {
+    m_bindRetryTimer.stop();
+    m_rebindTimer.stop();
+    m_bindRetryCount = 0;
+    m_receivedAny = false;
     m_staleTimer.stop();
     m_socket.close();
+}
+
+void RadioDiscovery::onBindRetry()
+{
+    startListening();
 }
 
 // SmartSDR discovery packets are ASCII key=value pairs separated by spaces.
@@ -85,6 +134,13 @@ void RadioDiscovery::onReadyRead()
     while (m_socket.hasPendingDatagrams()) {
         QNetworkDatagram datagram = m_socket.receiveDatagram();
         if (datagram.isNull()) continue;
+
+        // First packet received — stop the periodic re-bind, socket is healthy
+        if (!m_receivedAny) {
+            m_receivedAny = true;
+            m_rebindTimer.stop();
+            qCDebug(lcDiscovery) << "RadioDiscovery: first packet received, re-bind timer stopped";
+        }
 
         RadioInfo info = parseDiscoveryPacket(datagram.data());
 

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -52,8 +52,11 @@ class RadioDiscovery : public QObject {
     Q_OBJECT
 
 public:
-    static constexpr quint16 DISCOVERY_PORT = 4992;
-    static constexpr int STALE_TIMEOUT_MS  = 5000; // radio considered gone after 5s
+    static constexpr quint16 DISCOVERY_PORT  = 4992;
+    static constexpr int STALE_TIMEOUT_MS   = 5000;  // radio considered gone after 5s
+    static constexpr int BIND_RETRY_MS      = 2000;  // retry interval when bind fails
+    static constexpr int MAX_BIND_RETRIES   = 15;    // give up after 30s (15 × 2s)
+    static constexpr int REBIND_INTERVAL_MS = 5000;  // re-bind interval until first packet received
 
     explicit RadioDiscovery(QObject* parent = nullptr);
     ~RadioDiscovery() override;
@@ -71,6 +74,7 @@ signals:
 private slots:
     void onReadyRead();
     void onStaleCheck();
+    void onBindRetry();
 
 private:
     RadioInfo parseDiscoveryPacket(const QByteArray& data) const;
@@ -78,6 +82,10 @@ private:
 
     QUdpSocket        m_socket;
     QTimer            m_staleTimer;
+    QTimer            m_bindRetryTimer;  // retries bind if first attempt fails (e.g. macOS net consent)
+    QTimer            m_rebindTimer;     // periodic re-bind until first packet (handles interface changes)
+    int               m_bindRetryCount{0};
+    bool              m_receivedAny{false};
     QList<RadioInfo>  m_radios;
 
     // Track last-seen time per serial for staleness detection

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2080,7 +2080,8 @@ MainWindow::MainWindow(QWidget* parent)
     });
     clockTimer->start(1000);
 
-    // Start discovery
+    // Start discovery — show amber indicator while waiting for connection
+    if (m_titleBar) m_titleBar->setDiscovering(true);
     m_discovery.startListening();
 
     // Auto-connect to routed radios (probed, not broadcast-discovered)

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -530,11 +530,31 @@ void TitleBar::showFeatureRequestDialogImpl()
     dlg->show();
 }
 
+void TitleBar::setDiscovering(bool active)
+{
+    m_discovering = active;
+    if (active) {
+        // Solid amber — discovery in progress, no connection yet
+        m_heartbeatOffTimer->stop();
+        m_heartbeatAlarmTimer->stop();
+        m_heartbeat->setStyleSheet(
+            "QLabel { background: #e0a020; border-radius: 5px; }");
+        m_heartbeat->setToolTip("Searching for radio…");
+    } else {
+        m_heartbeat->setToolTip("Radio discovery heartbeat");
+        // Return to idle gray — onHeartbeat() will take over once pings arrive
+        m_heartbeat->setStyleSheet(
+            "QLabel { background: #404858; border-radius: 5px; }");
+    }
+}
+
 void TitleBar::onHeartbeat()
 {
+    m_discovering = false;
     m_missedBeats = 0;
     m_heartbeatAlarmTimer->stop();
     m_alarmRed = false;
+    m_heartbeat->setToolTip("Radio discovery heartbeat");
     m_heartbeat->setStyleSheet(
         "QLabel { background: #20c060; border-radius: 5px; }");
     if (m_blinkEnabled) {

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -27,6 +27,7 @@ public:
     void setMultiFlexStatus(int clientCount, const QStringList& names);
     void onHeartbeat();       // Call when a discovery packet arrives
     void onHeartbeatLost();   // Call when radio lost from discovery
+    void setDiscovering(bool active); // Solid amber while discovering / not yet connected
     void setMinimalMode(bool on);
     void setBlinkEnabled(bool enabled); // Toggle heartbeat animation on/off
 
@@ -67,6 +68,7 @@ private:
     int          m_missedBeats{0};
     bool         m_alarmRed{false};
     bool         m_blinkEnabled{true};  // persisted via AppSettings "HeartbeatBlinkEnabled"
+    bool         m_discovering{false};  // solid amber while waiting for connection
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
## Summary

On first application run, AetherSDR fails to run radio discovery on the network after network discovery consent is granted.  The application looks hung until the user restarts it.

- **Bind retry**: if `bind()` fails (e.g. macOS blocks the socket while showing the Local Network consent dialog), retries every 2s up to 15 attempts (~30s window) — then logs a warning and stops
- **Periodic rebind**: after a successful bind, re-binds every 5s until the first discovery packet arrives — recovers from stale sockets when the network interface was down at launch or came back up after binding
- **Amber indicator**: title bar heartbeat dot shows solid amber from app launch until the first TCP ping is received, giving the user clear visual feedback during the discovery/consent phase

## Test plan

- [ ] Fresh install (consent never granted): launch with WiFi on — amber → both consent dialogs appear → accept → green on first ping
- [ ] Interface down at launch: WiFi off → launch (amber) → turn WiFi on → radio discovered and connected within ~5s
- [ ] Normal launch (consent already granted, network up): amber briefly → green as usual, no regression
- [ ] Linux/Windows build: no platform-specific code, CI should pass clean

## Notes

All changes are contained in `RadioDiscovery` (UDP discovery hardening) and `TitleBar`/`MainWindow` (amber indicator). No changes to `RadioModel`, reconnect logic, or TCP connection flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)