### PR TITLE
Add richer network status tooltip and make diagnostics non-modal

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -24,6 +24,12 @@
 
 namespace AetherSDR {
 
+void AudioEngine::updateRxBufferStats()
+{
+    m_rxBufferBytes.store(m_rxBuffer.size());
+    m_rxBufferPeakBytes.store(std::max(m_rxBufferPeakBytes.load(), m_rxBuffer.size()));
+}
+
 AudioEngine::AudioEngine(QObject* parent)
     : QObject(parent)
 {
@@ -76,13 +82,20 @@ AudioEngine::AudioEngine(QObject* parent)
             m_rxBuffer.remove(0, m_rxBuffer.size() - maxBufBytes);
         }
 
-        qsizetype len = m_audioSink->bytesFree();
+        const qsizetype freeBytes = m_audioSink->bytesFree();
+        if (freeBytes > 0 && m_rxBuffer.isEmpty()) {
+            m_rxBufferUnderrunCount.fetch_add(1);
+        }
+
+        qsizetype len = freeBytes;
         len = std::min(len, m_rxBuffer.size());
         if (len > 0)
         {
             len = m_audioDevice->write(m_rxBuffer.left(len));
             m_rxBuffer.remove(0, len);
         }
+
+        m_rxBufferBytes.store(m_rxBuffer.size());
     });
     m_rxTimer->start();
 }
@@ -107,6 +120,12 @@ QAudioFormat AudioEngine::makeFormat() const
 bool AudioEngine::startRxStream()
 {
     if (m_audioSink) return true;   // already running
+
+    m_rxBuffer.clear();
+    m_rxBufferBytes.store(0);
+    m_rxBufferPeakBytes.store(0);
+    m_rxBufferUnderrunCount.store(0);
+    m_rxBufferSampleRate.store(DEFAULT_SAMPLE_RATE);
 
     QAudioFormat fmt = makeFormat();
     const QAudioDevice dev = m_outputDevice.isNull()
@@ -195,12 +214,17 @@ bool AudioEngine::startRxStream()
         }, Qt::QueuedConnection);
     });
     qCDebug(lcAudio) << "AudioEngine: RX stream started";
+    m_rxBufferSampleRate.store(fmt.sampleRate());
     emit rxStarted();
     return true;
 }
 
 void AudioEngine::stopRxStream()
 {
+    m_rxBuffer.clear();
+    m_rxBufferBytes.store(0);
+    m_rxBufferSampleRate.store(DEFAULT_SAMPLE_RATE);
+
     if (m_audioSink) {
         // Guard: same stale-device-handle crash can occur on the RX side (#1059).
         if (m_audioSink->state() != QAudio::StoppedState)
@@ -247,7 +271,8 @@ void AudioEngine::feedAudioData(const QByteArray& pcm)
         if (m_resampleTo48k)
             m_rxBuffer.append(resampleStereo(data));
         else
-            m_rxBuffer.append(data); 
+            m_rxBuffer.append(data);
+        updateRxBufferStats();
     };
 
     // Bypass client-side DSP during TX (#367). NR2/RN2/BNR adapt their
@@ -607,7 +632,8 @@ void AudioEngine::processBnr(const QByteArray& stereoPcm)
             if (m_resampleTo48k)
                 m_rxBuffer.append(resampleStereo(chunk));
             else
-                m_rxBuffer.append(chunk); 
+                m_rxBuffer.append(chunk);
+            updateRxBufferStats();
         }
         emit levelChanged(computeRMS(chunk));
     }
@@ -1428,6 +1454,7 @@ void AudioEngine::feedDecodedSpeech(const QByteArray& pcm)
         m_rxBuffer.append(resampleStereo(pcm));
     else
         m_rxBuffer.append(pcm);
+    updateRxBufferStats();
 }
 
 } // namespace AetherSDR

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -156,6 +156,10 @@ public:
     void setInputDevice(const QAudioDevice& dev);
     QAudioDevice outputDevice() const { return m_outputDevice; }
     QAudioDevice inputDevice()  const { return m_inputDevice; }
+    qsizetype rxBufferBytes() const { return m_rxBufferBytes.load(); }
+    qsizetype rxBufferPeakBytes() const { return m_rxBufferPeakBytes.load(); }
+    quint64 rxBufferUnderrunCount() const { return m_rxBufferUnderrunCount.load(); }
+    int rxBufferSampleRate() const { return m_rxBufferSampleRate.load(); }
 
 public slots:
     // Receives stripped PCM from PanadapterStream::audioDataReady().
@@ -186,6 +190,7 @@ private:
     void sendVoiceTxPacket(const QByteArray& pcmData, quint32 streamId);
     QByteArray resampleStereo(const QByteArray& pcm);
     void processNr2(const QByteArray& stereoPcm);
+    void updateRxBufferStats();
 
     // RX
     QAudioSink*   m_audioSink{nullptr};
@@ -278,6 +283,10 @@ private:
     // RX audio buffer handling
     QTimer*       m_rxTimer{nullptr};
     QByteArray    m_rxBuffer;
+    std::atomic<qsizetype> m_rxBufferBytes{0};
+    std::atomic<qsizetype> m_rxBufferPeakBytes{0};
+    std::atomic<quint64>   m_rxBufferUnderrunCount{0};
+    std::atomic<int>       m_rxBufferSampleRate{DEFAULT_SAMPLE_RATE};
 
     // VITA-49 TX constants
     static constexpr int    TX_SAMPLES_PER_PACKET = 128;  // audio frames per packet

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -88,6 +88,13 @@ bool PanadapterStream::start(RadioConnection* conn)
 {
     if (isRunning()) stop();  // clean up previous session before rebinding (#561)
 
+    m_audioPacketGapMs.store(0);
+    m_audioPacketGapMaxMs.store(0);
+    m_audioPacketJitterMs.store(0);
+    m_audioPacketTimerStarted = false;
+    m_previousAudioPacketGapMs = 0;
+    m_audioPacketJitterEstimateMs = 0.0;
+
     // Try 4991 first (VPN/firewall rules may allow this port specifically),
     // then count down for Multi-Flex (multiple clients on the same host).
     static constexpr quint16 LAN_VITA_PORT = 4991;
@@ -180,6 +187,13 @@ bool PanadapterStream::startWan(const QHostAddress& radioAddr, quint16 radioUdpP
 {
     if (isRunning()) stop();  // clean up previous session before rebinding (#561)
 
+    m_audioPacketGapMs.store(0);
+    m_audioPacketGapMaxMs.store(0);
+    m_audioPacketJitterMs.store(0);
+    m_audioPacketTimerStarted = false;
+    m_previousAudioPacketGapMs = 0;
+    m_audioPacketJitterEstimateMs = 0.0;
+
     // For WAN: bind to any port. The actual UDP registration happens later
     // in startWanUdpRegister() once the client handle is known.
     bool bound = m_socket.bind(QHostAddress::AnyIPv4, 0);
@@ -236,6 +250,12 @@ void PanadapterStream::stop()
     m_radioPort = 0;
     m_localAddress = QHostAddress();
     m_localPort = 0;
+    m_audioPacketGapMs.store(0);
+    m_audioPacketGapMaxMs.store(0);
+    m_audioPacketJitterMs.store(0);
+    m_audioPacketTimerStarted = false;
+    m_previousAudioPacketGapMs = 0;
+    m_audioPacketJitterEstimateMs = 0.0;
 }
 
 // ─── Datagram reception ───────────────────────────────────────────────────────
@@ -390,6 +410,25 @@ void PanadapterStream::processDatagram(const QByteArray& data)
             }
         }
         stats.lastSeq = seq;
+
+        if (cat == CatAudio) {
+            if (m_audioPacketTimerStarted) {
+                const int gapMs = static_cast<int>(m_audioPacketTimer.restart());
+                m_audioPacketGapMs.store(gapMs);
+                m_audioPacketGapMaxMs.store(std::max(m_audioPacketGapMaxMs.load(), gapMs));
+                if (m_previousAudioPacketGapMs > 0) {
+                    const double variation = std::abs(gapMs - m_previousAudioPacketGapMs);
+                    m_audioPacketJitterEstimateMs +=
+                        (variation - m_audioPacketJitterEstimateMs) / 8.0;
+                    m_audioPacketJitterMs.store(
+                        static_cast<int>(std::lround(m_audioPacketJitterEstimateMs)));
+                }
+                m_previousAudioPacketGapMs = gapMs;
+            } else {
+                m_audioPacketTimer.start();
+                m_audioPacketTimerStarted = true;
+            }
+        }
     }
 
     if (daxChannel >= 0) {

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -10,6 +10,7 @@
 #include <QElapsedTimer>
 #include <QMutex>
 #include <QMutexLocker>
+#include <atomic>
 
 namespace AetherSDR {
 
@@ -206,10 +207,20 @@ public:
     int packetTotalCount() const;
     qint64 totalRxBytes() const { return m_totalRxBytes; }
     qint64 totalTxBytes() const { return m_totalTxBytes; }
+    int audioPacketGapMs() const { return m_audioPacketGapMs.load(); }
+    int audioPacketGapMaxMs() const { return m_audioPacketGapMaxMs.load(); }
+    int audioPacketJitterMs() const { return m_audioPacketJitterMs.load(); }
 
 private:
     qint64 m_totalRxBytes{0};
     qint64 m_totalTxBytes{0};
+    std::atomic<int> m_audioPacketGapMs{0};
+    std::atomic<int> m_audioPacketGapMaxMs{0};
+    std::atomic<int> m_audioPacketJitterMs{0};
+    QElapsedTimer m_audioPacketTimer;
+    bool m_audioPacketTimerStarted{false};
+    int m_previousAudioPacketGapMs{0};
+    double m_audioPacketJitterEstimateMs{0.0};
 
     // Opus audio decoder (lazy-initialized on first Opus packet)
     OpusCodec* m_opusCodec{nullptr};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -119,6 +119,7 @@
 #else
 #include <sys/resource.h>
 #endif
+#include <QLocale>
 
 namespace AetherSDR {
 
@@ -136,6 +137,60 @@ static bool macDaxDriverInstalled()
 #else
     return true;
 #endif
+}
+
+static QString formatNetworkMs(int ms)
+{
+    return ms < 1 ? "< 1 ms" : QString("%1 ms").arg(ms);
+}
+
+static QString formatNetworkSeqErrors(int errors, int packets)
+{
+    if (packets == 0) {
+        return "0 / 0 packets";
+    }
+
+    const double pct = (errors * 100.0) / packets;
+    return QString("%1 / %2 packets (%3%)")
+        .arg(errors)
+        .arg(packets)
+        .arg(pct, 0, 'f', 2);
+}
+
+static QString formatNetworkSeqErrors(const PanadapterStream::CategoryStats& stats)
+{
+    return formatNetworkSeqErrors(stats.errors, stats.packets);
+}
+
+static QString buildNetworkTooltip(const RadioModel& model)
+{
+    const PanadapterStream::CategoryStats audioStats =
+        model.categoryStats(PanadapterStream::CatAudio);
+    const PanadapterStream::CategoryStats fftStats =
+        model.categoryStats(PanadapterStream::CatFFT);
+    const PanadapterStream::CategoryStats waterfallStats =
+        model.categoryStats(PanadapterStream::CatWaterfall);
+    const PanadapterStream::CategoryStats meterStats =
+        model.categoryStats(PanadapterStream::CatMeter);
+    const PanadapterStream::CategoryStats daxStats =
+        model.categoryStats(PanadapterStream::CatDAX);
+
+    QStringList lines;
+    lines
+        << QString("Network: %1").arg(model.networkQuality())
+        << QString("Latency (RTT): %1").arg(formatNetworkMs(model.lastPingRtt()))
+        << QString("Max RTT (session): %1").arg(formatNetworkMs(model.maxPingRtt()))
+        << QString("Total sequence gaps: %1")
+               .arg(formatNetworkSeqErrors(model.packetDropCount(), model.packetTotalCount()))
+        << QString("Audio: %1").arg(formatNetworkSeqErrors(audioStats))
+        << QString("FFT: %1").arg(formatNetworkSeqErrors(fftStats))
+        << QString("Waterfall: %1").arg(formatNetworkSeqErrors(waterfallStats))
+        << QString("Meters: %1").arg(formatNetworkSeqErrors(meterStats))
+        << QString("DAX: %1").arg(formatNetworkSeqErrors(daxStats))
+        << QString("UDP RX bytes: %1").arg(QLocale().formattedDataSize(model.rxBytes()))
+        << QString("UDP TX bytes: %1").arg(QLocale().formattedDataSize(model.txBytes()))
+        << "Double-click for full diagnostics";
+    return lines.join('\n');
 }
 
 // ─── Shortcut guard (file-scope for use as std::function<bool()>) ───────────
@@ -1810,8 +1865,8 @@ MainWindow::MainWindow(QWidget* parent)
         else if (quality == "Good") color = "#00b4d8";
         m_networkLabel->setText(QString("[<span style='color:%1'>%2</span>]")
             .arg(color, quality));
-        m_networkLabel->setToolTip(QString("Network: %1\nLatency (RTT): %2")
-            .arg(quality, pingMs < 1 ? "< 1 ms" : QString("%1 ms").arg(pingMs)));
+        Q_UNUSED(pingMs);
+        m_networkLabel->setToolTip(buildNetworkTooltip(m_radioModel));
     });
 
     connect(&m_radioModel.meterModel(), &MeterModel::hwTelemetryChanged,
@@ -2073,6 +2128,21 @@ void MainWindow::keyReleaseEvent(QKeyEvent* event)
     QMainWindow::keyReleaseEvent(event);
 }
 
+void MainWindow::showNetworkDiagnosticsDialog()
+{
+    if (!m_networkDiagnosticsDialog) {
+        auto* dlg = new NetworkDiagnosticsDialog(&m_radioModel, m_audio, this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        dlg->setModal(false);
+        dlg->setWindowModality(Qt::NonModal);
+        m_networkDiagnosticsDialog = dlg;
+    }
+
+    m_networkDiagnosticsDialog->show();
+    m_networkDiagnosticsDialog->raise();
+    m_networkDiagnosticsDialog->activateWindow();
+}
+
 bool MainWindow::eventFilter(QObject* obj, QEvent* event)
 {
     // Space PTT: intercept at application level so it works regardless of
@@ -2100,8 +2170,7 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
         return true;
     }
     if (obj == m_networkLabel && event->type() == QEvent::MouseButtonDblClick) {
-        NetworkDiagnosticsDialog dlg(&m_radioModel, this);
-        dlg.exec();
+        showNetworkDiagnosticsDialog();
         return true;
     }
     if (obj == m_stationNickLabel && event->type() == QEvent::MouseButtonDblClick) {
@@ -2432,8 +2501,7 @@ void MainWindow::buildMenuBar()
 #endif
     auto* networkAction = settingsMenu->addAction("Network...");
     connect(networkAction, &QAction::triggered, this, [this] {
-        NetworkDiagnosticsDialog dlg(&m_radioModel, this);
-        dlg.exec();
+        showNetworkDiagnosticsDialog();
     });
     auto* memoryAction = settingsMenu->addAction("Memory...");
     connect(memoryAction, &QAction::triggered, this, [this] {
@@ -3872,6 +3940,7 @@ void MainWindow::buildUI()
     m_networkLabel->setStyleSheet("QLabel { color: #607080; font-size: 12px; }");
     m_networkLabel->setTextFormat(Qt::RichText);
     m_networkLabel->setAlignment(Qt::AlignCenter);
+    m_networkLabel->setToolTip(buildNetworkTooltip(m_radioModel));
     m_networkLabel->installEventFilter(this);
     netVbox->addWidget(m_networkLabel);
     hbox->addWidget(netStack);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -131,6 +131,7 @@ private:
     void createPansSequentially(const QString& layoutId, int total,
                                 std::shared_ptr<QStringList> panIds, int created);
     void updatePaTempLabel();
+    void showNetworkDiagnosticsDialog();
     void setPaTempDisplayUnit(bool useFahrenheit);
     void syncMemorySpot(int memoryIndex);
     void removeMemorySpot(int memoryIndex);
@@ -223,6 +224,7 @@ private:
     // Modeless dialogs
     QPointer<QDialog> m_spotHubDialog;
     QPointer<QDialog> m_radioSetupDialog;
+    QPointer<QDialog> m_networkDiagnosticsDialog;
     QPointer<QDialog> m_memoryDialog;
     QPointer<WhatsNewDialog> m_whatsNewDialog;
     QPointer<QDialog> m_dspDialog;

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -1,6 +1,8 @@
 #include "NetworkDiagnosticsDialog.h"
+#include "core/AudioEngine.h"
 #include "models/RadioModel.h"
 
+#include <QScrollArea>
 #include <QVBoxLayout>
 #include <QGroupBox>
 #include <QGridLayout>
@@ -8,17 +10,33 @@
 
 namespace AetherSDR {
 
-NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model, QWidget* parent)
-    : QDialog(parent), m_model(model)
+NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model, AudioEngine* audio, QWidget* parent)
+    : QDialog(parent), m_model(model), m_audio(audio)
 {
     setWindowTitle("Network Diagnostics");
-    setFixedSize(460, 640);
+    setMinimumSize(920, 680);
+    resize(980, 760);
 
     auto* root = new QVBoxLayout(this);
+    auto* scroll = new QScrollArea(this);
+    scroll->setWidgetResizable(true);
+    scroll->setFrameShape(QFrame::NoFrame);
+    root->addWidget(scroll);
+
+    auto* content = new QWidget;
+    scroll->setWidget(content);
+    auto* contentLayout = new QGridLayout(content);
+    contentLayout->setContentsMargins(8, 8, 8, 8);
+    contentLayout->setColumnStretch(0, 1);
+    contentLayout->setColumnStretch(1, 1);
+    contentLayout->setHorizontalSpacing(16);
+    contentLayout->setVerticalSpacing(14);
 
     auto makeVal = [](const QString& init = "") {
         auto* l = new QLabel(init);
-        l->setAlignment(Qt::AlignRight);
+        l->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        l->setWordWrap(true);
+        l->setMinimumHeight(l->fontMetrics().height() + 1);
         l->setStyleSheet("QLabel { color: #c8d8e8; font-weight: bold; }");
         return l;
     };
@@ -27,12 +45,24 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model, QWidget* p
         return makeVal(init);
     };
 
+    auto makeNote = [](const QString& text) {
+        auto* l = new QLabel(text);
+        l->setWordWrap(true);
+        l->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; line-height: 1.2; }");
+        return l;
+    };
+
     // ── Network Status group ─────────────────────────────────────────────
     auto* statusGroup = new QGroupBox("Network Status");
     auto* statusGrid = new QGridLayout(statusGroup);
     statusGrid->setColumnStretch(1, 1);
+    statusGrid->setVerticalSpacing(2);
+    statusGrid->setHorizontalSpacing(12);
 
     int row = 0;
+    statusGrid->addWidget(makeNote(
+        "Connection path and TCP latency. Use this to confirm the selected route "
+        "to the radio is stable."), row++, 0, 1, 2);
     statusGrid->addWidget(new QLabel("Status:"), row, 0);
     m_statusLabel = makeVal();
     statusGrid->addWidget(m_statusLabel, row++, 1);
@@ -66,14 +96,17 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model, QWidget* p
     m_maxRttLabel = makeVal();
     statusGrid->addWidget(m_maxRttLabel, row++, 1);
 
-    root->addWidget(statusGroup);
-
     // ── Stream Rates group ───────────────────────────────────────────────
-    auto* rateGroup = new QGroupBox("Stream Rates");
+    auto* rateGroup = new QGroupBox("Incoming Stream Rates");
     auto* rateGrid = new QGridLayout(rateGroup);
     rateGrid->setColumnStretch(1, 1);
+    rateGrid->setVerticalSpacing(2);
+    rateGrid->setHorizontalSpacing(12);
 
     row = 0;
+    rateGrid->addWidget(makeNote(
+        "Current receive/transmit bitrates by stream type. Large swings can indicate "
+        "bursty delivery even when no packets are lost."), row++, 0, 1, 2);
     rateGrid->addWidget(new QLabel("Audio:"), row, 0);
     m_audioRateLabel = makeVal();
     rateGrid->addWidget(m_audioRateLabel, row++, 1);
@@ -102,14 +135,17 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model, QWidget* p
     m_txRateLabel = makeDim();
     rateGrid->addWidget(m_txRateLabel, row++, 1);
 
-    root->addWidget(rateGroup);
-
     // ── Packet Loss group ────────────────────────────────────────────────
-    auto* dropGroup = new QGroupBox("Packet Loss");
+    auto* dropGroup = new QGroupBox("Packet Loss (Sequence Gaps)");
     auto* dropGrid = new QGridLayout(dropGroup);
     dropGrid->setColumnStretch(1, 1);
+    dropGrid->setVerticalSpacing(2);
+    dropGrid->setHorizontalSpacing(12);
 
     row = 0;
+    dropGrid->addWidget(makeNote(
+        "Inferred packet loss from missing VITA sequence numbers. Zero loss here does "
+        "not rule out jitter or late bursts."), row++, 0, 1, 2);
     dropGrid->addWidget(new QLabel("Audio:"), row, 0);
     m_audioDropLabel = makeDim();
     dropGrid->addWidget(m_audioDropLabel, row++, 1);
@@ -135,9 +171,50 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model, QWidget* p
     m_droppedLabel->setStyleSheet("QLabel { color: #c8d8e8; font-weight: bold; }");
     dropGrid->addWidget(m_droppedLabel, row++, 0, 1, 2);
 
-    root->addWidget(dropGroup);
+    // ── Audio Playback group ──────────────────────────────────────────────
+    auto* audioGroup = new QGroupBox("Audio Playback");
+    auto* audioGrid = new QGridLayout(audioGroup);
+    audioGrid->setColumnStretch(1, 1);
+    audioGrid->setVerticalSpacing(2);
+    audioGrid->setHorizontalSpacing(12);
 
-    root->addStretch();
+    row = 0;
+    audioGrid->addWidget(makeNote(
+        "Speaker-side buffer health. If underruns rise while the buffer stays near zero, "
+        "playback is starving. Arrival gap and jitter measure timing, not packet loss."),
+        row++, 0, 1, 2);
+    audioGrid->addWidget(new QLabel("RX Buffer Now:"), row, 0);
+    m_audioBufferLabel = makeVal();
+    audioGrid->addWidget(m_audioBufferLabel, row++, 1);
+
+    audioGrid->addWidget(new QLabel("RX Buffer Peak:"), row, 0);
+    m_audioBufferPeakLabel = makeVal();
+    audioGrid->addWidget(m_audioBufferPeakLabel, row++, 1);
+
+    audioGrid->addWidget(new QLabel("Underruns (total):"), row, 0);
+    m_audioUnderrunLabel = makeVal();
+    audioGrid->addWidget(m_audioUnderrunLabel, row++, 1);
+
+    audioGrid->addWidget(new QLabel("Underruns (last sec):"), row, 0);
+    m_audioUnderrunRateLabel = makeVal();
+    audioGrid->addWidget(m_audioUnderrunRateLabel, row++, 1);
+
+    audioGrid->addWidget(new QLabel("Audio Arrival Gap:"), row, 0);
+    m_audioPacketGapLabel = makeVal();
+    audioGrid->addWidget(m_audioPacketGapLabel, row++, 1);
+
+    audioGrid->addWidget(new QLabel("Max Arrival Gap:"), row, 0);
+    m_audioPacketGapMaxLabel = makeVal();
+    audioGrid->addWidget(m_audioPacketGapMaxLabel, row++, 1);
+
+    audioGrid->addWidget(new QLabel("Jitter Estimate:"), row, 0);
+    m_audioJitterLabel = makeVal();
+    audioGrid->addWidget(m_audioJitterLabel, row++, 1);
+
+    contentLayout->addWidget(statusGroup, 0, 0);
+    contentLayout->addWidget(rateGroup, 0, 1);
+    contentLayout->addWidget(dropGroup, 1, 0);
+    contentLayout->addWidget(audioGroup, 1, 1);
 
     // ── Close button ─────────────────────────────────────────────────────
     auto* closeBtn = new QPushButton("Close");
@@ -151,6 +228,7 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model, QWidget* p
     // Snapshot initial byte counts for rate calculation
     m_lastRxBytes = m_model->rxBytes();
     m_lastTxBytes = m_model->txBytes();
+    m_lastAudioUnderrunCount = m_audio ? m_audio->rxBufferUnderrunCount() : 0;
     for (int i = 0; i < PanadapterStream::CatCount; ++i)
         m_lastCatBytes[i] = m_model->categoryStats(static_cast<PanadapterStream::StreamCategory>(i)).bytes;
 
@@ -171,6 +249,23 @@ static QString formatRate(qint64 bytesDelta)
 {
     const int kbps = static_cast<int>((bytesDelta * 8) / 1000);
     return QString("%1 kbps").arg(kbps);
+}
+
+static QString formatAudioBuffer(qsizetype bytes, int sampleRate)
+{
+    if (sampleRate <= 0) {
+        return QString("%1 bytes").arg(bytes);
+    }
+
+    static constexpr int kStereoChannels = 2;
+    static constexpr int kFloatBytesPerSample = 4;
+    const double ms = (bytes * 1000.0) / (sampleRate * kStereoChannels * kFloatBytesPerSample);
+    return QString("%1 bytes (%2 ms)").arg(bytes).arg(ms, 0, 'f', 1);
+}
+
+static QString formatMsValue(int value)
+{
+    return value < 1 ? "< 1 ms" : QString("%1 ms").arg(value);
 }
 
 void NetworkDiagnosticsDialog::refresh()
@@ -234,6 +329,29 @@ void NetworkDiagnosticsDialog::refresh()
                 .arg(dropped).arg(total).arg(pct, 0, 'f', 2));
     } else {
         m_droppedLabel->setText("No packets received yet");
+    }
+
+    if (m_audio) {
+        const int sampleRate = m_audio->rxBufferSampleRate();
+        const quint64 underruns = m_audio->rxBufferUnderrunCount();
+        m_audioBufferLabel->setText(formatAudioBuffer(m_audio->rxBufferBytes(), sampleRate));
+        m_audioBufferPeakLabel->setText(formatAudioBuffer(m_audio->rxBufferPeakBytes(), sampleRate));
+        m_audioUnderrunLabel->setText(QString::number(underruns));
+        m_audioUnderrunRateLabel->setText(QString::number(underruns - m_lastAudioUnderrunCount));
+        m_lastAudioUnderrunCount = underruns;
+
+        auto* panStream = m_model->panStream();
+        m_audioPacketGapLabel->setText(formatMsValue(panStream->audioPacketGapMs()));
+        m_audioPacketGapMaxLabel->setText(formatMsValue(panStream->audioPacketGapMaxMs()));
+        m_audioJitterLabel->setText(formatMsValue(panStream->audioPacketJitterMs()));
+    } else {
+        m_audioBufferLabel->setText("Unavailable");
+        m_audioBufferPeakLabel->setText("Unavailable");
+        m_audioUnderrunLabel->setText("Unavailable");
+        m_audioUnderrunRateLabel->setText("Unavailable");
+        m_audioPacketGapLabel->setText("Unavailable");
+        m_audioPacketGapMaxLabel->setText("Unavailable");
+        m_audioJitterLabel->setText("Unavailable");
     }
 
     // Color the status label

--- a/src/gui/NetworkDiagnosticsDialog.h
+++ b/src/gui/NetworkDiagnosticsDialog.h
@@ -9,17 +9,19 @@
 namespace AetherSDR {
 
 class RadioModel;
+class AudioEngine;
 
 class NetworkDiagnosticsDialog : public QDialog {
     Q_OBJECT
 
 public:
-    explicit NetworkDiagnosticsDialog(RadioModel* model, QWidget* parent = nullptr);
+    explicit NetworkDiagnosticsDialog(RadioModel* model, AudioEngine* audio, QWidget* parent = nullptr);
 
 private:
     void refresh();
 
     RadioModel* m_model;
+    AudioEngine* m_audio;
     QTimer      m_refreshTimer;
 
     QLabel* m_statusLabel;
@@ -47,9 +49,17 @@ private:
     QLabel* m_wfDropLabel;
     QLabel* m_meterDropLabel;
     QLabel* m_daxDropLabel;
+    QLabel* m_audioBufferLabel;
+    QLabel* m_audioBufferPeakLabel;
+    QLabel* m_audioUnderrunLabel;
+    QLabel* m_audioUnderrunRateLabel;
+    QLabel* m_audioPacketGapLabel;
+    QLabel* m_audioPacketGapMaxLabel;
+    QLabel* m_audioJitterLabel;
 
     qint64 m_lastRxBytes{0};
     qint64 m_lastTxBytes{0};
+    quint64 m_lastAudioUnderrunCount{0};
 
     // Per-category byte snapshots for rate calculation
     qint64 m_lastCatBytes[PanadapterStream::CatCount]{};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1241,6 +1241,7 @@ void RadioModel::startNetworkMonitor()
     m_stateCountdown = 0;
     m_lastErrorCount = 0;
     m_lastPingRtt = 0;
+    m_maxPingRtt = 0;
     m_pingMissCount = 0;
 
     // RTT is read from kernel TCP_INFO (smoothed RTT from TCP ACK timing),


### PR DESCRIPTION
## Summary

- Expand status-bar network tooltip with RTT, max RTT, per-stream sequence gaps, UDP byte totals
- Make Network Diagnostics dialog non-modal so main window stays interactive
- Add Audio Playback section: RX buffer stats, underruns, packet gap, jitter estimate
- Add audio/network instrumentation via atomics in AudioEngine and PanadapterStream

Based on work by @rfoust in #1301.

## Test plan

- [ ] Hover network indicator — tooltip should show expanded stats
- [ ] Double-click network indicator — diagnostics opens non-modally
- [ ] Settings → Network... — same non-modal dialog
- [ ] Verify Audio Playback section updates in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)