### PR TITLE
[ux] Stop persisting LCK across application restarts

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -514,9 +514,11 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
                               "value changes while scrolling");
         m_lockBtn->setAccessibleName("Lock controls");
         m_lockBtn->setAccessibleDescription("Lock sidebar controls to prevent accidental value changes");
-        bool locked = settings.value("ControlsLocked", "False").toString() == "True";
-        m_lockBtn->setChecked(locked);
-        ControlsLock::setLocked(locked);
+        // LCK is session-only: start every app launch unlocked and do not
+        // restore or persist the prior session's state.
+        AppSettings::instance().remove("ControlsLocked");
+        m_lockBtn->setChecked(false);
+        ControlsLock::setLocked(false);
         btnLayout2->addWidget(m_lockBtn);
         connect(m_lockBtn, &QPushButton::toggled, this, [this](bool on) {
             setControlsLocked(on);
@@ -873,7 +875,6 @@ void AppletPanel::setControlsLocked(bool locked)
     ControlsLock::setLocked(locked);
     m_lockBtn->setText("LCK");
     m_lockBtn->setChecked(locked);
-    AppSettings::instance().setValue("ControlsLocked", locked ? "True" : "False");
 }
 
 void AppletPanel::setSlice(SliceModel* slice)


### PR DESCRIPTION
Session-only LCK behavior.

This change makes the sidebar control lock a session-only safety feature. The app now always starts unlocked on launch, and it no longer persists the `LCK` state between sessions.

We are doing this because new users can easily lock themselves out of the sidebar sliders and not realize what happened. Keeping the lock temporary preserves the accidental-change protection while they are actively using the app, but avoids trapping them in a locked state across restarts before they have learned the UI.

Behaviorally, the lock still works the same during the current session. The only change is that a fresh app launch now always begins unlocked, so users can get back to the controls immediately.
