### PR TITLE
[ux] Add WIDE indicator support

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -196,6 +196,17 @@ static bool shortcutGuard() {
     return s_keyboardShortcutsEnabled && !isTextInputFocused();
 }
 
+static void syncWideIndicator(PanadapterModel* pan, SpectrumWidget* sw)
+{
+    if (!pan || !sw)
+        return;
+
+    QObject::connect(pan, &PanadapterModel::wideChanged,
+                     sw, &SpectrumWidget::setWideActive,
+                     Qt::UniqueConnection);
+    sw->setWideActive(pan->wideActive());
+}
+
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
 {
@@ -907,10 +918,13 @@ MainWindow::MainWindow(QWidget* parent)
 
         // Skip if this pan already has an applet
         if (m_panStack->panadapter(pan->panId())) {
-            connect(pan, &PanadapterModel::infoChanged,
-                    m_panStack->spectrum(pan->panId()), &SpectrumWidget::setFrequencyRange);
-            connect(pan, &PanadapterModel::levelChanged,
-                    m_panStack->spectrum(pan->panId()), &SpectrumWidget::setDbmRange);
+            if (auto* sw = m_panStack->spectrum(pan->panId())) {
+                connect(pan, &PanadapterModel::infoChanged,
+                        sw, &SpectrumWidget::setFrequencyRange, Qt::UniqueConnection);
+                connect(pan, &PanadapterModel::levelChanged,
+                        sw, &SpectrumWidget::setDbmRange, Qt::UniqueConnection);
+                syncWideIndicator(pan, sw);
+            }
             return;
         }
 
@@ -942,6 +956,7 @@ MainWindow::MainWindow(QWidget* parent)
             applet->spectrumWidget()->setRfGain(gain);
             applet->spectrumWidget()->overlayMenu()->setRfGain(gain);
         });
+        syncWideIndicator(pan, applet->spectrumWidget());
 
         // Push display dimensions to the radio so it sends full-size FFT bins.
         // Without this, the radio uses xpixels=50 ypixels=20 (default) and
@@ -4986,6 +5001,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         }
     }
 
+    if (auto* pan = m_radioModel.panadapter(applet->panId()))
+        syncWideIndicator(pan, sw);
+
     // ── Tuning step size → this pan's spectrum widget ─────────────────────
     // The global connection only covers AppSettings + radio command.
     // Each pan must also receive stepSizeChanged so scroll-to-tune
@@ -6708,6 +6726,7 @@ void MainWindow::createPansSequentially(const QString& layoutId, int total,
                     applet->spectrumWidget()->setDbmRange(pan->minDbm(), pan->maxDbm());
                     applet->spectrumWidget()->setFrequencyRange(
                         pan->centerMhz(), pan->bandwidthMhz());
+                    syncWideIndicator(pan, applet->spectrumWidget());
                 }
             }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2230,12 +2230,14 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         if (m_centerMhz != m_lastDetectCenter || m_bandwidthMhz != m_lastDetectBw ||
             m_refLevel != m_lastDetectRef || m_dynamicRange != m_lastDetectDyn ||
             m_spectrumFrac != m_lastDetectFrac ||
-            m_wnbActive != m_lastDetectWnb || m_rfGainValue != m_lastDetectRfGain) {
+            m_wnbActive != m_lastDetectWnb || m_rfGainValue != m_lastDetectRfGain ||
+            m_wideActive != m_lastDetectWide) {
             markOverlayDirty();
             m_lastDetectCenter = m_centerMhz; m_lastDetectBw = m_bandwidthMhz;
             m_lastDetectRef = m_refLevel; m_lastDetectDyn = m_dynamicRange;
             m_lastDetectFrac = m_spectrumFrac;
             m_lastDetectWnb = m_wnbActive; m_lastDetectRfGain = m_rfGainValue;
+            m_lastDetectWide = m_wideActive;
         }
     }
 
@@ -2371,13 +2373,13 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                     && m_propKIndex >= 0
                     && m_propAIndex >= 0
                     && m_propSfi > 0;
-                if (m_wnbActive || m_rfGainValue != 0 || showProp) {
+                if (m_wnbActive || m_rfGainValue != 0 || showProp || m_wideActive) {
                     QFont indFont(p.font().family(), 14, QFont::Bold);
                     p.setFont(indFont);
                     p.setPen(QColor(0xc8, 0xd8, 0xe8, 180));
                     const QFontMetrics fm(indFont);
                     int y = specRect.top() + fm.ascent() + 4;
-                    // Build combined label (left to right: prop, WNB, RF gain), right-align
+                    // Build combined label (left to right: prop, WNB, RF gain, WIDE), right-align
                     QString label;
                     if (showProp) {
                         label += QString("K%1  A%2  SFI %3")
@@ -2393,6 +2395,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                         if (!label.isEmpty()) { label += QStringLiteral("   "); }
                         label += QStringLiteral("%1%2 dB")
                             .arg(m_rfGainValue > 0 ? "+" : "").arg(m_rfGainValue);
+                    }
+                    if (m_wideActive) {
+                        if (!label.isEmpty()) { label += QStringLiteral("   "); }
+                        label += QStringLiteral("WIDE");
                     }
                     int x = specRect.right() - DBM_STRIP_W - 8 - fm.horizontalAdvance(label);
                     p.drawText(x, y, label);
@@ -2971,7 +2977,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
             && m_propKIndex >= 0
             && m_propAIndex >= 0
             && m_propSfi > 0;
-        if (m_wnbActive || m_rfGainValue != 0 || showProp) {
+        if (m_wnbActive || m_rfGainValue != 0 || showProp || m_wideActive) {
             QFont indFont = p.font();
             indFont.setPointSize(18);
             indFont.setBold(true);
@@ -2984,7 +2990,15 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
 
             int x = rightEdge;
 
-            // RF Gain (rightmost)
+            // WIDE (rightmost)
+            if (m_wideActive) {
+                int ww = fm.horizontalAdvance("WIDE");
+                x -= ww;
+                p.drawText(x, topY, "WIDE");
+                x -= 10;
+            }
+
+            // RF Gain (to the left of WIDE)
             if (m_rfGainValue != 0) {
                 QString gainStr = (m_rfGainValue > 0)
                     ? QString("+%1dB").arg(m_rfGainValue)

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -134,8 +134,15 @@ public:
     // WNB and RF gain state for on-screen indicators.
     bool wnbActive()   const { return m_wnbActive; }
     int  rfGainValue() const { return m_rfGainValue; }
+    bool wideActive()  const { return m_wideActive; }
     void setWnbActive(bool on) { m_wnbActive = on; markOverlayDirty(); }
     void setRfGain(int gain) { m_rfGainValue = gain; markOverlayDirty(); }
+    void setWideActive(bool on) {
+        if (m_wideActive != on) {
+            m_wideActive = on;
+            markOverlayDirty();
+        }
+    }
 
     // HF propagation forecast overlay (K-index, A-index, and Solar Flux Index).
     // Values of -1 mean not yet fetched; visible only when enabled.
@@ -483,6 +490,7 @@ private:
     // On-screen indicators (WNB, RF Gain)
     bool m_wnbActive{false};
     int  m_rfGainValue{0};
+    bool m_wideActive{false};
 
     // HF propagation forecast overlay
     bool m_propForecastVisible{false};
@@ -520,6 +528,7 @@ private:
     float  m_lastDetectFrac{0};
     bool   m_lastDetectWnb{false};
     int    m_lastDetectRfGain{0};
+    bool   m_lastDetectWide{false};
 
     // NB Waterfall Blanker (#277)
     bool  m_wfBlankerEnabled{false};

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -87,6 +87,13 @@ void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
             emit wnbChanged(m_wnbActive, m_wnbLevel);
         }
     }
+    if (kvs.contains("wide")) {
+        bool wide = kvs["wide"].toInt() != 0;
+        if (wide != m_wideActive) {
+            m_wideActive = wide;
+            emit wideChanged(m_wideActive);
+        }
+    }
     if (kvs.contains("ant_list")) {
         QStringList ants = kvs["ant_list"].split(',', Qt::SkipEmptyParts);
         if (ants != m_antList) {

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -38,6 +38,7 @@ public:
     void setRfGainInfo(int low, int high, int step);
     bool wnbActive() const { return m_wnbActive; }
     int wnbLevel() const { return m_wnbLevel; }
+    bool wideActive() const { return m_wideActive; }
     QString preamp() const { return m_preamp; }
     void setPreamp(const QString& pre) {
         if (m_preamp != pre) { m_preamp = pre; emit rfGainChanged(m_rfGain, m_preamp); }
@@ -61,6 +62,7 @@ signals:
     void rfGainChanged(int gain, const QString& preamp);
     void rfGainInfoChanged(int low, int high, int step);
     void wnbChanged(bool active, int level);
+    void wideChanged(bool active);
     void waterfallIdChanged(const QString& wfId);
     void daxiqChannelChanged(int channel);
 
@@ -78,6 +80,7 @@ private:
     int         m_rfGainHigh{32};
     int         m_rfGainStep{8};
     bool        m_wnbActive{false};
+    bool        m_wideActive{false};
     int         m_wnbLevel{50};
     QString     m_preamp;
     int         m_daxiqChannel{0};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -79,6 +79,7 @@ QJsonObject panToJson(const PanadapterModel* pan, const QString& activePanId)
     obj["preamp"] = pan->preamp();
     obj["wnb_active"] = pan->wnbActive();
     obj["wnb_level"] = pan->wnbLevel();
+    obj["wide_active"] = pan->wideActive();
     obj["resized"] = pan->isResized();
     obj["waterfall_configured"] = pan->isWaterfallConfigured();
     return obj;


### PR DESCRIPTION
## Summary

- add radio-authoritative WIDE state to `PanadapterModel` and expose it in per-pan debug JSON
- wire panadapter wide updates into `SpectrumWidget` for new, reused, and post-layout applets
- render the read-only `WIDE` badge in both GPU and QWidget top-right indicator paths with the correct ordering

## Why

The Flex radio already reports `wide` in `display pan` status, but the panadapter UI did not surface it. This change keeps WIDE display tied directly to radio state without adding any client-side heuristic or user toggle.

## Validation

- built successfully with `cmake -S . -B build -G Ninja`
- built successfully with `cmake --build build --parallel 10`
- built successfully with `cmake -S . -B build-nogpu -G Ninja -DAETHER_GPU_SPECTRUM=OFF`
- built successfully with `cmake --build build-nogpu --parallel 10`
- manually verified resize behavior while wide is active
- manually verified cross-client band/state changes still show the correct WIDE state
- runtime-validated on macOS; Linux/Windows support is based on platform-agnostic Qt code paths and compile-time validation of both rendering modes

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.4 Pro) and tested by @jensenpat
