### PR TITLE
Add License Info section to Radio Setup dialog

### DIFF
--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -12,6 +12,7 @@
 #include "core/FirmwareUploader.h"
 #include "core/FirmwareStager.h"
 
+#include <QCloseEvent>
 #include <QTabWidget>
 #include <QVBoxLayout>
 #include <QHBoxLayout>

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -237,6 +237,61 @@ QWidget* RadioSetupDialog::buildRadioTab()
         vbox->addWidget(group);
     }
 
+    // License Info group (matches SmartSDR Radio Setup → License Info section)
+    {
+        auto* group = new QGroupBox("License Info");
+        group->setStyleSheet(kGroupStyle);
+        auto* grid = new QGridLayout(group);
+        grid->setSpacing(6);
+        grid->setColumnStretch(1, 1);
+        grid->setColumnStretch(3, 1);
+
+        // Row 0: Subscription | Expiration
+        grid->addWidget(new QLabel("Subscription:"), 0, 0);
+        m_licSubscriptionLabel = new QLabel(
+            m_model->licenseSubscription().isEmpty() ? "—" : m_model->licenseSubscription());
+        m_licSubscriptionLabel->setStyleSheet(kValueStyle);
+        grid->addWidget(m_licSubscriptionLabel, 0, 1);
+
+        grid->addWidget(new QLabel("Expiration:"), 0, 2);
+        m_licExpirationLabel = new QLabel(
+            m_model->licenseExpirationDate().isEmpty() ? "—" : m_model->licenseExpirationDate());
+        m_licExpirationLabel->setStyleSheet(kValueStyle);
+        grid->addWidget(m_licExpirationLabel, 0, 3);
+
+        // Row 1: Radio ID | Licensed version
+        grid->addWidget(new QLabel("Radio ID:"), 1, 0);
+        m_licRadioIdLabel = new QLabel(
+            m_model->licenseRadioId().isEmpty() ? "—" : m_model->licenseRadioId());
+        m_licRadioIdLabel->setStyleSheet(kValueStyle);
+        grid->addWidget(m_licRadioIdLabel, 1, 1);
+
+        grid->addWidget(new QLabel("Licensed version:"), 1, 2);
+        m_licMaxVersionLabel = new QLabel(
+            m_model->licenseMaxVersion().isEmpty() ? "—" : m_model->licenseMaxVersion());
+        m_licMaxVersionLabel->setStyleSheet(kValueStyle);
+        grid->addWidget(m_licMaxVersionLabel, 1, 3);
+
+        for (auto* lbl : group->findChildren<QLabel*>()) {
+            if (lbl->styleSheet().isEmpty())
+                lbl->setStyleSheet(kLabelStyle);
+        }
+
+        // Update labels live if license status arrives after dialog opens
+        connect(m_model, &RadioModel::infoChanged, this, [this] {
+            if (!m_model->licenseSubscription().isEmpty())
+                m_licSubscriptionLabel->setText(m_model->licenseSubscription());
+            if (!m_model->licenseExpirationDate().isEmpty())
+                m_licExpirationLabel->setText(m_model->licenseExpirationDate());
+            if (!m_model->licenseRadioId().isEmpty())
+                m_licRadioIdLabel->setText(m_model->licenseRadioId());
+            if (!m_model->licenseMaxVersion().isEmpty())
+                m_licMaxVersionLabel->setText(m_model->licenseMaxVersion());
+        });
+
+        vbox->addWidget(group);
+    }
+
     // Firmware Update group
     {
         auto* group = new QGroupBox("Firmware Update");

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -60,7 +60,7 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio, QWidge
     : QDialog(parent), m_model(model), m_audio(audio)
 {
     setWindowTitle("Radio Setup");
-    setMinimumSize(820, 520);
+    setMinimumSize(820, 620);
     setStyleSheet("QDialog { background: #0f0f1a; }");
 
     auto* layout = new QVBoxLayout(this);
@@ -97,6 +97,20 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio, QWidge
         "QPushButton:hover { background: #203040; }");
     connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::close);
     layout->addWidget(buttons);
+
+    // Restore saved geometry so the dialog reopens at the user's last size.
+    const QString geomB64 = AppSettings::instance()
+        .value("RadioSetupDialogGeometry", "").toString();
+    if (!geomB64.isEmpty())
+        restoreGeometry(QByteArray::fromBase64(geomB64.toLatin1()));
+}
+
+void RadioSetupDialog::closeEvent(QCloseEvent* event)
+{
+    AppSettings::instance().setValue("RadioSetupDialogGeometry",
+        QString::fromLatin1(saveGeometry().toBase64()));
+    AppSettings::instance().save();
+    QDialog::closeEvent(event);
 }
 
 // ── Radio tab ─────────────────────────────────────────────────────────────────

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QDialog>
-#include <QCloseEvent>
 
 class QTabWidget;
 class QLabel;

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QCloseEvent>
 
 class QTabWidget;
 class QLabel;
@@ -28,6 +29,9 @@ public:
 
 signals:
     void txBandSettingsRequested();
+
+protected:
+    void closeEvent(QCloseEvent* event) override;
 
 private:
     QWidget* buildRadioTab();

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -60,6 +60,12 @@ private:
     QLineEdit* m_callsignEdit{nullptr};
     QPushButton* m_remoteOnBtn{nullptr};
 
+    // License Info
+    QLabel* m_licSubscriptionLabel{nullptr};
+    QLabel* m_licExpirationLabel{nullptr};
+    QLabel* m_licRadioIdLabel{nullptr};
+    QLabel* m_licMaxVersionLabel{nullptr};
+
     // Firmware update
     QLabel*       m_fwStatusLabel{nullptr};
     QProgressBar* m_fwProgress{nullptr};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1597,20 +1597,20 @@ void RadioModel::onStatusReceived(const QString& object,
     // Subscription tier is inferred from the highest `reason` seen:
     //   PLUS → "SmartSDR+"  |  BUILT_IN / LICENSE_FILE → "SmartSDR"
     if (object == "license" && !kvs.contains("name")) {
-        if (kvs.contains("radio_id"))
+        if (kvs.contains("radio_id")) {
             m_licenseRadioId = kvs["radio_id"];
-        if (kvs.contains("highest_major_version"))
+        }
+        if (kvs.contains("highest_major_version")) {
             m_licenseMaxVersion = kvs["highest_major_version"];
+        }
         if (kvs.contains("issued")) {
-            // Store issued date and compute expiration as issued + 365 days.
+            // Compute expiration as issued + 365 days.
             // The radio sends ISO-8601: "2025-10-31T18:43:24.944Z"
-            QString iso = kvs["issued"];
-            m_licenseIssuedDate = iso.left(10);  // "YYYY-MM-DD"
-            QDate issued = QDate::fromString(m_licenseIssuedDate, Qt::ISODate);
+            const QString issuedStr = kvs["issued"].left(10);  // "YYYY-MM-DD"
+            const QDate issued = QDate::fromString(issuedStr, Qt::ISODate);
             if (issued.isValid()) {
-                QDate expiry = issued.addDays(365);
                 m_licenseExpirationDate =
-                    expiry.toString("MM/dd/yyyy");  // matches SmartSDR display
+                    issued.addDays(365).toString("MM/dd/yyyy");  // matches SmartSDR display
             }
         }
         emit infoChanged();
@@ -1619,10 +1619,11 @@ void RadioModel::onStatusReceived(const QString& object,
     if (object == "license feature") {
         // Infer subscription tier from reason codes.
         // PLUS features indicate a SmartSDR+ subscription.
-        if (kvs.value("reason") == "PLUS" && kvs.value("enabled") == "1")
+        if (kvs.value("reason") == "PLUS" && kvs.value("enabled") == "1") {
             m_licenseSubscription = "SmartSDR+";
-        else if (m_licenseSubscription.isEmpty())
+        } else if (m_licenseSubscription.isEmpty()) {
             m_licenseSubscription = "SmartSDR";
+        }
         emit infoChanged();
         return;
     }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1591,6 +1591,42 @@ void RadioModel::onStatusReceived(const QString& object,
         return;
     }
 
+    // License info (fw v1.4.0.0): two sub-objects:
+    //   "license"         — radio_id, issued, last_refreshed_date, highest_major_version, region
+    //   "license feature" — name, enabled, reason  (one message per feature)
+    // Subscription tier is inferred from the highest `reason` seen:
+    //   PLUS → "SmartSDR+"  |  BUILT_IN / LICENSE_FILE → "SmartSDR"
+    if (object == "license" && !kvs.contains("name")) {
+        if (kvs.contains("radio_id"))
+            m_licenseRadioId = kvs["radio_id"];
+        if (kvs.contains("highest_major_version"))
+            m_licenseMaxVersion = kvs["highest_major_version"];
+        if (kvs.contains("issued")) {
+            // Store issued date and compute expiration as issued + 365 days.
+            // The radio sends ISO-8601: "2025-10-31T18:43:24.944Z"
+            QString iso = kvs["issued"];
+            m_licenseIssuedDate = iso.left(10);  // "YYYY-MM-DD"
+            QDate issued = QDate::fromString(m_licenseIssuedDate, Qt::ISODate);
+            if (issued.isValid()) {
+                QDate expiry = issued.addDays(365);
+                m_licenseExpirationDate =
+                    expiry.toString("MM/dd/yyyy");  // matches SmartSDR display
+            }
+        }
+        emit infoChanged();
+        return;
+    }
+    if (object == "license feature") {
+        // Infer subscription tier from reason codes.
+        // PLUS features indicate a SmartSDR+ subscription.
+        if (kvs.value("reason") == "PLUS" && kvs.value("enabled") == "1")
+            m_licenseSubscription = "SmartSDR+";
+        else if (m_licenseSubscription.isEmpty())
+            m_licenseSubscription = "SmartSDR";
+        emit infoChanged();
+        return;
+    }
+
     if (object == "radio oscillator") {
         if (kvs.contains("state"))        m_oscState    = kvs["state"];
         if (kvs.contains("setting"))      m_oscSetting  = kvs["setting"];

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -112,7 +112,6 @@ public:
 
     // License info (populated from "sub license all" responses)
     QString licenseRadioId()        const { return m_licenseRadioId; }
-    QString licenseIssuedDate()     const { return m_licenseIssuedDate; }
     QString licenseExpirationDate() const { return m_licenseExpirationDate; }
     QString licenseMaxVersion()     const { return m_licenseMaxVersion; }
     QString licenseSubscription()   const { return m_licenseSubscription; }
@@ -407,7 +406,6 @@ private:
     QString     m_region;
     QString     m_radioOptions;
     QString     m_licenseRadioId;
-    QString     m_licenseIssuedDate;
     QString     m_licenseExpirationDate;
     QString     m_licenseMaxVersion;
     QString     m_licenseSubscription;   // e.g. "SmartSDR+", "SmartSDR", "Unknown"

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -109,6 +109,14 @@ public:
     QString region()       const { return m_region; }
     int     rttyMarkDefault() const { return m_rttyMarkDefault; }
     QString radioOptions() const { return m_radioOptions; }
+
+    // License info (populated from "sub license all" responses)
+    QString licenseRadioId()        const { return m_licenseRadioId; }
+    QString licenseIssuedDate()     const { return m_licenseIssuedDate; }
+    QString licenseExpirationDate() const { return m_licenseExpirationDate; }
+    QString licenseMaxVersion()     const { return m_licenseMaxVersion; }
+    QString licenseSubscription()   const { return m_licenseSubscription; }
+
     QString ip()          const { return m_ip; }
     QString netmask()     const { return m_netmask; }
     QString gateway()     const { return m_gateway; }
@@ -398,6 +406,11 @@ private:
     QString     m_nickname;
     QString     m_region;
     QString     m_radioOptions;
+    QString     m_licenseRadioId;
+    QString     m_licenseIssuedDate;
+    QString     m_licenseExpirationDate;
+    QString     m_licenseMaxVersion;
+    QString     m_licenseSubscription;   // e.g. "SmartSDR+", "SmartSDR", "Unknown"
     QString     m_ip;
     QString     m_netmask;
     QString     m_gateway;


### PR DESCRIPTION
## Summary

This PR is submitted in response to issue ten9876/AetherSDR#964, which reported that License Info and Subscription Status were missing from the Radio Setup dialog.

- Parses `sub license all` responses from the radio — two distinct object types:
  - `license` → `radio_id`, `issued` date, `highest_major_version`
  - `license feature` → per-feature `name`/`enabled`/`reason` (one message per feature)
- Subscription tier inferred from `reason` codes: any feature with `reason=PLUS` and `enabled=1` indicates `SmartSDR+`, otherwise `SmartSDR`
- Expiration date computed as issued + 365 days, matching SmartSDR's display format (`MM/dd/yyyy`)
- New **License Info** group added to Radio Setup → Radio tab, between Radio Identification and Firmware Update, matching SmartSDR's layout
- Labels update live via `infoChanged()` if the dialog is opened before license status messages have arrived
- Increased minimum dialog height from 520 → 620 px to prevent content clipping with the additional group
- Dialog geometry now persists via `AppSettings` so it reopens at the user's last size

## Reference

Verified against pcap capture of firmware v1.4.0.0 / FLEX-8400. The radio responds to `sub license all` (already sent during connection sequence at line 994 of RadioModel.cpp) with the above message format — no new subscriptions or protocol changes required.

## Screenshot

<img width="952" height="779" alt="image" src="https://github.com/user-attachments/assets/220635f9-35f9-4aa8-8167-25df48e6b9bd" />

## Test Plan

- [x] Open Radio Setup → Radio tab — License Info group visible with correct Subscription, Expiration, Radio ID, Licensed version
- [x] Verify Subscription shows `SmartSDR+` for a Plus-licensed radio
- [x] Verify Expiration is issued date + 365 days in MM/dd/yyyy format
- [x] Open dialog before connecting — fields show `—`; connect to radio — fields populate automatically
- [x] Resize dialog, close, reopen — size is remembered

🤖 Generated with [Claude Code](https://claude.com/claude-code)