### PR TITLE
Fix macOS DAX RX audio corrupted after float32 migration

### DIFF
--- a/packaging/macos/Info.plist.in
+++ b/packaging/macos/Info.plist.in
@@ -24,6 +24,8 @@
 	<string></string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>AetherSDR needs microphone access for voice transmission (SSB, AM, FM, RADE digital voice).</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>AetherSDR needs local network access to discover and communicate with FlexRadio devices via UDP broadcast on port 4992.</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 </dict>

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -396,18 +396,17 @@ void PanadapterStream::processDatagram(const QByteArray& data)
         int channel = daxChannel;
         QByteArray pcm;
         if (pcc == PCC_IF_NARROW) {
+            // Float32 stereo big-endian from radio → native float32 stereo
             const int payloadStart = VITA49_HEADER_BYTES;
             const int payloadBytes = data.size() - payloadStart - (hasTrailer ? 4 : 0);
             if (payloadBytes < 4) return;
             const int numFloats = payloadBytes / 4;
             const uchar* src = raw + payloadStart;
-            pcm.resize(numFloats * 2);
-            auto* dst = reinterpret_cast<qint16*>(pcm.data());
+            pcm.resize(numFloats * static_cast<int>(sizeof(float)));
+            auto* dst = reinterpret_cast<float*>(pcm.data());
             for (int i = 0; i < numFloats; ++i) {
                 const quint32 u = qFromBigEndian<quint32>(src + i * 4);
-                float f;
-                std::memcpy(&f, &u, 4);
-                dst[i] = static_cast<qint16>(qBound(-1.0f, f, 1.0f) * 32767.0f);
+                std::memcpy(&dst[i], &u, 4);
             }
         } else if (pcc == PCC_IF_NARROW_REDUCED) {
             const int payloadStart = VITA49_HEADER_BYTES;

--- a/src/core/VirtualAudioBridge.cpp
+++ b/src/core/VirtualAudioBridge.cpp
@@ -234,18 +234,19 @@ void VirtualAudioBridge::feedDaxAudio(int channel, const QByteArray& pcm)
         }
     }
 
-    // Input: int16 stereo PCM @ 24 kHz from the radio (native DAX rate).
+    // Input: float32 stereo PCM @ 24 kHz from the radio (native DAX rate).
+    //        After the float32 migration (502b934, b0c49d7), both PCC_IF_NARROW
+    //        and PCC_IF_NARROW_REDUCED emit float32 stereo from PanadapterStream.
     // Output: float32 stereo @ 24 kHz into the ring buffer — direct 1:1 copy.
     // HAL plugin also runs at 24 kHz, so no resampling needed.
-    const auto* samples = reinterpret_cast<const int16_t*>(pcm.constData());
-    const int numSamples = pcm.size() / 2;  // total int16 count (L,R,L,R,...)
+    const auto* samples = reinterpret_cast<const float*>(pcm.constData());
+    const int numSamples = pcm.size() / static_cast<int>(sizeof(float));  // total float count (L,R,L,R,...)
 
     const float chGain = m_channelGain[channel - 1];
-    const float scale = chGain / 32768.0f;
     uint32_t wp = block->writePos.load(std::memory_order_relaxed);
 
     for (int i = 0; i < numSamples; ++i) {
-        block->ringBuffer[wp % DaxShmBlock::RING_SIZE] = samples[i] * scale;
+        block->ringBuffer[wp % DaxShmBlock::RING_SIZE] = samples[i] * chGain;
         ++wp;
     }
 
@@ -256,7 +257,7 @@ void VirtualAudioBridge::feedDaxAudio(int channel, const QByteArray& pcm)
     if (++meterCount[channel - 1] % 10 == 0) {
         float sum = 0;
         for (int i = 0; i < numSamples; i += 2)
-            sum += (samples[i] / 32768.0f) * (samples[i] / 32768.0f);
+            sum += samples[i] * samples[i];
         float rms = std::sqrt(sum / std::max(1, numSamples / 2));
         emit daxRxLevel(channel, rms);
     }


### PR DESCRIPTION
## Summary

The float32 audio pipeline migration (502b934, b0c49d7) missed the macOS `VirtualAudioBridge` and the `PCC_IF_NARROW` DAX path in `PanadapterStream`, causing **severe audio corruption** on the macOS DAX virtual sound card. Digital mode software (VARA HF, WSJT-X) connected via the AetherSDR DAX device sees the audio spectrum displaced from the expected ~1500 Hz center frequency, making modems unable to decode signals.

## Root Cause

After the float32 migration, `PanadapterStream::daxAudioReady` emits **float32 stereo** PCM. All downstream consumers were updated accordingly — `TciServer::onDaxAudioReady`, `RADEEngine::feedRxAudio`, and the Linux `PipeWireAudioBridge` (3400133) — but the macOS `VirtualAudioBridge::feedDaxAudio()` was not. It still `reinterpret_cast`'s the incoming `QByteArray` as `int16_t*` and divides by 32768.0f:

```cpp
// Before (broken): reads float32 bytes as int16
const auto* samples = reinterpret_cast<const int16_t*>(pcm.constData());
const float scale = chGain / 32768.0f;
block->ringBuffer[wp % RING_SIZE] = samples[i] * scale;
```

When float32 samples (4 bytes each) are reinterpreted as int16 (2 bytes each), every sample value is completely wrong — the ring buffer is filled with garbage, and the HAL plugin outputs corrupted audio to VARA/WSJT-X.

Additionally, `PanadapterStream`'s `PCC_IF_NARROW` path (full-bandwidth stereo DAX) was still converting radio float32 → int16 via `qBound(-1.0f, f, 1.0f) * 32767.0f` before emission. This was missed by b0c49d7 which only fixed `PCC_IF_NARROW_REDUCED`. The lossy int16 conversion (clamping to ±1.0) combined with the format mismatch in VirtualAudioBridge compounded the corruption.

## Fix

- **`VirtualAudioBridge::feedDaxAudio()`**: Read payload as `float*`, compute sample count by dividing by `sizeof(float)`, multiply by `chGain` directly (no `/32768` normalization). Update RMS meter to operate on float samples natively.
- **`PanadapterStream` PCC_IF_NARROW path**: Emit native float32 stereo (`memcpy` from big-endian-swapped `uint32` to `float`) instead of converting to int16. Now consistent with `PCC_IF_NARROW_REDUCED` and all downstream consumers.
- **`Info.plist.in`**: Add `NSLocalNetworkUsageDescription` — required by macOS for UDP broadcast discovery of FlexRadio devices on port 4992. Without this key, the radio does not appear in the device list.

## Test plan

- [x] Build on macOS (ARM64, Qt 6.11)
- [x] Connect to FLEX-8600 (FW 1.4.0.0) in DIGU mode with DAX enabled
- [x] Verify VARA HF v4.9.0 receives audio spectrum correctly centered at ~1500 Hz via AetherSDR DAX virtual sound card
- [x] Verify radio appears in device list on macOS (NSLocalNetworkUsageDescription)

🤖 Generated with [Claude Code](https://claude.com/claude-code)