### PR TITLE
Add slice tab toggle to RxApplet header

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -901,6 +901,16 @@ void AppletPanel::setAntennaList(const QStringList& ants)
     m_rxApplet->setAntennaList(ants);
 }
 
+void AppletPanel::setMaxSlices(int maxSlices)
+{
+    m_rxApplet->setMaxSlices(maxSlices);
+}
+
+void AppletPanel::updateSliceButtons(const QList<SliceModel*>& slices, int activeSliceId)
+{
+    m_rxApplet->updateSliceButtons(slices, activeSliceId);
+}
+
 void AppletPanel::floatSMeter()
 {
     if (m_floatingWindows.contains("VU")) { return; }

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -40,6 +40,8 @@ public:
 
     void setSlice(SliceModel* slice);
     void setAntennaList(const QStringList& ants);
+    void setMaxSlices(int maxSlices);
+    void updateSliceButtons(const QList<SliceModel*>& slices, int activeSliceId);
 
     RxApplet*     rxApplet()      { return m_rxApplet; }
     SMeterWidget* sMeterWidget()  { return m_sMeter; }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1148,6 +1148,10 @@ MainWindow::MainWindow(QWidget* parent)
         if (auto* s = activeSlice()) s->setAudioGain(v);
     });
 
+    // ── Slice tab toggle: click A/B/C/D → switch active slice (#1278) ──
+    connect(m_appletPanel->rxApplet(), &RxApplet::sliceActivationRequested,
+            this, &MainWindow::setActiveSlice);
+
     // ── NR2/RN2 feedback: AudioEngine → all VFO + overlay buttons ──────
     // Iterate all panadapter spectrums to find VFO widgets and overlay menus,
     // since spectrum()/vfoWidget() lookups can return null depending on
@@ -4122,6 +4126,10 @@ void MainWindow::onConnectionStateChanged(bool connected)
         m_stationLabel->setText(m_radioModel.nickname());
         m_connStatusLabel->setText("Connected");
         m_connPanel->setStatusText("Connected");
+
+        // Initialize slice tab toggle in RxApplet (#1278)
+        m_appletPanel->setMaxSlices(m_radioModel.maxSlices());
+
         // Show DIV button on dual-SCU radios
         {
             const QString& model = m_radioModel.model();
@@ -4783,6 +4791,9 @@ void MainWindow::onSliceAdded(SliceModel* s)
             centerActiveSliceInPanadapter(true, startupCenter);
         });
     }
+
+    // Refresh slice tab buttons (#1278)
+    m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
 }
 
 void MainWindow::onSliceRemoved(int id)
@@ -4856,6 +4867,9 @@ void MainWindow::onSliceRemoved(int id)
         else
             m_activeSliceId = -1;
     }
+
+    // Refresh slice tab buttons (#1278)
+    m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
 }
 
 SliceModel* MainWindow::activeSlice() const
@@ -4900,6 +4914,7 @@ void MainWindow::setActiveSlice(int sliceId)
             m_panStack->activeApplet()->setSliceId(sliceId);
     }
     m_appletPanel->setSlice(s);
+    m_appletPanel->updateSliceButtons(m_radioModel.slices(), sliceId);
     auto* sw = spectrum();
     if (sw) {
         sw->overlayMenu()->setSlice(s);

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -16,6 +16,8 @@
 #include <QHBoxLayout>
 #include <QGridLayout>
 #include <QMenu>
+#include <QToolButton>
+#include <QButtonGroup>
 #include <QInputDialog>
 #include "core/AppSettings.h"
 #include <QAction>
@@ -237,6 +239,19 @@ void RxApplet::buildUI()
     root->setContentsMargins(4, 2, 4, 2);
     root->setSpacing(2);
     outer->addWidget(inner);
+
+    // ── Slice tab toggle row (populated later by setMaxSlices) ──────────
+    {
+        m_sliceTabRow = new QWidget;
+        m_sliceTabRow->setVisible(false);  // hidden until setMaxSlices called
+        auto* tabLayout = new QHBoxLayout(m_sliceTabRow);
+        tabLayout->setContentsMargins(0, 0, 0, 0);
+        tabLayout->setSpacing(2);
+        m_sliceGroup = new QButtonGroup(this);
+        m_sliceGroup->setExclusive(true);
+        tabLayout->addStretch();
+        root->addWidget(m_sliceTabRow);
+    }
 
     // ── Header: slice badge | lock | RX ant | TX ant | filter width | QSK ──
     {
@@ -976,6 +991,81 @@ void RxApplet::setAfGain(int pct)
 }
 
 // ─── Slice wiring ─────────────────────────────────────────────────────────────
+
+void RxApplet::setMaxSlices(int maxSlices)
+{
+    // Only create buttons once
+    if (!m_sliceBtns.isEmpty()) return;
+
+    if (maxSlices <= 1) {
+        m_sliceTabRow->setVisible(false);
+        return;
+    }
+
+    auto* layout = qobject_cast<QHBoxLayout*>(m_sliceTabRow->layout());
+    // Insert buttons before the trailing stretch
+    const int stretchIdx = layout->count() - 1;
+
+    for (int i = 0; i < maxSlices; ++i) {
+        auto* btn = new QToolButton;
+        btn->setText(QString(QChar('A' + i)));
+        btn->setCheckable(true);
+        btn->setEnabled(false);  // disabled until a slice occupies this slot
+        btn->setFixedSize(22, 20);
+
+        const char* color = (i < kSliceColorCount) ? kSliceColors[i].hexActive : "#888888";
+        btn->setStyleSheet(
+            QString("QToolButton { background: #2a2a2a; color: %1; border: 1px solid %1; "
+                    "border-radius: 3px; font-weight: bold; font-size: 10px; padding: 0; }"
+                    "QToolButton:checked { background: %1; color: #000000; }"
+                    "QToolButton:disabled { background: #1a1a1a; color: #444444; "
+                    "border-color: #333333; }").arg(color));
+
+        m_sliceGroup->addButton(btn, i);
+        layout->insertWidget(stretchIdx + i, btn);
+        m_sliceBtns.append(btn);
+    }
+
+    // Wire button clicks to emit sliceActivationRequested
+    connect(m_sliceGroup, QOverload<int>::of(&QButtonGroup::idClicked),
+            this, [this](int /*buttonId*/) {
+        // The button ID is the slot index (0=A, 1=B, ...); we need the actual
+        // slice ID. Store the mapping in each button's user data via property.
+        auto* btn = qobject_cast<QToolButton*>(m_sliceGroup->checkedButton());
+        if (btn) {
+            bool ok = false;
+            int sliceId = btn->property("sliceId").toInt(&ok);
+            if (ok) emit sliceActivationRequested(sliceId);
+        }
+    });
+
+    m_sliceTabRow->setVisible(true);
+}
+
+void RxApplet::updateSliceButtons(const QList<SliceModel*>& slices, int activeSliceId)
+{
+    if (m_sliceBtns.isEmpty()) return;
+
+    // Build a map: slot index → slice ID for open slices
+    // sliceId 0 = slot A, sliceId 1 = slot B, etc.
+    QMap<int, int> slotToId;
+    for (auto* s : slices)
+        slotToId[s->sliceId()] = s->sliceId();
+
+    QSignalBlocker blocker(m_sliceGroup);
+    for (int i = 0; i < m_sliceBtns.size(); ++i) {
+        auto* btn = m_sliceBtns[i];
+        if (slotToId.contains(i)) {
+            btn->setEnabled(true);
+            btn->setProperty("sliceId", slotToId[i]);
+            btn->setChecked(i == activeSliceId);
+        } else {
+            btn->setEnabled(false);
+            btn->setChecked(false);
+            btn->setProperty("sliceId", QVariant());
+        }
+    }
+}
 
 void RxApplet::setSlice(SliceModel* slice)
 {

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -6,6 +6,7 @@
 class ScrollableLabel;
 namespace AetherSDR { class FilterPassbandWidget; }
 
+class QButtonGroup;
 class QHBoxLayout;
 class QGridLayout;
 class QPushButton;
@@ -15,6 +16,7 @@ class QLineEdit;
 class QStackedWidget;
 class QComboBox;
 class QDoubleSpinBox;
+class QToolButton;
 
 namespace AetherSDR {
 
@@ -51,7 +53,17 @@ public:
     // Set the available antenna list (from ant_list in panadapter status).
     void setAntennaList(const QStringList& ants);
 
+    // Slice tab toggle — create N buttons (A..H) capped at hardware max.
+    // If maxSlices <= 1, the row is hidden.
+    void setMaxSlices(int maxSlices);
+
+    // Enable/disable buttons based on which slices are open, and check the
+    // button for the currently active slice.
+    void updateSliceButtons(const QList<SliceModel*>& slices, int activeSliceId);
+
 signals:
+    // Emitted when the user clicks a slice tab button.
+    void sliceActivationRequested(int sliceId);
     // Emitted when the user adjusts the AF gain slider (0–100).
     void afGainChanged(int value);
     // Emitted when the user changes the tuning step size (Hz).
@@ -96,6 +108,11 @@ private:
     QPushButton* m_stepDown{nullptr};   // "<" button
     ScrollableLabel* m_stepLabel{nullptr};  // current step value display
     QPushButton* m_stepUp{nullptr};     // ">" button
+
+    // ── Slice tab toggle row ─────────────────────────────────────────────
+    QWidget*                m_sliceTabRow{nullptr};
+    QButtonGroup*           m_sliceGroup{nullptr};
+    QVector<QToolButton*>   m_sliceBtns;
 
     // ── Header row ────────────────────────────────────────────────────────
     QLabel*      m_sliceBadge{nullptr};   // "A" / "B" / "C" / "D"

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2202,8 +2202,10 @@ void RadioModel::handleRadioStatus(const QMap<QString, QString>& kvs)
     bool changed = false;
     if (kvs.contains("model"))    { m_model = kvs["model"]; changed = true; }
     if (kvs.contains("slices")) {
-        int n = kvs["slices"].toInt();
-        if (n > m_maxSlices) m_maxSlices = n;  // track highest seen
+        // slices=N reports available (unused) slots; total capacity = open + available
+        int available = kvs["slices"].toInt();
+        int total = m_slices.size() + available;
+        if (total > m_maxSlices) m_maxSlices = total;
         changed = true;
     }
     if (kvs.contains("callsign")) { m_callsign = kvs["callsign"]; changed = true; }


### PR DESCRIPTION
## Summary
- Add clickable A/B/C/D... slice badges to RxApplet header
- Button count matches radio's max slice capacity
- Click to switch active slice without leaving the applet panel

Fixes #1278. From AetherClaude PR #1286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)