### PR TITLE
[network] Add routed manual source-path binding for radios over VPN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,7 @@ set(CORE_SOURCES
     src/core/BandStackSettings.cpp
     src/core/RadioDiscovery.cpp
     src/core/RadioConnection.cpp
+    src/core/NetworkPathResolver.cpp
     src/core/TgxlConnection.cpp
     src/core/CommandParser.cpp
     src/core/AudioEngine.cpp

--- a/src/core/NetworkPathResolver.cpp
+++ b/src/core/NetworkPathResolver.cpp
@@ -1,0 +1,127 @@
+#include "NetworkPathResolver.h"
+
+#include <QNetworkInterface>
+
+#include <algorithm>
+
+namespace AetherSDR {
+
+namespace {
+
+QString interfaceLabel(const QNetworkInterface& iface)
+{
+    const QString human = iface.humanReadableName().trimmed();
+    if (!human.isEmpty())
+        return human;
+    return iface.name().trimmed();
+}
+
+}
+
+bool NetworkPathCandidate::isValid() const
+{
+    return NetworkPathResolver::isUsableIpv4(address);
+}
+
+QString NetworkPathCandidate::label() const
+{
+    QString iface = interfaceName.trimmed();
+    if (iface.isEmpty())
+        iface = interfaceId.trimmed();
+    if (iface.isEmpty())
+        return address.toString();
+    return QStringLiteral("%1 (%2)").arg(iface, address.toString());
+}
+
+QList<NetworkPathCandidate> NetworkPathResolver::enumerateIpv4Candidates()
+{
+    QList<NetworkPathCandidate> out;
+
+    const auto interfaces = QNetworkInterface::allInterfaces();
+    for (const QNetworkInterface& iface : interfaces) {
+        const auto flags = iface.flags();
+        if (!(flags & QNetworkInterface::IsUp) ||
+            !(flags & QNetworkInterface::IsRunning) ||
+            (flags & QNetworkInterface::IsLoopBack)) {
+            continue;
+        }
+
+        for (const QNetworkAddressEntry& entry : iface.addressEntries()) {
+            const QHostAddress addr = entry.ip();
+            if (!isUsableIpv4(addr))
+                continue;
+
+            NetworkPathCandidate candidate;
+            candidate.interfaceId = iface.name();
+            candidate.interfaceName = interfaceLabel(iface);
+            candidate.address = addr;
+            out.append(candidate);
+        }
+    }
+
+    std::sort(out.begin(), out.end(), [](const NetworkPathCandidate& lhs,
+                                         const NetworkPathCandidate& rhs) {
+        if (lhs.interfaceName == rhs.interfaceName)
+            return lhs.address.toString() < rhs.address.toString();
+        return lhs.interfaceName < rhs.interfaceName;
+    });
+    return out;
+}
+
+NetworkPathCandidate NetworkPathResolver::resolveExplicitSelection(const QString& interfaceId,
+                                                                   const QString& interfaceName,
+                                                                   const QHostAddress& lastSuccessfulAddress)
+{
+    const auto candidates = enumerateIpv4Candidates();
+
+    auto findMatch = [&](auto&& predicate) -> NetworkPathCandidate {
+        for (const auto& candidate : candidates) {
+            if (predicate(candidate))
+                return candidate;
+        }
+        return {};
+    };
+
+    if (!interfaceId.trimmed().isEmpty()) {
+        auto match = findMatch([&](const NetworkPathCandidate& candidate) {
+            return candidate.interfaceId == interfaceId;
+        });
+        if (match.isValid())
+            return match;
+    }
+
+    if (!interfaceName.trimmed().isEmpty()) {
+        auto match = findMatch([&](const NetworkPathCandidate& candidate) {
+            return candidate.interfaceName == interfaceName;
+        });
+        if (match.isValid())
+            return match;
+    }
+
+    if (isUsableIpv4(lastSuccessfulAddress)) {
+        auto match = findMatch([&](const NetworkPathCandidate& candidate) {
+            return candidate.address == lastSuccessfulAddress;
+        });
+        if (match.isValid())
+            return match;
+    }
+
+    return {};
+}
+
+NetworkPathCandidate NetworkPathResolver::autoCandidate()
+{
+    const auto candidates = enumerateIpv4Candidates();
+    if (candidates.size() == 1)
+        return candidates.first();
+    return {};
+}
+
+bool NetworkPathResolver::isUsableIpv4(const QHostAddress& address)
+{
+    return !address.isNull()
+        && address.protocol() == QAbstractSocket::IPv4Protocol
+        && !address.isLoopback();
+}
+
+} // namespace AetherSDR

--- a/src/core/NetworkPathResolver.h
+++ b/src/core/NetworkPathResolver.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QHostAddress>
+#include <QList>
+#include <QString>
+
+namespace AetherSDR {
+
+struct NetworkPathCandidate {
+    QString      interfaceId;
+    QString      interfaceName;
+    QHostAddress address;
+
+    bool isValid() const;
+    QString label() const;
+};
+
+class NetworkPathResolver {
+public:
+    static QList<NetworkPathCandidate> enumerateIpv4Candidates();
+    static NetworkPathCandidate resolveExplicitSelection(const QString& interfaceId,
+                                                         const QString& interfaceName,
+                                                         const QHostAddress& lastSuccessfulAddress);
+    static NetworkPathCandidate autoCandidate();
+    static bool isUsableIpv4(const QHostAddress& address);
+};
+
+} // namespace AetherSDR

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -48,7 +48,9 @@ void PanadapterStream::init()
         if (m_radioAddress.isNull() || m_wanClientHandle == 0) return;
         const QString hex = QString::number(m_wanClientHandle, 16).toUpper();
         const QByteArray cmd = QStringLiteral("client udp_register handle=0x%1").arg(hex).toUtf8();
-        m_socket.writeDatagram(cmd, m_radioAddress, m_radioPort);
+        const qint64 sent = m_socket.writeDatagram(cmd, m_radioAddress, m_radioPort);
+        if (sent > 0)
+            m_totalTxBytes += sent;
     });
 
     // WAN ping keepalive: send "client ping handle=0x<handle>" every 5s
@@ -58,8 +60,22 @@ void PanadapterStream::init()
         const QString hex = QString::number(m_wanClientHandle, 16).toUpper();
         const QByteArray cmd = QStringLiteral("client ping handle=0x%1").arg(hex).toUtf8();
         m_socket.writeDatagram(cmd, m_radioAddress, m_radioPort);
+        m_totalTxBytes += cmd.size();
         qCDebug(lcVita49) << "PanadapterStream: WAN ping keepalive"
                  << "(totalRx:" << m_totalRxBytes << "bytes)";
+    });
+
+    connect(&m_routedPrimeTimer, &QTimer::timeout, this, [this] {
+        if (m_isWanMode || m_hasReceivedPacket || m_radioAddress.isNull())
+            return;
+        if (!m_routedPrimeElapsed.isValid() || m_routedPrimeElapsed.elapsed() >= 2000) {
+            m_routedPrimeTimer.stop();
+            return;
+        }
+        const QByteArray reg(1, '\x00');
+        const qint64 sent = m_socket.writeDatagram(reg, m_radioAddress, 4992);
+        if (sent > 0)
+            m_totalTxBytes += sent;
     });
 }
 
@@ -73,23 +89,64 @@ bool PanadapterStream::start(RadioConnection* conn)
     if (isRunning()) stop();  // clean up previous session before rebinding (#561)
 
     static constexpr quint16 LAN_VITA_PORT = 4991;
-    bool bound = m_socket.bind(QHostAddress::AnyIPv4, LAN_VITA_PORT,
-                               QAbstractSocket::ReuseAddressHint);
-    if (bound)
-        qCDebug(lcVita49) << "PanadapterStream: bound to LAN VITA-49 port" << LAN_VITA_PORT;
-    else {
-        qCDebug(lcVita49) << "PanadapterStream: port" << LAN_VITA_PORT
-                 << "unavailable, using OS-assigned port";
-        bound = m_socket.bind(QHostAddress::AnyIPv4, 0);
+    m_isWanMode = false;
+    m_hasReceivedPacket = false;
+
+    const QHostAddress explicitAddr = conn ? conn->explicitLocalBindAddress() : QHostAddress();
+    const QHostAddress sessionAddr = conn ? conn->sessionLocalBindAddress() : QHostAddress();
+    const QHostAddress tcpAddr = conn ? conn->localAddress() : QHostAddress();
+    const RadioBindMode bindMode = conn ? conn->bindMode() : RadioBindMode::Auto;
+
+    QHostAddress chosenAddress;
+    QString chosenReason;
+    if (!explicitAddr.isNull() && explicitAddr.protocol() == QAbstractSocket::IPv4Protocol) {
+        chosenAddress = explicitAddr;
+        chosenReason = QStringLiteral("explicit");
+    } else if (!sessionAddr.isNull() && sessionAddr.protocol() == QAbstractSocket::IPv4Protocol) {
+        chosenAddress = sessionAddr;
+        chosenReason = QStringLiteral("probe-session");
+    } else if (!tcpAddr.isNull() && tcpAddr.protocol() == QAbstractSocket::IPv4Protocol) {
+        chosenAddress = tcpAddr;
+        chosenReason = QStringLiteral("tcp-local");
+    }
+
+    bool bound = false;
+    if (!chosenAddress.isNull()) {
+        bound = m_socket.bind(chosenAddress, LAN_VITA_PORT, QAbstractSocket::ReuseAddressHint);
+        if (bound) {
+            qCDebug(lcVita49) << "PanadapterStream: bound UDP to"
+                              << chosenAddress.toString() << ":" << LAN_VITA_PORT
+                              << "using" << chosenReason;
+        } else {
+            qCDebug(lcVita49) << "PanadapterStream: port" << LAN_VITA_PORT
+                              << "unavailable on" << chosenAddress.toString()
+                              << "- retrying with OS-assigned port";
+            bound = m_socket.bind(chosenAddress, 0, QAbstractSocket::ReuseAddressHint);
+        }
+    } else if (bindMode == RadioBindMode::Auto) {
+        bound = m_socket.bind(QHostAddress::AnyIPv4, LAN_VITA_PORT,
+                              QAbstractSocket::ReuseAddressHint);
+        if (bound)
+            qCDebug(lcVita49) << "PanadapterStream: auto-bound to LAN VITA-49 port" << LAN_VITA_PORT;
+        else {
+            qCDebug(lcVita49) << "PanadapterStream: auto path unavailable on port" << LAN_VITA_PORT
+                              << "- using OS-assigned port";
+            bound = m_socket.bind(QHostAddress::AnyIPv4, 0, QAbstractSocket::ReuseAddressHint);
+        }
     }
     if (!bound) {
         qCWarning(lcVita49) << "PanadapterStream: failed to bind UDP socket:"
-                   << m_socket.errorString();
+                            << m_socket.errorString()
+                            << "mode=" << (bindMode == RadioBindMode::Explicit ? "Explicit" : "Auto")
+                            << "chosen=" << (chosenAddress.isNull() ? QStringLiteral("<none>")
+                                                                    : chosenAddress.toString());
         return false;
     }
 
+    m_localAddress = m_socket.localAddress();
     m_localPort = m_socket.localPort();
-    qCDebug(lcVita49) << "PanadapterStream: bound to UDP port" << m_localPort;
+    qCDebug(lcVita49) << "PanadapterStream: local UDP endpoint"
+                      << m_localAddress.toString() << ":" << m_localPort;
 
     // Send a one-byte UDP registration datagram to the radio's VITA-49 port.
     // The radio learns our IP:port from the source address of this datagram.
@@ -99,12 +156,16 @@ bool PanadapterStream::start(RadioConnection* conn)
     if (!radioAddr.isNull()) {
         const QByteArray reg(1, '\x00');
         const qint64 sent = m_socket.writeDatagram(reg, radioAddr, 4992);
-        if (sent == 1)
+        if (sent == 1) {
+            m_totalTxBytes += sent;
             qCDebug(lcVita49) << "PanadapterStream: sent UDP registration to"
-                     << radioAddr.toString() << ":4992";
-        else
+                              << radioAddr.toString() << ":4992";
+            m_routedPrimeElapsed.restart();
+            m_routedPrimeTimer.start(250);
+        } else {
             qCWarning(lcVita49) << "PanadapterStream: UDP registration send failed:"
-                       << m_socket.errorString();
+                                << m_socket.errorString();
+        }
     } else {
         qCWarning(lcVita49) << "PanadapterStream: radio address unknown — skipping UDP registration";
     }
@@ -131,10 +192,12 @@ bool PanadapterStream::startWan(const QHostAddress& radioAddr, quint16 radioUdpP
     }
 
     m_localPort = m_socket.localPort();
+    m_localAddress = m_socket.localAddress();
     m_radioAddress = radioAddr;
     m_radioPort = radioUdpPort;
     m_isWanMode = true;
     m_wanRegistered = false;
+    m_hasReceivedPacket = false;
 
     qCDebug(lcVita49) << "PanadapterStream: WAN — bound to UDP port" << m_localPort
              << "radio=" << radioAddr.toString() << ":" << radioUdpPort;
@@ -155,7 +218,9 @@ void PanadapterStream::startWanUdpRegister(quint32 clientHandle)
 
     // Send first registration immediately, then every 50ms until confirmed
     const QByteArray cmd = QStringLiteral("client udp_register handle=0x%1").arg(hex).toUtf8();
-    m_socket.writeDatagram(cmd, m_radioAddress, m_radioPort);
+    const qint64 sent = m_socket.writeDatagram(cmd, m_radioAddress, m_radioPort);
+    if (sent > 0)
+        m_totalTxBytes += sent;
     m_wanRegisterTimer.start(50);
 }
 
@@ -163,10 +228,15 @@ void PanadapterStream::stop()
 {
     m_wanRegisterTimer.stop();
     m_wanPingTimer.stop();
+    m_routedPrimeTimer.stop();
     m_isWanMode = false;
     m_wanRegistered = false;
     m_wanClientHandle = 0;
+    m_hasReceivedPacket = false;
     m_socket.close();
+    m_radioAddress = QHostAddress();
+    m_radioPort = 0;
+    m_localAddress = QHostAddress();
     m_localPort = 0;
 }
 
@@ -232,6 +302,12 @@ void PanadapterStream::onDatagramReady()
     while (m_socket.hasPendingDatagrams()) {
         const QNetworkDatagram dg = m_socket.receiveDatagram();
         if (!dg.isNull()) {
+            if (!m_hasReceivedPacket) {
+                m_hasReceivedPacket = true;
+                m_routedPrimeTimer.stop();
+                qCDebug(lcVita49) << "PanadapterStream: first UDP packet received from"
+                                  << dg.senderAddress().toString() << ":" << dg.senderPort();
+            }
             // On first VITA-49 packet in WAN mode: registration confirmed.
             // Stop the rapid udp_register timer and switch to ping keepalive.
             if (m_isWanMode && !m_wanRegistered) {

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -7,6 +7,7 @@
 #include <QMap>
 #include <QSet>
 #include <QTimer>
+#include <QElapsedTimer>
 #include <QMutex>
 #include <QMutexLocker>
 
@@ -56,7 +57,9 @@ public:
     void startWanUdpRegister(quint32 clientHandle);
     void stop();
 
+    QHostAddress localAddress() const { return m_localAddress; }
     quint16 localPort() const { return m_localPort; }
+    bool    hasReceivedPackets() const { return m_hasReceivedPacket; }
     bool    isRunning() const;
 
     // Update the dBm range used to scale incoming FFT bins for a specific stream.
@@ -217,13 +220,17 @@ private:
     QMap<quint32, int> m_iqStreamIds;
     QHostAddress m_radioAddress;
     quint16      m_radioPort{0};
+    QHostAddress m_localAddress;
+    bool         m_hasReceivedPacket{false};
 
     // WAN UDP registration and keepalive
     QTimer   m_wanRegisterTimer;   // 50ms: "client udp_register" until first packet
     QTimer   m_wanPingTimer;       // 5s: "client ping" keepalive after registration
+    QTimer   m_routedPrimeTimer;   // 250ms: non-WAN UDP prime retry until first packet
     bool     m_isWanMode{false};
     bool     m_wanRegistered{false};
     quint32  m_wanClientHandle{0};
+    QElapsedTimer m_routedPrimeElapsed;
 };
 
 } // namespace AetherSDR

--- a/src/core/RadioConnection.cpp
+++ b/src/core/RadioConnection.cpp
@@ -74,13 +74,67 @@ void RadioConnection::init()
 
 void RadioConnection::connectToRadio(const RadioInfo& info)
 {
-    connectToHost(info.address, info.port);
+    connectToHost(info.address, info.port,
+                  info.bindSettings.mode,
+                  info.bindSettings.bindAddress,
+                  info.sessionBindAddress);
 }
 
-void RadioConnection::connectToHost(const QHostAddress& address, quint16 port)
+void RadioConnection::connectToHost(const QHostAddress& address,
+                                    quint16 port,
+                                    RadioBindMode bindMode,
+                                    const QHostAddress& explicitBindAddr,
+                                    const QHostAddress& sessionBindAddr)
 {
     if (m_state.load() != ConnectionState::Disconnected) return;
     if (!m_socket) { qCWarning(lcConnection) << "RadioConnection: init() not called"; return; }
+
+    m_bindMode = bindMode;
+    m_explicitBindAddr = explicitBindAddr;
+    m_sessionBindAddr = sessionBindAddr;
+    m_radioAddr = address;
+    m_localAddr = QHostAddress();
+    m_localPort = 0;
+    m_socket->abort();
+
+    const QHostAddress preferredBindAddr =
+        (bindMode == RadioBindMode::Explicit) ? explicitBindAddr : sessionBindAddr;
+    const bool shouldBind =
+        !preferredBindAddr.isNull() &&
+        preferredBindAddr.protocol() == QAbstractSocket::IPv4Protocol;
+
+    if (shouldBind) {
+        if (!m_socket->bind(preferredBindAddr, 0)) {
+            const QString msg = QStringLiteral("Failed to bind local TCP source address %1: %2")
+                                    .arg(preferredBindAddr.toString(), m_socket->errorString());
+            if (bindMode == RadioBindMode::Explicit) {
+                qCWarning(lcConnection) << "RadioConnection:" << msg;
+                m_socket->abort();
+                m_socket->close();
+                setState(ConnectionState::Error);
+                emit errorOccurred(msg);
+                return;
+            }
+
+            qCDebug(lcConnection) << "RadioConnection: auto bind to"
+                                  << preferredBindAddr.toString()
+                                  << "failed, falling back to OS routing:"
+                                  << m_socket->errorString();
+        } else {
+            qCDebug(lcConnection) << "RadioConnection: bound local TCP source to"
+                                  << preferredBindAddr.toString()
+                                  << ":" << m_socket->localPort()
+                                  << "(mode"
+                                  << (bindMode == RadioBindMode::Explicit ? "Explicit" : "Auto")
+                                  << ")";
+        }
+    } else {
+        qCDebug(lcConnection) << "RadioConnection: no explicit local TCP bind, letting OS route"
+                              << "(mode"
+                              << (bindMode == RadioBindMode::Explicit ? "Explicit" : "Auto")
+                              << ")";
+    }
+
     qCDebug(lcConnection) << "RadioConnection: connecting to" << address.toString() << ":" << port;
     setState(ConnectionState::Connecting);
     m_socket->connectToHost(address, port);
@@ -114,7 +168,10 @@ void RadioConnection::onSocketConnected()
     qCDebug(lcConnection) << "RadioConnection: TCP connected";
     m_socket->setSocketOption(QAbstractSocket::LowDelayOption, 1);
     m_radioAddr = m_socket->peerAddress();
+    m_localAddr = m_socket->localAddress();
     m_localPort = m_socket->localPort();
+    qCDebug(lcConnection) << "RadioConnection: local TCP endpoint"
+                          << m_localAddr.toString() << ":" << m_localPort;
     qDebug() << "RTT method:" << (kernelRttMs() >= 0 ? "kernel TCP_INFO" : "QElapsedTimer fallback");
 }
 
@@ -122,6 +179,8 @@ void RadioConnection::onSocketDisconnected()
 {
     qCDebug(lcConnection) << "RadioConnection: TCP disconnected";
     if (m_heartbeat) m_heartbeat->stop();
+    m_localAddr = QHostAddress();
+    m_localPort = 0;
     setState(ConnectionState::Disconnected);
     emit disconnected();
 }

--- a/src/core/RadioConnection.h
+++ b/src/core/RadioConnection.h
@@ -35,14 +35,22 @@ public:
     quint32 clientHandle() const        { return m_handle; }
     bool isConnected() const            { return m_state.load() == ConnectionState::Connected; }
     QHostAddress radioAddress() const   { return m_radioAddr; }
+    QHostAddress localAddress() const   { return m_localAddr; }
     quint16      localTcpPort() const   { return m_localPort; }
+    RadioBindMode bindMode() const      { return m_bindMode; }
+    QHostAddress explicitLocalBindAddress() const { return m_explicitBindAddr; }
+    QHostAddress sessionLocalBindAddress() const  { return m_sessionBindAddr; }
 
     using ResponseCallback = std::function<void(int resultCode, const QString& body)>;
 
 public slots:
     void init();  // Create socket + timer on the worker thread
     void connectToRadio(const RadioInfo& info);
-    void connectToHost(const QHostAddress& address, quint16 port = 4992);
+    void connectToHost(const QHostAddress& address,
+                       quint16 port = 4992,
+                       RadioBindMode bindMode = RadioBindMode::Auto,
+                       const QHostAddress& explicitBindAddr = {},
+                       const QHostAddress& sessionBindAddr = {});
     void disconnectFromRadio();
     // Write a pre-sequenced command to the socket. Called from RadioModel
     // via QMetaObject::invokeMethod (auto-queued to worker thread). (#502)
@@ -83,7 +91,11 @@ private:
     QElapsedTimer m_pingStopwatch;  // fallback when kernel TCP_INFO unavailable
 
     QHostAddress m_radioAddr;   // cached for cross-thread reads
+    QHostAddress m_localAddr;
     quint16      m_localPort{0};
+    RadioBindMode m_bindMode{RadioBindMode::Auto};
+    QHostAddress m_explicitBindAddr;
+    QHostAddress m_sessionBindAddr;
 
     // Callbacks removed — responses emitted via commandResponse signal (#502)
 };

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -10,6 +10,44 @@
 
 namespace AetherSDR {
 
+enum class RadioBindMode : quint8 {
+    Auto,
+    Explicit
+};
+
+struct RadioBindSettings {
+    RadioBindMode mode{RadioBindMode::Auto};
+    QHostAddress  bindAddress;
+    QString       interfaceId;
+    QString       interfaceName;
+
+    bool hasBindableAddress() const
+    {
+        return !bindAddress.isNull() && bindAddress.protocol() == QAbstractSocket::IPv4Protocol;
+    }
+
+    QString modeString() const
+    {
+        return mode == RadioBindMode::Explicit ? QStringLiteral("Explicit")
+                                               : QStringLiteral("Auto");
+    }
+
+    QString selectionLabel() const
+    {
+        if (mode == RadioBindMode::Auto)
+            return QStringLiteral("Auto");
+
+        QString iface = interfaceName.trimmed();
+        if (iface.isEmpty())
+            iface = interfaceId.trimmed();
+        if (iface.isEmpty())
+            return bindAddress.toString();
+        if (bindAddress.isNull())
+            return iface;
+        return QStringLiteral("%1 (%2)").arg(iface, bindAddress.toString());
+    }
+};
+
 // Represents a discovered FlexRadio on the network.
 struct RadioInfo {
     QString name;           // e.g. "FLEX-6600"
@@ -24,6 +62,8 @@ struct RadioInfo {
     int maxLicensedVersion{0};
     bool inUse{false};
     bool isRouted{false};
+    RadioBindSettings bindSettings;
+    QHostAddress sessionBindAddress;
 
     // Connected GUI client info (from discovery broadcast)
     QStringList guiClientStations;

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -1,5 +1,6 @@
 #include "ConnectionPanel.h"
 #include "core/AppSettings.h"
+#include "core/NetworkPathResolver.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -9,8 +10,63 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QDebug>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSignalBlocker>
 
 namespace AetherSDR {
+
+namespace {
+
+constexpr int kSourceModeRole = Qt::UserRole + 10;
+constexpr int kSourceInterfaceIdRole = Qt::UserRole + 11;
+constexpr int kSourceInterfaceNameRole = Qt::UserRole + 12;
+constexpr int kSourceAddressRole = Qt::UserRole + 13;
+constexpr int kSourceStaleRole = Qt::UserRole + 14;
+
+QJsonObject loadRoutedProfiles()
+{
+    const QByteArray json =
+        AppSettings::instance().value("RoutedProfilesJson", "{}").toString().toUtf8();
+    const QJsonDocument doc = QJsonDocument::fromJson(json);
+    return doc.isObject() ? doc.object() : QJsonObject{};
+}
+
+void saveRoutedProfiles(const QJsonObject& profiles)
+{
+    auto& settings = AppSettings::instance();
+    settings.setValue("RoutedProfilesJson",
+                      QString::fromUtf8(QJsonDocument(profiles).toJson(QJsonDocument::Compact)));
+    settings.save();
+}
+
+RadioBindSettings bindSettingsFromProfile(const QJsonObject& profile)
+{
+    const QJsonObject bind = profile.value("bind").toObject();
+    RadioBindSettings settings;
+    settings.mode = bind.value("mode").toString() == "explicit"
+        ? RadioBindMode::Explicit
+        : RadioBindMode::Auto;
+    settings.interfaceId = bind.value("interface_id").toString();
+    settings.interfaceName = bind.value("interface_name").toString();
+    settings.bindAddress = QHostAddress(bind.value("last_successful_ipv4").toString());
+    return settings;
+}
+
+QString staleSelectionText(const RadioBindSettings& settings)
+{
+    QString iface = settings.interfaceName.trimmed();
+    if (iface.isEmpty())
+        iface = settings.interfaceId.trimmed();
+    if (iface.isEmpty())
+        iface = QStringLiteral("Saved source");
+    const QString addr = settings.bindAddress.isNull()
+        ? QStringLiteral("unknown IPv4")
+        : settings.bindAddress.toString();
+    return QStringLiteral("%1 (unavailable, last %2)").arg(iface, addr);
+}
+
+}
 
 ConnectionPanel::ConnectionPanel(QWidget* parent)
     : QWidget(parent)
@@ -114,6 +170,20 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     manRow->addWidget(m_manualProbeBtn);
     manBox->addLayout(manRow);
 
+    auto* sourceRow = new QHBoxLayout;
+    sourceRow->setContentsMargins(0, 0, 0, 0);
+    sourceRow->addWidget(new QLabel("Source:", m_manualGroup));
+    m_manualSourceCombo = new QComboBox(m_manualGroup);
+    sourceRow->addWidget(m_manualSourceCombo, 1);
+    manBox->addLayout(sourceRow);
+
+    m_manualSourceWarningLabel = new QLabel(m_manualGroup);
+    m_manualSourceWarningLabel->setVisible(false);
+    m_manualSourceWarningLabel->setWordWrap(true);
+    m_manualSourceWarningLabel->setStyleSheet("QLabel { color: #ffbb66; font-size: 10px; }");
+    manBox->addWidget(m_manualSourceWarningLabel);
+    refreshManualSourceOptions();
+
     connect(m_manualProbeBtn, &QPushButton::clicked, this, [this] {
         const QString ip = m_manualIpEdit->text().trimmed();
         if (!ip.isEmpty()) probeRadio(ip);
@@ -122,6 +192,8 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
         const QString ip = m_manualIpEdit->text().trimmed();
         if (!ip.isEmpty()) probeRadio(ip);
     });
+    connect(m_manualIpEdit, &QLineEdit::textChanged,
+            this, &ConnectionPanel::onManualIpChanged);
 
     vbox->addWidget(m_manualGroup);
 
@@ -336,12 +408,169 @@ void ConnectionPanel::paintEvent(QPaintEvent*)
     p.fillRect(rect(), QColor(15, 15, 26));
 }
 
+void ConnectionPanel::refreshManualSourceOptions(const RadioBindSettings* selected)
+{
+    const QSignalBlocker blocker(m_manualSourceCombo);
+    m_manualSourceCombo->clear();
+
+    m_manualSourceCombo->addItem("Auto");
+    m_manualSourceCombo->setItemData(0, static_cast<int>(RadioBindMode::Auto), kSourceModeRole);
+    m_manualSourceCombo->setItemData(0, false, kSourceStaleRole);
+
+    int selectedIndex = 0;
+    const auto candidates = NetworkPathResolver::enumerateIpv4Candidates();
+    for (const auto& candidate : candidates) {
+        const int idx = m_manualSourceCombo->count();
+        m_manualSourceCombo->addItem(candidate.label());
+        m_manualSourceCombo->setItemData(idx, static_cast<int>(RadioBindMode::Explicit), kSourceModeRole);
+        m_manualSourceCombo->setItemData(idx, candidate.interfaceId, kSourceInterfaceIdRole);
+        m_manualSourceCombo->setItemData(idx, candidate.interfaceName, kSourceInterfaceNameRole);
+        m_manualSourceCombo->setItemData(idx, candidate.address.toString(), kSourceAddressRole);
+        m_manualSourceCombo->setItemData(idx, false, kSourceStaleRole);
+
+        if (selected &&
+            selected->mode == RadioBindMode::Explicit &&
+            ((!selected->interfaceId.isEmpty() && selected->interfaceId == candidate.interfaceId) ||
+             (!selected->bindAddress.isNull() && selected->bindAddress == candidate.address))) {
+            selectedIndex = idx;
+        }
+    }
+
+    if (selected &&
+        selected->mode == RadioBindMode::Explicit &&
+        selectedIndex == 0) {
+        selectedIndex = m_manualSourceCombo->count();
+        m_manualSourceCombo->addItem(staleSelectionText(*selected));
+        m_manualSourceCombo->setItemData(selectedIndex, static_cast<int>(RadioBindMode::Explicit), kSourceModeRole);
+        m_manualSourceCombo->setItemData(selectedIndex, selected->interfaceId, kSourceInterfaceIdRole);
+        m_manualSourceCombo->setItemData(selectedIndex, selected->interfaceName, kSourceInterfaceNameRole);
+        m_manualSourceCombo->setItemData(selectedIndex, selected->bindAddress.toString(), kSourceAddressRole);
+        m_manualSourceCombo->setItemData(selectedIndex, true, kSourceStaleRole);
+    }
+
+    m_manualSourceCombo->setCurrentIndex(selectedIndex);
+}
+
+void ConnectionPanel::applySavedSourceSelection(const QString& ip)
+{
+    const QString trimmedIp = ip.trimmed();
+    m_manualProfileIp = trimmedIp;
+    m_manualSourceWarningLabel->clear();
+    m_manualSourceWarningLabel->setVisible(false);
+
+    if (trimmedIp.isEmpty()) {
+        refreshManualSourceOptions();
+        return;
+    }
+
+    const QJsonObject profiles = loadRoutedProfiles();
+    const QJsonObject profile = profiles.value(trimmedIp).toObject();
+    if (profile.isEmpty()) {
+        refreshManualSourceOptions();
+        return;
+    }
+
+    RadioBindSettings settings = bindSettingsFromProfile(profile);
+    if (settings.mode == RadioBindMode::Explicit) {
+        const auto resolved = NetworkPathResolver::resolveExplicitSelection(
+            settings.interfaceId, settings.interfaceName, settings.bindAddress);
+        if (resolved.isValid()) {
+            settings.interfaceId = resolved.interfaceId;
+            settings.interfaceName = resolved.interfaceName;
+            settings.bindAddress = resolved.address;
+        } else {
+            m_manualSourceWarningLabel->setText(
+                QStringLiteral("Saved source path for %1 is unavailable. Re-select a live IPv4 source before connecting.")
+                    .arg(trimmedIp));
+            m_manualSourceWarningLabel->setVisible(true);
+        }
+    }
+
+    refreshManualSourceOptions(&settings);
+}
+
+RadioBindSettings ConnectionPanel::currentManualBindSettings(bool* staleSelection) const
+{
+    RadioBindSettings settings;
+    const int index = m_manualSourceCombo->currentIndex();
+    settings.mode = static_cast<RadioBindMode>(
+        m_manualSourceCombo->itemData(index, kSourceModeRole).toInt());
+    settings.interfaceId = m_manualSourceCombo->itemData(index, kSourceInterfaceIdRole).toString();
+    settings.interfaceName = m_manualSourceCombo->itemData(index, kSourceInterfaceNameRole).toString();
+    settings.bindAddress = QHostAddress(m_manualSourceCombo->itemData(index, kSourceAddressRole).toString());
+    if (staleSelection)
+        *staleSelection = m_manualSourceCombo->itemData(index, kSourceStaleRole).toBool();
+    return settings;
+}
+
+void ConnectionPanel::saveManualProfile(const QString& targetIp,
+                                        const RadioBindSettings& settings,
+                                        const QHostAddress& lastSuccessfulLocalIp)
+{
+    if (targetIp.trimmed().isEmpty())
+        return;
+
+    QJsonObject profiles = loadRoutedProfiles();
+    QJsonObject profile;
+    profile["schema_version"] = 1;
+
+    QJsonObject identity;
+    identity["target_address"] = targetIp;
+    profile["identity"] = identity;
+
+    QJsonObject bind;
+    bind["mode"] = settings.mode == RadioBindMode::Explicit ? "explicit" : "auto";
+    bind["interface_id"] = settings.interfaceId;
+    bind["interface_name"] = settings.interfaceName;
+    bind["last_successful_ipv4"] = lastSuccessfulLocalIp.toString();
+    profile["bind"] = bind;
+
+    profiles[targetIp] = profile;
+    saveRoutedProfiles(profiles);
+}
+
+void ConnectionPanel::onManualIpChanged(const QString& ip)
+{
+    const QString trimmed = ip.trimmed();
+    if (trimmed == m_manualProfileIp)
+        return;
+    applySavedSourceSelection(trimmed);
+}
+
 void ConnectionPanel::probeRadio(const QString& ip)
 {
+    if (m_manualIpEdit->text().trimmed() != ip) {
+        m_manualIpEdit->setText(ip);
+        applySavedSourceSelection(ip);
+    } else if (m_manualProfileIp != ip) {
+        applySavedSourceSelection(ip);
+    }
+
+    bool staleSelection = false;
+    const RadioBindSettings bindSettings = currentManualBindSettings(&staleSelection);
+    if (bindSettings.mode == RadioBindMode::Explicit && staleSelection) {
+        m_manualSourceWarningLabel->setText(
+            QStringLiteral("Selected source path is unavailable. Choose a live IPv4 source before probing."));
+        m_manualSourceWarningLabel->setVisible(true);
+        return;
+    }
+
     m_manualProbeBtn->setEnabled(false);
     m_manualProbeBtn->setText("Probing...");
+    m_manualSourceWarningLabel->setVisible(false);
 
     auto* sock = new QTcpSocket(this);
+    if (bindSettings.mode == RadioBindMode::Explicit &&
+        !sock->bind(bindSettings.bindAddress, 0)) {
+        m_manualSourceWarningLabel->setText(
+            QStringLiteral("Failed to bind source %1: %2")
+                .arg(bindSettings.bindAddress.toString(), sock->errorString()));
+        m_manualSourceWarningLabel->setVisible(true);
+        sock->deleteLater();
+        m_manualProbeBtn->setEnabled(true);
+        m_manualProbeBtn->setText("Go");
+        return;
+    }
     sock->connectToHost(ip, 4992);
 
     // 3-second timeout
@@ -350,14 +579,14 @@ void ConnectionPanel::probeRadio(const QString& ip)
             sock->abort();
             sock->deleteLater();
             m_manualProbeBtn->setEnabled(true);
-            m_manualProbeBtn->setText("Connect");
+            m_manualProbeBtn->setText("Go");
         }
     });
 
-    connect(sock, &QTcpSocket::connected, this, [this, sock, ip] {
+    connect(sock, &QTcpSocket::connected, this, [this, sock, ip, bindSettings] {
         // Connected — read V/H lines, then disconnect
         auto* buf = new QByteArray;
-        connect(sock, &QTcpSocket::readyRead, this, [this, sock, ip, buf] {
+        connect(sock, &QTcpSocket::readyRead, this, [this, sock, ip, buf, bindSettings] {
             buf->append(sock->readAll());
 
             // We need V<version>\n and H<handle>\n
@@ -371,6 +600,7 @@ void ConnectionPanel::probeRadio(const QString& ip)
                     version = line.mid(1);
                 else if (line.startsWith('H')) {
                     // Got both V and H — we have enough info
+                    const QHostAddress localSource = sock->localAddress();
                     sock->disconnectFromHost();
                     sock->deleteLater();
                     delete buf;
@@ -385,6 +615,10 @@ void ConnectionPanel::probeRadio(const QString& ip)
                     info.name = "FLEX";
                     info.serial = ip;  // use IP as unique ID for routed radios
                     info.isRouted = true;
+                    info.bindSettings = bindSettings;
+                    info.sessionBindAddress = localSource;
+
+                    saveManualProfile(ip, bindSettings, info.sessionBindAddress);
 
                     // Check if already in list
                     for (int i = 0; i < m_radios.size(); ++i) {
@@ -406,7 +640,9 @@ void ConnectionPanel::probeRadio(const QString& ip)
                     emit routedRadioFound(info);
 
                     qDebug() << "ConnectionPanel: routed radio found at" << ip
-                             << "version:" << version;
+                             << "version:" << version
+                             << "localSource:" << info.sessionBindAddress.toString()
+                             << "mode:" << info.bindSettings.modeString();
                     return;
                 }
             }
@@ -418,7 +654,7 @@ void ConnectionPanel::probeRadio(const QString& ip)
         qWarning() << "ConnectionPanel: probe failed:" << sock->errorString();
         sock->deleteLater();
         m_manualProbeBtn->setEnabled(true);
-        m_manualProbeBtn->setText("Connect");
+        m_manualProbeBtn->setText("Go");
     });
 }
 

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -48,8 +48,16 @@ signals:
 private slots:
     void onConnectClicked();
     void onListSelectionChanged();
+    void onManualIpChanged(const QString& ip);
 
 private:
+    void refreshManualSourceOptions(const RadioBindSettings* selected = nullptr);
+    void applySavedSourceSelection(const QString& ip);
+    RadioBindSettings currentManualBindSettings(bool* staleSelection = nullptr) const;
+    void saveManualProfile(const QString& targetIp,
+                           const RadioBindSettings& settings,
+                           const QHostAddress& lastSuccessfulLocalIp);
+
     QListWidget* m_radioList;
     QPushButton* m_connectBtn;
     QCheckBox*   m_lowBwCheck;
@@ -72,7 +80,10 @@ private:
     // Manual (routed) connection
     QWidget*     m_manualGroup{nullptr};
     QLineEdit*   m_manualIpEdit{nullptr};
+    QComboBox*   m_manualSourceCombo{nullptr};
+    QLabel*      m_manualSourceWarningLabel{nullptr};
     QPushButton* m_manualProbeBtn{nullptr};
+    QString      m_manualProfileIp;
 };
 
 } // namespace AetherSDR

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -12,7 +12,7 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model, QWidget* p
     : QDialog(parent), m_model(model)
 {
     setWindowTitle("Network Diagnostics");
-    setFixedSize(420, 530);
+    setFixedSize(460, 640);
 
     auto* root = new QVBoxLayout(this);
 
@@ -36,6 +36,27 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model, QWidget* p
     statusGrid->addWidget(new QLabel("Status:"), row, 0);
     m_statusLabel = makeVal();
     statusGrid->addWidget(m_statusLabel, row++, 1);
+
+    statusGrid->addWidget(new QLabel("Target Radio IP:"), row, 0);
+    m_targetIpLabel = makeVal();
+    statusGrid->addWidget(m_targetIpLabel, row++, 1);
+
+    statusGrid->addWidget(new QLabel("Selected Source:"), row, 0);
+    m_sourcePathLabel = makeVal();
+    m_sourcePathLabel->setWordWrap(true);
+    statusGrid->addWidget(m_sourcePathLabel, row++, 1);
+
+    statusGrid->addWidget(new QLabel("Local TCP:"), row, 0);
+    m_tcpEndpointLabel = makeVal();
+    statusGrid->addWidget(m_tcpEndpointLabel, row++, 1);
+
+    statusGrid->addWidget(new QLabel("Local UDP:"), row, 0);
+    m_udpEndpointLabel = makeVal();
+    statusGrid->addWidget(m_udpEndpointLabel, row++, 1);
+
+    statusGrid->addWidget(new QLabel("First UDP Packet:"), row, 0);
+    m_udpSeenLabel = makeVal();
+    statusGrid->addWidget(m_udpSeenLabel, row++, 1);
 
     statusGrid->addWidget(new QLabel("Latency (RTT):"), row, 0);
     m_rttLabel = makeVal();
@@ -156,6 +177,13 @@ void NetworkDiagnosticsDialog::refresh()
 {
     // Status and RTT
     m_statusLabel->setText(m_model->networkQuality());
+    m_targetIpLabel->setText(m_model->targetRadioIp().isEmpty()
+                                 ? "Not connected"
+                                 : m_model->targetRadioIp());
+    m_sourcePathLabel->setText(m_model->selectedSourcePath());
+    m_tcpEndpointLabel->setText(m_model->localTcpEndpoint());
+    m_udpEndpointLabel->setText(m_model->localUdpEndpoint());
+    m_udpSeenLabel->setText(m_model->firstUdpPacketSeen() ? "Yes" : "No");
 
     const int rtt = m_model->lastPingRtt();
     m_rttLabel->setText(rtt < 1 ? "< 1 ms" : QString("%1 ms").arg(rtt));
@@ -171,14 +199,12 @@ void NetworkDiagnosticsDialog::refresh()
     QLabel* rateLabels[] = { m_audioRateLabel, m_fftRateLabel, m_wfRateLabel, m_meterRateLabel };
     QLabel* dropLabels[] = { m_audioDropLabel, m_fftDropLabel, m_wfDropLabel, m_meterDropLabel };
 
-    qint64 catSum = 0;
     for (int i = 0; i < 4; ++i) {
         auto cs = m_model->categoryStats(cats[i]);
         const qint64 delta = cs.bytes - m_lastCatBytes[cats[i]];
         rateLabels[i]->setText(formatRate(delta));
         m_lastCatBytes[cats[i]] = cs.bytes;
         dropLabels[i]->setText(formatDrop(cs));
-        catSum += delta;
     }
 
     // DAX traffic

--- a/src/gui/NetworkDiagnosticsDialog.h
+++ b/src/gui/NetworkDiagnosticsDialog.h
@@ -23,6 +23,11 @@ private:
     QTimer      m_refreshTimer;
 
     QLabel* m_statusLabel;
+    QLabel* m_targetIpLabel;
+    QLabel* m_sourcePathLabel;
+    QLabel* m_tcpEndpointLabel;
+    QLabel* m_udpEndpointLabel;
+    QLabel* m_udpSeenLabel;
     QLabel* m_rttLabel;
     QLabel* m_maxRttLabel;
     QLabel* m_rxRateLabel;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -12,7 +12,6 @@
 #include <QtEndian>
 #include <algorithm>
 #include <cmath>
-#include "core/AppSettings.h"
 
 namespace AetherSDR {
 
@@ -831,12 +830,19 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
         // within 10 seconds (e.g. VPN blocks UDP), warn the user. (#894)
         QTimer::singleShot(10000, this, [this]() {
             if (!isConnected()) return;
-            if (m_panStream->totalRxBytes() == 0) {
+            if (!m_wanConn && !m_panStream->hasReceivedPackets()) {
                 qCWarning(lcProtocol) << "RadioModel: no VITA-49 UDP data received after 10s"
-                             << "— possible VPN/firewall blocking UDP (#894)";
-                emit connectionError(tr("No spectrum data received. UDP traffic from the "
-                                        "radio may be blocked by a VPN or firewall. "
-                                        "Ensure UDP port 4991 is routable."));
+                                      << "target=" << targetRadioIp()
+                                      << "sourceMode=" << selectedSourceMode()
+                                      << "sourcePath=" << selectedSourcePath()
+                                      << "localTcp=" << localTcpEndpoint()
+                                      << "localUdp=" << localUdpEndpoint()
+                                      << "udpSeen=" << firstUdpPacketSeen();
+                emit connectionError(
+                    tr("No spectrum data received from %1. Source mode: %2. TCP: %3. UDP: %4. "
+                       "UDP traffic from the radio may be blocked, or the wrong source path may be selected.")
+                        .arg(targetRadioIp(), selectedSourceMode(),
+                             localTcpEndpoint(), localUdpEndpoint()));
             }
         });
 
@@ -1380,6 +1386,55 @@ qint64 RadioModel::rxBytes() const
 qint64 RadioModel::txBytes() const
 {
     return m_panStream->totalTxBytes();
+}
+
+QString RadioModel::targetRadioIp() const
+{
+    return m_lastInfo.address.toString();
+}
+
+QString RadioModel::selectedSourceMode() const
+{
+    return m_lastInfo.bindSettings.modeString();
+}
+
+QString RadioModel::selectedSourcePath() const
+{
+    if (m_lastInfo.bindSettings.mode == RadioBindMode::Explicit)
+        return m_lastInfo.bindSettings.selectionLabel();
+
+    QHostAddress resolved = m_lastInfo.sessionBindAddress;
+    if (resolved.isNull())
+        resolved = m_connection->localAddress();
+    if (!resolved.isNull() && resolved.protocol() == QAbstractSocket::IPv4Protocol)
+        return QStringLiteral("Auto (%1)").arg(resolved.toString());
+    return QStringLiteral("Auto");
+}
+
+QString RadioModel::localTcpEndpoint() const
+{
+    if (m_wanConn)
+        return QStringLiteral("SmartLink/WAN");
+
+    const QHostAddress localAddr = m_connection->localAddress();
+    const quint16 localPort = m_connection->localTcpPort();
+    if (localAddr.isNull() || localPort == 0)
+        return QStringLiteral("Not connected");
+    return QStringLiteral("%1:%2").arg(localAddr.toString()).arg(localPort);
+}
+
+QString RadioModel::localUdpEndpoint() const
+{
+    const QHostAddress localAddr = m_panStream->localAddress();
+    const quint16 localPort = m_panStream->localPort();
+    if (localAddr.isNull() || localPort == 0)
+        return QStringLiteral("Not bound");
+    return QStringLiteral("%1:%2").arg(localAddr.toString()).arg(localPort);
+}
+
+bool RadioModel::firstUdpPacketSeen() const
+{
+    return m_panStream->hasReceivedPackets();
 }
 
 PanadapterStream::CategoryStats RadioModel::categoryStats(PanadapterStream::StreamCategory cat) const

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -604,6 +604,12 @@ public:
     int     packetTotalCount() const;
     qint64  rxBytes()          const;
     qint64  txBytes()          const;
+    QString targetRadioIp()    const;
+    QString selectedSourceMode() const;
+    QString selectedSourcePath() const;
+    QString localTcpEndpoint() const;
+    QString localUdpEndpoint() const;
+    bool    firstUdpPacketSeen() const;
 
     // Per-category stream stats (Audio, FFT, Waterfall, Meter, DAX)
     PanadapterStream::CategoryStats categoryStats(PanadapterStream::StreamCategory cat) const;


### PR DESCRIPTION

<img width="346" height="493" alt="Screenshot 2026-04-11 at 8 00 22 PM" src="https://github.com/user-attachments/assets/2cefe79f-c977-4791-9473-40beeedeb31e" />

<img width="503" height="714" alt="Screenshot 2026-04-11 at 8 00 57 PM" src="https://github.com/user-attachments/assets/f0caf4d3-65d5-49a2-bbd0-91ddd9c784d9" />

## Summary

This PR adds robust source-path selection and bind reuse for manual/private-routed Flex radio connections so routed VPN sessions can use the same local source path for both TCP control traffic and non-WAN UDP streams.

The main goal is to make manual connections work reliably over private IP reachability such as WireGuard, ZeroTier, UniFi-style routed VPNs, and same-subnet bridged VPNs without introducing a new transport, without SmartLink, and without using OS-specific routing APIs.

In practice, this fixes the multihomed case where the OS may pick the correct TCP path to reach the radio, but the existing UDP socket still binds on `AnyIPv4` and advertises the wrong source interface back to the radio. After this change, manual/routed sessions can either:

- use `Auto` and let the app follow the resolved TCP path, or
- use an explicit user-selected IPv4 source path and bind both TCP and UDP to it

SmartLink/WAN behavior is intentionally left unchanged.

## Problem

Before this change, manual routed connections could probe and connect to a Flex radio over TCP, but the non-WAN UDP stream still used a generic `AnyIPv4` bind in `PanadapterStream::start()`. On multihomed machines, especially macOS or Windows systems with both Wi-Fi and a VPN interface active, that meant:

- manual TCP control could succeed over the VPN/private route
- `client udpport` could still advertise a UDP socket bound on the wrong local path
- the radio would send VITA packets to an interface that was unreachable or incorrect for the routed connection
- diagnostics did not make the mismatch obvious

That is exactly the failure mode users see when a private routed/VPN session connects but never receives spectrum/audio UDP.

## Design Constraints

This implementation keeps the existing architecture intact:

- no new transport layer
- no SmartLink redesign
- no WAN behavior changes
- no OS-specific route-table inspection
- no platform-specific networking frameworks
- no discovery relay or broadcast-forwarder hacks
- no IPv6 expansion in this patch

The change is deliberately incremental and stays inside the existing Manual Connection -> `RadioInfo` -> `RadioConnection` -> `PanadapterStream` flow.

## What Changed

### 1. Manual Connection now exposes source-path selection

The manual connection UI now includes a `Source` combo box beneath the IP entry.

It offers:

- `Auto` (default)
- one entry per active non-loopback IPv4 address, labeled as interface name + IPv4

Enumeration is implemented entirely with Qt networking APIs.

### 2. Routed connection metadata now carries bind information

`RadioInfo` now carries lightweight bind metadata for routed/manual sessions:

- bind mode: `Auto` vs `Explicit`
- bind address
- interface id/name for persistence and re-resolution
- session bind address captured from the successful probe/connect path

This keeps the change backward-compatible while allowing the routed path to carry just enough information to keep TCP and UDP aligned.

### 3. Added a Qt-only network-path helper

A new `NetworkPathResolver` helper was added to:

- enumerate live IPv4 bind candidates
- produce stable UI labels
- resolve a saved interface selection to a current live IPv4 address
- provide a conservative `Auto` candidate when only one obvious IPv4 path exists

This stays within Qt and avoids OS-specific route APIs.

### 4. Manual probe now honors the selected source path

`ConnectionPanel::probeRadio()` now:

- binds the probe `QTcpSocket` to the selected IPv4 address in explicit mode before `connectToHost()`
- leaves the socket unbound in auto mode so the OS can choose the route
- captures the successful probe socket's `localAddress()` before teardown
- stores that resolved local address into the routed `RadioInfo`

This matters because the successful probe path can now be reused by the real session, and the fix was tightened so the local source is captured before the probe socket begins disconnecting.

### 5. `RadioConnection` can now bind TCP locally when needed

`RadioConnection` now accepts bind metadata and, for non-WAN routed connections, can bind the local TCP socket before connecting.

Behavior:

- explicit mode: bind the requested local IPv4 before `connectToHost()`
- auto mode: optionally reuse the previously successful session bind address when available, but fall back to unbound connect if needed
- explicit bind failures are surfaced clearly instead of silently ignored

It also now exposes the connected socket's local address/port so downstream diagnostics and UDP setup can follow the actual TCP path.

### 6. Non-WAN UDP now follows the same local path as TCP

`PanadapterStream::start(RadioConnection* conn)` now selects a preferred local UDP bind address in this order:

1. explicit bind address from connection metadata
2. resolved session bind address captured during probe
3. connected TCP socket's actual local address
4. `AnyIPv4` only when the mode is `Auto` and no concrete address is available

When a concrete address is available, UDP bind attempts are:

- `<chosen address>:4991`
- then `<chosen address>:0`

Only true auto-without-a-concrete-address falls back to the old `AnyIPv4` behavior.

This keeps the existing `client udpport <port>` flow intact while ensuring the socket the radio streams back to actually lives on the same source path as TCP.

### 7. Added a short routed UDP prime retry

For manual/routed non-WAN sessions, the existing 1-byte UDP registration datagram is now retried every 250 ms for about 2 seconds, stopping when the first UDP packet is received.

This is intentionally separate from SmartLink's WAN `udp_register` path and does not redesign or reuse that WAN behavior.

### 8. Diagnostics now expose source-path decisions

The network diagnostics UI and runtime logging now show the information needed to understand routed failures:

- target radio IP
- selected source path
- actual local TCP endpoint
- actual local UDP endpoint
- whether any UDP packet has been observed

The existing 10-second "no UDP" warning was also improved so a wrong-interface failure is much easier to diagnose.

### 9. Source selections are persisted per manual target

The selected routed/manual source path is stored in `RoutedProfilesJson` using a JSON object keyed by target radio address.

Each target currently stores:

- bind mode
- interface id/name
- last successful local IPv4

The schema is structured so it can be migrated later from target-IP identity to a stronger radio identity if needed.

Saved explicit selections are re-resolved against current live interfaces on startup/use. If the saved interface is stale, the UI now surfaces a clear warning instead of silently discarding the selection.

## Files of Interest

Core networking and data flow:

- `src/core/RadioDiscovery.h`
- `src/core/RadioConnection.h`
- `src/core/RadioConnection.cpp`
- `src/core/PanadapterStream.h`
- `src/core/PanadapterStream.cpp`
- `src/core/NetworkPathResolver.h`
- `src/core/NetworkPathResolver.cpp`

Manual UI and diagnostics:

- `src/gui/ConnectionPanel.h`
- `src/gui/ConnectionPanel.cpp`
- `src/gui/NetworkDiagnosticsDialog.h`
- `src/gui/NetworkDiagnosticsDialog.cpp`

Model plumbing:

- `src/models/RadioModel.h`
- `src/models/RadioModel.cpp`

Build wiring:

- `CMakeLists.txt`

## Final Bind-Selection Logic

For routed/manual non-WAN sessions, the final local bind choice is:

### TCP

- explicit mode: bind to the selected source IPv4 before connect
- auto mode: connect unbound unless a previously resolved session bind address is available and usable

### UDP

- explicit bind address from connection metadata, if valid
- else resolved session bind address captured during probe, if valid
- else `RadioConnection::localAddress()` after TCP connect, if valid
- else no concrete address and auto fallback to `AnyIPv4`

UDP then binds on:

- `<chosen address>:4991`
- then `<chosen address>:0`
- only when no concrete chosen address exists in auto mode does it fall back to `AnyIPv4`

## Validation

Built and tested locally:

- `cmake -S /Users/patj/aether/AetherSDR-vpn-routed-source-path -B /tmp/aethersdr-vpn-build`
- `cmake --build /tmp/aethersdr-vpn-build -j10`

Manual runtime validation covered:

- LAN local connection still works
- SmartLink over 5G tether still works
- manual address + manual interface selection over WireGuard VPN works on macOS

Observed diagnostics during the successful WireGuard test showed:

- target radio IP on the private LAN
- selected source `utun8 (10.10.0.2)`
- local TCP bound to `10.10.0.2`
- local UDP bound to `10.10.0.2:4991`
- first UDP packet received successfully

The follow-up probe-time fix was also verified in logs so the probe now correctly records the successful local source address instead of losing it during socket teardown.

## User Impact

This makes private/routed manual connections behave much more predictably on multihomed systems.

Users connecting to a Flex radio over a VPN no longer have to rely on the OS choosing the same source path for UDP that it used for TCP, and when something still goes wrong, the diagnostics now make the bind/interface choice visible.

That means fewer "manual connect succeeds but no spectrum/audio arrives" failures, and much clearer debugging when a saved interface is stale or UDP is blocked upstream.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.3 Pro) and tested by @jensenpat
