### PR TITLE
Add CW Zero Beat button to P/CW applet

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1788,6 +1788,23 @@ MainWindow::MainWindow(QWidget* parent)
     }
     m_appletPanel->phoneCwApplet()->setTransmitModel(&m_radioModel.transmitModel());
 
+    // ── CW zero-beat: pitch tracking + VFO adjustment ───────────────────────
+    connect(&m_cwDecoder, &CwDecoder::statsUpdated,
+            m_appletPanel->phoneCwApplet(), [this](float pitchHz, float) {
+        m_appletPanel->phoneCwApplet()->setCwDetectedPitch(pitchHz);
+    });
+
+    connect(m_appletPanel->phoneCwApplet(), &PhoneCwApplet::zeroBeatRequested,
+            this, [this]() {
+        SliceModel* slice = activeSlice();
+        if (!slice) return;
+        float detected = m_cwDecoder.estimatedPitch();
+        if (detected <= 0.0f) return;
+        int configured = m_radioModel.transmitModel().cwPitch();
+        double offsetMhz = (detected - configured) / 1.0e6;
+        slice->setFrequency(slice->frequency() + offsetMhz);
+    });
+
     // ── PHNE applet: VOX + CW controls ──────────────────────────────────────
     m_appletPanel->phoneApplet()->setTransmitModel(&m_radioModel.transmitModel());
 

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -519,6 +519,18 @@ void PhoneCwApplet::buildCwPanel()
         m_iambicBtn->setStyleSheet(QString(kButtonBase) + kBlueActive);
         row->addWidget(m_iambicBtn);
 
+        m_zeroBtn = new QPushButton("Zero");
+        m_zeroBtn->setFixedHeight(22);
+        m_zeroBtn->setEnabled(false);
+        m_zeroBtn->setAccessibleName("CW zero beat");
+        m_zeroBtn->setAccessibleDescription(
+            "Adjust VFO to zero-beat the incoming CW signal");
+        m_zeroBtn->setToolTip("Zero-beat incoming CW signal");
+        m_zeroBtn->setStyleSheet(kButtonBase);
+        connect(m_zeroBtn, &QPushButton::clicked, this,
+                &PhoneCwApplet::zeroBeatRequested);
+        row->addWidget(m_zeroBtn);
+
         row->addStretch();
 
         // Pitch: label + < value > stepper (inset display matching RIT/XIT style)
@@ -728,6 +740,12 @@ void PhoneCwApplet::updateCompression(float compPeak)
 void PhoneCwApplet::updateAlc(float alc)
 {
     m_alcGauge->setValue(alc);
+}
+
+void PhoneCwApplet::setCwDetectedPitch(float pitchHz)
+{
+    // Enable the Zero button only when the decoder has a valid pitch estimate.
+    m_zeroBtn->setEnabled(pitchHz > 0.0f);
 }
 
 } // namespace AetherSDR

--- a/src/gui/PhoneCwApplet.h
+++ b/src/gui/PhoneCwApplet.h
@@ -26,6 +26,7 @@ public:
 
 signals:
     void micLevelChanged(int level);  // slider value 0-100
+    void zeroBeatRequested();         // CW zero-beat button pressed
 
 public slots:
     // Phone meters (mic level / compression)
@@ -38,6 +39,9 @@ public slots:
 
     // Switch between Phone and CW sub-panels based on slice mode.
     void setMode(const QString& mode);
+
+    // Update the Zero button enabled state based on detected CW pitch.
+    void setCwDetectedPitch(float pitchHz);
 
 private:
     void buildPhonePanel();
@@ -92,6 +96,8 @@ private:
     QLabel*      m_pitchLabel{nullptr};
     QPushButton* m_pitchDown{nullptr};
     QPushButton* m_pitchUp{nullptr};
+
+    QPushButton* m_zeroBtn{nullptr};
 
     // ── Shared state ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add "Zero" button to CW panel — one-shot client-side zero-beat using ggmorse pitch estimate
- Button disabled until decoder has a valid pitch detection
- Provides zero-beat for users without SmartSDR+ (radio's auto_tune is license-gated)

Fixes #1228. From AetherClaude PR #1256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)