### PR TITLE
[memory] Show full memory frequency in dialog

### DIFF
--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -232,7 +232,8 @@ void MemoryDialog::populateTable()
         int col = 0;
         m_table->setItem(row, col++, new QTableWidgetItem(m.group));
         m_table->setItem(row, col++, new QTableWidgetItem(m.owner));
-        auto* freqItem = new MemoryTableItem(QString::number(m.freq, 'f', 3));
+        // Show the full MHz value so the last 3 digits (Hz) are not lost.
+        auto* freqItem = new MemoryTableItem(QString::number(m.freq, 'f', 6));
         freqItem->setData(Qt::UserRole, m.freq);
         m_table->setItem(row, col++, freqItem);
         m_table->setItem(row, col++, new QTableWidgetItem(m.name));


### PR DESCRIPTION
## Summary
- show memory frequencies with 6 decimal places in the Memory dialog
- preserve the last 3 digits so the displayed value matches the full stored frequency

## Root Cause
The Memory dialog formatted frequencies with only 3 decimal places, which truncated the displayed MHz value and hid the last 3 digits.

## Validation
- confirmed the fix locally in the worktree
- user reports this fix is working
