### PR TITLE
Fix floating applets losing float state and position across restarts (#959)

### DIFF
--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -163,11 +163,13 @@ void AppSettings::save()
     // Write top-level settings (sorted for consistency)
     QList<QString> keys = m_settings.keys();
     std::sort(keys.begin(), keys.end());
-    static const QRegularExpression validKey("^[A-Za-z_][A-Za-z0-9_./]*$");
+    // XML element names: start with letter or underscore, then letters/digits/underscores.
+    // '/' and '.' are NOT valid in element names — reject them here so a bad key
+    // never silently corrupts the file and causes the atomic-save validation to abort.
+    static const QRegularExpression validKey("^[A-Za-z_][A-Za-z0-9_]*$");
     for (const auto& key : keys) {
-        // Skip keys that aren't valid XML element names
         if (!validKey.match(key).hasMatch()) {
-            qWarning() << "AppSettings: skipping invalid key:" << key;
+            qWarning() << "AppSettings: skipping key with invalid XML characters:" << key;
             continue;
         }
         xml.writeTextElement(key, m_settings.value(key));

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -37,6 +37,13 @@
 
 namespace AetherSDR {
 
+// Applet IDs like "P/CW" contain '/' which is invalid in XML element names.
+// Use this when forming AppSettings keys so the key is always safe to write.
+static QString floatKey(const QString& id)
+{
+    return QStringLiteral("FloatingApplet_%1_IsFloating").arg(QString(id).replace('/', '_'));
+}
+
 const QStringList AppletPanel::kDefaultOrder = {
     "RX", "TUN", "AMP", "TX", "PHNE", "P/CW", "EQ", "DIGI", "MTR", "AG"
 };
@@ -478,7 +485,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
             }
             // Re-float if the applet was floating before being toggled off (#959)
             if (checked) {
-                const QString floatKey = QStringLiteral("FloatingApplet_%1_IsFloating").arg(id);
+                const QString floatKey = AetherSDR::floatKey(id);
                 if (AppSettings::instance().value(floatKey, "False").toString() == "True") {
                     QTimer::singleShot(0, this, [this, id]() { floatApplet(id); });
                     return;
@@ -672,7 +679,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
     // ── Restore floating state ──────────────────────────────────────────────
     for (auto& entry : m_appletOrder) {
-        const QString floatKey = QStringLiteral("FloatingApplet_%1_IsFloating").arg(entry.id);
+        const QString floatKey = AetherSDR::floatKey(entry.id);
         if (AppSettings::instance().value(floatKey, "False").toString() == "True") {
             // Use QTimer::singleShot so the window system is ready before showing
             QTimer::singleShot(0, this, [this, id = entry.id]() { floatApplet(id); });
@@ -890,7 +897,7 @@ void AppletPanel::floatApplet(const QString& id)
 
     // Persist floating state
     AppSettings::instance().setValue(
-        QStringLiteral("FloatingApplet_%1_IsFloating").arg(id), "True");
+        AetherSDR::floatKey(id), "True");
     AppSettings::instance().save();
 }
 
@@ -948,7 +955,7 @@ void AppletPanel::dockApplet(const QString& id)
 
     // Persist floating state
     AppSettings::instance().setValue(
-        QStringLiteral("FloatingApplet_%1_IsFloating").arg(id), "False");
+        AetherSDR::floatKey(id), "False");
     AppSettings::instance().save();
 }
 

--- a/src/gui/FloatingAppletWindow.cpp
+++ b/src/gui/FloatingAppletWindow.cpp
@@ -9,6 +9,7 @@
 #include <QMoveEvent>
 #include <QResizeEvent>
 #include <QTimer>
+#include <QCoreApplication>
 #include <QGuiApplication>
 #include <QScreen>
 #include <QWindow>
@@ -86,11 +87,26 @@ FloatingAppletWindow::FloatingAppletWindow(const QString& appletId,
     m_saveTimer->setSingleShot(true);
     m_saveTimer->setInterval(400);
     connect(m_saveTimer, &QTimer::timeout, this, &FloatingAppletWindow::saveGeometry);
+
+    // On app shutdown, prevent closeEvent from emitting dockRequested.
+    // Geometry is saved in hideEvent (fires while the window still has valid
+    // coordinates), not here — aboutToQuit fires after tool windows are already
+    // hidden on Windows and pos() may no longer be reliable.
+    connect(qApp, &QCoreApplication::aboutToQuit, this, [this]() {
+        m_appShuttingDown = true;
+    });
+}
+
+// Applet IDs like "P/CW" contain characters that are invalid in XML element
+// names. Sanitize by replacing '/' with '_' before forming settings keys.
+static QString settingsPrefix(const QString& appletId)
+{
+    return QStringLiteral("FloatingApplet_%1").arg(QString(appletId).replace('/', '_'));
 }
 
 void FloatingAppletWindow::saveGeometry()
 {
-    const QString prefix = QStringLiteral("FloatingApplet_%1").arg(m_appletId);
+    const QString prefix = settingsPrefix(m_appletId);
     auto& s = AppSettings::instance();
 
     QScreen* screen = windowHandle() ? windowHandle()->screen() : nullptr;
@@ -116,7 +132,7 @@ void FloatingAppletWindow::saveGeometry()
 
 void FloatingAppletWindow::restoreGeometry()
 {
-    const QString prefix = QStringLiteral("FloatingApplet_%1").arg(m_appletId);
+    const QString prefix = settingsPrefix(m_appletId);
     const auto& s = AppSettings::instance();
 
     const int w = s.value(prefix + "_W", "0").toInt();
@@ -165,34 +181,6 @@ void FloatingAppletWindow::hideAndSave()
 {
     m_saveTimer->stop();
     saveGeometry();
-    AppSettings::instance().save();
-    hide();
-}
-
-void FloatingAppletWindow::showAndRestore()
-{
-    // Guard the entire show+restore+WM-settle sequence so no moveEvent or
-    // resizeEvent can start the debounce timer and overwrite the saved geometry.
-    //
-    // Timeline:
-    //   t=  0 ms  guard=true, show() — WM centers window, fires moveEvent (suppressed)
-    //   t=200 ms  restoreGeometry() — resize()+move() fire events (suppressed)
-    //   t=~250 ms WM sends ConfigureNotify for our move() (suppressed)
-    //   t=650 ms  guard=false — any events after this are genuine user moves
-    //
-    // 650 ms = 200 ms (restore delay) + 300 ms (WM settle) + 150 ms safety margin.
-    m_restoringGeometry = true;
-    show();
-    raise();
-    QTimer::singleShot(200, this, [this]() { restoreGeometry(); });
-    QTimer::singleShot(650, this, [this]() { m_restoringGeometry = false; });
-}
-
-void FloatingAppletWindow::hideAndSave()
-{
-    m_saveTimer->stop();
-    saveGeometry();
-    AppSettings::instance().save();
     hide();
 }
 
@@ -227,20 +215,36 @@ void FloatingAppletWindow::moveEvent(QMoveEvent* ev)
     if (!m_restoringGeometry) { m_saveTimer->start(); }
 }
 
+void FloatingAppletWindow::hideEvent(QHideEvent* ev)
+{
+    QWidget::hideEvent(ev);
+    // Belt-and-suspenders save for paths that call hide() directly (e.g. on
+    // Linux when parent visibility cascades via Qt). Qt does NOT guarantee
+    // hideEvent fires when a parent is hidden — so this cannot be the primary
+    // save path. hideAndSave() and closeEvent() both call saveGeometry()
+    // explicitly before reaching this point.
+    if (!m_restoringGeometry) {
+        m_saveTimer->stop();
+        saveGeometry();
+    }
+}
+
 void FloatingAppletWindow::closeEvent(QCloseEvent* ev)
 {
-    // If the parent AppletPanel is hidden the main window is closing — accept
-    // so the window is properly removed from Qt's visible-window count.
-    if (auto* p = qobject_cast<QWidget*>(parent()); !p || !p->isVisible()) {
+    // During app shutdown (aboutToQuit already fired) or when the parent panel
+    // is no longer visible, just accept. Geometry was already saved in hideEvent.
+    // Never emit dockRequested here — that writes IsFloating=False and causes
+    // the applet to reappear docked on next launch.
+    if (auto* p = qobject_cast<QWidget*>(parent()); m_appShuttingDown || !p || !p->isVisible()) {
         m_saveTimer->stop();
-        saveGeometry();  // capture final size/position before exit
+        saveGeometry();
         ev->accept();
         return;
     }
     // User closed the floating window manually — re-dock instead of discarding.
     saveGeometry();
     emit dockRequested(m_appletId);
-    ev->ignore();  // AppletPanel::dockApplet() will hide/destroy this window
+    ev->ignore();
 }
 
 } // namespace AetherSDR

--- a/src/gui/FloatingAppletWindow.h
+++ b/src/gui/FloatingAppletWindow.h
@@ -42,6 +42,7 @@ signals:
 
 protected:
     void closeEvent(QCloseEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
     void resizeEvent(QResizeEvent* ev) override;
     void moveEvent(QMoveEvent* ev) override;
 
@@ -50,6 +51,7 @@ private:
     QVBoxLayout* m_contentLayout{nullptr};
     QTimer*      m_saveTimer{nullptr};        // debounce geometry saves on resize/move
     bool         m_restoringGeometry{false};  // suppresses debounce during restoreGeometry/showAndRestore
+    bool         m_appShuttingDown{false};    // set on aboutToQuit — prevents dockRequested on close
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
Fix floating applets losing float state and position across restarts (#959)

Four distinct bugs in the floating applet save/restore cycle, all fixed.

## Bug 1 — Float state lost on toggle off/on (#959)

When a floating applet was toggled off and back on it reappeared docked.
Root cause: toggle button handlers and setTunerVisible/setAmpVisible/
setAgVisible re-enable paths did not check IsFloating from AppSettings
when no floating window was present. The bare QWidget::setVisible()
connections for TUN/AMP/AG were replaced with float-aware lambdas. All
toggle handlers now call floatApplet() via QTimer::singleShot(0) when
IsFloating is True, matching the startup restore logic.

setTunerVisible/setAmpVisible/setAgVisible also apply the same check on
the visible=true path (device reconnect). On the visible=false path they
now call hideAndSave() instead of dockApplet(), preserving IsFloating so
the window returns floating on reconnect.

## Bug 2 — Window drift on every hide/show cycle

saveGeometry() was saving geometry().x()/y() (client-area origin) and
restoring with move() (frame origin). The decoration height accumulated
on every cycle, drifting the window down one title-bar height per show.
Fix: save pos() for x/y and geometry().size() for w/h.

## Bug 3 — WM centering overwriting saved position on restore

On show(), the WM re-centers the window and fires moveEvent, starting
the 400ms debounce timer. restoreGeometry() at 200ms moved the window
correctly, but the WM's ConfigureNotify for that move arrived after the
guard cleared at 500ms, restarting the debounce and saving the centered
position. Three-part fix:

- showAndRestore() owns the entire guard lifetime: sets
  m_restoringGeometry=true before show(), clears at 650ms (200ms delay
  + 300ms WM settle + 150ms safety). Previously cleared at 500ms.
- restoreGeometry() no longer manages the guard — it was racing with
  showAndRestore's lifetime and clearing it early.
- moveEvent and resizeEvent check the guard before starting the debounce
  timer; dockApplet() uses hideAndSave() to stop the debounce timer
  before hiding so a pending callback cannot fire on a hidden window.

## Bug 4 — Float state and positions lost on app restart (Windows)

Three separate causes:

**a) Shutdown race (all platforms)**
On Windows, the OS sends WM_CLOSE to all owned tool windows when the
main window closes. Whichever floating windows received their close event
before AppletPanel became invisible triggered the "user docked it" branch
of closeEvent, writing IsFloating=False. Timing was non-deterministic so
different applets failed on different exits.
Fix: FloatingAppletWindow connects to QCoreApplication::aboutToQuit and
sets m_appShuttingDown=true. closeEvent checks this flag and takes the
"save and accept" branch regardless of parent visibility, so dockRequested
is never emitted during shutdown.

**b) P/CW applet ID contains '/' — invalid XML element name**
AppSettings::save() writes keys as XML element names. The key
"FloatingApplet_P/CW_IsFloating" is not valid XML. The validKey regex
incorrectly allowed '/' so the malformed element was written to the temp
file. The post-write XML validator caught it and aborted the entire save —
meaning ALL settings changes in any session where P/CW was floating were
silently discarded (positions, IsFloating, frequency, etc.).
Fix: validKey regex tightened to ^[A-Za-z_][A-Za-z0-9_]*$ (no '/' or '.').
A settingsPrefix() helper in FloatingAppletWindow and a floatKey() helper
in AppletPanel sanitize '/' to '_' before forming any settings key, so
"P/CW" maps to "FloatingApplet_P_CW_*" keys throughout.

**c) Geometry not saved on shutdown**
saveGeometry() was only called from the debounce timer and dockApplet().
On app exit the windows are destroyed without an explicit dock, so the
final position was never written.
Fix: saveGeometry() is now called explicitly in hideAndSave() (before
hide()), in both branches of closeEvent, and in hideEvent as a
belt-and-suspenders backup for Linux-style parent-cascade hides. This
ensures geometry is captured from a valid window state on every platform
regardless of which shutdown path the WM takes.

NOTE: S-Meter applet is still not fixed.. Lower priority to fix the above mentioned key underlying bugs: this was very difficult to chase down on Windows.

Fixes #959