### PR TITLE
Add detachable panadapters with drag-to-float and drag-to-dock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,6 +433,8 @@ set(GUI_SOURCES
     src/gui/ProfileManagerDialog.cpp
     src/gui/PanadapterApplet.cpp
     src/gui/PanadapterStack.cpp
+    src/gui/PanDropOverlay.cpp
+    src/gui/PanFloatingWindow.cpp
     src/gui/PanLayoutDialog.cpp
     src/gui/AppletPanel.cpp
     src/gui/FloatingAppletWindow.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3,6 +3,7 @@
 #include "TitleBar.h"
 #include "PanadapterApplet.h"
 #include "PanadapterStack.h"
+#include "PanFloatingWindow.h"
 #include "PanLayoutDialog.h"
 #include "core/CommandParser.h"
 #include "core/LogManager.h"
@@ -80,6 +81,9 @@
 #include <QActionGroup>
 #include <QLabel>
 #include <QCloseEvent>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QMimeData>
 #include <QMessageBox>
 #include <QShortcut>
 #include <QScrollArea>
@@ -200,6 +204,7 @@ MainWindow::MainWindow(QWidget* parent)
     setWindowIcon(QIcon(":/icon.png"));
     setMinimumSize(1024, 600);
     resize(1400, 800);
+    setAcceptDrops(true);
 
     applyDarkTheme();
 
@@ -934,11 +939,16 @@ MainWindow::MainWindow(QWidget* parent)
 
         // Debounced layout restore: after all pans are added on connect,
         // rearrange to the saved layout (e.g. 2h instead of default vertical).
+        // Only run during initial connection — not when the user manually adds pans.
+        // Once the timer fires once, it won't fire again (user-added pans skip it).
         if (!m_layoutRestoreTimer) {
             m_layoutRestoreTimer = new QTimer(this);
             m_layoutRestoreTimer->setSingleShot(true);
             m_layoutRestoreTimer->setInterval(1000);
             connect(m_layoutRestoreTimer, &QTimer::timeout, this, [this]() {
+                // Mark that initial layout restore has completed —
+                // subsequent panadapterAdded signals won't retrigger this.
+                m_layoutRestoreTimer->setProperty("fired", true);
                 // The radio restores pans from the GUIClientID session.
                 // Accept whatever the radio gives and arrange based on count.
                 int panCount = m_panStack->count();
@@ -974,10 +984,36 @@ MainWindow::MainWindow(QWidget* parent)
                         if (pan->panStreamId())
                             m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
                     }
+
+                    // Restore floating pan state from last session (by ordinal index)
+                    QList<int> floatIndices = m_panStack->savedFloatingIndices();
+                    qDebug() << "Float restore: indices =" << floatIndices
+                             << "panCount =" << m_panStack->count();
+                    if (!floatIndices.isEmpty()) {
+                        QList<PanadapterApplet*> allApplets = m_panStack->allApplets();
+                        qDebug() << "Float restore: allApplets.size =" << allApplets.size();
+                        for (int idx : floatIndices) {
+                            if (idx >= 0 && idx < allApplets.size()) {
+                                const QString fid = allApplets[idx]->panId();
+                                qDebug() << "Float restore: floating pan idx" << idx
+                                         << "panId =" << fid;
+                                if (!m_panStack->isFloating(fid)) {
+                                    m_panStack->floatPanadapter(fid);
+                                }
+                            } else {
+                                qDebug() << "Float restore: index" << idx
+                                         << "out of range (applets:" << allApplets.size() << ")";
+                            }
+                        }
+                    }
                 });
             });
         }
-        m_layoutRestoreTimer->start();  // restart on each new pan
+        // Only restart during initial connection — once the timer has fired
+        // (initial layout applied), later panadapterAdded signals are user-created.
+        if (!m_layoutRestoreTimer->property("fired").toBool()) {
+            m_layoutRestoreTimer->start();
+        }
     });
     // Re-push xpixels/ypixels when the radio requests it (profile change, reconnect, etc.)
     connect(&m_radioModel, &RadioModel::panDimensionsNeeded,
@@ -1020,6 +1056,53 @@ MainWindow::MainWindow(QWidget* parent)
             m_panStack->rearrangeLayout("2v");
         else if (remaining == 3)
             m_panStack->rearrangeLayout("2h1");
+    });
+
+    // ── Float/dock: re-push xpixels/ypixels after layout change ─────────
+    connect(m_panStack, &PanadapterStack::panFloated,
+            this, [this](const QString& panId) {
+        // After floating, ALL pans may have resized (including the floated one)
+        QTimer::singleShot(200, this, [this]() {
+            for (auto* applet : m_panStack->allApplets()) {
+                auto* sw = applet->spectrumWidget();
+                auto* pan = m_radioModel.panadapter(applet->panId());
+                if (!sw || !pan) {
+                    continue;
+                }
+                int xpix = qMax(sw->width(), 200);
+                int ypix = qMax(sw->height(), 200);
+                m_radioModel.sendCommand(
+                    QString("display pan set %1 xpixels=%2 ypixels=%3")
+                        .arg(pan->panId()).arg(xpix).arg(ypix));
+                if (pan->panStreamId()) {
+                    m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
+                }
+            }
+        });
+        Q_UNUSED(panId);
+    });
+
+    connect(m_panStack, &PanadapterStack::panDocked,
+            this, [this](const QString& panId) {
+        // After docking, all pans (including newly docked) may have resized
+        QTimer::singleShot(200, this, [this]() {
+            for (auto* applet : m_panStack->allApplets()) {
+                auto* sw = applet->spectrumWidget();
+                auto* pan = m_radioModel.panadapter(applet->panId());
+                if (!sw || !pan) {
+                    continue;
+                }
+                int xpix = qMax(sw->width(), 200);
+                int ypix = qMax(sw->height(), 200);
+                m_radioModel.sendCommand(
+                    QString("display pan set %1 xpixels=%2 ypixels=%3")
+                        .arg(pan->panId()).arg(xpix).arg(ypix));
+                if (pan->panStreamId()) {
+                    m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
+                }
+            }
+        });
+        Q_UNUSED(panId);
     });
 
     // ── Per-panadapter signal wiring (extracted for multi-pan support) ──────
@@ -1980,6 +2063,13 @@ MainWindow::~MainWindow()
 void MainWindow::closeEvent(QCloseEvent* event)
 {
     m_shuttingDown = true;
+
+    // Mark floating panadapter windows as shutting down so their closeEvent
+    // accepts the close instead of trying to dock (Cmd+Q fix).
+    if (m_panStack) {
+        m_panStack->prepareShutdown();
+    }
+
     auto& s = AppSettings::instance();
     s.setValue("MainWindowGeometry", saveGeometry().toBase64());
     s.setValue("MainWindowState",   saveState().toBase64());
@@ -2006,6 +2096,11 @@ void MainWindow::closeEvent(QCloseEvent* event)
     // DEXP saved on-change in PhoneApplet — do NOT overwrite here, because
     // the radio may have reset DEXP to off (model reflects radio state, not
     // the user's preference).
+
+    // Save floating panadapter state
+    if (m_panStack) {
+        m_panStack->saveFloatState();
+    }
 
     s.save();
 
@@ -2048,8 +2143,63 @@ void MainWindow::keyReleaseEvent(QKeyEvent* event)
     QMainWindow::keyReleaseEvent(event);
 }
 
+// ── Drag-and-drop: accept panadapter drops anywhere on MainWindow to
+//    prevent QDrag snap-back animation when floating a panadapter. ─────────
+
+void MainWindow::dragEnterEvent(QDragEnterEvent* event)
+{
+    if (event->mimeData()->hasFormat(PanadapterApplet::kMimeType)) {
+        event->acceptProposedAction();
+    } else {
+        QMainWindow::dragEnterEvent(event);
+    }
+}
+
+void MainWindow::dropEvent(QDropEvent* event)
+{
+    if (!event->mimeData()->hasFormat(PanadapterApplet::kMimeType)) {
+        QMainWindow::dropEvent(event);
+        return;
+    }
+    event->acceptProposedAction();
+
+    const QString panId = QString::fromUtf8(
+        event->mimeData()->data(PanadapterApplet::kMimeType));
+
+    // If the drop landed on PanadapterStack, it already handled rearrangement
+    // via its own dropEvent. Only float if it landed outside the stack.
+    if (m_panStack) {
+        const QPoint stackLocal = m_panStack->mapFromGlobal(
+            mapToGlobal(event->position().toPoint()));
+        if (m_panStack->rect().contains(stackLocal)) {
+            return;  // PanadapterStack::dropEvent already handled it
+        }
+    }
+
+    // Drop landed outside the stack but inside MainWindow → float
+    if (m_panStack && !m_panStack->isFloating(panId)) {
+        int dockedCount = 0;
+        for (auto* ap : m_panStack->allApplets()) {
+            if (!m_panStack->isFloating(ap->panId())) {
+                dockedCount++;
+            }
+        }
+        if (dockedCount > 1) {
+            m_panStack->floatPanadapter(panId, QCursor::pos());
+        }
+    }
+}
+
 bool MainWindow::eventFilter(QObject* obj, QEvent* event)
 {
+    // Cmd+Q / app quit: mark floating windows as shutting down BEFORE
+    // closeAllWindows() sends them close events (which would dock them).
+    if (event->type() == QEvent::Quit) {
+        if (m_panStack) {
+            m_panStack->prepareShutdown();
+        }
+    }
+
     // Space PTT: intercept at application level so it works regardless of
     // which widget has focus (buttons, combos, etc. won't steal Space).
     if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease) {
@@ -2196,21 +2346,93 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
         return true;
     }
     if (obj == m_addPanLabel && event->type() == QEvent::MouseButtonPress) {
-        if (!m_radioModel.isConnected()) return true;
-        int maxPans = m_radioModel.maxPanadapters();
-        // Determine current layout from actual pan count, not saved setting
-        int activePanCount = m_panStack ? m_panStack->count() : 1;
-        QString currentLayout = "1";
-        if (activePanCount >= 2)
-            currentLayout = AppSettings::instance()
-                .value("PanadapterLayout", "1").toString();
-        PanLayoutDialog dlg(maxPans, currentLayout, this);
-        if (dlg.exec() == QDialog::Accepted && !dlg.selectedLayout().isEmpty()) {
-            const QString layoutId = dlg.selectedLayout();
-            auto& s = AppSettings::instance();
-            s.setValue("PanadapterLayout", layoutId);
-            s.save();
-            applyPanLayout(layoutId);
+        if (!m_radioModel.isConnected()) {
+            return true;
+        }
+        auto* me = static_cast<QMouseEvent*>(event);
+
+        if (me->button() == Qt::LeftButton) {
+            // Left-click: create a new panadapter at the bottom of the stack
+            int maxPans = m_radioModel.maxPanadapters();
+            int activePanCount = m_panStack ? m_panStack->count() : 1;
+            if (activePanCount >= maxPans) {
+                return true;  // already at max
+            }
+            m_radioModel.sendCmdPublic(
+                "display panafall create x=100 y=100",
+                [this](int code, const QString& body) {
+                    if (code != 0) {
+                        qWarning() << "addPan: panafall create failed, code"
+                                   << Qt::hex << code << body;
+                        return;
+                    }
+                    const auto kvs = CommandParser::parseKVs(body);
+                    QString panId;
+                    if (kvs.contains("pan"))       panId = kvs["pan"];
+                    else if (kvs.contains("id"))   panId = kvs["id"];
+                    else                           panId = body.trimmed();
+                    if (!panId.isEmpty()) {
+                        m_radioModel.sendCommand(
+                            QString("display pan set %1 xpixels=1024 ypixels=700").arg(panId));
+                        m_radioModel.sendCommand(
+                            QString("display pan set %1 fps=25").arg(panId));
+                    }
+                });
+            return true;
+        }
+
+        if (me->button() == Qt::RightButton) {
+            // Right-click: context menu
+            auto* menu = new QMenu(this);
+            menu->setAttribute(Qt::WA_DeleteOnClose);
+
+            menu->addAction("Add Panadapter", this, [this]() {
+                if (!m_radioModel.isConnected()) {
+                    return;
+                }
+                int maxPans = m_radioModel.maxPanadapters();
+                int activePanCount = m_panStack ? m_panStack->count() : 1;
+                if (activePanCount >= maxPans) {
+                    return;
+                }
+                m_radioModel.sendCmdPublic(
+                    "display panafall create x=100 y=100",
+                    [this](int code, const QString& body) {
+                        if (code != 0) return;
+                        const auto kvs = CommandParser::parseKVs(body);
+                        QString panId;
+                        if (kvs.contains("pan"))       panId = kvs["pan"];
+                        else if (kvs.contains("id"))   panId = kvs["id"];
+                        else                           panId = body.trimmed();
+                        if (!panId.isEmpty()) {
+                            m_radioModel.sendCommand(
+                                QString("display pan set %1 xpixels=1024 ypixels=700").arg(panId));
+                            m_radioModel.sendCommand(
+                                QString("display pan set %1 fps=25").arg(panId));
+                        }
+                    });
+            });
+
+            menu->addAction("Select Panadapter Grid...", this, [this]() {
+                int maxPans = m_radioModel.maxPanadapters();
+                int activePanCount = m_panStack ? m_panStack->count() : 1;
+                QString currentLayout = "1";
+                if (activePanCount >= 2) {
+                    currentLayout = AppSettings::instance()
+                        .value("PanadapterLayout", "1").toString();
+                }
+                PanLayoutDialog dlg(maxPans, currentLayout, this);
+                if (dlg.exec() == QDialog::Accepted && !dlg.selectedLayout().isEmpty()) {
+                    const QString layoutId = dlg.selectedLayout();
+                    auto& s = AppSettings::instance();
+                    s.setValue("PanadapterLayout", layoutId);
+                    s.save();
+                    applyPanLayout(layoutId);
+                }
+            });
+
+            menu->popup(me->globalPosition().toPoint());
+            return true;
         }
         return true;
     }
@@ -3988,6 +4210,10 @@ void MainWindow::onConnectionStateChanged(bool connected)
 {
     m_connPanel->setConnected(connected);
     if (connected) {
+        // Reset layout restore timer so it can fire again for this session
+        if (m_layoutRestoreTimer) {
+            m_layoutRestoreTimer->setProperty("fired", false);
+        }
         m_radioInfoLabel->setText(m_radioModel.model());
         m_radioVersionLabel->setText(m_radioModel.version());
         m_stationLabel->setText(m_radioModel.nickname());
@@ -4419,8 +4645,15 @@ void MainWindow::onSliceAdded(SliceModel* s)
     // Set the panadapter applet's slice label (e.g. "Slice B") based on
     // which pan this slice belongs to
     if (m_panStack && !s->panId().isEmpty()) {
-        if (auto* applet = m_panStack->panadapter(s->panId()))
+        if (auto* applet = m_panStack->panadapter(s->panId())) {
             applet->setSliceId(s->sliceId());
+            // Also update floating window title if this pan is detached
+            if (auto* fw = m_panStack->floatingWindow(s->panId())) {
+                static const char kLetters[] = "ABCD";
+                char letter = (s->sliceId() >= 0 && s->sliceId() < 4) ? kLetters[s->sliceId()] : '?';
+                fw->setTitle(QStringLiteral("Panadapter \u2014 Slice %1").arg(letter));
+            }
+        }
     }
 
     // Set initial hasTxSlice for waterfall freeze logic
@@ -4986,6 +5219,31 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // Don't close the last pan
         if (m_panStack->count() <= 1) return;
         m_radioModel.sendCommand(QString("display pan remove %1").arg(panId));
+    });
+
+    // ── Drag-out-to-float: when a drag is released outside the stack
+    //    (QDrag::exec returned IgnoreAction), float the panadapter. ────────
+    connect(applet, &PanadapterApplet::dragDroppedOutside,
+            this, [this](const QString& panId) {
+        if (m_panStack->isFloating(panId)) {
+            return;
+        }
+        PanadapterApplet* a = m_panStack->panadapter(panId);
+        if (!a) {
+            return;
+        }
+        // Count how many pans are currently docked (not floating)
+        int dockedCount = 0;
+        for (auto* ap : m_panStack->allApplets()) {
+            if (!m_panStack->isFloating(ap->panId())) {
+                dockedCount++;
+            }
+        }
+        // Don't float the last docked pan
+        if (dockedCount <= 1) {
+            return;
+        }
+        m_panStack->floatPanadapter(panId, QCursor::pos());
     });
 
     // ── User drag actions from spectrum → radio (per-pan) ──────────────────

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -79,6 +79,8 @@ protected:
     void closeEvent(QCloseEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void keyReleaseEvent(QKeyEvent* event) override;
+    void dragEnterEvent(QDragEnterEvent* event) override;
+    void dropEvent(QDropEvent* event) override;
     bool eventFilter(QObject* obj, QEvent* event) override;
 
 private slots:

--- a/src/gui/PanDropOverlay.cpp
+++ b/src/gui/PanDropOverlay.cpp
@@ -1,0 +1,111 @@
+#include "PanDropOverlay.h"
+
+#include <QPainter>
+#include <QPaintEvent>
+
+namespace AetherSDR {
+
+PanDropOverlay::PanDropOverlay(QWidget* parent)
+    : QWidget(parent)
+{
+    setAttribute(Qt::WA_TransparentForMouseEvents, false);
+    setAttribute(Qt::WA_NoSystemBackground, true);
+    setAutoFillBackground(false);
+}
+
+DropZone PanDropOverlay::zoneAt(const QPoint& localPos) const
+{
+    const int w = width();
+    const int h = height();
+    if (w == 0 || h == 0) {
+        return DropZone::None;
+    }
+
+    // Normalized position [0.0, 1.0]
+    const double nx = static_cast<double>(localPos.x()) / w;
+    const double ny = static_cast<double>(localPos.y()) / h;
+
+    // Center zone: inner 40% rectangle
+    static constexpr double kEdge = 0.30;
+    if (nx > kEdge && nx < (1.0 - kEdge) && ny > kEdge && ny < (1.0 - kEdge)) {
+        return DropZone::Center;
+    }
+
+    // Edge zones: whichever edge is closest
+    const double distTop    = ny;
+    const double distBottom = 1.0 - ny;
+    const double distLeft   = nx;
+    const double distRight  = 1.0 - nx;
+
+    const double minDist = std::min({distTop, distBottom, distLeft, distRight});
+
+    if (minDist == distTop) {
+        return DropZone::Top;
+    }
+    if (minDist == distBottom) {
+        return DropZone::Bottom;
+    }
+    if (minDist == distLeft) {
+        return DropZone::Left;
+    }
+    return DropZone::Right;
+}
+
+void PanDropOverlay::setActiveZone(DropZone zone)
+{
+    if (m_activeZone == zone) {
+        return;
+    }
+    m_activeZone = zone;
+    update();
+}
+
+void PanDropOverlay::paintEvent(QPaintEvent* /*ev*/)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, false);
+
+    const int w = width();
+    const int h = height();
+
+    // Light scrim over the entire widget
+    p.fillRect(rect(), QColor(15, 15, 26, 60));  // #0f0f1a at ~24% opacity
+
+    if (m_activeZone == DropZone::None) {
+        return;
+    }
+
+    // Highlight rect for the active zone
+    QRect zoneRect;
+    const int halfW = w / 2;
+    const int halfH = h / 2;
+
+    switch (m_activeZone) {
+    case DropZone::Top:
+        zoneRect = QRect(0, 0, w, halfH);
+        break;
+    case DropZone::Bottom:
+        zoneRect = QRect(0, halfH, w, h - halfH);
+        break;
+    case DropZone::Left:
+        zoneRect = QRect(0, 0, halfW, h);
+        break;
+    case DropZone::Right:
+        zoneRect = QRect(halfW, 0, w - halfW, h);
+        break;
+    case DropZone::Center:
+        zoneRect = rect();
+        break;
+    default:
+        return;
+    }
+
+    // Accent fill: #00b4d8 at ~30% opacity
+    p.fillRect(zoneRect, QColor(0, 180, 216, 77));
+
+    // Border around the zone
+    p.setPen(QPen(QColor(0, 180, 216, 140), 2));
+    p.drawRect(zoneRect.adjusted(1, 1, -1, -1));
+}
+
+} // namespace AetherSDR

--- a/src/gui/PanDropOverlay.h
+++ b/src/gui/PanDropOverlay.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QWidget>
+
+namespace AetherSDR {
+
+// Identifies which drop zone the cursor is hovering over.
+enum class DropZone {
+    None,
+    Top,
+    Bottom,
+    Left,
+    Right,
+    Center
+};
+
+// Semi-transparent overlay drawn on top of a PanadapterApplet during a
+// drag-and-drop operation.  Shows five zones (top/bottom/left/right/center)
+// and highlights the active zone with a dim accent block, VSCode-style.
+class PanDropOverlay : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit PanDropOverlay(QWidget* parent = nullptr);
+
+    // Update which zone is highlighted based on the cursor position
+    // (in overlay-local coordinates).
+    void setActiveZone(DropZone zone);
+    DropZone activeZone() const { return m_activeZone; }
+
+    // Determine which zone a local point falls in.
+    DropZone zoneAt(const QPoint& localPos) const;
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+
+private:
+    DropZone m_activeZone{DropZone::None};
+};
+
+} // namespace AetherSDR

--- a/src/gui/PanFloatingWindow.cpp
+++ b/src/gui/PanFloatingWindow.cpp
@@ -1,0 +1,134 @@
+#include "PanFloatingWindow.h"
+#include "PanadapterApplet.h"
+#include "core/AppSettings.h"
+
+#include <QVBoxLayout>
+#include <QCloseEvent>
+#include <QMoveEvent>
+#include <QResizeEvent>
+#include <QTimer>
+#include <QCoreApplication>
+#include <QGuiApplication>
+#include <QScreen>
+
+namespace AetherSDR {
+
+PanFloatingWindow::PanFloatingWindow(PanadapterApplet* applet, QWidget* parent)
+    : QWidget(parent, Qt::Window)
+    , m_applet(applet)
+{
+    setWindowTitle(QStringLiteral("Panadapter"));
+    setAttribute(Qt::WA_DeleteOnClose, false);
+    setMinimumSize(400, 300);
+
+    setStyleSheet(
+        "PanFloatingWindow { background: #0f0f1a; }");
+
+    m_contentLayout = new QVBoxLayout(this);
+    m_contentLayout->setContentsMargins(0, 0, 0, 0);
+    m_contentLayout->setSpacing(0);
+    applet->setParent(this);
+    applet->setDockButtonVisible(true);
+    m_contentLayout->addWidget(applet);
+    applet->show();
+
+    // Dock button on applet title bar → re-dock
+    connect(applet, &PanadapterApplet::dockRequested,
+            this, &PanFloatingWindow::dockRequested);
+
+    resize(800, 500);
+
+    // Debounce geometry saves
+    m_saveTimer = new QTimer(this);
+    m_saveTimer->setSingleShot(true);
+    m_saveTimer->setInterval(400);
+    connect(m_saveTimer, &QTimer::timeout, this, &PanFloatingWindow::saveWindowGeometry);
+
+    connect(qApp, &QCoreApplication::aboutToQuit, this, [this]() {
+        m_appShuttingDown = true;
+    });
+}
+
+QString PanFloatingWindow::panId() const
+{
+    return m_applet ? m_applet->panId() : QString();
+}
+
+PanadapterApplet* PanFloatingWindow::takeApplet()
+{
+    PanadapterApplet* a = m_applet;
+    if (a) {
+        a->setDockButtonVisible(false);
+        m_contentLayout->removeWidget(a);
+        a->setParent(nullptr);
+        m_applet = nullptr;
+    }
+    return a;
+}
+
+void PanFloatingWindow::setTitle(const QString& title)
+{
+    setWindowTitle(title);
+}
+
+void PanFloatingWindow::saveWindowGeometry()
+{
+    auto& s = AppSettings::instance();
+    const QString key = QStringLiteral("PanFloat_%1_Geometry").arg(panId());
+    const QRect r = geometry();
+    s.setValue(key, QStringLiteral("%1,%2,%3,%4")
+        .arg(r.x()).arg(r.y()).arg(r.width()).arg(r.height()));
+    s.save();
+}
+
+void PanFloatingWindow::restoreWindowGeometry()
+{
+    auto& s = AppSettings::instance();
+    const QString key = QStringLiteral("PanFloat_%1_Geometry").arg(panId());
+    const QString val = s.value(key, "").toString();
+    if (val.isEmpty()) {
+        return;
+    }
+    const QStringList parts = val.split(',');
+    if (parts.size() != 4) {
+        return;
+    }
+    const QRect r(parts[0].toInt(), parts[1].toInt(),
+                  parts[2].toInt(), parts[3].toInt());
+    // Validate the geometry is on a visible screen
+    bool onScreen = false;
+    for (QScreen* screen : QGuiApplication::screens()) {
+        if (screen->availableGeometry().intersects(r)) {
+            onScreen = true;
+            break;
+        }
+    }
+    if (onScreen) {
+        setGeometry(r);
+    }
+}
+
+void PanFloatingWindow::closeEvent(QCloseEvent* ev)
+{
+    if (!m_appShuttingDown) {
+        saveWindowGeometry();
+        emit dockRequested(panId());
+        ev->ignore();  // dockPanadapter will destroy us
+    } else {
+        ev->accept();
+    }
+}
+
+void PanFloatingWindow::resizeEvent(QResizeEvent* ev)
+{
+    QWidget::resizeEvent(ev);
+    m_saveTimer->start();
+}
+
+void PanFloatingWindow::moveEvent(QMoveEvent* ev)
+{
+    QWidget::moveEvent(ev);
+    m_saveTimer->start();
+}
+
+} // namespace AetherSDR

--- a/src/gui/PanFloatingWindow.h
+++ b/src/gui/PanFloatingWindow.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <QWidget>
+
+class QTimer;
+class QVBoxLayout;
+
+namespace AetherSDR {
+
+class PanadapterApplet;
+
+// Top-level window that hosts a single detached PanadapterApplet.
+// The window is frameless with a thin custom title bar. Dragging the
+// title bar over the PanadapterStack re-docks the applet. Closing
+// the window also re-docks.
+class PanFloatingWindow : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit PanFloatingWindow(PanadapterApplet* applet, QWidget* parent = nullptr);
+
+    PanadapterApplet* applet() const { return m_applet; }
+    QString panId() const;
+
+    // Update the displayed title (e.g. "Panadapter — Slice A")
+    void setTitle(const QString& title);
+
+    // Take the applet back out of this window (caller becomes new parent).
+    // Returns the applet and nulls the internal pointer.
+    PanadapterApplet* takeApplet();
+
+    void saveWindowGeometry();
+    void restoreWindowGeometry();
+
+    // Mark this window as part of application shutdown (closeEvent will accept).
+    void setAppShuttingDown() { m_appShuttingDown = true; }
+
+signals:
+    void dockRequested(const QString& panId);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+
+private:
+    PanadapterApplet* m_applet{nullptr};
+    QVBoxLayout*      m_contentLayout{nullptr};
+    QTimer*           m_saveTimer{nullptr};
+    bool              m_appShuttingDown{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -10,6 +10,12 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QTextEdit>
+#include <QMouseEvent>
+#include <QDrag>
+#include <QMimeData>
+#include <QApplication>
+#include <QPainter>
+#include <QTimer>
 
 namespace AetherSDR {
 
@@ -21,18 +27,20 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     layout->setSpacing(0);
 
     // ── Title bar (16px gradient, matching applet style) ─────────────────
-    auto* titleBar = new QWidget;
-    titleBar->setFixedHeight(16);
-    titleBar->setStyleSheet(
+    m_titleBarWidget = new QWidget;
+    m_titleBarWidget->setFixedHeight(16);
+    m_titleBarWidget->setCursor(Qt::OpenHandCursor);
+    m_titleBarWidget->installEventFilter(this);
+    m_titleBarWidget->setStyleSheet(
         "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
         "stop:0 #3a4a5a, stop:0.5 #2a3a4a, stop:1 #1a2a38); "
         "border-bottom: 1px solid #0a1a28; }");
 
-    auto* barLayout = new QHBoxLayout(titleBar);
+    auto* barLayout = new QHBoxLayout(m_titleBarWidget);
     barLayout->setContentsMargins(6, 1, 4, 1);
     barLayout->setSpacing(2);
 
-    m_titleLabel = new QLabel("Slice A");
+    m_titleLabel = new QLabel;
     m_titleLabel->setStyleSheet("QLabel { background: transparent; color: #8aa8c0; "
                                 "font-size: 10px; font-weight: bold; }");
     barLayout->addWidget(m_titleLabel);
@@ -43,15 +51,32 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
         "border: none; font-size: 9px; padding: 0; }"
         "QPushButton:hover { color: #c8d8e8; }");
 
+    // ── Dock button (hidden by default, shown when floating) ─────────
+    m_dockBtn = new QPushButton(QStringLiteral("\u21a9 Dock"));
+    m_dockBtn->setFixedHeight(14);
+    m_dockBtn->setCursor(Qt::ArrowCursor);
+    m_dockBtn->setToolTip("Return panadapter to the main window");
+    m_dockBtn->setStyleSheet(
+        "QPushButton { background: #1a2a3a; color: #8aa8c0; "
+        "border: 1px solid #304050; border-radius: 3px; "
+        "font-size: 9px; padding: 0 5px; }"
+        "QPushButton:hover { background: #243848; color: #c8d8e8; }");
+    m_dockBtn->hide();
+    connect(m_dockBtn, &QPushButton::clicked, this, [this]() {
+        emit dockRequested(m_panId);
+    });
+    barLayout->addWidget(m_dockBtn);
+
     auto* closeBtn = new QPushButton("\u00D7");
     closeBtn->setFixedSize(14, 14);
+    closeBtn->setCursor(Qt::ArrowCursor);
     closeBtn->setStyleSheet(btnStyle + "QPushButton:hover { color: #ff4040; }");
     connect(closeBtn, &QPushButton::clicked, this, [this]() {
         emit closeRequested(m_panId);
     });
     barLayout->addWidget(closeBtn);
 
-    layout->addWidget(titleBar);
+    layout->addWidget(m_titleBarWidget);
 
     // ── Spectrum widget (FFT + waterfall) ────────────────────────────────
     m_spectrum = new SpectrumWidget(this);
@@ -219,14 +244,18 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
 
 void PanadapterApplet::setSliceId(int id)
 {
-    const char letters[] = "ABCD";
-    const char letter = (id >= 0 && id < 4) ? letters[id] : '?';
-    m_titleLabel->setText(QString("Slice %1").arg(letter));
+    Q_UNUSED(id);
+    // Title bar is intentionally blank — slice info shown in the spectrum overlay
 }
 
 void PanadapterApplet::clearSliceTitle()
 {
     m_titleLabel->clear();
+}
+
+void PanadapterApplet::setDockButtonVisible(bool visible)
+{
+    m_dockBtn->setVisible(visible);
 }
 
 void PanadapterApplet::setCwPanelVisible(bool visible)
@@ -274,8 +303,97 @@ void PanadapterApplet::clearCwText()
 
 bool PanadapterApplet::eventFilter(QObject* obj, QEvent* ev)
 {
-    if (ev->type() == QEvent::MouseButtonPress)
+    if (ev->type() == QEvent::MouseButtonPress) {
         emit activated(m_panId);
+
+        // Title bar drag initiation: record start position
+        if (obj == m_titleBarWidget) {
+            auto* me = static_cast<QMouseEvent*>(ev);
+            if (me->button() == Qt::LeftButton) {
+                m_dragStartPos = me->pos();
+            }
+        }
+    }
+
+    // Title bar drag threshold check
+    if (obj == m_titleBarWidget && ev->type() == QEvent::MouseMove) {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if ((me->buttons() & Qt::LeftButton) && !m_dragStartPos.isNull()) {
+            if ((me->pos() - m_dragStartPos).manhattanLength() >= QApplication::startDragDistance()) {
+                m_titleBarWidget->setCursor(Qt::ClosedHandCursor);
+
+                auto* drag = new QDrag(this);
+                auto* mimeData = new QMimeData;
+                mimeData->setData(kMimeType, m_panId.toUtf8());
+                drag->setMimeData(mimeData);
+
+                // Build a semi-transparent preview thumbnail
+                QPixmap snapshot = this->grab();
+                constexpr int kPreviewWidth = 320;
+                QSize previewSize = snapshot.size().scaled(
+                    kPreviewWidth, kPreviewWidth, Qt::KeepAspectRatio);
+                snapshot = snapshot.scaled(
+                    previewSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+                QPixmap previewPm(snapshot.size());
+                previewPm.fill(Qt::transparent);
+                {
+                    QPainter painter(&previewPm);
+                    painter.setOpacity(0.65);
+                    painter.drawPixmap(0, 0, snapshot);
+                    painter.setOpacity(1.0);
+                    painter.setPen(QPen(QColor(0x00, 0xb4, 0xd8, 180), 2));
+                    painter.drawRect(previewPm.rect().adjusted(1, 1, -1, -1));
+                }
+
+                // Show the preview as a floating window that tracks the cursor.
+                // The QDrag pixmap is 1x1 transparent so the OS snap-back
+                // animation is invisible when the drop is not accepted.
+                QPixmap transparent(1, 1);
+                transparent.fill(Qt::transparent);
+                drag->setPixmap(transparent);
+
+                auto* previewWin = new QWidget(nullptr,
+                    Qt::ToolTip | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
+                previewWin->setAttribute(Qt::WA_TranslucentBackground);
+                previewWin->setAttribute(Qt::WA_ShowWithoutActivating);
+                previewWin->setFixedSize(previewPm.size() / previewPm.devicePixelRatio());
+                auto* pmLabel = new QLabel(previewWin);
+                pmLabel->setPixmap(previewPm);
+                pmLabel->setGeometry(0, 0, previewWin->width(), previewWin->height());
+                previewWin->move(QCursor::pos() - QPoint(previewWin->width() / 2, 12));
+                previewWin->show();
+
+                auto* tracker = new QTimer(previewWin);
+                connect(tracker, &QTimer::timeout, previewWin, [previewWin]() {
+                    previewWin->move(QCursor::pos() - QPoint(previewWin->width() / 2, 12));
+                });
+                tracker->start(16);  // ~60 fps
+
+                emit dragStarted(m_panId);
+                m_dragStartPos = QPoint();  // reset
+
+                Qt::DropAction result = drag->exec(Qt::MoveAction);
+
+                // Destroy the floating preview immediately
+                delete previewWin;
+
+                // If the drop was not accepted by any target (released outside
+                // the PanadapterStack), signal that we should float this pan.
+                if (result == Qt::IgnoreAction) {
+                    emit dragDroppedOutside(m_panId);
+                }
+
+                m_titleBarWidget->setCursor(Qt::OpenHandCursor);
+                return true;
+            }
+        }
+    }
+
+    // Reset drag on release
+    if (obj == m_titleBarWidget && ev->type() == QEvent::MouseButtonRelease) {
+        m_dragStartPos = QPoint();
+    }
+
     return QWidget::eventFilter(obj, ev);
 }
 

--- a/src/gui/PanadapterApplet.h
+++ b/src/gui/PanadapterApplet.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QWidget>
+#include <QPoint>
 
 class QLabel;
 class QPushButton;
@@ -15,6 +16,7 @@ class SpectrumWidget;
 // Adds a title bar with placeholder min/max/close buttons above the
 // SpectrumWidget.  Prepares for future multi-slice stacking where each
 // slice gets its own PanadapterApplet in a vertical splitter.
+// Title bar supports drag-to-rearrange and drag-out-to-float.
 class PanadapterApplet : public QWidget {
     Q_OBJECT
 
@@ -27,9 +29,12 @@ public:
     QString panId() const { return m_panId; }
     void setPanId(const QString& id) { m_panId = id; }
 
-    // Set the slice ID (0=A, 1=B, 2=C, 3=D) shown in the title bar.
+    // Set the slice ID (0=A, 1=B, 2=C, 3=D) for internal tracking.
     void setSliceId(int id);
     void clearSliceTitle();
+
+    // Show/hide the "Dock" button in the title bar (for floating windows).
+    void setDockButtonVisible(bool visible);
 
     // CW decode panel
     void setCwPanelVisible(bool visible);
@@ -41,10 +46,16 @@ public:
 
     QSize sizeHint() const override { return {800, 316}; }
 
+    // MIME type used for panadapter drag-and-drop
+    static constexpr const char* kMimeType = "application/x-aethersdr-panadapter";
+
 signals:
     void activated(const QString& panId);
     void closeRequested(const QString& panId);
+    void dockRequested(const QString& panId);
     void pitchRangeChanged(int minHz, int maxHz);
+    void dragStarted(const QString& panId);
+    void dragDroppedOutside(const QString& panId);
 
 protected:
     bool eventFilter(QObject* obj, QEvent* ev) override;
@@ -52,7 +63,10 @@ protected:
 private:
     QString m_panId;
     SpectrumWidget* m_spectrum{nullptr};
+    QWidget*        m_titleBarWidget{nullptr};
     QLabel*         m_titleLabel{nullptr};
+    QPushButton*    m_dockBtn{nullptr};
+    QPoint          m_dragStartPos;
 
     // CW decode
     QWidget*   m_cwPanel{nullptr};

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -1,17 +1,51 @@
 #include "PanadapterStack.h"
 #include "BandStackPanel.h"
 #include "PanadapterApplet.h"
+#include "PanDropOverlay.h"
+#include "PanFloatingWindow.h"
 #include "SpectrumWidget.h"
+#include "core/AppSettings.h"
 
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QTimer>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QMimeData>
+#include <QWindow>
 
 namespace AetherSDR {
+
+// Force a QRhiWidget to recreate its native surface after a cross-window
+// reparent.  QRhiWidget (with WA_NativeWindow on macOS) binds its Metal
+// surface to the top-level window; moving to a different top-level leaves
+// the surface stale.  Hiding the widget, destroying its native handle, and
+// showing it again forces Qt to create a fresh surface in the new window.
+static void resetNativeSurface(SpectrumWidget* sw)
+{
+    if (!sw) {
+        return;
+    }
+#ifdef AETHER_GPU_SPECTRUM
+    sw->hide();
+    if (QWindow* w = sw->windowHandle()) {
+        w->destroy();
+    }
+    // Re-assert the attribute so Qt creates a new native window on show()
+    sw->setAttribute(Qt::WA_NativeWindow);
+    sw->show();
+    // Defer an update so the new surface gets its first frame
+    QTimer::singleShot(50, sw, [sw]() {
+        sw->update();
+    });
+#endif
+}
 
 PanadapterStack::PanadapterStack(QWidget* parent)
     : QWidget(parent)
 {
+    setAcceptDrops(true);
+
     auto* hbox = new QHBoxLayout(this);
     hbox->setContentsMargins(0, 0, 0, 0);
     hbox->setSpacing(0);
@@ -163,11 +197,16 @@ void PanadapterStack::equalizeSizes()
 
 void PanadapterStack::rearrangeLayout(const QString& layoutId)
 {
-    // Collect applets in order
-    QList<PanadapterApplet*> applets = m_pans.values();
+    // Collect only docked applets — floating ones stay in their windows
+    QList<PanadapterApplet*> applets;
+    for (auto it = m_pans.constBegin(); it != m_pans.constEnd(); ++it) {
+        if (!m_floatingWindows.contains(it.key())) {
+            applets.append(it.value());
+        }
+    }
     if (applets.isEmpty()) return;
 
-    // Remove all applets from current splitter (don't delete them)
+    // Remove docked applets from current splitter (don't delete them)
     for (auto* a : applets)
         a->setParent(nullptr);
 
@@ -245,6 +284,13 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
 
 void PanadapterStack::removeAll()
 {
+    // Close floating windows first
+    for (auto* fw : m_floatingWindows) {
+        fw->takeApplet();  // don't let it emit dockRequested
+        delete fw;
+    }
+    m_floatingWindows.clear();
+
     qDeleteAll(m_pans);
     m_pans.clear();
     m_activePanId.clear();
@@ -255,6 +301,403 @@ void PanadapterStack::removeAll()
     m_splitter->setHandleWidth(3);
     m_splitter->setChildrenCollapsible(false);
     layout()->addWidget(m_splitter);
+}
+
+// ── Float / Dock ──────────────────────────────────────────────────────────
+
+void PanadapterStack::floatPanadapter(const QString& panId, const QPoint& globalPos)
+{
+    PanadapterApplet* applet = m_pans.value(panId, nullptr);
+    if (!applet) {
+        return;
+    }
+    if (m_floatingWindows.contains(panId)) {
+        return;  // already floating
+    }
+
+    // Remove from splitter (don't remove from m_pans — applet stays tracked)
+    applet->setParent(nullptr);
+
+    // Collapse any degenerate splitters left behind
+    collapseSplitters();
+
+    // Create floating window
+    auto* fw = new PanFloatingWindow(applet, nullptr);
+    m_floatingWindows[panId] = fw;
+
+    if (!globalPos.isNull()) {
+        fw->move(globalPos - QPoint(40, 10));
+    }
+    fw->restoreWindowGeometry();
+    fw->show();
+    fw->raise();
+
+    // Force the SpectrumWidget (QRhiWidget) to recreate its GPU surface
+    // now that it lives in a different top-level window.
+    resetNativeSurface(applet->spectrumWidget());
+
+    connect(fw, &PanFloatingWindow::dockRequested,
+            this, &PanadapterStack::dockPanadapterDefault);
+
+    // Re-equalize the remaining docked pans
+    QTimer::singleShot(0, this, [this]() { equalizeSizes(); });
+
+    saveFloatState();
+    emit panFloated(panId);
+}
+
+void PanadapterStack::dockPanadapter(const QString& panId,
+                                      const QString& targetPanId,
+                                      DropZone zone)
+{
+    PanFloatingWindow* fw = m_floatingWindows.take(panId);
+    PanadapterApplet* applet = nullptr;
+    if (fw) {
+        applet = fw->takeApplet();
+        fw->deleteLater();
+    } else {
+        // Not floating — it's a rearrange within the stack
+        applet = m_pans.value(panId, nullptr);
+        if (applet) {
+            applet->setParent(nullptr);
+            collapseSplitters();
+        }
+    }
+    if (!applet) {
+        return;
+    }
+
+    PanadapterApplet* target = m_pans.value(targetPanId, nullptr);
+    if (!target || zone == DropZone::None) {
+        // Fallback: append to root splitter
+        m_splitter->addWidget(applet);
+        applet->show();
+    } else if (zone == DropZone::Center) {
+        // Swap positions: find target in its parent splitter, replace
+        QSplitter* parentSplitter = qobject_cast<QSplitter*>(target->parentWidget());
+        if (parentSplitter) {
+            int targetIdx = parentSplitter->indexOf(target);
+            // Insert the dragged applet at the target's position
+            parentSplitter->insertWidget(targetIdx, applet);
+            applet->show();
+            // Target stays where it is (shifted by one)
+        } else {
+            m_splitter->addWidget(applet);
+            applet->show();
+        }
+    } else {
+        insertBySplit(target, applet, zone);
+        applet->show();
+    }
+
+    collapseSplitters();
+    QTimer::singleShot(0, this, [this]() { equalizeSizes(); });
+
+    // Force the SpectrumWidget to recreate its GPU surface in the new window
+    resetNativeSurface(applet->spectrumWidget());
+
+    saveFloatState();
+    emit panDocked(panId);
+}
+
+void PanadapterStack::dockPanadapterDefault(const QString& panId)
+{
+    // Dock at the bottom of the root splitter (simple re-attach)
+    PanFloatingWindow* fw = m_floatingWindows.take(panId);
+    PanadapterApplet* applet = nullptr;
+    if (fw) {
+        applet = fw->takeApplet();
+        fw->deleteLater();
+    }
+    if (!applet) {
+        return;
+    }
+
+    m_splitter->addWidget(applet);
+    applet->show();
+
+    // Force the SpectrumWidget to recreate its GPU surface in the main window
+    resetNativeSurface(applet->spectrumWidget());
+
+    QTimer::singleShot(0, this, [this]() { equalizeSizes(); });
+
+    saveFloatState();
+    emit panDocked(panId);
+}
+
+bool PanadapterStack::isFloating(const QString& panId) const
+{
+    return m_floatingWindows.contains(panId);
+}
+
+PanFloatingWindow* PanadapterStack::floatingWindow(const QString& panId) const
+{
+    return m_floatingWindows.value(panId, nullptr);
+}
+
+void PanadapterStack::saveFloatState() const
+{
+    auto& s = AppSettings::instance();
+    // Save ordinal indices of floating pans (pan IDs change between sessions)
+    QStringList indices;
+    QList<QString> allKeys = m_pans.keys();
+    for (auto it = m_floatingWindows.constBegin(); it != m_floatingWindows.constEnd(); ++it) {
+        int idx = allKeys.indexOf(it.key());
+        if (idx >= 0) {
+            indices.append(QString::number(idx));
+        }
+        it.value()->saveWindowGeometry();
+    }
+    s.setValue("PanFloatingIndices", indices.join(','));
+    s.save();
+    qDebug() << "PanadapterStack::saveFloatState: indices =" << indices
+             << "keys =" << allKeys;
+}
+
+QList<int> PanadapterStack::savedFloatingIndices() const
+{
+    const QString val = AppSettings::instance()
+        .value("PanFloatingIndices", "").toString();
+    if (val.isEmpty()) {
+        return {};
+    }
+    QList<int> result;
+    for (const QString& s : val.split(',', Qt::SkipEmptyParts)) {
+        bool ok = false;
+        int idx = s.toInt(&ok);
+        if (ok && idx >= 0) {
+            result.append(idx);
+        }
+    }
+    return result;
+}
+
+void PanadapterStack::clearSavedFloatState()
+{
+    AppSettings::instance().setValue("PanFloatingIndices", "");
+}
+
+void PanadapterStack::prepareShutdown()
+{
+    for (auto* fw : m_floatingWindows) {
+        fw->setAppShuttingDown();
+    }
+}
+
+// ── Drag-and-Drop Event Handlers ─────────────────────────────────────────
+
+void PanadapterStack::dragEnterEvent(QDragEnterEvent* ev)
+{
+    if (ev->mimeData()->hasFormat(PanadapterApplet::kMimeType)) {
+        ev->acceptProposedAction();
+    }
+}
+
+void PanadapterStack::dragMoveEvent(QDragMoveEvent* ev)
+{
+    if (!ev->mimeData()->hasFormat(PanadapterApplet::kMimeType)) {
+        return;
+    }
+    ev->acceptProposedAction();
+
+    PanadapterApplet* target = appletAt(ev->position().toPoint());
+    if (!target) {
+        hideDropOverlay();
+        return;
+    }
+
+    // Don't show overlay on the dragged applet itself
+    const QString draggedId = QString::fromUtf8(
+        ev->mimeData()->data(PanadapterApplet::kMimeType));
+    if (target->panId() == draggedId) {
+        hideDropOverlay();
+        return;
+    }
+
+    // Create or reposition overlay
+    if (!m_dropOverlay) {
+        m_dropOverlay = new PanDropOverlay(this);
+    }
+
+    // Position overlay to cover the target applet
+    const QPoint targetTopLeft = target->mapTo(this, QPoint(0, 0));
+    m_dropOverlay->setGeometry(targetTopLeft.x(), targetTopLeft.y(),
+                                target->width(), target->height());
+    m_dropOverlay->raise();
+    m_dropOverlay->show();
+
+    // Determine which zone the cursor is in
+    const QPoint localInOverlay = ev->position().toPoint() - targetTopLeft;
+    DropZone zone = m_dropOverlay->zoneAt(localInOverlay);
+    m_dropOverlay->setActiveZone(zone);
+    m_dropTargetPanId = target->panId();
+}
+
+void PanadapterStack::dragLeaveEvent(QDragLeaveEvent* /*ev*/)
+{
+    hideDropOverlay();
+
+    // If the drag left the PanadapterStack entirely, float the panadapter.
+    // We use a short timer so that spurious leave events (e.g. passing over
+    // a splitter handle) don't trigger a float.
+    // Note: The actual float is triggered from the QDrag result in PanadapterApplet.
+}
+
+void PanadapterStack::dropEvent(QDropEvent* ev)
+{
+    hideDropOverlay();
+
+    if (!ev->mimeData()->hasFormat(PanadapterApplet::kMimeType)) {
+        return;
+    }
+
+    const QString draggedId = QString::fromUtf8(
+        ev->mimeData()->data(PanadapterApplet::kMimeType));
+
+    PanadapterApplet* target = appletAt(ev->position().toPoint());
+    if (!target || target->panId() == draggedId) {
+        // Dropped on empty space or self — if floating, dock at bottom
+        if (m_floatingWindows.contains(draggedId)) {
+            dockPanadapterDefault(draggedId);
+        }
+        ev->acceptProposedAction();
+        return;
+    }
+
+    // Determine drop zone
+    const QPoint targetTopLeft = target->mapTo(this, QPoint(0, 0));
+    const QPoint localInTarget = ev->position().toPoint() - targetTopLeft;
+
+    // Use a temporary overlay calc to get the zone
+    PanDropOverlay tempOverlay;
+    tempOverlay.resize(target->size());
+    DropZone zone = tempOverlay.zoneAt(localInTarget);
+
+    dockPanadapter(draggedId, target->panId(), zone);
+
+    ev->acceptProposedAction();
+}
+
+// ── Internal Helpers ─────────────────────────────────────────────────────
+
+PanadapterApplet* PanadapterStack::appletAt(const QPoint& localPos) const
+{
+    for (auto it = m_pans.constBegin(); it != m_pans.constEnd(); ++it) {
+        PanadapterApplet* applet = it.value();
+        if (m_floatingWindows.contains(it.key())) {
+            continue;  // skip floating applets
+        }
+        if (!applet->isVisible()) {
+            continue;
+        }
+        const QRect r(applet->mapTo(const_cast<PanadapterStack*>(this), QPoint(0, 0)),
+                      applet->size());
+        if (r.contains(localPos)) {
+            return applet;
+        }
+    }
+    return nullptr;
+}
+
+void PanadapterStack::insertBySplit(QWidget* target, QWidget* inserted, DropZone zone)
+{
+    QSplitter* parentSplitter = qobject_cast<QSplitter*>(target->parentWidget());
+    if (!parentSplitter) {
+        // Target is directly in root — use root splitter
+        parentSplitter = m_splitter;
+    }
+
+    const int targetIdx = parentSplitter->indexOf(target);
+
+    // Determine orientation needed for this split
+    Qt::Orientation needed = Qt::Vertical;
+    if (zone == DropZone::Left || zone == DropZone::Right) {
+        needed = Qt::Horizontal;
+    }
+
+    // If parent splitter already has the right orientation, just insert adjacent
+    if (parentSplitter->orientation() == needed) {
+        if (zone == DropZone::Top || zone == DropZone::Left) {
+            parentSplitter->insertWidget(targetIdx, inserted);
+        } else {
+            parentSplitter->insertWidget(targetIdx + 1, inserted);
+        }
+        return;
+    }
+
+    // Need to wrap target + inserted in a new sub-splitter with the needed orientation
+    auto* newSplitter = new QSplitter(needed);
+    newSplitter->setHandleWidth(3);
+    newSplitter->setChildrenCollapsible(false);
+
+    // Replace target with the new splitter in the parent
+    parentSplitter->insertWidget(targetIdx, newSplitter);
+
+    // Move target into the new splitter
+    if (zone == DropZone::Top || zone == DropZone::Left) {
+        newSplitter->addWidget(inserted);
+        newSplitter->addWidget(target);
+    } else {
+        newSplitter->addWidget(target);
+        newSplitter->addWidget(inserted);
+    }
+
+    // Equalize the new sub-splitter
+    const int total = (needed == Qt::Horizontal) ? newSplitter->width() : newSplitter->height();
+    newSplitter->setSizes({total / 2, total / 2});
+}
+
+void PanadapterStack::collapseSplitters()
+{
+    collapseSplittersRecursive(m_splitter);
+}
+
+void PanadapterStack::collapseSplittersRecursive(QSplitter* splitter)
+{
+    if (!splitter) {
+        return;
+    }
+
+    // First recurse into nested splitters
+    for (int i = splitter->count() - 1; i >= 0; --i) {
+        if (auto* nested = qobject_cast<QSplitter*>(splitter->widget(i))) {
+            collapseSplittersRecursive(nested);
+        }
+    }
+
+    // If this splitter has exactly one child, promote it to the parent
+    if (splitter->count() == 1 && splitter != m_splitter) {
+        QWidget* child = splitter->widget(0);
+        QSplitter* parentSplitter = qobject_cast<QSplitter*>(splitter->parentWidget());
+        if (parentSplitter) {
+            int idx = parentSplitter->indexOf(splitter);
+            child->setParent(nullptr);
+            parentSplitter->insertWidget(idx, child);
+            splitter->deleteLater();
+        }
+    }
+
+    // If root splitter has exactly one child that is itself a splitter,
+    // promote that splitter's children into root
+    if (splitter == m_splitter && splitter->count() == 1) {
+        if (auto* onlyChild = qobject_cast<QSplitter*>(splitter->widget(0))) {
+            // Move all children of onlyChild into root
+            while (onlyChild->count() > 0) {
+                QWidget* w = onlyChild->widget(0);
+                m_splitter->addWidget(w);
+            }
+            m_splitter->setOrientation(onlyChild->orientation());
+            onlyChild->deleteLater();
+        }
+    }
+}
+
+void PanadapterStack::hideDropOverlay()
+{
+    if (m_dropOverlay) {
+        m_dropOverlay->hide();
+    }
+    m_dropTargetPanId.clear();
 }
 
 void PanadapterStack::applyLayout(const QString& layoutId, const QStringList& panIds)

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -4,15 +4,25 @@
 #include <QMap>
 #include <QSplitter>
 
+class QDragEnterEvent;
+class QDragMoveEvent;
+class QDragLeaveEvent;
+class QDropEvent;
+
 namespace AetherSDR {
 
 class BandStackPanel;
 class PanadapterApplet;
+class PanDropOverlay;
+class PanFloatingWindow;
 class SpectrumWidget;
+
+enum class DropZone;
 
 // Vertical stack of N PanadapterApplet instances, each showing an
 // independent FFT + waterfall for a different panadapter on the radio.
 // Single-pan mode: one applet fills the stack (no visible divider).
+// Supports drag-to-rearrange and drag-out-to-float (detach to a separate window).
 class PanadapterStack : public QWidget {
     Q_OBJECT
 
@@ -47,14 +57,55 @@ public:
     void equalizeSizes();
     void rearrangeLayout(const QString& layoutId);
 
+    // Float/dock a panadapter (detach to separate window / re-attach)
+    void floatPanadapter(const QString& panId, const QPoint& globalPos = {});
+    void dockPanadapter(const QString& panId, const QString& targetPanId, DropZone zone);
+    void dockPanadapterDefault(const QString& panId);  // dock at bottom of root splitter
+    bool isFloating(const QString& panId) const;
+    PanFloatingWindow* floatingWindow(const QString& panId) const;
+
+    // Save/restore which pans are floating (persisted as ordinal indices)
+    void saveFloatState() const;
+    QList<int> savedFloatingIndices() const;
+    void clearSavedFloatState();
+
+    // Mark all floating windows as shutting down so Cmd+Q close events
+    // are accepted instead of triggering dock.
+    void prepareShutdown();
+
 signals:
     void activePanChanged(const QString& panId);
+    void panFloated(const QString& panId);
+    void panDocked(const QString& panId);
+
+protected:
+    void dragEnterEvent(QDragEnterEvent* ev) override;
+    void dragMoveEvent(QDragMoveEvent* ev) override;
+    void dragLeaveEvent(QDragLeaveEvent* ev) override;
+    void dropEvent(QDropEvent* ev) override;
 
 private:
+    // Find which applet the local position is over
+    PanadapterApplet* appletAt(const QPoint& localPos) const;
+
+    // Insert a widget next to target in its parent splitter, splitting as needed
+    void insertBySplit(QWidget* target, QWidget* inserted, DropZone zone);
+
+    // Collapse degenerate splitters (single-child) in the tree
+    void collapseSplitters();
+    void collapseSplittersRecursive(QSplitter* splitter);
+
+    void hideDropOverlay();
+
     BandStackPanel* m_bandStackPanel{nullptr};
     QSplitter* m_splitter{nullptr};
     QMap<QString, PanadapterApplet*> m_pans;
+    QMap<QString, PanFloatingWindow*> m_floatingWindows;
     QString m_activePanId;
+
+    // Drop overlay shown during drag
+    PanDropOverlay* m_dropOverlay{nullptr};
+    QString         m_dropTargetPanId;
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
Drag a panadapter's title bar outside the main window to detach it into its own OS-native window. Drag it back into the stack with VSCode-style drop zones for free-form grid layouts.

## Features

- **Drag to float** — drag a panadapter title bar outside the main window to detach
- **Drag to dock** — drag a floating panadapter back with drop zone indicators (top/bottom/left/right/center)
- **Dock button** — `↩ Dock` button in floating panadapter title bar for one-click re-dock
- **Drag preview** — semi-transparent thumbnail follows cursor during drag (no snap-back animation)
- **Free-form grid** — nested QSplitters created on drop for arbitrary pan arrangements
- **State persistence** — floating pan indices + window geometry saved to AppSettings, restored on reconnect
- **Add Panadapter button** — left-click creates a new pan at the bottom of the stack; right-click opens a context menu with **Add Panadapter** and **Select Panadapter Grid** (legacy grid layout dialog)
- **Cmd+Q / app quit** — properly saves state and closes all windows without docking floating pans first
- **GPU surface reset** — `resetNativeSurface()` recreates QRhiWidget Metal/Vulkan surface after cross-window reparent

## New Files

- `PanDropOverlay.h/.cpp` — VSCode-style drop zone overlay with zone detection + cyan accent painting
- `PanFloatingWindow.h/.cpp` — top-level window hosting a detached panadapter, OS-native title bar, geometry persistence

## Modified Files

- `PanadapterApplet.h/.cpp` — title bar drag initiation, floating preview, dock button, `dockRequested` signal
- `PanadapterStack.h/.cpp` — float/dock/drop logic, splitter insertion, GPU surface reset, state persistence, `prepareShutdown()`
- `MainWindow.h/.cpp` — drag→float wiring, `dragEnterEvent`/`dropEvent` (snap-back fix), Cmd+Q shutdown, add-pan button split (left-click/right-click), float state restore
- `CMakeLists.txt` — added new source files