### PR TITLE
Fix RADE status label not appearing after mode selection

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6705,17 +6705,24 @@ void MainWindow::activateRADE(int sliceId)
     }
 
     // RADE status indicator in VFO widget
-    if (auto* vfo = spectrum()->vfoWidget()) {
-        vfo->setRadeActive(true);
-        // Show initial unsynchronised state immediately — syncChanged only fires
-        // from feedRxAudio() which requires DAX audio to be flowing first.
-        vfo->setRadeSynced(false);
-        connect(m_radeEngine, &RADEEngine::syncChanged,
-                vfo, &VfoWidget::setRadeSynced);
-        connect(m_radeEngine, &RADEEngine::snrChanged,
-                vfo, &VfoWidget::setRadeSnr);
-        connect(m_radeEngine, &RADEEngine::freqOffsetChanged,
-                vfo, &VfoWidget::setRadeFreqOffset);
+    {
+        SpectrumWidget* sw = spectrum();
+        VfoWidget* vfo = sw ? sw->vfoWidget() : nullptr;
+        qInfo() << "MainWindow: activateRADE — spectrum=" << sw
+                << "vfoWidget=" << vfo
+                << "vfoWidget(sliceId)=" << (sw ? sw->vfoWidget(sliceId) : nullptr);
+        if (vfo) {
+            vfo->setRadeActive(true);
+            // Show initial unsynchronised state immediately — syncChanged only fires
+            // from feedRxAudio() which requires DAX audio to be flowing first.
+            vfo->setRadeSynced(false);
+            connect(m_radeEngine, &RADEEngine::syncChanged,
+                    vfo, &VfoWidget::setRadeSynced);
+            connect(m_radeEngine, &RADEEngine::snrChanged,
+                    vfo, &VfoWidget::setRadeSnr);
+            connect(m_radeEngine, &RADEEngine::freqOffsetChanged,
+                    vfo, &VfoWidget::setRadeFreqOffset);
+        }
     }
 
     qInfo() << "MainWindow: RADE mode activated on slice" << sliceId;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6704,14 +6704,11 @@ void MainWindow::activateRADE(int sliceId)
         audioStartTx(m_radioModel.radioAddress(), 4991);
     }
 
-    // RADE status indicator in VFO widget
-    {
-        SpectrumWidget* sw = spectrum();
-        VfoWidget* vfo = sw ? sw->vfoWidget() : nullptr;
-        qInfo() << "MainWindow: activateRADE — spectrum=" << sw
-                << "vfoWidget=" << vfo
-                << "vfoWidget(sliceId)=" << (sw ? sw->vfoWidget(sliceId) : nullptr);
-        if (vfo) {
+    // RADE status indicator in VFO widget.
+    // Use vfoWidget(sliceId) — the no-arg alias (m_vfoWidget) may be null
+    // if setActiveVfoWidget() hasn't been called yet for this slice.
+    if (auto* sw = spectrum()) {
+        if (auto* vfo = sw->vfoWidget(sliceId)) {
             vfo->setRadeActive(true);
             // Show initial unsynchronised state immediately — syncChanged only fires
             // from feedRxAudio() which requires DAX audio to be flowing first.
@@ -6734,11 +6731,13 @@ void MainWindow::deactivateRADE()
     if (m_radeSliceId >= 0) {
         if (auto* s = m_radioModel.slice(m_radeSliceId))
             s->setAudioMute(m_radePrevMute);
+        // Clear RADE status label before resetting sliceId
+        if (auto* sw = spectrum()) {
+            if (auto* vfo = sw->vfoWidget(m_radeSliceId))
+                vfo->setRadeActive(false);
+        }
         m_radeSliceId = -1;
     }
-
-    if (auto* vfo = spectrum()->vfoWidget())
-        vfo->setRadeActive(false);
 
     m_audio->setRadeMode(false);
     m_audio->clearTxAccumulators();  // flush stale RADE modem data

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6707,6 +6707,9 @@ void MainWindow::activateRADE(int sliceId)
     // RADE status indicator in VFO widget
     if (auto* vfo = spectrum()->vfoWidget()) {
         vfo->setRadeActive(true);
+        // Show initial unsynchronised state immediately — syncChanged only fires
+        // from feedRxAudio() which requires DAX audio to be flowing first.
+        vfo->setRadeSynced(false);
         connect(m_radeEngine, &RADEEngine::syncChanged,
                 vfo, &VfoWidget::setRadeSynced);
         connect(m_radeEngine, &RADEEngine::snrChanged,


### PR DESCRIPTION
## Summary

- The RADE status label (showing sync state and SNR) never appeared after selecting RADE mode, even though the engine started and activated successfully.
- Deactivating RADE also silently failed to clear the label.

## Root Cause

`activateRADE()` and `deactivateRADE()` both used `spectrum()->vfoWidget()` (no-arg), which returns `m_vfoWidget` — an alias maintained by `setActiveVfoWidget()`. This alias is only set when the user switches between slices. **In the most common case — a single-slice session — `setActiveVfoWidget()` is never called because there is no slice-switch event to trigger it, so `m_vfoWidget` remains null for the entire session.** Both functions were silently skipping all label updates via a null pointer guard.

Confirmed via debug logging:
```
spectrum= 0x... vfoWidget= QWidget(0x0) vfoWidget(sliceId)= AetherSDR::VfoWidget(0x...)
```

`vfoWidget(sliceId)` looks up by slice ID in the `m_vfoWidgets` map and always returns the correct widget regardless of whether a slice switch has occurred.

## Changes

- `activateRADE()`: use `sw->vfoWidget(sliceId)` instead of `sw->vfoWidget()`; call `setRadeSynced(false)` immediately after `setRadeActive(true)` so the label shows "RADE ○ ---" before any DAX audio arrives (previously `syncChanged` would only fire once `feedRxAudio()` ran, requiring an active received signal)
- `deactivateRADE()`: same fix, and also moved the `setRadeActive(false)` call before `m_radeSliceId = -1` since the slice ID was already cleared by the time the old lookup ran

## Test plan

- [x] Connect radio, select RADE from mode dropdown — status label shows "RADE ○ ---" immediately
- [ ] Receive a RADE signal — label updates to show sync state and SNR
- [x] Switch away from RADE — label disappears
- [x] Repeat with a single slice open (most common case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)