### PR TITLE
[spots] Restore custom spot colors on launch

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5051,6 +5051,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setSpotStartPct(s.value("SpotsStartingHeightPercentage", "50").toInt());
         sw->setSpotOverrideColors(s.value("IsSpotsOverrideColorsEnabled", "False").toString() == "True");
         sw->setSpotOverrideBg(s.value("IsSpotsOverrideBackgroundColorsEnabled", "True").toString() == "True");
+        sw->setSpotColor(QColor(s.value("SpotsOverrideColor", "#FFFF00").toString()));
+        sw->setSpotBgColor(QColor(s.value("SpotsOverrideBgColor", "#000000").toString()));
+        sw->setSpotBgOpacity(s.value("SpotsBackgroundOpacity", 48).toInt());
     }
 
     // ── Per-pan display controls (client-side) ───────────────────────────


### PR DESCRIPTION
## Summary
- restore saved custom spot text/background colors and opacity when wiring each spectrum widget at launch
- ensure custom spot appearance matches the saved Spot settings immediately after app startup

## Root Cause
The startup path restored the override booleans but did not reapply the saved custom spot colors and background opacity to newly created spectrum widgets, so they fell back to defaults until a later refresh path ran.

## Validation
- confirmed the fix locally in the worktree
- user reports this fix is working
