### PR TITLE
Add FlexControl knob button (X4S) as configurable action

### DIFF
--- a/src/core/FlexControlManager.cpp
+++ b/src/core/FlexControlManager.cpp
@@ -100,10 +100,10 @@ void FlexControlManager::processCommand(const QByteArray& cmd)
 
     } else if (cmd.startsWith('X') && cmd.size() >= 3) {
         // Button press: X<button><action>
-        //   button: 1, 2, 3
+        //   button: 1, 2, 3, 4 (4 = knob press)
         //   action: S=tap(0), C=double-tap(1), L=hold(2)
         int button = cmd.at(1) - '0';
-        if (button < 1 || button > 3) return;
+        if (button < 1 || button > 4) return;
         char action = cmd.at(2);
         int actionId = (action == 'S') ? 0 : (action == 'C') ? 1 : 2;
         emit buttonPressed(button, actionId);

--- a/src/core/FlexControlManager.h
+++ b/src/core/FlexControlManager.h
@@ -19,6 +19,7 @@ namespace AetherSDR {
 //   X1S;    — button 1 tap (S=tap, C=double, L=hold)
 //   X2S;    — button 2 tap
 //   X3S;    — button 3 tap
+//   X4S;    — knob button tap
 //   F0304;  — device init/reset
 class FlexControlManager : public QObject {
     Q_OBJECT
@@ -42,7 +43,7 @@ public:
 signals:
     // +N = tune up N steps, -N = tune down N steps
     void tuneSteps(int steps);
-    // button 1-3, action: 0=tap, 1=double-tap, 2=hold
+    // button 1-4, action: 0=tap, 1=double-tap, 2=hold
     void buttonPressed(int button, int action);
     void connectionChanged(bool connected);
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1544,12 +1544,13 @@ MainWindow::MainWindow(QWidget* parent)
             this, [this](int button, int action) {
         QString key = QString("FlexControlBtn%1Action%2").arg(button).arg(action);
         auto& settings = AppSettings::instance();
-        static const char* defaults[3][3] = {
+        static const char* defaults[4][3] = {
             {"StepUp",     "StepDown",     "None"},
             {"ToggleMox",  "ToggleTune",   "None"},
             {"ToggleMute", "ToggleLock",   "None"},
+            {"StepUp",     "StepDown",     "None"},  // Knob button
         };
-        const char* def = (button >= 1 && button <= 3 && action >= 0 && action <= 2)
+        const char* def = (button >= 1 && button <= 4 && action >= 0 && action <= 2)
                           ? defaults[button-1][action] : "None";
         QString actionName = settings.value(key, def).toString();
 

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -2902,15 +2902,16 @@ QWidget* RadioSetupDialog::buildSerialTab()
             "NextSlice", "PrevSlice",
             "ToggleAgc", "VolumeUp", "VolumeDown"
         };
-        static const char* defaultActions[3][2] = {
+        static const char* defaultActions[4][2] = {
             {"StepUp", "StepDown"},
             {"ToggleMox", "ToggleTune"},
             {"ToggleMute", "ToggleLock"},
+            {"StepUp", "StepDown"},      // Knob button
         };
-        static const char* btnLabels[3] = {"Button 1:", "Button 2:", "Button 3:"};
+        static const char* btnLabels[4] = {"Button 1:", "Button 2:", "Button 3:", "Knob Button:"};
         static const char* actLabels[2] = {"Tap", "Double"};
 
-        for (int b = 0; b < 3; ++b) {
+        for (int b = 0; b < 4; ++b) {
             grid->addWidget(new QLabel(btnLabels[b]), b + 1, 0);
             auto* row = new QHBoxLayout;
             for (int a = 0; a < 2; ++a) {
@@ -2942,7 +2943,7 @@ QWidget* RadioSetupDialog::buildSerialTab()
             s.setValue("FlexControlAutoDetect", on ? "True" : "False");
             s.save();
         });
-        grid->addWidget(autoDetect, 4, 0, 1, 3);
+        grid->addWidget(autoDetect, 5, 0, 1, 3);
 
         auto* invertDir = new QCheckBox("Invert tuning direction");
         invertDir->setStyleSheet("QCheckBox { color: #c8d8e8; }");
@@ -2952,7 +2953,7 @@ QWidget* RadioSetupDialog::buildSerialTab()
             s.setValue("FlexControlInvertDir", on ? "True" : "False");
             s.save();
         });
-        grid->addWidget(invertDir, 5, 0, 1, 3);
+        grid->addWidget(invertDir, 6, 0, 1, 3);
 
         vbox->addWidget(group);
     }


### PR DESCRIPTION
## Summary
- Handle X4S serial command (knob press) alongside existing X1S/X2S/X3S
- Add "Knob Button" config row in Radio Setup with tap/double action dropdowns
- Default: StepUp (tap), StepDown (double-tap)

Fixes #1295. From AetherClaude PR #1296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)