### PR TITLE
[ux] Center startup slice on launch

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1874,6 +1874,8 @@ MainWindow::MainWindow(QWidget* parent)
 
     // Restore saved geometry from XML settings
     auto& s = AppSettings::instance();
+    m_startupCenterMhz = s.value("LastFrequency", "0").toDouble();
+    m_startupCenterPending = (m_startupCenterMhz > 0.0);
     const QString geomB64 = s.value("MainWindowGeometry").toString();
     if (!geomB64.isEmpty())
         restoreGeometry(QByteArray::fromBase64(geomB64.toLatin1()));
@@ -4308,9 +4310,10 @@ void MainWindow::onSliceAdded(SliceModel* s)
     if (m_applyingLayout) return;
 
     qDebug() << "MainWindow: slice added" << s->sliceId();
+    const bool firstSlice = (m_activeSliceId < 0);
 
     // First slice — wire everything up
-    if (m_activeSliceId < 0) {
+    if (firstSlice) {
         setActiveSlice(s->sliceId());
 
         // Detect initial band from radio's frequency
@@ -4628,6 +4631,14 @@ void MainWindow::onSliceAdded(SliceModel* s)
         updateSplitState();
         // Auto-focus the TX VFO so the user can immediately tune the TX offset
         setActiveSlice(s->sliceId());
+    }
+
+    if (firstSlice && m_startupCenterPending) {
+        m_startupCenterPending = false;
+        const double startupCenter = m_startupCenterMhz;
+        QTimer::singleShot(0, this, [this, startupCenter]() {
+            centerActiveSliceInPanadapter(true, startupCenter);
+        });
     }
 }
 
@@ -5955,6 +5966,35 @@ void MainWindow::updateKeyerAvailability(const QString& mode)
         m_dvkIndicator->setStyleSheet(isSsb ? kAvail : kDisabled);
     }
     m_dvkIndicator->setCursor(isSsb ? Qt::PointingHandCursor : Qt::ArrowCursor);
+}
+
+void MainWindow::centerActiveSliceInPanadapter(bool forceRadioCenter, double centerMhz)
+{
+    auto* s = activeSlice();
+    if (!s || s->panId().isEmpty()) return;
+
+    auto* sw = spectrumForSlice(s);
+    if (!sw) return;
+
+    auto* pan = m_radioModel.panadapter(s->panId());
+    const double bandwidthMhz = pan ? pan->bandwidthMhz() : m_radioModel.panBandwidthMhz();
+    const double targetMhz = (centerMhz > 0.0) ? centerMhz : s->frequency();
+
+    if (m_panStack) {
+        if (auto* applet = m_panStack->panadapter(s->panId()))
+            m_panStack->setActivePan(applet->panId());
+    }
+
+    // Keep the local spectrum centered immediately so the active slice marker
+    // is visible before the radio's status echo arrives.
+    sw->setFrequencyRange(targetMhz, bandwidthMhz);
+    sw->setVfoFrequency(targetMhz);
+
+    if (forceRadioCenter && m_radioModel.isConnected()) {
+        m_radioModel.sendCommand(
+            QString("display pan set %1 center=%2")
+                .arg(s->panId()).arg(targetMhz, 0, 'f', 6));
+    }
 }
 
 void MainWindow::registerShortcutActions()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -105,6 +105,7 @@ private:
     SpectrumWidget* spectrum() const;
     void setActiveSlice(int sliceId);
     void updateFilterLimitsForMode(const QString& mode);
+    void centerActiveSliceInPanadapter(bool forceRadioCenter, double centerMhz = -1.0);
     void pushSliceOverlay(SliceModel* s);
     void updateSplitState();
     void disableSplit();
@@ -286,6 +287,8 @@ private:
     QTimer* m_layoutRestoreTimer{nullptr}; // debounced layout rearrange after pans added on connect
     QTimer* m_heartbeatMissTimer{nullptr}; // fires every 1.5s to detect missed discovery beats
     bool m_keyboardShortcutsEnabled{false}; // global enable for keyboard shortcuts (View menu)
+    bool m_startupCenterPending{false};      // one-shot: center active slice on launch
+    double m_startupCenterMhz{0.0};          // persisted frequency to center on launch
     bool m_spacePttActive{false};          // true while Space is held for PTT
     bool m_minimalMode{false};             // true when spectrum is hidden (#208)
     QAction* m_minimalModeAction{nullptr};


### PR DESCRIPTION
## What changed
- center the initial active slice on the persisted startup frequency after the first owned slice appears
- keep the active slice visible immediately in the local panadapter view while the radio status echo catches up

## Why
The app already persists the active slice frequency across runs, but launch did not explicitly recenter the panadapter on that restored frequency. Users could start with the slice box off-screen even though the correct frequency had been restored.

## Validation
- built with `cmake --build /tmp/build-startup-center --parallel 10`

## Impact
Startup now consistently opens with the restored active slice centered in its panadapter.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.3 Pro) and tested by @jensenpat