### PR TITLE
[shortcuts] Fix keyboard tuning: stale base, auto-repeat, auto-center

### DIFF
--- a/src/core/ShortcutManager.cpp
+++ b/src/core/ShortcutManager.cpp
@@ -13,7 +13,8 @@ ShortcutManager::ShortcutManager(QObject* parent)
 
 void ShortcutManager::registerAction(const QString& id, const QString& displayName,
                                      const QString& category, const QKeySequence& defaultKey,
-                                     std::function<void()> handler)
+                                     std::function<void()> handler,
+                                     bool autoRepeat)
 {
     // Prevent duplicate registration
     for (const auto& a : m_actions) {
@@ -22,7 +23,8 @@ void ShortcutManager::registerAction(const QString& id, const QString& displayNa
             return;
         }
     }
-    m_actions.append({id, displayName, category, defaultKey, defaultKey, std::move(handler)});
+    m_actions.append({id, displayName, category, defaultKey, defaultKey,
+                      std::move(handler), autoRepeat});
 }
 
 void ShortcutManager::setBinding(const QString& actionId, const QKeySequence& key)
@@ -126,7 +128,7 @@ void ShortcutManager::rebuildShortcuts(QWidget* parent,
         if (a.currentKey.isEmpty() || !a.handler) continue;
 
         auto* sc = new QShortcut(a.currentKey, parent);
-        sc->setAutoRepeat(false);
+        sc->setAutoRepeat(a.autoRepeat);
         auto handler = a.handler;
         connect(sc, &QShortcut::activated, this, [guardFn, handler]() {
             if (guardFn && !guardFn()) return;

--- a/src/core/ShortcutManager.h
+++ b/src/core/ShortcutManager.h
@@ -19,6 +19,7 @@ public:
         QKeySequence defaultKey;
         QKeySequence currentKey;
         std::function<void()> handler;
+        bool autoRepeat{false};   // allow key-hold repeat (e.g. tuning)
     };
 
     explicit ShortcutManager(QObject* parent = nullptr);
@@ -26,7 +27,8 @@ public:
     // Register an action with its default key binding and handler
     void registerAction(const QString& id, const QString& displayName,
                         const QString& category, const QKeySequence& defaultKey,
-                        std::function<void()> handler);
+                        std::function<void()> handler,
+                        bool autoRepeat = false);
 
     // Binding management
     void setBinding(const QString& actionId, const QKeySequence& key);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1557,6 +1557,7 @@ MainWindow::MainWindow(QWidget* parent)
         qDebug() << "HID encoder:" << (connected ? "connected" : "disconnected") << name;
     });
 
+    // StreamDeck native integration removed — use TCI StreamController plugin instead.
 #endif
 
     // Start the external controller thread — objects are already moved
@@ -5793,18 +5794,16 @@ void MainWindow::updateKeyerAvailability(const QString& mode)
 
 void MainWindow::registerShortcutActions()
 {
-    // Helper: nudge active slice frequency by N steps on the active pan
+    // Helper: nudge active slice frequency by N steps.
+    // Uses tuneAndRecenter() so m_frequency is updated immediately (no stale
+    // base on rapid presses) and the radio keeps the slice centered in the pan.
     auto nudgeFreq = [this](int steps) {
         if (!m_radioModel.isConnected()) return;
         auto* s = activeSlice();
         if (!s || s->isLocked()) return;
         int stepHz = spectrum() ? spectrum()->stepSize() : 100;
         double newMhz = s->frequency() + steps * stepHz / 1e6;
-        QString panId = m_panStack ? m_panStack->activePanId() : m_radioModel.panId();
-        if (!panId.isEmpty())
-            m_radioModel.sendCommand(
-                QString("slice m %1 pan=%2").arg(newMhz, 0, 'f', 6).arg(panId));
-        if (spectrum()) spectrum()->setVfoFrequency(newMhz);
+        s->tuneAndRecenter(newMhz);
     };
 
     // Step cycle helper
@@ -5823,14 +5822,15 @@ void MainWindow::registerShortcutActions()
     };
 
     // ── Frequency ───────────────────────────────────────────────────────
+    // autoRepeat=true so holding the key continuously tunes (accessibility).
     m_shortcutManager.registerAction("tune_up_1", "Tune Up (1 step)", "Frequency",
-        QKeySequence(Qt::Key_Right), [nudgeFreq]() { nudgeFreq(1); });
+        QKeySequence(Qt::Key_Right), [nudgeFreq]() { nudgeFreq(1); }, true);
     m_shortcutManager.registerAction("tune_down_1", "Tune Down (1 step)", "Frequency",
-        QKeySequence(Qt::Key_Left), [nudgeFreq]() { nudgeFreq(-1); });
+        QKeySequence(Qt::Key_Left), [nudgeFreq]() { nudgeFreq(-1); }, true);
     m_shortcutManager.registerAction("tune_up_10", "Tune Up (10 steps)", "Frequency",
-        QKeySequence(Qt::SHIFT | Qt::Key_Right), [nudgeFreq]() { nudgeFreq(10); });
+        QKeySequence(Qt::SHIFT | Qt::Key_Right), [nudgeFreq]() { nudgeFreq(10); }, true);
     m_shortcutManager.registerAction("tune_down_10", "Tune Down (10 steps)", "Frequency",
-        QKeySequence(Qt::SHIFT | Qt::Key_Left), [nudgeFreq]() { nudgeFreq(-10); });
+        QKeySequence(Qt::SHIFT | Qt::Key_Left), [nudgeFreq]() { nudgeFreq(-10); }, true);
     m_shortcutManager.registerAction("tune_up_1mhz", "Tune Up 1 MHz", "Frequency",
         QKeySequence(), [nudgeFreq]() { nudgeFreq(10000); });
     m_shortcutManager.registerAction("tune_down_1mhz", "Tune Down 1 MHz", "Frequency",


### PR DESCRIPTION
## Summary

Fixes three related issues with arrow-key (Left/Right, Shift+Left/Right) frequency tuning that made keyboard-only operation unreliable:

- **Bug fix — Right arrow tuned in the wrong direction.** The `nudgeFreq` helper sent a raw `slice m` command without updating the local `m_frequency` field. Every keypress computed its delta from the last *radio-confirmed* frequency rather than the optimistic local state. Under normal use the VFO display raced ahead of `m_frequency`, and subsequent presses computed a target from the stale (lower) base — producing a frequency lower than what was displayed, making the right arrow appear to tune left after ~10 presses. Fixed by calling `tuneAndRecenter()` which updates `m_frequency` immediately before sending the command, matching the scroll-wheel and FlexControl encoder tuning paths that already worked correctly.

- **Enhancement — Hold arrow keys to continuously tune.** All keyboard shortcuts had `setAutoRepeat(false)` hardcoded, forcing users to press the key individually for every single tuning step. Added a per-action `autoRepeat` flag to `ShortcutManager::Action` (defaults to `false`) so only the four tuning shortcuts opt in. Toggle actions (MOX, band, mode, etc.) remain single-fire. Qt handles the OS key-repeat rate automatically on all platforms.

- **Enhancement — Slice stays centered during keyboard tuning.** The original code used `slice m` which recentered the panadapter, but the initial bug fix replacement `setFrequency()` sends `slice tune autopan=0` which does not — causing the slice marker to drift off-screen during extended tuning. Switched to `tuneAndRecenter()` which sends `slice tune` without `autopan=0`, keeping the slice centered so VFO controls remain accessible.

## Files changed

- `src/core/ShortcutManager.h` — Added `autoRepeat` field to `Action` struct and optional parameter to `registerAction()`
- `src/core/ShortcutManager.cpp` — Wire `autoRepeat` flag through registration and `rebuildShortcuts()`
- `src/gui/MainWindow.cpp` — `nudgeFreq` uses `tuneAndRecenter()` instead of raw `sendCommand()`; four tuning shortcuts pass `autoRepeat=true`

## Test plan

- [ ] Press Right arrow — frequency increases, slice stays centered in panadapter
- [ ] Press Left arrow — frequency decreases, slice stays centered
- [ ] Rapid-fire Right arrow 20+ times — frequency increases monotonically, never reverses
- [ ] Hold Right arrow — continuous tuning at OS key-repeat rate
- [ ] Hold Shift+Right arrow — continuous tuning at 10× step rate
- [ ] Scroll wheel on panadapter — still works correctly (separate code path, unchanged)
- [ ] Click-to-tune on panadapter — still works correctly (unchanged)
- [ ] MOX / band / mode shortcuts — do NOT auto-repeat when held
- [ ] Verify on macOS and Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)