### PR TITLE
Fix Multi-Flex: use OS-assigned UDP port instead of binding 4991

### DIFF
--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -72,16 +72,11 @@ bool PanadapterStream::start(RadioConnection* conn)
 {
     if (isRunning()) stop();  // clean up previous session before rebinding (#561)
 
-    static constexpr quint16 LAN_VITA_PORT = 4991;
-    bool bound = m_socket.bind(QHostAddress::AnyIPv4, LAN_VITA_PORT,
-                               QAbstractSocket::ReuseAddressHint);
-    if (bound)
-        qCDebug(lcVita49) << "PanadapterStream: bound to LAN VITA-49 port" << LAN_VITA_PORT;
-    else {
-        qCDebug(lcVita49) << "PanadapterStream: port" << LAN_VITA_PORT
-                 << "unavailable, using OS-assigned port";
-        bound = m_socket.bind(QHostAddress::AnyIPv4, 0);
-    }
+    // Use an OS-assigned port instead of the well-known VITA-49 port (4991).
+    // The radio learns our actual port from the UDP registration packet, so
+    // the local port number doesn't matter.  Binding 4991 would prevent other
+    // SmartSDR clients on the same host from receiving VITA-49 data (Multi-Flex).
+    bool bound = m_socket.bind(QHostAddress::AnyIPv4, 0);
     if (!bound) {
         qCWarning(lcVita49) << "PanadapterStream: failed to bind UDP socket:"
                    << m_socket.errorString();

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -27,7 +27,7 @@ class OpusCodec;
 // All packets from the radio use ExtDataWithStream (VITA-49 type 3), not IFDataWithStream.
 //
 // Protocol:
-//   1. Call start(conn) — binds port 4991 (LAN VITA port), falls back to OS-assigned.
+//   1. Call start(conn) — binds an OS-assigned UDP port (avoids monopolising 4991).
 //   2. Register the port with the radio via "client udpport <port>" (done by RadioModel).
 //   3. The radio streams panadapter and audio to that port.
 


### PR DESCRIPTION
Running AetherSDR and SmartSDR for Mac simultaneously on the same computer failed — SmartSDR would connect via TCP but never receive spectrum or audio data.

### Root Cause

`PanadapterStream::start()` bound its VITA-49 receive socket to UDP port 4991 (the well-known FlexRadio VITA-49 LAN port). When a second client on the same host also tried to bind 4991, its bind failed silently and it received no UDP data.

The local port number is irrelevant — the radio discovers each client's actual UDP address from the source IP:port of the `\x00` registration packet (and the `client udpport` TCP command). The WAN code path already used port 0 for this reason.

### Fix

Bind to port 0 (OS-assigned) instead of attempting port 4991 first. This lets multiple SmartSDR-compatible clients coexist on the same machine.

### Changes
- `PanadapterStream.cpp`: Replace "try 4991, fall back to 0" with direct bind to port 0
- `PanadapterStream.h`: Update comment to reflect new behavior