### PR TITLE
Add right-click context menu on off-screen slice indicators

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5443,6 +5443,11 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         if (m_radioModel.slices().size() <= 1) return;
         m_radioModel.sendCommand(QString("slice remove %1").arg(sliceId));
     });
+    connect(sw, &SpectrumWidget::sliceTuneRequested,
+            this, [this](int sliceId, double freqMhz) {
+        if (auto* s = m_radioModel.slice(sliceId))
+            s->setFrequency(freqMhz);
+    });
 
     // ── Band selection ───────────────────────────────────────────────────
     connect(menu, &SpectrumOverlayMenu::bandSelected,

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -911,14 +911,16 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
         return;
     }
 
-    // Click on off-screen slice indicator → absorb or switch slice
-    for (int oi = 0; oi < m_offScreenRects.size(); ++oi) {
-        if (!m_offScreenRects[oi].isNull() &&
-            m_offScreenRects[oi].contains(QPoint(static_cast<int>(ev->position().x()), y))) {
-            const auto& so = m_sliceOverlays[oi];
-            if (!so.isActive) emit sliceClicked(so.sliceId);
-            ev->accept();
-            return;
+    // Left-click on off-screen slice indicator → absorb or switch slice
+    if (ev->button() == Qt::LeftButton) {
+        for (int oi = 0; oi < m_offScreenRects.size(); ++oi) {
+            if (!m_offScreenRects[oi].isNull() &&
+                m_offScreenRects[oi].contains(QPoint(static_cast<int>(ev->position().x()), y))) {
+                const auto& so = m_sliceOverlays[oi];
+                if (!so.isActive) emit sliceClicked(so.sliceId);
+                ev->accept();
+                return;
+            }
         }
     }
 
@@ -962,6 +964,30 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
     if (ev->button() == Qt::RightButton) {
         m_draggingTnfId = -1;
         const int mx = static_cast<int>(ev->position().x());
+
+        // Right-click on off-screen slice indicator → slice context menu
+        for (int oi = 0; oi < m_offScreenRects.size(); ++oi) {
+            if (!m_offScreenRects[oi].isNull() &&
+                m_offScreenRects[oi].contains(QPoint(mx, y))) {
+                const auto& so = m_sliceOverlays[oi];
+                const QChar letter = QChar('A' + (so.sliceId & 3));
+                QMenu menu(this);
+                menu.addAction(QString("Close Slice %1").arg(letter), this,
+                    [this, id = so.sliceId]{ emit sliceCloseRequested(id); });
+                menu.addAction(QString("Move Slice %1 Here").arg(letter), this,
+                    [this, id = so.sliceId]{ emit sliceTuneRequested(id, m_centerMhz); });
+                menu.addAction(QString("Center Slice %1").arg(letter), this,
+                    [this, freq = so.freqMhz]{
+                        m_centerMhz = freq;
+                        markOverlayDirty();
+                        emit centerChangeRequested(m_centerMhz);
+                    });
+                menu.exec(ev->globalPosition().toPoint());
+                ev->accept();
+                return;
+            }
+        }
+
         const double freqMhz = xToMhz(mx);
         const int hitTnf = tnfAtPixel(mx);
 

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -303,6 +303,7 @@ signals:
     void tnfDepthRequested(int id, int depthDb);
     void tnfPermanentRequested(int id, bool permanent);
     void sliceCloseRequested(int sliceId);
+    void sliceTuneRequested(int sliceId, double freqMhz);
     void sliceTxRequested(int sliceId);
     // Spot signals
     void spotAddRequested(double freqMhz, const QString& callsign,


### PR DESCRIPTION
Right-clicking an off-screen slice helper icon now shows a context menu with three options:

- **Close Slice** — removes the slice receiver
- **Move Slice Here** — tunes the slice to the panadapter center frequency
- **Center Slice** — recenters the panadapter display around the slice

Left-click behavior (activate slice) is unchanged.

### Changes
- `SpectrumWidget.h`: Added `sliceTuneRequested(int sliceId, double freqMhz)` signal
- `SpectrumWidget.cpp`: Added right-click context menu for off-screen indicators; gated existing left-click handler to `Qt::LeftButton` only
- `MainWindow.cpp`: Wired `sliceTuneRequested` to `SliceModel::setFrequency()`