### PR TITLE
Add panadapter zoom +/- buttons and trackpad pinch-to-zoom

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4735,6 +4735,10 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     // Wire band plan manager to this spectrum widget
     sw->setBandPlanManager(m_bandPlanMgr);
 
+    // Set panadapter bandwidth zoom limits based on radio model
+    sw->setBandwidthLimits(m_radioModel.minPanBandwidthMhz(),
+                           m_radioModel.maxPanBandwidthMhz());
+
     // Set panId on the overlay menu so +RX routes to the correct pan
     menu->setPanId(applet->panId());
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -251,6 +251,9 @@ private:
     QLabel* m_gpsStatusLabel{nullptr};
     QLabel* m_gridLabel{nullptr};
     QLabel* m_paTempLabel{nullptr};
+    QLabel* m_cpuLabel{nullptr};
+    int     m_cpuDisplayMode{0};
+    QTimer* m_cpuTimer{nullptr};
     QLabel* m_supplyVoltLabel{nullptr};
     QLabel* m_networkLabel{nullptr};
     QLabel* m_tgxlIndicator{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -173,21 +173,15 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     });
 
     // Bandwidth zoom: − zooms out (wider BW), + zooms in (narrower BW)
+    // Send both bandwidth AND current center to prevent the radio from
+    // auto-centering the panadapter (which causes band jumps).
     auto emitZoom = [this](double factor) {
-        const double newBw = std::clamp(m_bandwidthMhz * factor, 0.004, 14.0);
-        double zoomCenter = m_centerMhz;
-        if (const auto* ao = activeOverlay()) {
-            if (m_mode == "USB" || m_mode == "LSB" || m_mode == "DIGU" || m_mode == "DIGL" || m_mode == "RTTY") {
-                zoomCenter = ao->freqMhz + (ao->filterLowHz + ao->filterHighHz) / 2.0 / 1.0e6;
-            } else {
-                zoomCenter = ao->freqMhz;
-            }
-        }
+        const double newBw = m_bandwidthMhz * factor;
+        if (newBw < m_minBwMhz || newBw > m_maxBwMhz) { return; }  // at limit
         m_bandwidthMhz = newBw;
-        m_centerMhz = zoomCenter;
         markOverlayDirty();
         emit bandwidthChangeRequested(newBw);
-        emit centerChangeRequested(zoomCenter);
+        emit centerChangeRequested(m_centerMhz);  // anchor the current center
     };
     connect(m_zoomOutBtn, &QPushButton::clicked, this, [emitZoom]() { emitZoom(1.5); });
     connect(m_zoomInBtn,  &QPushButton::clicked, this, [emitZoom]() { emitZoom(1.0 / 1.5); });
@@ -1623,23 +1617,22 @@ bool SpectrumWidget::event(QEvent* ev)
         if (ge->gestureType() == Qt::ZoomNativeGesture) {
             // value > 0 = pinch out (zoom in = narrower BW)
             // value < 0 = pinch in  (zoom out = wider BW)
+            // Zoom anchored on the frequency under the cursor: the frequency
+            // at the mouse position stays at that pixel after the zoom.
             const double delta = ge->value();
             if (qFuzzyIsNull(delta)) { return true; }
             const double factor = 1.0 / (1.0 + delta);  // invert: pinch-out narrows BW
-            const double newBw = std::clamp(m_bandwidthMhz * factor, 0.004, 14.0);
-            double zoomCenter = m_centerMhz;
-            if (const auto* ao = activeOverlay()) {
-                if (m_mode == "USB" || m_mode == "LSB" || m_mode == "DIGU" || m_mode == "DIGL" || m_mode == "RTTY") {
-                    zoomCenter = ao->freqMhz + (ao->filterLowHz + ao->filterHighHz) / 2.0 / 1.0e6;
-                } else {
-                    zoomCenter = ao->freqMhz;
-                }
-            }
+            const double newBw = m_bandwidthMhz * factor;
+            if (newBw < m_minBwMhz || newBw > m_maxBwMhz) { return true; }  // at limit
+            // Anchor: keep the frequency under the cursor at the same pixel.
+            const double mouseXFrac = ge->position().x() / width() - 0.5;
+            const double anchorMhz = m_centerMhz + mouseXFrac * m_bandwidthMhz;
+            const double newCenter = anchorMhz - mouseXFrac * newBw;
             m_bandwidthMhz = newBw;
-            m_centerMhz = zoomCenter;
+            m_centerMhz = newCenter;
             markOverlayDirty();
             emit bandwidthChangeRequested(newBw);
-            emit centerChangeRequested(zoomCenter);
+            emit centerChangeRequested(newCenter);
             return true;
         }
     }

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -13,6 +13,7 @@
 #include <QResizeEvent>
 #include <QMouseEvent>
 #include <QWheelEvent>
+#include <QNativeGestureEvent>
 #include <QMenu>
 #include <QToolTip>
 #include <QDialog>
@@ -160,6 +161,8 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     };
     m_zoomSegBtn  = makeBtn("S");
     m_zoomBandBtn = makeBtn("B");
+    m_zoomOutBtn  = makeBtn("\u2212");  // minus sign U+2212
+    m_zoomInBtn   = makeBtn("+");
 
     // SmartSDR pcap: B sends "band_zoom=1", S sends "segment_zoom=1"
     connect(m_zoomBandBtn, &QPushButton::clicked, this, [this]() {
@@ -168,6 +171,26 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     connect(m_zoomSegBtn, &QPushButton::clicked, this, [this]() {
         emit segmentZoomRequested();
     });
+
+    // Bandwidth zoom: − zooms out (wider BW), + zooms in (narrower BW)
+    auto emitZoom = [this](double factor) {
+        const double newBw = std::clamp(m_bandwidthMhz * factor, 0.004, 14.0);
+        double zoomCenter = m_centerMhz;
+        if (const auto* ao = activeOverlay()) {
+            if (m_mode == "USB" || m_mode == "LSB" || m_mode == "DIGU" || m_mode == "DIGL" || m_mode == "RTTY") {
+                zoomCenter = ao->freqMhz + (ao->filterLowHz + ao->filterHighHz) / 2.0 / 1.0e6;
+            } else {
+                zoomCenter = ao->freqMhz;
+            }
+        }
+        m_bandwidthMhz = newBw;
+        m_centerMhz = zoomCenter;
+        markOverlayDirty();
+        emit bandwidthChangeRequested(newBw);
+        emit centerChangeRequested(zoomCenter);
+    };
+    connect(m_zoomOutBtn, &QPushButton::clicked, this, [emitZoom]() { emitZoom(1.5); });
+    connect(m_zoomInBtn,  &QPushButton::clicked, this, [emitZoom]() { emitZoom(1.0 / 1.5); });
 }
 
 // ── Multi-VfoWidget management ────────────────────────────────────────────────
@@ -1593,6 +1616,36 @@ void SpectrumWidget::setBackgroundImage(const QString& path)
     markOverlayDirty();
 }
 
+bool SpectrumWidget::event(QEvent* ev)
+{
+    if (ev->type() == QEvent::NativeGesture) {
+        auto* ge = static_cast<QNativeGestureEvent*>(ev);
+        if (ge->gestureType() == Qt::ZoomNativeGesture) {
+            // value > 0 = pinch out (zoom in = narrower BW)
+            // value < 0 = pinch in  (zoom out = wider BW)
+            const double delta = ge->value();
+            if (qFuzzyIsNull(delta)) { return true; }
+            const double factor = 1.0 / (1.0 + delta);  // invert: pinch-out narrows BW
+            const double newBw = std::clamp(m_bandwidthMhz * factor, 0.004, 14.0);
+            double zoomCenter = m_centerMhz;
+            if (const auto* ao = activeOverlay()) {
+                if (m_mode == "USB" || m_mode == "LSB" || m_mode == "DIGU" || m_mode == "DIGL" || m_mode == "RTTY") {
+                    zoomCenter = ao->freqMhz + (ao->filterLowHz + ao->filterHighHz) / 2.0 / 1.0e6;
+                } else {
+                    zoomCenter = ao->freqMhz;
+                }
+            }
+            m_bandwidthMhz = newBw;
+            m_centerMhz = zoomCenter;
+            markOverlayDirty();
+            emit bandwidthChangeRequested(newBw);
+            emit centerChangeRequested(zoomCenter);
+            return true;
+        }
+    }
+    return SPECTRUM_BASE_CLASS::event(ev);
+}
+
 void SpectrumWidget::wheelEvent(QWheelEvent* ev)
 {
     // Skip scroll on the divider + freq scale bar.
@@ -1690,9 +1743,12 @@ void SpectrumWidget::positionZoomButtons()
     constexpr int sz = 22;
     const int botY = height() - pad;
 
-    // S | B at bottom-left
-    m_zoomSegBtn->move(pad, botY - sz);
-    m_zoomBandBtn->move(pad + sz + 2, botY - sz);
+    // Row 1 (bottom): − | + (bandwidth zoom)
+    m_zoomOutBtn->move(pad, botY - sz);
+    m_zoomInBtn->move(pad + sz + 2, botY - sz);
+    // Row 0 (above): S | B (segment/band zoom)
+    m_zoomSegBtn->move(pad, botY - sz - sz - 2);
+    m_zoomBandBtn->move(pad + sz + 2, botY - sz - sz - 2);
 }
 
 // ─── Colour map ───────────────────────────────────────────────────────────────

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -110,6 +110,9 @@ public:
     int stepSize() const { return m_stepHz; }
     void setStepSize(int hz) { m_stepHz = hz; }
 
+    // Set panadapter bandwidth zoom limits (MHz). Called per-radio model.
+    void setBandwidthLimits(double minMhz, double maxMhz) { m_minBwMhz = minMhz; m_maxBwMhz = maxMhz; }
+
     // Set the per-mode filter limits (Hz). Called when mode changes.
     void setFilterLimits(int minHz, int maxHz) { m_filterMinHz = minHz; m_filterMaxHz = maxHz; }
 
@@ -382,6 +385,10 @@ private:
     int m_scrollAccum{0};   // trackpad pixel scroll accumulator (macOS)
     int m_angleAccum{0};    // mouse wheel angle accumulator (#390)
     qint64 m_lastWheelMs{0}; // debounce: timestamp of last accepted wheel step
+
+    // Panadapter bandwidth zoom limits (MHz), set per-radio model
+    double m_minBwMhz{0.010};   // 10 kHz default
+    double m_maxBwMhz{5.400};   // safe default for unknown radios
 
     // ── FFT display controls (radio-side via "display pan set") ──────────
     int   m_panIndex{0};             // per-pan settings index (0, 1, 2, 3)

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -319,6 +319,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent* event) override;
     void mouseDoubleClickEvent(QMouseEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
+    bool event(QEvent* event) override;
     void leaveEvent(QEvent* event) override;
 
 public:
@@ -533,9 +534,11 @@ private:
     QMap<int, VfoWidget*> m_vfoWidgets;
     VfoWidget* m_vfoWidget{nullptr};  // alias to active slice widget (compat)
 
-    // Bottom-left waterfall zoom buttons: S(egment), B(and)
+    // Bottom-left waterfall zoom buttons: S(egment), B(and), −/+ (bandwidth)
     QPushButton* m_zoomSegBtn{nullptr};
     QPushButton* m_zoomBandBtn{nullptr};
+    QPushButton* m_zoomOutBtn{nullptr};
+    QPushButton* m_zoomInBtn{nullptr};
 
 #ifdef AETHER_GPU_SPECTRUM
     bool m_rhiInitialized{false};

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -150,6 +150,29 @@ public:
         return 2;
     }
 
+    // Panadapter bandwidth limits by radio model (MHz).
+    // Values based on each radio's ADC / RX coverage.
+    double maxPanBandwidthMhz() const {
+        if (m_model.contains("6700"))
+            return 7.500;   // dual SCU, wide ADC — tested on 6700
+        if (m_model.contains("6500"))
+            return 7.200;   // RX: 0.03–72 MHz
+        // 6300, 6400: RX: 0.03–54 MHz
+        if (m_model.contains("6300") || m_model.contains("6400"))
+            return 5.400;
+        // 6600: RX: 0.03–54 MHz
+        if (m_model.contains("6600"))
+            return 5.400;
+        // 8400 / 8600: 30 kHz–54 MHz
+        if (m_model.contains("8400") || m_model.contains("8600"))
+            return 5.400;
+        // Aurora AU-510 / AU-520: 30 kHz–54 MHz
+        if (m_model.contains("AU-"))
+            return 5.400;
+        return 5.400;   // safe default for unknown radios
+    }
+    double minPanBandwidthMhz() const { return 0.010; }  // 10 kHz — all models
+
     // Oscillator / RX settings
     QString oscState()     const { return m_oscState; }
     QString oscSetting()   const { return m_oscSetting; }


### PR DESCRIPTION
## Summary

Adds bandwidth zoom controls to the panadapter:

- **\u2212/+ buttons** below the existing S/B buttons for stepped bandwidth zoom (1.5\u00d7 per click)
- **Trackpad pinch-to-zoom** gesture support (macOS `NativeGesture` events), with cursor-anchored zooming \u2014 the frequency under the cursor stays in place while bandwidth expands/contracts around it
- **Per-radio bandwidth limits** based on model string to prevent wrapping at hardware limits:
  - FLEX-6700: 10 kHz \u2013 7.5 MHz
  - FLEX-6500: 10 kHz \u2013 7.2 MHz
  - FLEX-6300/6400/6600/8400/8600/Aurora: 10 kHz \u2013 5.4 MHz
  - Unknown/future radios: 10 kHz \u2013 5.4 MHz (safe default)

Both bandwidth and center are sent together on zoom to prevent the radio from auto-centering the panadapter.

## Files Changed

- `src/gui/SpectrumWidget.h` \u2014 zoom button members, bandwidth limit members, `event()` override, `setBandwidthLimits()` setter
- `src/gui/SpectrumWidget.cpp` \u2014 button creation, pinch gesture handler, `positionZoomButtons()` layout
- `src/models/RadioModel.h` \u2014 `minPanBandwidthMhz()` / `maxPanBandwidthMhz()` per-model lookup
- `src/gui/MainWindow.cpp` \u2014 wire `setBandwidthLimits()` in `wirePanadapter()`

## Note

This branch also includes a **separate first commit** fixing missing `m_cpuLabel`/`m_cpuDisplayMode`/`m_cpuTimer` declarations in `MainWindow.h` (introduced by commit 5a74901 / PR #1078). That fix can be cherry-picked independently if preferred.

Tested on FLEX-6700, firmware v1.4.0.0.