### PR TITLE
[support] Add Reset Settings button

### DIFF
--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -135,6 +135,13 @@ void AppSettings::load()
 
 void AppSettings::save()
 {
+    if (QCoreApplication* app = QCoreApplication::instance()) {
+        if (app->property("AetherSettingsResetInProgress").toBool()) {
+            qWarning() << "AppSettings: skipping save during reset-triggered shutdown";
+            return;
+        }
+    }
+
     // Guard: refuse to save if we'd lose more than half the settings.
     // This catches cases where the app crashes early or settings were
     // cleared from memory before save() runs.
@@ -218,6 +225,14 @@ void AppSettings::save()
     if (!QFile::rename(tmpPath, m_filePath)) {
         qWarning() << "AppSettings: atomic rename failed from" << tmpPath << "to" << m_filePath;
     }
+}
+
+void AppSettings::reset()
+{
+    m_settings.clear();
+    m_stationSettings.clear();
+    m_stationName = "AetherSDR";
+    m_loadedCount = 0;
 }
 
 // ─── Top-level accessors ──────────────────────────────────────────────────────

--- a/src/core/AppSettings.h
+++ b/src/core/AppSettings.h
@@ -46,6 +46,9 @@ public:
     // File path for the settings file.
     QString filePath() const { return m_filePath; }
 
+    // Clear all loaded settings from memory without writing anything back out.
+    void reset();
+
     // Migrate from old QSettings (INI format) if XML file doesn't exist yet.
     void migrateFromQSettings();
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -274,10 +274,14 @@ static QString wisdomDir()
     return dir;
 }
 
+QString AudioEngine::wisdomFilePath()
+{
+    return wisdomDir() + "aethersdr_fftw_wisdom";
+}
+
 bool AudioEngine::needsWisdomGeneration()
 {
-    QString path = wisdomDir() + "aethersdr_fftw_wisdom";
-    return !QFile::exists(path);
+    return !QFile::exists(wisdomFilePath());
 }
 
 void AudioEngine::generateWisdom(std::function<void(int,int,const std::string&)> progress)

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -148,6 +148,7 @@ public:
     // Ensure FFTW wisdom is loaded/generated. Returns true if wisdom
     // needs to be generated (slow). Call generateWisdom() in that case.
     static bool needsWisdomGeneration();
+    static QString wisdomFilePath();
     // Must be called from a worker thread — blocks for several minutes.
     static void generateWisdom(std::function<void(int,int,const std::string&)> progress = nullptr);
 

--- a/src/gui/SupportDialog.cpp
+++ b/src/gui/SupportDialog.cpp
@@ -1,4 +1,6 @@
 #include "SupportDialog.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
 #include "core/LogManager.h"
 #include "core/SupportBundle.h"
 #include "models/RadioModel.h"
@@ -7,6 +9,8 @@
 #include <QCheckBox>
 #include <QCursor>
 #include <QDesktopServices>
+#include <QDir>
+#include <QFile>
 #include <QMessageBox>
 #include <QFileInfo>
 #include <QGridLayout>
@@ -16,6 +20,7 @@
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QScrollBar>
+#include <QStringList>
 #include <QUrl>
 #include <QUrlQuery>
 #include <QClipboard>
@@ -114,12 +119,16 @@ void SupportDialog::buildUI()
     auto* refreshBtn = new QPushButton("Refresh");
     auto* clearBtn = new QPushButton("Clear Log");
     auto* openBtn = new QPushButton("Open Log Folder");
+    auto* resetBtn = new QPushButton("Reset Settings");
     refreshBtn->setFixedHeight(26);
     clearBtn->setFixedHeight(26);
     openBtn->setFixedHeight(26);
+    resetBtn->setFixedHeight(26);
+    resetBtn->setToolTip("Delete AetherSDR's local settings and NR2 wisdom cache. Radio settings stay on the radio.");
     connect(refreshBtn, &QPushButton::clicked, this, &SupportDialog::refreshLog);
     connect(clearBtn, &QPushButton::clicked, this, &SupportDialog::clearLog);
     connect(openBtn, &QPushButton::clicked, this, &SupportDialog::openLogFolder);
+    connect(resetBtn, &QPushButton::clicked, this, &SupportDialog::resetSettings);
     auto* sendBtn = new QPushButton("File an Issue");
     sendBtn->setFixedHeight(26);
     sendBtn->setStyleSheet("QPushButton { background: #00607a; color: #e0f0ff; font-weight: bold; }");
@@ -269,6 +278,7 @@ void SupportDialog::buildUI()
     actionRow->addWidget(refreshBtn);
     actionRow->addWidget(clearBtn);
     actionRow->addWidget(openBtn);
+    actionRow->addWidget(resetBtn);
     actionRow->addStretch();
     actionRow->addWidget(sendBtn);
     layout->addLayout(actionRow);
@@ -337,6 +347,66 @@ void SupportDialog::openLogFolder()
 {
     QFileInfo fi(LogManager::instance().logFilePath());
     QDesktopServices::openUrl(QUrl::fromLocalFile(fi.absolutePath()));
+}
+
+void SupportDialog::resetSettings()
+{
+    QStringList resetPaths = {
+        AppSettings::instance().filePath(),
+        AudioEngine::wisdomFilePath()
+    };
+#ifdef Q_OS_MAC
+    resetPaths << (QDir::homePath() + "/Library/Preferences/com.aethersdr.AetherSDR.plist");
+#endif
+
+    const QString prompt = QString(
+        "This will remove AetherSDR's app-specific settings only.\n"
+        "It will not change settings stored on the radio.\n"
+        "AetherSDR will close immediately after reset so these files are not recreated.\n\n"
+        "Files to remove:\n"
+        "%1\n\n"
+        "Continue?")
+        .arg(QString("- %1").arg(resetPaths.join("\n- ")));
+
+    if (QMessageBox::question(this, "Reset Settings", prompt,
+            QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel) != QMessageBox::Yes) {
+        return;
+    }
+
+    QCoreApplication::instance()->setProperty("AetherSettingsResetInProgress", true);
+
+    QStringList removed;
+    QStringList failed;
+
+    const auto removeIfPresent = [&](const QString& path) {
+        if (!QFileInfo::exists(path))
+            return;
+        if (QFile::remove(path))
+            removed << path;
+        else
+            failed << path;
+    };
+
+    for (const QString& path : resetPaths)
+        removeIfPresent(path);
+
+    AppSettings::instance().reset();
+
+    if (failed.isEmpty()) {
+        QApplication::quit();
+        return;
+    }
+
+    QMessageBox::warning(
+        this, "Reset Settings",
+        QString(
+            "Some files could not be removed.\n\n"
+            "Removed: %1\n"
+            "Failed: %2\n\n"
+            "AetherSDR will now close to avoid rewriting settings.")
+            .arg(removed.isEmpty() ? "none" : removed.join("\n"),
+                 failed.join("\n")));
+    QApplication::quit();
 }
 
 void SupportDialog::enableAll()

--- a/src/gui/SupportDialog.h
+++ b/src/gui/SupportDialog.h
@@ -23,6 +23,7 @@ private slots:
     void refreshLog();
     void clearLog();
     void openLogFolder();
+    void resetSettings();
     void enableAll();
     void disableAll();
     void sendToSupport();


### PR DESCRIPTION
## Summary
- add a Reset Settings action to Help -> Support
- remove the local XML settings file, NR2 wisdom cache, and the macOS bundle plist during reset
- close the app immediately after reset and suppress shutdown saves so settings are not recreated

## User Impact
Users can now reset local AetherSDR client settings more reliably without touching radio settings, and the app exits cleanly before any shutdown save hooks rewrite the deleted config.

## Validation
- built with `cmake --build /tmp/aethersdr-build --parallel 10 --clean-first`
- manually verified the reset flow logic and shutdown save suppression in the rebuilt app

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.3 Pro) and tested by @jensenpat