### PR TITLE
[memory] Persist memory window across restarts

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1883,6 +1883,12 @@ MainWindow::MainWindow(QWidget* parent)
         QTimer::singleShot(500, this, [this]() { toggleConnectionDialog(); });
     }
 
+    // Restore the Memory dialog if it was open when the app last exited.
+    QTimer::singleShot(0, this, [this]() {
+        if (AppSettings::instance().value("MemoryDialogOpen", "False").toString() == "True")
+            showMemoryDialog();
+    });
+
     // What's New dialog — show on version change (#483)
     // Also check for newer release and offer upgrade (#486)
     QTimer::singleShot(600, this, [this]() {
@@ -1961,11 +1967,19 @@ MainWindow::~MainWindow()
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
+    m_shuttingDown = true;
     auto& s = AppSettings::instance();
     s.setValue("MainWindowGeometry", saveGeometry().toBase64());
     s.setValue("MainWindowState",   saveState().toBase64());
     // SplitterState no longer saved (2-pane layout uses stretch factors)
     // ConnPanelCollapsed removed — panel is now a popup dialog
+
+    if (m_memoryDialog && m_memoryDialog->isVisible()) {
+        s.setValue("MemoryDialogOpen", "True");
+        s.setValue("MemoryDialogGeometry", m_memoryDialog->saveGeometry().toBase64());
+    } else {
+        s.setValue("MemoryDialogOpen", "False");
+    }
 
     // Save active slice frequency/mode for restore on next launch
     auto* sl = activeSlice();
@@ -2214,6 +2228,28 @@ void MainWindow::toggleConnectionDialog()
     m_connPanel->raise();
 }
 
+void MainWindow::showMemoryDialog()
+{
+    if (m_memoryDialog) {
+        m_memoryDialog->show();
+        m_memoryDialog->raise();
+        m_memoryDialog->activateWindow();
+        return;
+    }
+
+    auto* dlg = new MemoryDialog(&m_radioModel, this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    connect(dlg, &QObject::destroyed, this, [this] {
+        if (m_shuttingDown)
+            return;
+        auto& s = AppSettings::instance();
+        s.setValue("MemoryDialogOpen", "False");
+        s.save();
+    });
+    m_memoryDialog = dlg;
+    dlg->show();
+}
+
 void MainWindow::updatePaTempLabel()
 {
     const QString unit = m_paTempUseFahrenheit ? "F" : "C";
@@ -2370,15 +2406,7 @@ void MainWindow::buildMenuBar()
     });
     auto* memoryAction = settingsMenu->addAction("Memory...");
     connect(memoryAction, &QAction::triggered, this, [this] {
-        if (m_memoryDialog) {
-            m_memoryDialog->raise();
-            m_memoryDialog->activateWindow();
-            return;
-        }
-        auto* dlg = new MemoryDialog(&m_radioModel, this);
-        dlg->setAttribute(Qt::WA_DeleteOnClose);
-        m_memoryDialog = dlg;
-        dlg->show();
+        showMemoryDialog();
     });
     auto* usbCablesAction = settingsMenu->addAction("USB Cables...");
     connect(usbCablesAction, &QAction::triggered, this, [this] {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -118,6 +118,7 @@ private:
     void applyUiScale(int pct);
     void stepUiScale(int direction);  // +1 = zoom in, -1 = zoom out
     void toggleMinimalMode(bool on);
+    void showMemoryDialog();
     void updateKeyerAvailability(const QString& mode);
     void showNr2ParamPopup(const QPoint& globalPos);
     void showNr4ParamPopup(const QPoint& globalPos);
@@ -272,6 +273,7 @@ private:
     // Guard: set true while updating controls from the model, so that
     // onFrequencyChanged doesn't echo the change back to the radio.
     bool m_updatingFromModel{false};
+    bool m_shuttingDown{false};
     void toggleConnectionDialog();
     bool m_useSystemClock{true};     // true when no GPS installed
     bool m_paTempUseFahrenheit{true};

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -1,4 +1,5 @@
 #include "MemoryDialog.h"
+#include "core/AppSettings.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "core/RadioConnection.h"
@@ -10,6 +11,7 @@
 #include <QDebug>
 #include <QPointer>
 #include <QTimer>
+#include <QCloseEvent>
 
 namespace AetherSDR {
 
@@ -215,6 +217,17 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     // If cache is empty, memories may not have been pushed yet. As a fallback,
     // new memories created via Add will populate the table immediately.
     populateTable();
+
+    const QString geomB64 =
+        AppSettings::instance().value("MemoryDialogGeometry").toString();
+    if (!geomB64.isEmpty())
+        restoreGeometry(QByteArray::fromBase64(geomB64.toLatin1()));
+}
+
+void MemoryDialog::closeEvent(QCloseEvent* event)
+{
+    AppSettings::instance().setValue("MemoryDialogGeometry", saveGeometry().toBase64());
+    QDialog::closeEvent(event);
 }
 
 void MemoryDialog::populateTable()

--- a/src/gui/MemoryDialog.h
+++ b/src/gui/MemoryDialog.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QCloseEvent>
 #include <QTableWidget>
 #include <QMap>
 
@@ -13,6 +14,9 @@ class MemoryDialog : public QDialog {
 
 public:
     explicit MemoryDialog(RadioModel* model, QWidget* parent = nullptr);
+
+protected:
+    void closeEvent(QCloseEvent* event) override;
 
 private:
     void populateTable();


### PR DESCRIPTION
## Summary
- restore the Memory window automatically on launch if it was open when the app last exited
- persist and restore the Memory window geometry across restarts
- centralize Memory window creation so reopen behavior is consistent from the menu and startup restore path

## Root Cause
The Memory window did not persist its open/closed state, and its geometry was only transient. Because the dialog uses `WA_DeleteOnClose` and had no startup restore path, it always came back closed after relaunch and lost its previous position.

## Validation
- confirmed the fix locally in the worktree
- user requested PR after verifying the fix is working
