### PR TITLE
Add assignable FlexControl wheel modes for volume and TX power

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1527,6 +1527,25 @@ MainWindow::MainWindow(QWidget* parent)
     // FlexControl signals (auto-queued from worker → main)
     connect(m_flexControl, &FlexControlManager::tuneSteps,
             this, [this](int steps) {
+        switch (m_flexWheelMode) {
+        case FlexWheelMode::Volume: {
+            auto* s = activeSlice();
+            if (!s) return;
+            float gain = s->audioGain() + steps * 2.0f;
+            s->setAudioGain(std::clamp(gain, 0.0f, 100.0f));
+            return;
+        }
+        case FlexWheelMode::Power: {
+            auto& tx = m_radioModel.transmitModel();
+            int power = tx.rfPower() + steps;
+            tx.setRfPower(std::clamp(power, 0, 100));
+            return;
+        }
+        case FlexWheelMode::Frequency:
+        default:
+            break;
+        }
+        // Frequency mode (default)
         auto* s = activeSlice();
         if (!s || s->isLocked()) return;
         int stepHz = spectrum() ? spectrum()->stepSize() : 100;
@@ -1605,6 +1624,12 @@ MainWindow::MainWindow(QWidget* parent)
             if (auto* s = activeSlice()) {
                 s->setAudioGain(std::max(0.0f, s->audioGain() - 5.0f));
             }
+        } else if (actionName == "WheelFrequency") {
+            m_flexWheelMode = FlexWheelMode::Frequency;
+        } else if (actionName == "WheelVolume") {
+            m_flexWheelMode = FlexWheelMode::Volume;
+        } else if (actionName == "WheelPower") {
+            m_flexWheelMode = FlexWheelMode::Power;
         }
     });
 #endif

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -71,6 +71,9 @@ using DaxBridge = PipeWireAudioBridge;
 #endif
 class VfoWidget;
 
+// Wheel mode for FlexControl: determines what the encoder knob adjusts
+enum class FlexWheelMode { Frequency, Volume, Power };
+
 class MainWindow : public QMainWindow {
     Q_OBJECT
 
@@ -193,6 +196,7 @@ private:
     FlexControlManager*   m_flexControl{nullptr};
     QTimer               m_flexCoalesceTimer;
     double               m_flexTargetMhz{-1.0};
+    FlexWheelMode        m_flexWheelMode{FlexWheelMode::Frequency};
 #endif
 #ifdef HAVE_HIDAPI
     HidEncoderManager*   m_hidEncoder{nullptr};

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -2900,7 +2900,8 @@ QWidget* RadioSetupDialog::buildSerialTab()
             "None", "StepUp", "StepDown", "ToggleMox",
             "ToggleTune", "ToggleMute", "ToggleLock",
             "NextSlice", "PrevSlice",
-            "ToggleAgc", "VolumeUp", "VolumeDown"
+            "ToggleAgc", "VolumeUp", "VolumeDown",
+            "WheelFrequency", "WheelVolume", "WheelPower"
         };
         static const char* defaultActions[4][2] = {
             {"StepUp", "StepDown"},


### PR DESCRIPTION
## Summary
- Add WheelFrequency/WheelVolume/WheelPower as assignable FlexControl button actions
- Button press switches wheel mode; wheel adjusts the selected parameter
- Volume: ±2 per step, Power: ±1 per step, Frequency: existing behavior

Fixes #1282. From AetherClaude PR #1291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)