### PR TITLE
[feature] Add HF propagation conditions overlay (K-index + SFI) to panadapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,7 @@ set(CORE_SOURCES
     src/core/WsjtxClient.cpp
     src/core/SpotCollectorClient.cpp
     src/core/PotaClient.cpp
+    src/core/PropForecastClient.cpp
     src/core/RigctlServer.cpp
     src/core/TciServer.cpp
     src/core/TciProtocol.cpp

--- a/src/core/PropForecastClient.cpp
+++ b/src/core/PropForecastClient.cpp
@@ -1,0 +1,150 @@
+#include "PropForecastClient.h"
+#include "AppSettings.h"
+
+#include <QDateTime>
+#include <QLoggingCategory>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrl>
+#include <QXmlStreamReader>
+
+Q_LOGGING_CATEGORY(lcPropForecast, "aether.propforecast")
+
+namespace AetherSDR {
+
+PropForecastClient::PropForecastClient(QObject* parent)
+    : QObject(parent)
+{
+    m_timer.setSingleShot(false);
+    m_timer.setInterval(kIntervalMs);
+    connect(&m_timer, &QTimer::timeout, this, &PropForecastClient::onTimer);
+}
+
+// ── Enable / disable ─────────────────────────────────────────────────────────
+
+void PropForecastClient::setEnabled(bool on)
+{
+    if (m_enabled == on) { return; }
+    m_enabled = on;
+
+    if (on) {
+        // Restore cached values so the overlay appears instantly on startup.
+        loadCache();
+        if (m_last.kIndex >= 0 && m_last.sfi > 0) {
+            emit forecastUpdated(m_last);
+        }
+
+        // Only hit the network if the cache is stale (>= 1 hour old).
+        fetchIfStale();
+        m_timer.start();
+    } else {
+        m_timer.stop();
+    }
+}
+
+// ── Timer callback ───────────────────────────────────────────────────────────
+
+void PropForecastClient::onTimer()
+{
+    fetchIfStale();
+}
+
+// ── Fetch logic ──────────────────────────────────────────────────────────────
+
+void PropForecastClient::fetchIfStale()
+{
+    qint64 now = QDateTime::currentMSecsSinceEpoch();
+    qint64 age = now - m_lastFetchMs;
+
+    if (m_lastFetchMs > 0 && age < kIntervalMs) {
+        qCDebug(lcPropForecast) << "cache is" << (age / 1000) << "s old — skipping fetch";
+        return;
+    }
+
+    fetch();
+}
+
+void PropForecastClient::fetch()
+{
+    // Guard against overlapping requests (e.g. slow network + timer fires again).
+    if (m_fetchInFlight) {
+        qCDebug(lcPropForecast) << "fetch already in flight — skipping";
+        return;
+    }
+    m_fetchInFlight = true;
+
+    QNetworkRequest req{QUrl{QString(kUrl)}};
+    req.setHeader(QNetworkRequest::UserAgentHeader, "AetherSDR");
+    auto* reply = m_nam.get(req);
+
+    connect(reply, &QNetworkReply::finished, this, [this, reply] {
+        reply->deleteLater();
+        m_fetchInFlight = false;
+
+        if (reply->error() != QNetworkReply::NoError) {
+            qCWarning(lcPropForecast) << "fetch failed:" << reply->errorString();
+            emit fetchError(reply->errorString());
+            return;
+        }
+
+        QByteArray data = reply->readAll();
+        QXmlStreamReader xml(data);
+
+        PropForecast fc;
+        while (!xml.atEnd()) {
+            xml.readNext();
+            if (!xml.isStartElement()) { continue; }
+            QString tag = xml.name().toString();
+            if (tag == QLatin1String("kindex")) {
+                fc.kIndex = xml.readElementText().toInt();
+            } else if (tag == QLatin1String("solarflux")) {
+                fc.sfi = xml.readElementText().toInt();
+            }
+        }
+
+        if (xml.hasError()) {
+            qCWarning(lcPropForecast) << "XML parse error:" << xml.errorString();
+            emit fetchError(xml.errorString());
+            return;
+        }
+
+        if (fc.kIndex >= 0 && fc.sfi > 0) {
+            m_last = fc;
+            m_lastFetchMs = QDateTime::currentMSecsSinceEpoch();
+            saveCache();
+            emit forecastUpdated(m_last);
+            qCDebug(lcPropForecast) << "updated — K" << fc.kIndex << "SFI" << fc.sfi;
+        } else {
+            qCWarning(lcPropForecast) << "unexpected XML — kIndex:" << fc.kIndex << "sfi:" << fc.sfi;
+        }
+    });
+}
+
+// ── AppSettings persistence ──────────────────────────────────────────────────
+
+void PropForecastClient::loadCache()
+{
+    auto& s = AppSettings::instance();
+    int k   = s.value("PropForecastKIndex", "-1").toInt();
+    int sfi = s.value("PropForecastSfi",    "-1").toInt();
+    qint64 ts = s.value("PropForecastTimestamp", "0").toLongLong();
+
+    if (k >= 0 && sfi > 0 && ts > 0) {
+        m_last.kIndex  = k;
+        m_last.sfi     = sfi;
+        m_lastFetchMs  = ts;
+        qCDebug(lcPropForecast) << "restored cache — K" << k << "SFI" << sfi
+                                << "age" << ((QDateTime::currentMSecsSinceEpoch() - ts) / 1000) << "s";
+    }
+}
+
+void PropForecastClient::saveCache()
+{
+    auto& s = AppSettings::instance();
+    s.setValue("PropForecastKIndex",    QString::number(m_last.kIndex));
+    s.setValue("PropForecastSfi",       QString::number(m_last.sfi));
+    s.setValue("PropForecastTimestamp",  QString::number(m_lastFetchMs));
+    s.save();
+}
+
+} // namespace AetherSDR

--- a/src/core/PropForecastClient.h
+++ b/src/core/PropForecastClient.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <QObject>
+#include <QNetworkAccessManager>
+#include <QTimer>
+
+namespace AetherSDR {
+
+struct PropForecast {
+    int kIndex{-1};  // Planetary K-index 0-9; -1 = not yet fetched
+    int sfi{-1};     // Solar Flux Index (SFU); -1 = not yet fetched
+};
+
+// Fetches HF propagation conditions from https://www.hamqsl.com/solarxml.php
+// once per hour. The timer is only armed while enabled. Uses QNetworkAccessManager
+// (async) so the download never blocks radio operations.
+//
+// Hardening:
+//   - Persists last K/SFI + timestamp to AppSettings so the overlay is
+//     available immediately on restart without waiting for a network fetch.
+//   - Skips the network fetch if cached data is less than one hour old.
+//   - Guards against overlapping in-flight requests.
+class PropForecastClient : public QObject {
+    Q_OBJECT
+
+public:
+    explicit PropForecastClient(QObject* parent = nullptr);
+
+    void setEnabled(bool on);
+    bool isEnabled() const { return m_enabled; }
+
+    PropForecast lastForecast() const { return m_last; }
+
+signals:
+    void forecastUpdated(const PropForecast& forecast);
+    void fetchError(const QString& error);
+
+private slots:
+    void onTimer();
+
+private:
+    void fetchIfStale();          // only fetches when cache is older than kIntervalMs
+    void fetch();                 // unconditional network request
+
+    void loadCache();             // restore from AppSettings
+    void saveCache();             // persist to AppSettings
+
+    QNetworkAccessManager m_nam;
+    QTimer               m_timer;
+    PropForecast         m_last;
+    bool                 m_enabled{false};
+    bool                 m_fetchInFlight{false};
+    qint64               m_lastFetchMs{0};  // QDateTime::currentMSecsSinceEpoch of last success
+
+    static constexpr const char* kUrl = "https://www.hamqsl.com/solarxml.php";
+    static constexpr int kIntervalMs  = 60 * 60 * 1000;  // 1 hour
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -391,6 +391,19 @@ MainWindow::MainWindow(QWidget* parent)
 #endif
     m_spotThread->start();
 
+    // ── HF Propagation Forecast ────────────────────────────────────────────
+    m_propForecast = new PropForecastClient(this);
+    connect(m_propForecast, &PropForecastClient::forecastUpdated,
+            this, [this](const PropForecast& fc) {
+        for (PanadapterApplet* applet : m_panStack->allApplets()) {
+            applet->spectrumWidget()->setPropForecast(fc.kIndex, fc.sfi);
+        }
+    });
+    // Restore persisted setting — timer only arms if enabled
+    if (AppSettings::instance().value("PropForecastEnabled", "False").toString() == "True") {
+        m_propForecast->setEnabled(true);
+    }
+
     // ── Spot forwarding: dedup + batch queue + 1/sec flush ────────────────
 
     // Dedup helper — returns true if spot should be skipped
@@ -3288,6 +3301,27 @@ void MainWindow::buildMenuBar()
         toggleMinimalMode(on);
     });
 
+    auto* propForecastAct = viewMenu->addAction("Propagation Conditions");
+    propForecastAct->setCheckable(true);
+    propForecastAct->setChecked(
+        AppSettings::instance().value("PropForecastEnabled", "False").toString() == "True");
+    connect(propForecastAct, &QAction::toggled, this, [this](bool on) {
+        AppSettings::instance().setValue("PropForecastEnabled", on ? "True" : "False");
+        AppSettings::instance().save();
+        // Enable/disable the client (timer only runs when on)
+        m_propForecast->setEnabled(on);
+        // Show/hide the overlay on all panadapters immediately
+        for (PanadapterApplet* applet : m_panStack->allApplets()) {
+            applet->spectrumWidget()->setPropForecastVisible(on);
+        }
+        // If turning off, clear the stale values so they don't reappear
+        if (!on) {
+            for (PanadapterApplet* applet : m_panStack->allApplets()) {
+                applet->spectrumWidget()->setPropForecast(-1, -1);
+            }
+        }
+    });
+
     m_keyboardShortcutsEnabled = AppSettings::instance()
         .value("KeyboardShortcutsEnabled", "False").toString() == "True";
     auto* kbAct = viewMenu->addAction("Keyboard Shortcuts");
@@ -3455,6 +3489,9 @@ void MainWindow::buildMenuBar()
             "github.com/ten9876/AetherSDR</a></p>"
             "<p style='font-size:10px; color:#6a8090;'>"
             "SmartSDR protocol &copy; FlexRadio Systems</p>"
+            "<p style='font-size:10px; color:#6a8090;'>"
+            "HF propagation forecasts provided by "
+            "<a href='https://www.hamqsl.com/' style='color:#8aa8c0;'>hamqsl.com</a></p>"
             "</div>");
         footer->setAlignment(Qt::AlignCenter);
         footer->setOpenExternalLinks(true);
@@ -4848,6 +4885,15 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 
     // Set panId on the overlay menu so +RX routes to the correct pan
     menu->setPanId(applet->panId());
+
+    // Apply current prop forecast state to this (possibly new) panadapter
+    if (m_propForecast) {
+        sw->setPropForecastVisible(m_propForecast->isEnabled());
+        if (m_propForecast->isEnabled()) {
+            PropForecast fc = m_propForecast->lastForecast();
+            sw->setPropForecast(fc.kIndex, fc.sfi);
+        }
+    }
 
     // Restore per-pan cursor freq state from AppSettings
     {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -17,6 +17,7 @@
 #include "core/WsjtxClient.h"
 #include "core/SpotCollectorClient.h"
 #include "core/PotaClient.h"
+#include "core/PropForecastClient.h"
 #ifdef HAVE_WEBSOCKETS
 #include "core/FreeDvClient.h"
 #endif
@@ -159,7 +160,8 @@ private:
     DxClusterClient*   m_rbnClient{nullptr};
     WsjtxClient*       m_wsjtxClient{nullptr};
     SpotCollectorClient* m_spotCollectorClient{nullptr};
-    PotaClient*        m_potaClient{nullptr};
+    PotaClient*          m_potaClient{nullptr};
+    PropForecastClient*  m_propForecast{nullptr};
 #ifdef HAVE_WEBSOCKETS
     FreeDvClient*      m_freedvClient{nullptr};
 #endif

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2185,24 +2185,32 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             drawSliceMarkers(p, specRect, wfRect);
             drawOffScreenSlices(p, specRect);
 
-            // WNB / RF gain indicators (horizontal, top-left of spectrum)
-            if (m_wnbActive || m_rfGainValue != 0) {
-                QFont indFont(p.font().family(), 14, QFont::Bold);
-                p.setFont(indFont);
-                p.setPen(QColor(0xc8, 0xd8, 0xe8, 180));
-                const QFontMetrics fm(indFont);
-                int y = specRect.top() + fm.ascent() + 4;
-                // Build combined label, measure, and right-align
-                QString label;
-                if (m_wnbActive)
-                    label += QStringLiteral("WNB");
-                if (m_rfGainValue != 0) {
-                    if (!label.isEmpty()) label += QStringLiteral("   ");
-                    label += QStringLiteral("%1%2 dB")
-                        .arg(m_rfGainValue > 0 ? "+" : "").arg(m_rfGainValue);
+            // WNB / RF gain / Prop forecast indicators (top-right of spectrum)
+            {
+                const bool showProp = m_propForecastVisible && m_propKIndex >= 0 && m_propSfi > 0;
+                if (m_wnbActive || m_rfGainValue != 0 || showProp) {
+                    QFont indFont(p.font().family(), 14, QFont::Bold);
+                    p.setFont(indFont);
+                    p.setPen(QColor(0xc8, 0xd8, 0xe8, 180));
+                    const QFontMetrics fm(indFont);
+                    int y = specRect.top() + fm.ascent() + 4;
+                    // Build combined label (left to right: prop, WNB, RF gain), right-align
+                    QString label;
+                    if (showProp) {
+                        label += QString("K%1  SFI %2").arg(m_propKIndex).arg(m_propSfi);
+                    }
+                    if (m_wnbActive) {
+                        if (!label.isEmpty()) { label += QStringLiteral("   "); }
+                        label += QStringLiteral("WNB");
+                    }
+                    if (m_rfGainValue != 0) {
+                        if (!label.isEmpty()) { label += QStringLiteral("   "); }
+                        label += QStringLiteral("%1%2 dB")
+                            .arg(m_rfGainValue > 0 ? "+" : "").arg(m_rfGainValue);
+                    }
+                    int x = specRect.right() - DBM_STRIP_W - 8 - fm.horizontalAdvance(label);
+                    p.drawText(x, y, label);
                 }
-                int x = specRect.right() - DBM_STRIP_W - 8 - fm.horizontalAdvance(label);
-                p.drawText(x, y, label);
             }
 
             // Cursor frequency label (#726)
@@ -2688,36 +2696,48 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         m_overlayMenu->raiseAll();
     }
 
-    // ── WNB / RF Gain indicators (top-right of FFT area) ──────────────────
-    if (m_wnbActive || m_rfGainValue != 0) {
-        QFont indFont = p.font();
-        indFont.setPointSize(18);
-        indFont.setBold(true);
-        p.setFont(indFont);
-        p.setPen(QColor(255, 255, 255, 84));
+    // ── WNB / RF Gain / Prop Forecast indicators (top-right of FFT area) ────
+    {
+        const bool showProp = m_propForecastVisible && m_propKIndex >= 0 && m_propSfi > 0;
+        if (m_wnbActive || m_rfGainValue != 0 || showProp) {
+            QFont indFont = p.font();
+            indFont.setPointSize(18);
+            indFont.setBold(true);
+            p.setFont(indFont);
+            p.setPen(QColor(255, 255, 255, 84));
 
-        const QFontMetrics fm(indFont);
-        const int rightEdge = specRect.right() - DBM_STRIP_W - 6;
-        const int topY = specRect.top() + fm.ascent() + 2;
+            const QFontMetrics fm(indFont);
+            const int rightEdge = specRect.right() - DBM_STRIP_W - 6;
+            const int topY = specRect.top() + fm.ascent() + 2;
 
-        int x = rightEdge;
+            int x = rightEdge;
 
-        // RF Gain (rightmost)
-        if (m_rfGainValue != 0) {
-            QString gainStr = (m_rfGainValue > 0)
-                ? QString("+%1dB").arg(m_rfGainValue)
-                : QString("%1dB").arg(m_rfGainValue);
-            int gw = fm.horizontalAdvance(gainStr);
-            x -= gw;
-            p.drawText(x, topY, gainStr);
-            x -= 10;  // gap between labels
-        }
+            // RF Gain (rightmost)
+            if (m_rfGainValue != 0) {
+                QString gainStr = (m_rfGainValue > 0)
+                    ? QString("+%1dB").arg(m_rfGainValue)
+                    : QString("%1dB").arg(m_rfGainValue);
+                int gw = fm.horizontalAdvance(gainStr);
+                x -= gw;
+                p.drawText(x, topY, gainStr);
+                x -= 10;  // gap between labels
+            }
 
-        // WNB (to the left of RF Gain)
-        if (m_wnbActive) {
-            int ww = fm.horizontalAdvance("WNB");
-            x -= ww;
-            p.drawText(x, topY, "WNB");
+            // WNB (to the left of RF Gain)
+            if (m_wnbActive) {
+                int ww = fm.horizontalAdvance("WNB");
+                x -= ww;
+                p.drawText(x, topY, "WNB");
+                x -= 10;
+            }
+
+            // Prop forecast (leftmost: "K3  SFI 110")
+            if (showProp) {
+                QString propStr = QString("K%1  SFI %2").arg(m_propKIndex).arg(m_propSfi);
+                int pw = fm.horizontalAdvance(propStr);
+                x -= pw;
+                p.drawText(x, topY, propStr);
+            }
         }
     }
 

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -133,6 +133,12 @@ public:
     void setWnbActive(bool on) { m_wnbActive = on; markOverlayDirty(); }
     void setRfGain(int gain) { m_rfGainValue = gain; markOverlayDirty(); }
 
+    // HF propagation forecast overlay (K-index and Solar Flux Index).
+    // Values of -1 mean not yet fetched; visible only when enabled.
+    void setPropForecastVisible(bool on) { m_propForecastVisible = on; markOverlayDirty(); }
+    void setPropForecast(int kIndex, int sfi) { m_propKIndex = kIndex; m_propSfi = sfi; markOverlayDirty(); }
+    bool propForecastVisible() const { return m_propForecastVisible; }
+
     // NB Waterfall Blanker (#277) — client-side impulse suppression
     void setWfBlankerEnabled(bool on);
     void setWfBlankerThreshold(float t);
@@ -445,6 +451,11 @@ private:
     // On-screen indicators (WNB, RF Gain)
     bool m_wnbActive{false};
     int  m_rfGainValue{0};
+
+    // HF propagation forecast overlay
+    bool m_propForecastVisible{false};
+    int  m_propKIndex{-1};
+    int  m_propSfi{-1};
 
     // Background image
     QImage  m_bgImage;


### PR DESCRIPTION
<img width="1820" height="1126" alt="Screenshot 2026-04-07 at 8 06 17 PM" src="https://github.com/user-attachments/assets/abfabb14-beed-4b93-a193-0c6348ba4ed3" />

## Summary
- Display current K-index and Solar Flux Index (e.g. `K3  SFI 110`) in the upper-right corner of each panadapter, to the left of WNB / RF Gain indicators
- Data fetched asynchronously from [hamqsl.com](https://www.hamqsl.com/) XML API — max once per hour, cached in AppSettings across restarts
- Toggled via **View → Propagation Conditions**, persists across app launch
- Both GPU (`QRhiWidget`) and non-GPU (`paintEvent`) rendering paths supported
- In-flight request guard prevents overlapping fetches; stale-check skips network if cache is fresh
- hamqsl.com credit added to About dialog

## Test plan
- [ ] Enable View → Propagation Conditions, verify K-index and SFI appear in the panadapter top-right within a few seconds
- [ ] Restart the app — overlay should appear instantly from cache without waiting for network
- [ ] Toggle off and back on within a few minutes — verify no duplicate network request (check `aether.propforecast` debug log)
- [ ] Verify multi-pan: both panadapters show the overlay when a second pan is created
- [ ] Disable the menu item — overlay clears immediately from all pans

🤖 Generated with [Claude Code](https://claude.com/claude-code)