### PR TITLE
[macOS] [ux] Integrate Qt into macOS frameless window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -583,6 +583,10 @@ qt_add_resources(RESOURCES resources.qrc)
 
 add_executable(AetherSDR ${ALL_SOURCES} ${RNNOISE_SOURCES} ${GGMORSE_SOURCES} ${RADE_SOURCES} ${BNR_SOURCES} ${SPECBLEACH_SOURCES} ${RESOURCES})
 
+if(APPLE)
+    target_sources(AetherSDR PRIVATE src/platform/macos/MacWindowChrome.mm)
+endif()
+
 # Windows: GUI app (no console window) + icon resource
 if(WIN32)
     set_target_properties(AetherSDR PROPERTIES WIN32_EXECUTABLE TRUE)
@@ -599,7 +603,7 @@ if(APPLE)
         MACOSX_BUNDLE_ICON_FILE "AetherSDR.icns"
         MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/packaging/macos/Info.plist.in"
     )
-    target_link_libraries(AetherSDR PRIVATE "-framework AVFoundation")
+    target_link_libraries(AetherSDR PRIVATE "-framework AVFoundation" "-framework AppKit")
     set(MACOSX_ICON "${CMAKE_SOURCE_DIR}/docs/AetherSDR.icns")
     if(EXISTS "${MACOSX_ICON}")
         target_sources(AetherSDR PRIVATE "${MACOSX_ICON}")

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -57,7 +57,9 @@
 #endif
 #include "AetherDspDialog.h"
 #include "DspParamPopup.h"
+#include "platform/macos/MacWindowChrome.h"
 
+#include <algorithm>
 #include <memory>
 #include <functional>
 #include <QApplication>
@@ -101,6 +103,7 @@
 #include <QComboBox>
 #include <QProgressDialog>
 #include <QThread>
+#include <QWindow>
 #include "core/AppSettings.h"
 #ifdef HAVE_RADE
 #include "core/RADEEngine.h"
@@ -199,6 +202,7 @@ static bool shortcutGuard() {
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
 {
+    configureMacWindowFlags();
     setWindowTitle(QString("AetherSDR v%1").arg(QCoreApplication::applicationVersion()));
     setWindowIcon(QIcon(":/icon.png"));
     setMinimumSize(1024, 600);
@@ -2327,6 +2331,117 @@ void MainWindow::audioStartTx(const QHostAddress& addr, quint16 port)
     });
 }
 
+void MainWindow::showEvent(QShowEvent* event)
+{
+    QMainWindow::showEvent(event);
+    applyMacWindowChromeIfNeeded();
+}
+
+void MainWindow::resizeEvent(QResizeEvent* event)
+{
+    QMainWindow::resizeEvent(event);
+    applyMacWindowChromeIfNeeded();
+}
+
+void MainWindow::changeEvent(QEvent* event)
+{
+    QMainWindow::changeEvent(event);
+
+#ifdef Q_OS_MAC
+    if (!event)
+        return;
+
+    switch (event->type()) {
+    case QEvent::WindowStateChange:
+    case QEvent::ActivationChange:
+        applyMacWindowChromeIfNeeded();
+        break;
+    default:
+        break;
+    }
+#endif
+}
+
+void MainWindow::configureMacWindowFlags()
+{
+#ifdef Q_OS_MAC
+    // Keep a native titled window on macOS so the traffic lights, fullscreen,
+    // and edge resize behavior stay AppKit-managed instead of going frameless.
+    //
+    // Qt Widgets respects a window's safe area by default, which keeps a
+    // QMainWindow's internal layout below the titlebar. Opt the top-level
+    // widget layout into the full rect so the custom TitleBar can actually
+    // live inside the expanded client area.
+    setAttribute(Qt::WA_LayoutOnEntireRect, true);
+    setAttribute(Qt::WA_ContentsMarginsRespectsSafeArea, false);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    // Qt 6.9 added these client-area hints; older Qt still builds and falls
+    // back to the AppKit chrome helper below.
+    setWindowFlag(Qt::ExpandedClientAreaHint, true);
+    setWindowFlag(Qt::NoTitleBarBackgroundHint, true);
+#endif
+#endif
+}
+
+void MainWindow::applyMacWindowChromeIfNeeded()
+{
+#ifdef Q_OS_MAC
+    connectMacWindowSignals();
+    if (!m_macChromeApplied)
+        m_macChromeApplied = applyMacWindowChrome(window());
+    updateMacTitleBarMetrics();
+#endif
+}
+
+void MainWindow::updateMacTitleBarMetrics()
+{
+#ifdef Q_OS_MAC
+    if (!m_titleBar || !m_mainLayout)
+        return;
+
+    connectMacWindowSignals();
+
+    const MacChromeMetrics metrics = queryMacChromeMetrics(window());
+    int effectiveLeadingInset = metrics.leadingInsetPx;
+    int effectiveTitleBarHeight = metrics.titleBarHeightPx;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    // Qt 6.9 exposes safe-area changes for notched displays; older Qt keeps
+    // compiling without this code path.
+    if (auto* handle = windowHandle()) {
+        const QMargins safeArea = handle->safeAreaMargins();
+        effectiveLeadingInset = std::max(effectiveLeadingInset, safeArea.left());
+        effectiveTitleBarHeight = std::max(effectiveTitleBarHeight, safeArea.top());
+    }
+#endif
+
+    m_titleBar->setMacChromeMetrics(effectiveLeadingInset, effectiveTitleBarHeight);
+#endif
+}
+
+void MainWindow::connectMacWindowSignals()
+{
+#ifdef Q_OS_MAC
+    auto* handle = windowHandle();
+    if (!handle || m_macObservedWindow == handle)
+        return;
+
+    m_macObservedWindow = handle;
+    m_macChromeApplied = false;
+
+    connect(handle, &QWindow::screenChanged, this, [this](QScreen*) {
+        updateMacTitleBarMetrics();
+    });
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    // Guard the 6.9+ safe-area signal so older Qt branches still compile.
+    connect(handle, &QWindow::safeAreaMarginsChanged, this, [this](const QMargins&) {
+        updateMacTitleBarMetrics();
+    });
+#endif
+#endif
+}
+
 void MainWindow::audioStopTx()
 {
     QMetaObject::invokeMethod(m_audio, &AudioEngine::stopTxStream);
@@ -2336,6 +2451,10 @@ void MainWindow::audioStopTx()
 
 void MainWindow::buildMenuBar()
 {
+#ifdef Q_OS_MAC
+    menuBar()->setNativeMenuBar(true);
+#endif
+
     auto* fileMenu = menuBar()->addMenu("&File");
     auto* quitAct = fileMenu->addAction("&Quit");
     quitAct->setShortcut(QKeySequence::Quit);
@@ -3355,8 +3474,10 @@ void MainWindow::buildUI()
 {
     // ── Title bar + central splitter ─────────────────────────────────────────
     m_titleBar = new TitleBar(this);
-    // Embed the menu bar into the title bar (left side)
+#ifndef Q_OS_MAC
+    // Linux/Windows keep the in-window menu bar layout.
     m_titleBar->setMenuBar(menuBar());
+#endif
     connect(m_titleBar, &TitleBar::multiFlexClicked, this, [this] {
         MultiFlexDialog dlg(&m_radioModel, this);
         dlg.exec();
@@ -3373,11 +3494,13 @@ void MainWindow::buildUI()
     m_splitter->setHandleWidth(0);
 
     auto* central = new QWidget(this);
-    auto* vbox = new QVBoxLayout(central);
-    vbox->setContentsMargins(0, 0, 0, 0);
-    vbox->setSpacing(0);
-    vbox->addWidget(m_titleBar);
-    vbox->addWidget(m_splitter, 1);
+    central->setAttribute(Qt::WA_LayoutOnEntireRect, true);
+    central->setAttribute(Qt::WA_ContentsMarginsRespectsSafeArea, false);
+    m_mainLayout = new QVBoxLayout(central);
+    m_mainLayout->setContentsMargins(0, 0, 0, 0);
+    m_mainLayout->setSpacing(0);
+    m_mainLayout->addWidget(m_titleBar);
+    m_mainLayout->addWidget(m_splitter, 1);
     setCentralWidget(central);
 
     auto* splitter = m_splitter;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3494,8 +3494,10 @@ void MainWindow::buildUI()
     m_splitter->setHandleWidth(0);
 
     auto* central = new QWidget(this);
+#ifdef Q_OS_MAC
     central->setAttribute(Qt::WA_LayoutOnEntireRect, true);
     central->setAttribute(Qt::WA_ContentsMarginsRespectsSafeArea, false);
+#endif
     m_mainLayout = new QVBoxLayout(central);
     m_mainLayout->setContentsMargins(0, 0, 0, 0);
     m_mainLayout->setSpacing(0);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -47,6 +47,11 @@
 #include <QMenu>
 #include <QStatusBar>
 
+class QResizeEvent;
+class QShowEvent;
+class QWindow;
+class QVBoxLayout;
+
 namespace AetherSDR {
 
 class ConnectionPanel;
@@ -80,6 +85,9 @@ public:
 
 protected:
     void closeEvent(QCloseEvent* event) override;
+    void showEvent(QShowEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
+    void changeEvent(QEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void keyReleaseEvent(QKeyEvent* event) override;
     bool eventFilter(QObject* obj, QEvent* event) override;
@@ -98,6 +106,10 @@ private:
     void buildUI();
     void buildMenuBar();
     void applyDarkTheme();
+    void configureMacWindowFlags();
+    void applyMacWindowChromeIfNeeded();
+    void updateMacTitleBarMetrics();
+    void connectMacWindowSignals();
 
     // Audio thread helpers — invoke AudioEngine methods on the worker thread (#502)
     void audioStartRx();
@@ -212,6 +224,7 @@ private:
 
     // GUI — main area
     TitleBar*         m_titleBar{nullptr};
+    QVBoxLayout*      m_mainLayout{nullptr};
     QSplitter*        m_splitter{nullptr};
     PanadapterStack*  m_panStack{nullptr};
     QPointer<PanadapterApplet> m_panApplet;  // backward compat alias to active applet
@@ -314,6 +327,11 @@ private:
     QString m_savedMicSelection;  // restore on stopDax
     bool startDax();
     void stopDax();
+#endif
+
+#ifdef Q_OS_MAC
+    QPointer<QWindow> m_macObservedWindow;
+    bool m_macChromeApplied{false};
 #endif
 };
 

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -2,6 +2,7 @@
 #include "GuardedSlider.h"
 #include "core/AppSettings.h"
 
+#include <algorithm>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QDialog>
@@ -14,8 +15,10 @@
 #include <QDesktopServices>
 #include <QClipboard>
 #include <QApplication>
+#include <QMouseEvent>
 #include <QTimer>
 #include <QMenu>
+#include <QWindow>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QJsonDocument>
@@ -24,10 +27,54 @@
 
 namespace AetherSDR {
 
+#ifdef Q_OS_MAC
+namespace {
+
+class MacTitleDragStrip : public QWidget {
+public:
+    explicit MacTitleDragStrip(QWidget* parent = nullptr)
+        : QWidget(parent)
+    {
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        setCursor(Qt::OpenHandCursor);
+        setAccessibleName("Window drag strip");
+    }
+
+protected:
+    void mousePressEvent(QMouseEvent* event) override
+    {
+        if (event->button() == Qt::LeftButton && startNativeMove()) {
+            event->accept();
+            return;
+        }
+        QWidget::mousePressEvent(event);
+    }
+
+    void mouseMoveEvent(QMouseEvent* event) override
+    {
+        if ((event->buttons() & Qt::LeftButton) && startNativeMove()) {
+            event->accept();
+            return;
+        }
+        QWidget::mouseMoveEvent(event);
+    }
+
+private:
+    bool startNativeMove()
+    {
+        QWidget* topLevel = window();
+        QWindow* handle = topLevel ? topLevel->windowHandle() : nullptr;
+        return handle && handle->startSystemMove();
+    }
+};
+
+} // namespace
+#endif
+
 TitleBar::TitleBar(QWidget* parent)
     : QWidget(parent)
 {
-    setFixedHeight(32);
+    setFixedHeight(m_baseHeightPx);
     setStyleSheet("TitleBar { background: #0a0a14; border-bottom: 1px solid #203040; }");
 
     m_hbox = new QHBoxLayout(this);
@@ -96,6 +143,10 @@ TitleBar::TitleBar(QWidget* parent)
     m_hbox->addStretch(1);
     m_hbox->addWidget(m_heartbeat);
     m_hbox->addSpacing(4);
+#else
+    m_nativeInsetSpacer = new QWidget(this);
+    m_nativeInsetSpacer->setFixedWidth(0);
+    m_hbox->addWidget(m_nativeInsetSpacer);
 #endif
 
     auto* appName = new QLabel("AetherSDR");
@@ -120,9 +171,12 @@ TitleBar::TitleBar(QWidget* parent)
     // macOS: heartbeat after multiFLEX (left-aligned, no menu bar in title)
     m_hbox->addSpacing(4);
     m_hbox->addWidget(m_heartbeat);
-#endif
-
+    m_dragStrip = new MacTitleDragStrip(this);
+    m_dragStrip->setMinimumWidth(24);
+    m_hbox->addWidget(m_dragStrip, 1);
+#else
     m_hbox->addStretch(1);
+#endif
 
     // ── Right: Other client TX indicator + PC Audio + Master Vol + HP Vol ──
     m_otherTxLabel = new QLabel();
@@ -319,6 +373,19 @@ void TitleBar::setHeadphoneVolume(int pct)
     QSignalBlocker b(m_hpSlider);
     m_hpSlider->setValue(pct);
     m_hpLabel->setText(QString::number(pct));
+}
+
+void TitleBar::setMacChromeMetrics(int leadingInsetPx, int titleBarHeightPx)
+{
+#ifdef Q_OS_MAC
+    if (m_nativeInsetSpacer)
+        m_nativeInsetSpacer->setFixedWidth(std::max(0, leadingInsetPx));
+
+    setFixedHeight(std::max(m_baseHeightPx, titleBarHeightPx));
+#else
+    Q_UNUSED(leadingInsetPx);
+    Q_UNUSED(titleBarHeightPx);
+#endif
 }
 
 void TitleBar::setMultiFlexStatus(int count, const QStringList& names)

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -1,6 +1,7 @@
 #include "TitleBar.h"
 #include "GuardedSlider.h"
 #include "core/AppSettings.h"
+#include "platform/macos/MacWindowChrome.h"
 
 #include <algorithm>
 #include <QHBoxLayout>
@@ -57,6 +58,15 @@ protected:
             return;
         }
         QWidget::mouseMoveEvent(event);
+    }
+
+    void mouseDoubleClickEvent(QMouseEvent* event) override
+    {
+        if (event->button() == Qt::LeftButton && toggleMacWindowZoom(window())) {
+            event->accept();
+            return;
+        }
+        QWidget::mouseDoubleClickEvent(event);
     }
 
 private:

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -23,6 +23,7 @@ public:
     void setPcAudioEnabled(bool on);
     void setMasterVolume(int pct);
     void setHeadphoneVolume(int pct);
+    void setMacChromeMetrics(int leadingInsetPx, int titleBarHeightPx);
     void setOtherClientTx(bool transmitting, const QString& station);
     void setMultiFlexStatus(int clientCount, const QStringList& names);
     void onHeartbeat();       // Call when a discovery packet arrives
@@ -48,6 +49,8 @@ private:
     void showFeatureRequestDialogImpl();
     QHBoxLayout* m_hbox{nullptr};
     QMenuBar*    m_menuBar{nullptr};
+    QWidget*     m_nativeInsetSpacer{nullptr};
+    QWidget*     m_dragStrip{nullptr};
     QLabel*      m_otherTxLabel{nullptr};
     QPushButton* m_mfBtn{nullptr};
     QPushButton* m_pcBtn{nullptr};
@@ -69,6 +72,7 @@ private:
     bool         m_alarmRed{false};
     bool         m_blinkEnabled{true};  // persisted via AppSettings "HeartbeatBlinkEnabled"
     bool         m_discovering{false};  // solid amber while waiting for connection
+    int          m_baseHeightPx{32};
 };
 
 } // namespace AetherSDR

--- a/src/platform/macos/MacWindowChrome.h
+++ b/src/platform/macos/MacWindowChrome.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <QtGlobal>
+
+class QWidget;
+
+namespace AetherSDR {
+
+struct MacChromeMetrics {
+    int leadingInsetPx = 0;
+    int titleBarHeightPx = 0;
+    bool available = false;
+};
+
+#if defined(Q_OS_MAC)
+bool applyMacWindowChrome(QWidget* topLevel);
+MacChromeMetrics queryMacChromeMetrics(QWidget* topLevel);
+#else
+inline bool applyMacWindowChrome(QWidget*)
+{
+    return false;
+}
+
+inline MacChromeMetrics queryMacChromeMetrics(QWidget*)
+{
+    return {};
+}
+#endif
+
+} // namespace AetherSDR

--- a/src/platform/macos/MacWindowChrome.h
+++ b/src/platform/macos/MacWindowChrome.h
@@ -15,6 +15,7 @@ struct MacChromeMetrics {
 #if defined(Q_OS_MAC)
 bool applyMacWindowChrome(QWidget* topLevel);
 MacChromeMetrics queryMacChromeMetrics(QWidget* topLevel);
+bool toggleMacWindowZoom(QWidget* topLevel);
 #else
 inline bool applyMacWindowChrome(QWidget*)
 {
@@ -24,6 +25,11 @@ inline bool applyMacWindowChrome(QWidget*)
 inline MacChromeMetrics queryMacChromeMetrics(QWidget*)
 {
     return {};
+}
+
+inline bool toggleMacWindowZoom(QWidget*)
+{
+    return false;
 }
 #endif
 

--- a/src/platform/macos/MacWindowChrome.mm
+++ b/src/platform/macos/MacWindowChrome.mm
@@ -1,0 +1,112 @@
+#include "platform/macos/MacWindowChrome.h"
+
+#ifdef Q_OS_MAC
+
+#include <AppKit/AppKit.h>
+
+#include <QWidget>
+#include <QWindow>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+namespace {
+
+NSWindow* nativeWindowForWidget(QWidget* topLevel)
+{
+    if (!topLevel)
+        return nil;
+
+    QWidget* window = topLevel->window();
+    if (!window)
+        return nil;
+
+    // Qt top-level widgets are backed by an NSView on macOS; keep using the
+    // native titled window so AppKit still owns resize, fullscreen, and the
+    // traffic-light controls instead of emulating them with a frameless Qt window.
+    auto nativeViewId = window->winId();
+    if (!nativeViewId)
+        return nil;
+
+    auto* nsView = reinterpret_cast<NSView*>(nativeViewId);
+    if (!nsView)
+        return nil;
+
+    return nsView.window;
+}
+
+MacChromeMetrics metricsForWindow(NSWindow* nsWindow)
+{
+    MacChromeMetrics metrics;
+    if (!nsWindow)
+        return metrics;
+
+    NSView* contentView = nsWindow.contentView;
+    CGFloat clusterRight = 0.0;
+    bool foundButtons = false;
+
+    for (NSWindowButton buttonType : {
+             NSWindowCloseButton,
+             NSWindowMiniaturizeButton,
+             NSWindowZoomButton,
+         }) {
+        NSButton* button = [nsWindow standardWindowButton:buttonType];
+        if (!button)
+            continue;
+
+        NSRect buttonFrame = button.frame;
+        if (button.superview && contentView && button.superview != contentView)
+            buttonFrame = [button.superview convertRect:buttonFrame toView:contentView];
+
+        clusterRight = std::max(clusterRight, NSMaxX(buttonFrame));
+        foundButtons = true;
+    }
+
+    if (foundButtons)
+        metrics.leadingInsetPx = static_cast<int>(std::ceil(clusterRight + 10.0));
+
+    CGFloat titleBarHeight = 0.0;
+    if (contentView) {
+        const NSRect contentBounds = contentView.bounds;
+        const NSRect layoutRect = nsWindow.contentLayoutRect;
+        titleBarHeight = std::max<CGFloat>(0.0, NSMaxY(contentBounds) - NSMaxY(layoutRect));
+        if (titleBarHeight <= 0.0)
+            titleBarHeight = std::max<CGFloat>(0.0, NSHeight(contentBounds) - NSHeight(layoutRect));
+    }
+
+    if (titleBarHeight <= 0.0) {
+        const NSRect frameRect = nsWindow.frame;
+        const NSRect contentRect = [nsWindow contentRectForFrameRect:frameRect];
+        titleBarHeight = std::max<CGFloat>(0.0, NSHeight(frameRect) - NSHeight(contentRect));
+    }
+
+    if (titleBarHeight > 0.0)
+        metrics.titleBarHeightPx = static_cast<int>(std::ceil(titleBarHeight));
+
+    metrics.available = foundButtons || metrics.titleBarHeightPx > 0;
+    return metrics;
+}
+
+} // namespace
+
+bool applyMacWindowChrome(QWidget* topLevel)
+{
+    NSWindow* nsWindow = nativeWindowForWidget(topLevel);
+    if (!nsWindow)
+        return false;
+
+    nsWindow.titlebarAppearsTransparent = YES;
+    nsWindow.titleVisibility = NSWindowTitleHidden;
+    nsWindow.styleMask |= NSWindowStyleMaskFullSizeContentView;
+    return true;
+}
+
+MacChromeMetrics queryMacChromeMetrics(QWidget* topLevel)
+{
+    return metricsForWindow(nativeWindowForWidget(topLevel));
+}
+
+} // namespace AetherSDR
+
+#endif

--- a/src/platform/macos/MacWindowChrome.mm
+++ b/src/platform/macos/MacWindowChrome.mm
@@ -107,6 +107,18 @@ MacChromeMetrics queryMacChromeMetrics(QWidget* topLevel)
     return metricsForWindow(nativeWindowForWidget(topLevel));
 }
 
+bool toggleMacWindowZoom(QWidget* topLevel)
+{
+    NSWindow* nsWindow = nativeWindowForWidget(topLevel);
+    if (!nsWindow)
+        return false;
+
+    // Use AppKit's zoom behavior so double-clicking the custom titlebar strip
+    // matches the native titled window action without entering fullscreen.
+    [nsWindow zoom:nil];
+    return true;
+}
+
 } // namespace AetherSDR
 
 #endif


### PR DESCRIPTION
<img width="1727" height="1099" alt="Screenshot 2026-04-12 at 7 22 28 PM" src="https://github.com/user-attachments/assets/b0bc516f-7022-4399-a29f-217731c08a8b" />

## Summary

- Integrate the existing Qt `TitleBar` into the native macOS titlebar area without using a frameless window
- Preserve native traffic lights, fullscreen, dragging, edge/corner resize behavior, and titlebar double-click zoom
- Do not make any changes to core Qt code -- keep Linux and Windows on the existing layout path

## Why

On macOS, AetherSDR's custom title controls were rendered below the native titlebar instead of occupying the expanded client area. This change keeps the native titled `NSWindow` chrome intact while moving the existing app controls into the titlebar region to the right of the traffic lights.

## Root Cause

- the native `NSWindow` needed transparent titlebar/full-size content view configuration after the Qt window handle existed
- Qt Widgets was still respecting the titlebar safe area for `QMainWindow` layout, so the custom titlebar never entered the native titlebar region
- the titlebar needed real traffic-light geometry so the left-side controls could avoid overlapping native window buttons
- the draggable strip needed native AppKit zoom behavior for double-click maximize without entering fullscreen

## User Impact

- macOS gets a more native-looking window with the existing AetherSDR controls embedded in the titlebar area
- window controls, fullscreen, dragging, resize behavior, and double-click zoom remain native-feeling
- Linux and Windows behavior stays effectively unchanged

## Validation

- `cmake -S . -B build-no-mqtt -DENABLE_MQTT=OFF`
- `cmake --build build-no-mqtt -j10`

## Suggested Test Plan

### macOS core behavior

- Launch the app in normal windowed mode and confirm the custom titlebar visually sits inside the native macOS titlebar region with no extra dead band above it
- Verify native close, minimize, zoom, and fullscreen from the traffic lights
- Drag from the empty middle strip in the titlebar and confirm the window moves normally
- Double-click the empty titlebar strip and confirm it toggles zoom/maximize instead of entering fullscreen
- Verify titlebar buttons and sliders remain clickable and do not trigger dragging
- Resize from every edge and corner and confirm native resize behavior still works

### Layout and display changes

- Resize the window narrow and wide and confirm the titlebar content does not overlap the traffic lights
- Move the window between displays and confirm the titlebar inset still looks correct
- Test on a notched MacBook display if available and confirm the titlebar content respects the safe area
- Enter and exit fullscreen, then minimize/restore, and confirm the titlebar returns to the correct position after each transition
- Toggle minimal mode and confirm the titlebar still behaves correctly

### Cross-platform smoke

- Launch on Linux and confirm the existing embedded `TitleBar` + menu layout is unchanged
- Launch on Windows and confirm the existing titlebar layout and window chrome are unchanged

## Notes

- the default `build/` configuration still hits an unrelated existing MQTT/cJSON issue in this repo
- the feature work was validated in `build-no-mqtt`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.3 Pro) and tested by @jensenpat
