### PR TITLE
[shortcuts] Center slice before go-to-frequency entry

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5957,6 +5957,35 @@ void MainWindow::updateKeyerAvailability(const QString& mode)
     m_dvkIndicator->setCursor(isSsb ? Qt::PointingHandCursor : Qt::ArrowCursor);
 }
 
+void MainWindow::centerActiveSliceInPanadapter(bool forceRadioCenter, double centerMhz)
+{
+    auto* s = activeSlice();
+    if (!s || s->panId().isEmpty()) return;
+
+    auto* sw = spectrumForSlice(s);
+    if (!sw) return;
+
+    auto* pan = m_radioModel.panadapter(s->panId());
+    const double bandwidthMhz = pan ? pan->bandwidthMhz() : m_radioModel.panBandwidthMhz();
+    const double targetMhz = (centerMhz > 0.0) ? centerMhz : s->frequency();
+
+    if (m_panStack) {
+        if (auto* applet = m_panStack->panadapter(s->panId()))
+            m_panStack->setActivePan(applet->panId());
+    }
+
+    // Keep the local spectrum centered immediately so the active slice marker
+    // is visible before the radio's status echo arrives.
+    sw->setFrequencyRange(targetMhz, bandwidthMhz);
+    sw->setVfoFrequency(targetMhz);
+
+    if (forceRadioCenter && m_radioModel.isConnected()) {
+        m_radioModel.sendCommand(
+            QString("display pan set %1 center=%2")
+                .arg(s->panId()).arg(targetMhz, 0, 'f', 6));
+    }
+}
+
 void MainWindow::registerShortcutActions()
 {
     // Helper: nudge active slice frequency by N steps.
@@ -6005,7 +6034,13 @@ void MainWindow::registerShortcutActions()
             auto* s = activeSlice();
             auto* sw = s ? spectrumForSlice(s) : nullptr;
             auto* vfo = (s && sw) ? sw->vfoWidget(s->sliceId()) : nullptr;
-            if (vfo) vfo->beginDirectEntry();
+            if (!s || !vfo) return;
+            centerActiveSliceInPanadapter(true);
+            QPointer<VfoWidget> vfoGuard = vfo;
+            QTimer::singleShot(0, this, [vfoGuard]() {
+                if (vfoGuard)
+                    vfoGuard->beginDirectEntry();
+            });
         });
 
     // ── Band ────────────────────────────────────────────────────────────

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -105,6 +105,7 @@ private:
     SpectrumWidget* spectrum() const;
     void setActiveSlice(int sliceId);
     void updateFilterLimitsForMode(const QString& mode);
+    void centerActiveSliceInPanadapter(bool forceRadioCenter, double centerMhz = -1.0);
     void pushSliceOverlay(SliceModel* s);
     void updateSplitState();
     void disableSplit();


### PR DESCRIPTION
## What changed
- Previous commits addressed the centering behavior after the frequency was selected.  this brings the box to the center before the frequency is entered, so that the entry box is not instantiated off the panadapter.
- recenter the active slice's panadapter before starting direct frequency entry from the keyboard shortcut
- defer direct-entry activation by one event-loop tick so the centered slice box is visible before key presses are consumed

## Why
Go-to-frequency could start accepting typed input while the active slice box was still off-screen, which made the UI feel disconnected from the shortcut behavior.

## Validation
- built with `cmake --build /tmp/build-goto-center --parallel 10`

## Impact
The go-to-frequency shortcut now visibly centers the active slice before direct entry begins.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.3 Pro) and tested by @jensenpat