### PR TITLE
Fix mic bias/boost state not reflecting toggle in same session

### DIFF
--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1017,11 +1017,17 @@ QWidget* RadioSetupDialog::buildPhoneCwTab()
         row1->setSpacing(4);
         auto* biasBtn = mkTogBtn("BIAS", tx.micBias());
         connect(biasBtn, &QPushButton::toggled, this, [this](bool on) {
+            // Radio sends no status echo for mic bias — update optimistically.
+            // See upstream issue tagged protocol+upstream.
+            m_model->transmitModel().setMicBias(on);
             m_model->sendCommand(QString("mic bias %1").arg(on ? 1 : 0));
         });
         row1->addWidget(biasBtn);
         auto* boostBtn = mkTogBtn("+20dB", tx.micBoost());
         connect(boostBtn, &QPushButton::toggled, this, [this](bool on) {
+            // Radio sends no status echo for mic boost — update optimistically.
+            // See upstream issue tagged protocol+upstream.
+            m_model->transmitModel().setMicBoost(on);
             m_model->sendCommand(QString("mic boost %1").arg(on ? 1 : 0));
         });
         row1->addWidget(boostBtn);

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -59,7 +59,9 @@ public:
     int     voxLevel()      const { return m_voxLevel; }
     int     voxDelay()      const { return m_voxDelay; }
     bool    micBoost()      const { return m_micBoost; }
+    void    setMicBoost(bool v) { m_micBoost = v; }
     bool    micBias()       const { return m_micBias; }
+    void    setMicBias(bool v)  { m_micBias  = v; }
     bool    metInRx()       const { return m_metInRx; }
     bool    syncCwx()       const { return m_syncCwx; }
     int     amCarrierLevel() const { return m_amCarrierLevel; }


### PR DESCRIPTION
Fixes #951

## Summary

- The `mic bias N` and `mic boost N` commands are acknowledged by the radio (`R<seq>|0|`) but produce no status echo — confirmed via pcap from the issue reporter's support bundle. `TransmitModel::m_micBias` and `m_micBoost` therefore remained stale after toggling, so reopening the Phone/CW tab always showed the pre-toggle state.
- Added `setMicBias(bool)` and `setMicBoost(bool)` optimistic setters to `TransmitModel` and call them immediately before sending the radio command, per the project's optimistic update policy for commands with no status echo.
- The missing status echo has been reported upstream at #1045 (tagged `protocol` + `upstream`) per CLAUDE.md requirements.

## Multi-Flex note

Optimistic updates do not propagate to other clients. If a second client changes mic bias/boost, our model will not reflect it. This is an inherent limitation of the missing status echo and is tracked in #1045.

## Test plan

- [ ] Open Radio Setup → Phone/CW tab — note BIAS button state
- [ ] Uncheck BIAS — bias physically turns off
- [ ] Close and reopen Radio Setup — BIAS button remains unchecked
- [ ] Re-check BIAS, close, reopen — BIAS button remains checked
- [ ] Repeat above for +20dB boost button

🤖 Generated with [Claude Code](https://claude.com/claude-code)