### PR TITLE
[shortcuts] Add configurable pan zoom and memories shortcuts

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6227,6 +6227,36 @@ void MainWindow::registerShortcutActions()
             if (s) s->setLocked(!s->isLocked());
         });
 
+    auto zoomActivePanadapter = [this](double factor) {
+        if (!m_radioModel.isConnected()) {
+            return;
+        }
+
+        auto* s = activeSlice();
+        if (!s || s->panId().isEmpty()) {
+            return;
+        }
+
+        auto* sw = spectrumForSlice(s);
+        if (!sw) {
+            return;
+        }
+
+        const double currentBw = sw->bandwidthMhz();
+        const double newBw = currentBw * factor;
+        if (newBw < m_radioModel.minPanBandwidthMhz()
+                || newBw > m_radioModel.maxPanBandwidthMhz()) {
+            return;
+        }
+
+        const double currentCenter = sw->centerMhz();
+        sw->setFrequencyRange(currentCenter, newBw);
+        m_radioModel.sendCommand(
+            QString("display pan set %1 bandwidth=%2").arg(s->panId()).arg(newBw, 0, 'f', 6));
+        m_radioModel.sendCommand(
+            QString("display pan set %1 center=%2").arg(s->panId()).arg(currentCenter, 0, 'f', 6));
+    };
+
     // ── DSP ─────────────────────────────────────────────────────────────
     m_shortcutManager.registerAction("nb_toggle", "NB Toggle", "DSP",
         QKeySequence(), [this]() {
@@ -6291,6 +6321,12 @@ void MainWindow::registerShortcutActions()
             if (s) m_radioModel.sendCommand(
                 QString("slice set %1 segment_zoom=1").arg(s->sliceId()));
         });
+    m_shortcutManager.registerAction("pan_zoom_in", "Panadapter Zoom In", "Display",
+        QKeySequence(), [zoomActivePanadapter]() { zoomActivePanadapter(1.0 / 1.5); });
+    m_shortcutManager.registerAction("pan_zoom_out", "Panadapter Zoom Out", "Display",
+        QKeySequence(), [zoomActivePanadapter]() { zoomActivePanadapter(1.5); });
+    m_shortcutManager.registerAction("open_memories", "Open Memories Dialog", "Display",
+        QKeySequence(), [this]() { showMemoryDialog(); });
 
     // ── RIT/XIT ─────────────────────────────────────────────────────────
     m_shortcutManager.registerAction("rit_toggle", "RIT Toggle", "RIT/XIT",

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6322,11 +6322,11 @@ void MainWindow::registerShortcutActions()
                 QString("slice set %1 segment_zoom=1").arg(s->sliceId()));
         });
     m_shortcutManager.registerAction("pan_zoom_in", "Panadapter Zoom In", "Display",
-        QKeySequence(), [zoomActivePanadapter]() { zoomActivePanadapter(1.0 / 1.5); });
+        QKeySequence(Qt::Key_Equal), [zoomActivePanadapter]() { zoomActivePanadapter(1.0 / 1.5); });
     m_shortcutManager.registerAction("pan_zoom_out", "Panadapter Zoom Out", "Display",
-        QKeySequence(), [zoomActivePanadapter]() { zoomActivePanadapter(1.5); });
+        QKeySequence(Qt::Key_Minus), [zoomActivePanadapter]() { zoomActivePanadapter(1.5); });
     m_shortcutManager.registerAction("open_memories", "Open Memories Dialog", "Display",
-        QKeySequence(), [this]() { showMemoryDialog(); });
+        QKeySequence(Qt::Key_Slash), [this]() { showMemoryDialog(); });
 
     // ── RIT/XIT ─────────────────────────────────────────────────────────
     m_shortcutManager.registerAction("rit_toggle", "RIT Toggle", "RIT/XIT",

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -103,6 +103,8 @@ public:
     float spectrumFrac()  const { return m_spectrumFrac; }
     float refLevel()      const { return m_refLevel; }
     float dynamicRange()  const { return m_dynamicRange; }
+    double centerMhz()    const { return m_centerMhz; }
+    double bandwidthMhz() const { return m_bandwidthMhz; }
 
     // Set the FFT/waterfall split ratio programmatically.
     void setSpectrumFrac(float f);


### PR DESCRIPTION
## Summary
- add configurable shortcut actions for panadapter zoom in, panadapter zoom out, and opening the Memories dialog
- route shortcut-driven pan zoom through the live `SpectrumWidget` center/bandwidth state so each keypress matches the on-screen zoom buttons
- ship the new shortcuts with default bindings: `=` for zoom in, `-` for zoom out, and `/` for the Memories dialog

## Why
These controls were available in the UI but not in the configurable keyboard shortcut system. The shortcut zoom path also needed to mirror the widget's live zoom state so it would step cleanly instead of jumping between coarse widths.

## Validation
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build -j10`
- manual app test of pan zoom in/out and opening the Memories dialog via configured shortcuts

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.3 Pro) and tested by @jensenpat
