### PR TITLE
Add Nordic character support (Æ Ø Å) to CW decoder

### DIFF
--- a/third_party/ggmorse/src/ggmorse.cpp
+++ b/third_party/ggmorse/src/ggmorse.cpp
@@ -82,6 +82,9 @@ const TAlphabet kMorseCode = {
     { "010010",  '"',  },
     { "0001001", '$',  },
     { "011010",  '@',  },
+    { "0101",    '\xC6', }, // Æ (also Ä) — Latin-1 0xC6
+    { "1110",    '\xD8', }, // Ø (also Ö) — Latin-1 0xD8
+    { "01110",   '\xC5', }, // Å          — Latin-1 0xC5
 };
 
 uint64_t t_us() {


### PR DESCRIPTION
## Summary
- Add standard ITU Morse code entries for Æ, Ø, Å to ggmorse lookup table

Fixes #1280. From AetherClaude PR #1288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)