### PR TITLE
Add WIDE indicator to spectrum display

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -196,17 +196,6 @@ static bool shortcutGuard() {
     return s_keyboardShortcutsEnabled && !isTextInputFocused();
 }
 
-static void syncWideIndicator(PanadapterModel* pan, SpectrumWidget* sw)
-{
-    if (!pan || !sw)
-        return;
-
-    QObject::connect(pan, &PanadapterModel::wideChanged,
-                     sw, &SpectrumWidget::setWideActive,
-                     Qt::UniqueConnection);
-    sw->setWideActive(pan->wideActive());
-}
-
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
 {
@@ -921,10 +910,12 @@ MainWindow::MainWindow(QWidget* parent)
         if (m_panStack->panadapter(pan->panId())) {
             if (auto* sw = m_panStack->spectrum(pan->panId())) {
                 connect(pan, &PanadapterModel::infoChanged,
-                        sw, &SpectrumWidget::setFrequencyRange, Qt::UniqueConnection);
+                        sw, &SpectrumWidget::setFrequencyRange);
                 connect(pan, &PanadapterModel::levelChanged,
-                        sw, &SpectrumWidget::setDbmRange, Qt::UniqueConnection);
-                syncWideIndicator(pan, sw);
+                        sw, &SpectrumWidget::setDbmRange);
+                connect(pan, &PanadapterModel::wideChanged,
+                        sw, &SpectrumWidget::setWideActive);
+                sw->setWideActive(pan->wideActive());
             }
             return;
         }
@@ -957,7 +948,6 @@ MainWindow::MainWindow(QWidget* parent)
             applet->spectrumWidget()->setRfGain(gain);
             applet->spectrumWidget()->overlayMenu()->setRfGain(gain);
         });
-        syncWideIndicator(pan, applet->spectrumWidget());
 
         // Push display dimensions to the radio so it sends full-size FFT bins.
         // Without this, the radio uses xpixels=50 ypixels=20 (default) and
@@ -5006,8 +4996,11 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         }
     }
 
-    if (auto* pan = m_radioModel.panadapter(applet->panId()))
-        syncWideIndicator(pan, sw);
+    if (auto* pan = m_radioModel.panadapter(applet->panId())) {
+        connect(pan, &PanadapterModel::wideChanged,
+                sw, &SpectrumWidget::setWideActive);
+        sw->setWideActive(pan->wideActive());
+    }
 
     // ── Tuning step size → this pan's spectrum widget ─────────────────────
     // The global connection only covers AppSettings + radio command.
@@ -6765,7 +6758,6 @@ void MainWindow::createPansSequentially(const QString& layoutId, int total,
                     applet->spectrumWidget()->setDbmRange(pan->minDbm(), pan->maxDbm());
                     applet->spectrumWidget()->setFrequencyRange(
                         pan->centerMhz(), pan->bandwidthMhz());
-                    syncWideIndicator(pan, applet->spectrumWidget());
                 }
             }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -196,6 +196,17 @@ static bool shortcutGuard() {
     return s_keyboardShortcutsEnabled && !isTextInputFocused();
 }
 
+static void syncWideIndicator(PanadapterModel* pan, SpectrumWidget* sw)
+{
+    if (!pan || !sw)
+        return;
+
+    QObject::connect(pan, &PanadapterModel::wideChanged,
+                     sw, &SpectrumWidget::setWideActive,
+                     Qt::UniqueConnection);
+    sw->setWideActive(pan->wideActive());
+}
+
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
 {
@@ -908,10 +919,13 @@ MainWindow::MainWindow(QWidget* parent)
 
         // Skip if this pan already has an applet
         if (m_panStack->panadapter(pan->panId())) {
-            connect(pan, &PanadapterModel::infoChanged,
-                    m_panStack->spectrum(pan->panId()), &SpectrumWidget::setFrequencyRange);
-            connect(pan, &PanadapterModel::levelChanged,
-                    m_panStack->spectrum(pan->panId()), &SpectrumWidget::setDbmRange);
+            if (auto* sw = m_panStack->spectrum(pan->panId())) {
+                connect(pan, &PanadapterModel::infoChanged,
+                        sw, &SpectrumWidget::setFrequencyRange, Qt::UniqueConnection);
+                connect(pan, &PanadapterModel::levelChanged,
+                        sw, &SpectrumWidget::setDbmRange, Qt::UniqueConnection);
+                syncWideIndicator(pan, sw);
+            }
             return;
         }
 
@@ -943,6 +957,7 @@ MainWindow::MainWindow(QWidget* parent)
             applet->spectrumWidget()->setRfGain(gain);
             applet->spectrumWidget()->overlayMenu()->setRfGain(gain);
         });
+        syncWideIndicator(pan, applet->spectrumWidget());
 
         // Push display dimensions to the radio so it sends full-size FFT bins.
         // Without this, the radio uses xpixels=50 ypixels=20 (default) and
@@ -4991,6 +5006,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         }
     }
 
+    if (auto* pan = m_radioModel.panadapter(applet->panId()))
+        syncWideIndicator(pan, sw);
+
     // ── Tuning step size → this pan's spectrum widget ─────────────────────
     // The global connection only covers AppSettings + radio command.
     // Each pan must also receive stepSizeChanged so scroll-to-tune
@@ -6747,6 +6765,7 @@ void MainWindow::createPansSequentially(const QString& layoutId, int total,
                     applet->spectrumWidget()->setDbmRange(pan->minDbm(), pan->maxDbm());
                     applet->spectrumWidget()->setFrequencyRange(
                         pan->centerMhz(), pan->bandwidthMhz());
+                    syncWideIndicator(pan, applet->spectrumWidget());
                 }
             }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2247,12 +2247,14 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         if (m_centerMhz != m_lastDetectCenter || m_bandwidthMhz != m_lastDetectBw ||
             m_refLevel != m_lastDetectRef || m_dynamicRange != m_lastDetectDyn ||
             m_spectrumFrac != m_lastDetectFrac ||
-            m_wnbActive != m_lastDetectWnb || m_rfGainValue != m_lastDetectRfGain) {
+            m_wnbActive != m_lastDetectWnb || m_rfGainValue != m_lastDetectRfGain ||
+            m_wideActive != m_lastDetectWide) {
             markOverlayDirty();
             m_lastDetectCenter = m_centerMhz; m_lastDetectBw = m_bandwidthMhz;
             m_lastDetectRef = m_refLevel; m_lastDetectDyn = m_dynamicRange;
             m_lastDetectFrac = m_spectrumFrac;
             m_lastDetectWnb = m_wnbActive; m_lastDetectRfGain = m_rfGainValue;
+            m_lastDetectWide = m_wideActive;
         }
     }
 
@@ -2388,13 +2390,13 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                     && m_propKIndex >= 0
                     && m_propAIndex >= 0
                     && m_propSfi > 0;
-                if (m_wnbActive || m_rfGainValue != 0 || showProp) {
+                if (m_wnbActive || m_rfGainValue != 0 || showProp || m_wideActive) {
                     QFont indFont(p.font().family(), 14, QFont::Bold);
                     p.setFont(indFont);
                     p.setPen(QColor(0xc8, 0xd8, 0xe8, 180));
                     const QFontMetrics fm(indFont);
                     int y = specRect.top() + fm.ascent() + 4;
-                    // Build combined label (left to right: prop, WNB, RF gain), right-align
+                    // Build combined label (left to right: prop, WNB, RF gain, WIDE), right-align
                     QString label;
                     if (showProp) {
                         label += QString("K%1  A%2  SFI %3")
@@ -2410,6 +2412,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                         if (!label.isEmpty()) { label += QStringLiteral("   "); }
                         label += QStringLiteral("%1%2 dB")
                             .arg(m_rfGainValue > 0 ? "+" : "").arg(m_rfGainValue);
+                    }
+                    if (m_wideActive) {
+                        if (!label.isEmpty()) { label += QStringLiteral("   "); }
+                        label += QStringLiteral("WIDE");
                     }
                     int x = specRect.right() - DBM_STRIP_W - 8 - fm.horizontalAdvance(label);
                     p.drawText(x, y, label);
@@ -2988,7 +2994,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
             && m_propKIndex >= 0
             && m_propAIndex >= 0
             && m_propSfi > 0;
-        if (m_wnbActive || m_rfGainValue != 0 || showProp) {
+        if (m_wnbActive || m_rfGainValue != 0 || showProp || m_wideActive) {
             QFont indFont = p.font();
             indFont.setPointSize(18);
             indFont.setBold(true);
@@ -3001,7 +3007,15 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
 
             int x = rightEdge;
 
-            // RF Gain (rightmost)
+            // WIDE (rightmost)
+            if (m_wideActive) {
+                int ww = fm.horizontalAdvance("WIDE");
+                x -= ww;
+                p.drawText(x, topY, "WIDE");
+                x -= 10;
+            }
+
+            // RF Gain (to the left of WIDE)
             if (m_rfGainValue != 0) {
                 QString gainStr = (m_rfGainValue > 0)
                     ? QString("+%1dB").arg(m_rfGainValue)

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -136,8 +136,15 @@ public:
     // WNB and RF gain state for on-screen indicators.
     bool wnbActive()   const { return m_wnbActive; }
     int  rfGainValue() const { return m_rfGainValue; }
+    bool wideActive()  const { return m_wideActive; }
     void setWnbActive(bool on) { m_wnbActive = on; markOverlayDirty(); }
     void setRfGain(int gain) { m_rfGainValue = gain; markOverlayDirty(); }
+    void setWideActive(bool on) {
+        if (m_wideActive != on) {
+            m_wideActive = on;
+            markOverlayDirty();
+        }
+    }
 
     // HF propagation forecast overlay (K-index, A-index, and Solar Flux Index).
     // Values of -1 mean not yet fetched; visible only when enabled.
@@ -485,6 +492,7 @@ private:
     // On-screen indicators (WNB, RF Gain)
     bool m_wnbActive{false};
     int  m_rfGainValue{0};
+    bool m_wideActive{false};
 
     // HF propagation forecast overlay
     bool m_propForecastVisible{false};
@@ -522,6 +530,7 @@ private:
     float  m_lastDetectFrac{0};
     bool   m_lastDetectWnb{false};
     int    m_lastDetectRfGain{0};
+    bool   m_lastDetectWide{false};
 
     // NB Waterfall Blanker (#277)
     bool  m_wfBlankerEnabled{false};

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -87,6 +87,13 @@ void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
             emit wnbChanged(m_wnbActive, m_wnbLevel);
         }
     }
+    if (kvs.contains("wide")) {
+        bool wide = kvs["wide"].toInt() != 0;
+        if (wide != m_wideActive) {
+            m_wideActive = wide;
+            emit wideChanged(m_wideActive);
+        }
+    }
     if (kvs.contains("ant_list")) {
         QStringList ants = kvs["ant_list"].split(',', Qt::SkipEmptyParts);
         if (ants != m_antList) {

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -38,6 +38,7 @@ public:
     void setRfGainInfo(int low, int high, int step);
     bool wnbActive() const { return m_wnbActive; }
     int wnbLevel() const { return m_wnbLevel; }
+    bool wideActive() const { return m_wideActive; }
     QString preamp() const { return m_preamp; }
     void setPreamp(const QString& pre) {
         if (m_preamp != pre) { m_preamp = pre; emit rfGainChanged(m_rfGain, m_preamp); }
@@ -61,6 +62,7 @@ signals:
     void rfGainChanged(int gain, const QString& preamp);
     void rfGainInfoChanged(int low, int high, int step);
     void wnbChanged(bool active, int level);
+    void wideChanged(bool active);
     void waterfallIdChanged(const QString& wfId);
     void daxiqChannelChanged(int channel);
 
@@ -78,6 +80,7 @@ private:
     int         m_rfGainHigh{32};
     int         m_rfGainStep{8};
     bool        m_wnbActive{false};
+    bool        m_wideActive{false};
     int         m_wnbLevel{50};
     QString     m_preamp;
     int         m_daxiqChannel{0};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -79,6 +79,7 @@ QJsonObject panToJson(const PanadapterModel* pan, const QString& activePanId)
     obj["preamp"] = pan->preamp();
     obj["wnb_active"] = pan->wnbActive();
     obj["wnb_level"] = pan->wnbLevel();
+    obj["wide_active"] = pan->wideActive();
     obj["resized"] = pan->isResized();
     obj["waterfall_configured"] = pan->isWaterfallConfigured();
     return obj;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -79,7 +79,6 @@ QJsonObject panToJson(const PanadapterModel* pan, const QString& activePanId)
     obj["preamp"] = pan->preamp();
     obj["wnb_active"] = pan->wnbActive();
     obj["wnb_level"] = pan->wnbLevel();
-    obj["wide_active"] = pan->wideActive();
     obj["resized"] = pan->isResized();
     obj["waterfall_configured"] = pan->isWaterfallConfigured();
     return obj;


### PR DESCRIPTION
## Summary

- Surface the radio's `wide` panadapter status flag as a read-only "WIDE" badge in the spectrum top-right indicator area (alongside WNB, RF Gain, prop forecast)
- Parse `wide` from `display pan` status in `PanadapterModel`, wire to `SpectrumWidget` via 2 connection points
- Renders in both GPU (QRhiWidget) and QWidget paint paths

Based on work by @jensenpat in #1289, simplified:
- Removed `syncWideIndicator()` helper function
- Reduced MainWindow wiring from 4 call sites to 2
- Dropped debug JSON from RadioModel

## Test plan

- [ ] Connect to radio, zoom out until `wide=1` appears in pan status — verify "WIDE" badge shows in top-right indicators
- [ ] Zoom back in — verify badge disappears
- [ ] Multi-pan: verify each pan shows WIDE independently
- [ ] Build with `-DAETHER_GPU_SPECTRUM=OFF` — verify badge renders in QWidget path

🤖 Generated with [Claude Code](https://claude.com/claude-code)