### PR TITLE
[feature] Add A index to propagation overlay

### DIFF
--- a/src/core/PropForecastClient.cpp
+++ b/src/core/PropForecastClient.cpp
@@ -30,7 +30,7 @@ void PropForecastClient::setEnabled(bool on)
     if (on) {
         // Restore cached values so the overlay appears instantly on startup.
         loadCache();
-        if (m_last.kIndex >= 0 && m_last.sfi > 0) {
+        if (m_last.kIndex >= 0 && m_last.aIndex >= 0 && m_last.sfi > 0) {
             emit forecastUpdated(m_last);
         }
 
@@ -97,6 +97,8 @@ void PropForecastClient::fetch()
             QString tag = xml.name().toString();
             if (tag == QLatin1String("kindex")) {
                 fc.kIndex = xml.readElementText().toInt();
+            } else if (tag == QLatin1String("aindex")) {
+                fc.aIndex = xml.readElementText().toInt();
             } else if (tag == QLatin1String("solarflux")) {
                 fc.sfi = xml.readElementText().toInt();
             }
@@ -108,14 +110,16 @@ void PropForecastClient::fetch()
             return;
         }
 
-        if (fc.kIndex >= 0 && fc.sfi > 0) {
+        if (fc.kIndex >= 0 && fc.aIndex >= 0 && fc.sfi > 0) {
             m_last = fc;
             m_lastFetchMs = QDateTime::currentMSecsSinceEpoch();
             saveCache();
             emit forecastUpdated(m_last);
-            qCDebug(lcPropForecast) << "updated — K" << fc.kIndex << "SFI" << fc.sfi;
+            qCDebug(lcPropForecast) << "updated — K" << fc.kIndex << "A" << fc.aIndex
+                                    << "SFI" << fc.sfi;
         } else {
-            qCWarning(lcPropForecast) << "unexpected XML — kIndex:" << fc.kIndex << "sfi:" << fc.sfi;
+            qCWarning(lcPropForecast) << "unexpected XML — kIndex:" << fc.kIndex
+                                      << "aIndex:" << fc.aIndex << "sfi:" << fc.sfi;
         }
     });
 }
@@ -126,14 +130,16 @@ void PropForecastClient::loadCache()
 {
     auto& s = AppSettings::instance();
     int k   = s.value("PropForecastKIndex", "-1").toInt();
+    int a   = s.value("PropForecastAIndex", "-1").toInt();
     int sfi = s.value("PropForecastSfi",    "-1").toInt();
     qint64 ts = s.value("PropForecastTimestamp", "0").toLongLong();
 
-    if (k >= 0 && sfi > 0 && ts > 0) {
+    if (k >= 0 && a >= 0 && sfi > 0 && ts > 0) {
         m_last.kIndex  = k;
+        m_last.aIndex  = a;
         m_last.sfi     = sfi;
         m_lastFetchMs  = ts;
-        qCDebug(lcPropForecast) << "restored cache — K" << k << "SFI" << sfi
+        qCDebug(lcPropForecast) << "restored cache — K" << k << "A" << a << "SFI" << sfi
                                 << "age" << ((QDateTime::currentMSecsSinceEpoch() - ts) / 1000) << "s";
     }
 }
@@ -142,6 +148,7 @@ void PropForecastClient::saveCache()
 {
     auto& s = AppSettings::instance();
     s.setValue("PropForecastKIndex",    QString::number(m_last.kIndex));
+    s.setValue("PropForecastAIndex",    QString::number(m_last.aIndex));
     s.setValue("PropForecastSfi",       QString::number(m_last.sfi));
     s.setValue("PropForecastTimestamp",  QString::number(m_lastFetchMs));
     s.save();

--- a/src/core/PropForecastClient.h
+++ b/src/core/PropForecastClient.h
@@ -8,6 +8,7 @@ namespace AetherSDR {
 
 struct PropForecast {
     int kIndex{-1};  // Planetary K-index 0-9; -1 = not yet fetched
+    int aIndex{-1};  // Planetary A-index; -1 = not yet fetched
     int sfi{-1};     // Solar Flux Index (SFU); -1 = not yet fetched
 };
 
@@ -16,7 +17,7 @@ struct PropForecast {
 // (async) so the download never blocks radio operations.
 //
 // Hardening:
-//   - Persists last K/SFI + timestamp to AppSettings so the overlay is
+//   - Persists last K/A/SFI + timestamp to AppSettings so the overlay is
 //     available immediately on restart without waiting for a network fetch.
 //   - Skips the network fetch if cached data is less than one hour old.
 //   - Guards against overlapping in-flight requests.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -402,7 +402,7 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_propForecast, &PropForecastClient::forecastUpdated,
             this, [this](const PropForecast& fc) {
         for (PanadapterApplet* applet : m_panStack->allApplets()) {
-            applet->spectrumWidget()->setPropForecast(fc.kIndex, fc.sfi);
+            applet->spectrumWidget()->setPropForecast(fc.kIndex, fc.aIndex, fc.sfi);
         }
     });
     // Restore persisted setting — timer only arms if enabled
@@ -3070,7 +3070,7 @@ void MainWindow::buildMenuBar()
         // If turning off, clear the stale values so they don't reappear
         if (!on) {
             for (PanadapterApplet* applet : m_panStack->allApplets()) {
-                applet->spectrumWidget()->setPropForecast(-1, -1);
+                applet->spectrumWidget()->setPropForecast(-1, -1, -1);
             }
         }
     });
@@ -4906,7 +4906,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setPropForecastVisible(m_propForecast->isEnabled());
         if (m_propForecast->isEnabled()) {
             PropForecast fc = m_propForecast->lastForecast();
-            sw->setPropForecast(fc.kIndex, fc.sfi);
+            sw->setPropForecast(fc.kIndex, fc.aIndex, fc.sfi);
         }
     }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2242,7 +2242,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
 
             // WNB / RF gain / Prop forecast indicators (top-right of spectrum)
             {
-                const bool showProp = m_propForecastVisible && m_propKIndex >= 0 && m_propSfi > 0;
+                const bool showProp = m_propForecastVisible
+                    && m_propKIndex >= 0
+                    && m_propAIndex >= 0
+                    && m_propSfi > 0;
                 if (m_wnbActive || m_rfGainValue != 0 || showProp) {
                     QFont indFont(p.font().family(), 14, QFont::Bold);
                     p.setFont(indFont);
@@ -2252,7 +2255,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                     // Build combined label (left to right: prop, WNB, RF gain), right-align
                     QString label;
                     if (showProp) {
-                        label += QString("K%1  SFI %2").arg(m_propKIndex).arg(m_propSfi);
+                        label += QString("K%1  A%2  SFI %3")
+                            .arg(m_propKIndex)
+                            .arg(m_propAIndex)
+                            .arg(m_propSfi);
                     }
                     if (m_wnbActive) {
                         if (!label.isEmpty()) { label += QStringLiteral("   "); }
@@ -2753,7 +2759,10 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
 
     // ── WNB / RF Gain / Prop Forecast indicators (top-right of FFT area) ────
     {
-        const bool showProp = m_propForecastVisible && m_propKIndex >= 0 && m_propSfi > 0;
+        const bool showProp = m_propForecastVisible
+            && m_propKIndex >= 0
+            && m_propAIndex >= 0
+            && m_propSfi > 0;
         if (m_wnbActive || m_rfGainValue != 0 || showProp) {
             QFont indFont = p.font();
             indFont.setPointSize(18);
@@ -2786,9 +2795,12 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
                 x -= 10;
             }
 
-            // Prop forecast (leftmost: "K3  SFI 110")
+            // Prop forecast (leftmost: "K3  A12  SFI 110")
             if (showProp) {
-                QString propStr = QString("K%1  SFI %2").arg(m_propKIndex).arg(m_propSfi);
+                QString propStr = QString("K%1  A%2  SFI %3")
+                    .arg(m_propKIndex)
+                    .arg(m_propAIndex)
+                    .arg(m_propSfi);
                 int pw = fm.horizontalAdvance(propStr);
                 x -= pw;
                 p.drawText(x, topY, propStr);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -136,10 +136,15 @@ public:
     void setWnbActive(bool on) { m_wnbActive = on; markOverlayDirty(); }
     void setRfGain(int gain) { m_rfGainValue = gain; markOverlayDirty(); }
 
-    // HF propagation forecast overlay (K-index and Solar Flux Index).
+    // HF propagation forecast overlay (K-index, A-index, and Solar Flux Index).
     // Values of -1 mean not yet fetched; visible only when enabled.
     void setPropForecastVisible(bool on) { m_propForecastVisible = on; markOverlayDirty(); }
-    void setPropForecast(int kIndex, int sfi) { m_propKIndex = kIndex; m_propSfi = sfi; markOverlayDirty(); }
+    void setPropForecast(int kIndex, int aIndex, int sfi) {
+        m_propKIndex = kIndex;
+        m_propAIndex = aIndex;
+        m_propSfi = sfi;
+        markOverlayDirty();
+    }
     bool propForecastVisible() const { return m_propForecastVisible; }
 
     // NB Waterfall Blanker (#277) — client-side impulse suppression
@@ -466,6 +471,7 @@ private:
     // HF propagation forecast overlay
     bool m_propForecastVisible{false};
     int  m_propKIndex{-1};
+    int  m_propAIndex{-1};
     int  m_propSfi{-1};
 
     // Background image


### PR DESCRIPTION
## What changed

This extends the existing HF propagation conditions overlay in the panadapter to include the current A index alongside the existing K index and Solar Flux Index.

The overlay now displays:

`K<n>  A<n>  SFI <n>`

with the A index positioned between K and SFI in both rendering paths.

## Why this changed

The panadapter already exposes useful propagation context with K index and SFI, but it was missing the A index, which is another commonly used indicator for current geomagnetic conditions.

Adding it makes the propagation label more complete without changing the overall UI pattern.

## Implementation details

- Added `aIndex` to `PropForecast`
- Parsed `<aindex>` from the existing HamQSL solar XML feed
- Persisted/restored the A index in `AppSettings` alongside K, SFI, and timestamp
- Updated `MainWindow` plumbing so all panadapters receive the new three-value forecast state
- Updated the panadapter overlay text in both paint paths to render `K`, then `A`, then `SFI`

## User impact

Users who enable `View > Propagation Conditions` will now see the current A index directly in the panadapter overlay, between the K index and SFI.

## Validation

- Built from the latest `main` base in a dedicated worktree
- Verified bundled RADE/Opus dependency download/build path
- Ran `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- Ran `cmake --build build -j8`
- Launched the built app and visually confirmed the updated overlay renders correctly

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.3 Pro) and tested by @jensenpat 