### PR TITLE
Add close button to CW decoder panel

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5031,6 +5031,8 @@ void MainWindow::routeCwDecoderOutput()
                        &m_cwDecoder, &CwDecoder::lockSpeed);
         disconnect(m_cwDecoderApplet, &PanadapterApplet::pitchRangeChanged,
                    &m_cwDecoder, &CwDecoder::setPitchRange);
+        disconnect(m_cwDecoderApplet, &PanadapterApplet::cwPanelCloseRequested,
+                   &m_cwDecoder, &CwDecoder::stop);
     }
 
     m_cwDecoderApplet = target;
@@ -5047,6 +5049,8 @@ void MainWindow::routeCwDecoderOutput()
                 &m_cwDecoder, &CwDecoder::lockSpeed);
         connect(m_cwDecoderApplet, &PanadapterApplet::pitchRangeChanged,
                 &m_cwDecoder, &CwDecoder::setPitchRange);
+        connect(m_cwDecoderApplet, &PanadapterApplet::cwPanelCloseRequested,
+                &m_cwDecoder, &CwDecoder::stop);
     }
 }
 

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -227,6 +227,21 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     connect(clearBtn, &QPushButton::clicked, this, &PanadapterApplet::clearCwText);
     cwBar->addWidget(clearBtn);
 
+    auto* closeBtn = new QPushButton("\u2715");
+    closeBtn->setToolTip("Close CW decoder");
+    closeBtn->setStyleSheet(
+        "QPushButton { background: #1a2a3a; color: #8090a0; border: 1px solid #203040;"
+        " border-radius: 2px; font-size: 9px; font-weight: bold;"
+        " padding: 1px 6px; }"
+        "QPushButton:hover { color: #ff6060; background: #2a3a4a; }");
+    connect(closeBtn, &QPushButton::clicked, this, [this]() {
+        AppSettings::instance().setValue("CwDecodeOverlay", "False");
+        AppSettings::instance().save();
+        m_cwPanel->hide();
+        emit cwPanelCloseRequested();
+    });
+    cwBar->addWidget(closeBtn);
+
     cwLayout->addLayout(cwBar);
 
     // Text area

--- a/src/gui/PanadapterApplet.h
+++ b/src/gui/PanadapterApplet.h
@@ -49,6 +49,7 @@ signals:
     void popOutClicked();
     void dockClicked();
     void pitchRangeChanged(int minHz, int maxHz);
+    void cwPanelCloseRequested();
 
 protected:
     bool eventFilter(QObject* obj, QEvent* ev) override;


### PR DESCRIPTION
## Summary
- Add ✕ close button to CW decoder toolbar
- Persists setting (CwDecodeOverlay=False) and stops decoder

Fixes #1287. From AetherClaude PR #1294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)