### PR TITLE
Support 8 slices for Flex 6700

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1797,9 +1797,9 @@ MainWindow::MainWindow(QWidget* parent)
     connect(&m_antennaGenius, &AntennaGeniusModel::presenceChanged,
             m_appletPanel, &AppletPanel::setAgVisible);
 
-    // ── 4-channel CAT: rigctld + PTY (A-D, each bound to a slice) ────────────
+    // ── 8-channel CAT: rigctld + PTY (A-H, each bound to a slice) ────────────
     {
-        static const char kLetters[] = "ABCD";
+        static const char kLetters[] = "ABCDEFGH";
         for (int i = 0; i < kCatChannels; ++i) {
             m_rigctlServers[i] = new RigctlServer(&m_radioModel, this);
             m_rigctlServers[i]->setSliceIndex(i);
@@ -4134,7 +4134,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
             if (m_appletPanel && m_appletPanel->catApplet())
                 m_appletPanel->catApplet()->setTcpEnabled(true);
         }
-        // Auto-start 4-channel CAT virtual serial ports if enabled
+        // Auto-start 8-channel CAT virtual serial ports if enabled
         if (as.value("AutoStartCAT", "False").toString() == "True") {
             for (int i = 0; i < kCatChannels; ++i) {
                 if (m_rigctlPtys[i] && !m_rigctlPtys[i]->isRunning()) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -149,8 +149,8 @@ private:
     AudioEngine*      m_audio{nullptr};
     QThread*          m_audioThread{nullptr};
     BandSettings      m_bandSettings;
-    // 4-channel CAT: each channel (A-D) binds to a slice index (0-3)
-    static constexpr int kCatChannels = 4;
+    // 8-channel CAT: each channel (A-H) binds to a slice index (0-7)
+    static constexpr int kCatChannels = 8;
     RigctlServer*     m_rigctlServers[kCatChannels]{};
     RigctlPty*        m_rigctlPtys[kCatChannels]{};
 #ifdef HAVE_WEBSOCKETS

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -270,8 +270,8 @@ void PanadapterApplet::setFloatingState(bool floating)
 
 void PanadapterApplet::setSliceId(int id)
 {
-    const char letters[] = "ABCD";
-    const char letter = (id >= 0 && id < 4) ? letters[id] : '?';
+    const char letters[] = "ABCDEFGH";
+    const char letter = (id >= 0 && id < 8) ? letters[id] : '?';
     m_titleLabel->setText(QString("Slice %1").arg(letter));
 }
 

--- a/src/gui/SliceColors.h
+++ b/src/gui/SliceColors.h
@@ -2,7 +2,7 @@
 
 // Shared per-slice colour definitions used by SpectrumWidget, VfoWidget, and
 // RxApplet to ensure all slice markers/badges use identical colours.
-// Index by sliceId % 4.
+// Index by sliceId % 8.
 
 namespace AetherSDR {
 
@@ -17,8 +17,12 @@ inline constexpr SliceColorEntry kSliceColors[] = {
     {0xff, 0x40, 0xff,  0x80, 0x20, 0x80, "#ff40ff"},  // B = magenta
     {0x40, 0xff, 0x40,  0x20, 0x80, 0x20, "#40ff40"},  // C = green
     {0xff, 0xff, 0x00,  0x80, 0x80, 0x00, "#ffff00"},  // D = yellow
+    {0xff, 0xa0, 0x00,  0x80, 0x50, 0x00, "#ffa000"},  // E = orange
+    {0x00, 0xe0, 0xc0,  0x00, 0x70, 0x60, "#00e0c0"},  // F = teal
+    {0xff, 0x60, 0x80,  0x80, 0x30, 0x40, "#ff6080"},  // G = coral
+    {0xb0, 0x80, 0xff,  0x58, 0x40, 0x80, "#b080ff"},  // H = lavender
 };
 
-inline constexpr int kSliceColorCount = 4;
+inline constexpr int kSliceColorCount = 8;
 
 } // namespace AetherSDR

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -578,7 +578,7 @@ void SpectrumWidget::setDbmRange(float minDbm, float maxDbm)
 // ─── Slice color table (shared via SliceColors.h) ────────────────────────────
 
 static QColor sliceColor(int sliceId, bool active) {
-    const auto& c = kSliceColors[sliceId & 3];
+    const auto& c = kSliceColors[sliceId % kSliceColorCount];
     if (active) return QColor(c.r, c.g, c.b);
     return QColor(c.dr, c.dg, c.db);
 }
@@ -1084,7 +1084,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
             if (!m_offScreenRects[oi].isNull() &&
                 m_offScreenRects[oi].contains(QPoint(mx, y))) {
                 const auto& so = m_sliceOverlays[oi];
-                const QChar letter = QChar('A' + (so.sliceId & 3));
+                const QChar letter = QChar('A' + (so.sliceId % kSliceColorCount));
                 QMenu menu(this);
                 menu.addAction(QString("Close Slice %1").arg(letter), this,
                     [this, id = so.sliceId]{ emit sliceCloseRequested(id); });
@@ -3987,7 +3987,7 @@ void SpectrumWidget::drawOffScreenSlices(QPainter& p, const QRect& specRect)
 
         const bool isRight = (so.freqMhz > endMhz);
         const QColor col = sliceColor(so.sliceId, so.isActive);
-        const QChar letter = QChar('A' + (so.sliceId & 3));
+        const QChar letter = QChar('A' + (so.sliceId % kSliceColorCount));
 
         long long hz = static_cast<long long>(std::round(so.freqMhz * 1e6));
         int mhzPart = static_cast<int>(hz / 1000000);


### PR DESCRIPTION
## Summary
- Expand slice support from 4 to 8 for Flex 6700
- Add 4 new slice colors (orange, teal, coral, lavender)
- Fix slice color modulo from bitmask to proper modulo

Fixes #1281. From AetherClaude PR #1290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)