### PR TITLE
Add IQ stream support for TCI Remote

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -6,6 +6,7 @@
 #include "LogManager.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
+#include "models/DaxIqModel.h"
 #include "models/MeterModel.h"
 #include "models/TransmitModel.h"
 #include "models/SpotModel.h"
@@ -199,6 +200,24 @@ void TciServer::onClientDisconnected()
                     }, Qt::QueuedConnection);
                 }
             }
+            // Clean up IQ stream if this client started one
+            if (m_clients[i].iqEnabled && m_model) {
+                int ch = m_clients[i].iqChannel + 1;  // TRX 0 → DAX channel 1
+                // Only remove if no other client uses the same IQ channel
+                bool otherUsing = false;
+                for (int j = 0; j < m_clients.size(); ++j) {
+                    if (j != i && m_clients[j].iqEnabled &&
+                        m_clients[j].iqChannel == m_clients[i].iqChannel) {
+                        otherUsing = true;
+                        break;
+                    }
+                }
+                if (!otherUsing) {
+                    QMetaObject::invokeMethod(m_model, [this, ch]() {
+                        m_model->daxIqModel().removeStream(ch);
+                    }, Qt::QueuedConnection);
+                }
+            }
             delete m_clients[i].protocol;
             delete m_clients[i].resampler;
             m_clients.removeAt(i);
@@ -302,6 +321,35 @@ void TciServer::onTextMessage(const QString& msg)
             ws->sendTextMessage(QStringLiteral("tx_sensors_enable:%1;")
                                     .arg(client.txSensorsEnabled ? "true" : "false"));
             qCInfo(lcCat) << "TCI: tx_sensors" << (client.txSensorsEnabled ? "enabled" : "disabled");
+            continue;
+        }
+
+        // IQ start/stop — track per-client IQ state, then forward to protocol
+        if (trimmed.startsWith("iq_start:")) {
+            int colonIdx2 = trimmed.indexOf(':');
+            int trx = trimmed.mid(colonIdx2 + 1).trimmed().toInt();
+            client.iqEnabled = true;
+            client.iqChannel = trx;
+            qCInfo(lcCat) << "TCI: IQ started for client"
+                          << ws->peerAddress().toString()
+                          << "trx=" << trx;
+            // Forward to protocol to create DAX IQ stream on the radio
+            QString response = client.protocol->handleCommand(cmd.trimmed());
+            if (!response.isEmpty())
+                ws->sendTextMessage(response);
+            continue;
+        }
+        if (trimmed.startsWith("iq_stop:")) {
+            int colonIdx2 = trimmed.indexOf(':');
+            int trx = trimmed.mid(colonIdx2 + 1).trimmed().toInt();
+            if (client.iqChannel == trx)
+                client.iqEnabled = false;
+            qCInfo(lcCat) << "TCI: IQ stopped for client"
+                          << ws->peerAddress().toString()
+                          << "trx=" << trx;
+            QString response = client.protocol->handleCommand(cmd.trimmed());
+            if (!response.isEmpty())
+                ws->sendTextMessage(response);
             continue;
         }
 
@@ -576,13 +624,13 @@ QByteArray TciServer::buildAudioFrame(int receiver, int type,
                                       int sampleRate, int channels,
                                       const float* samples, int sampleCount)
 {
-    // sampleCount = number of frames (mono) or frame pairs (stereo counted as frames)
+    // sampleCount = number of frames (samples per channel)
     int totalFloats = sampleCount * channels;
     int payloadBytes = totalFloats * static_cast<int>(sizeof(float));
 
     QByteArray frame(sizeof(TciAudioHeader) + payloadBytes, Qt::Uninitialized);
 
-    // Fill header
+    // Fill header — length = samples per channel (frames), per TCI v2.0 spec
     TciAudioHeader hdr{};
     hdr.receiver   = static_cast<quint32>(receiver);
     hdr.sampleRate = static_cast<quint32>(sampleRate);
@@ -808,6 +856,38 @@ void TciServer::broadcastStatus()
                     cs.socket->sendTextMessage(freqMsg);
             }
         }
+    }
+}
+
+// ── IQ data from DAX IQ stream → TCI binary frames (type=0) ───────────
+
+void TciServer::onIqDataReady(int channel, const QByteArray& rawPayload, int sampleRate)
+{
+    // Check if any client wants IQ for this channel
+    bool anyIq = false;
+    int trx = channel - 1;  // DAX IQ channel 1 → TRX 0
+    for (const auto& cs : m_clients) {
+        if (cs.iqEnabled && cs.iqChannel == trx) { anyIq = true; break; }
+    }
+    if (!anyIq) return;
+
+    // Byte-swap big-endian float32 → native little-endian
+    const int numFloats = rawPayload.size() / 4;
+    QByteArray swapped(rawPayload.size(), Qt::Uninitialized);
+    const quint32* src = reinterpret_cast<const quint32*>(rawPayload.constData());
+    quint32* dst = reinterpret_cast<quint32*>(swapped.data());
+    for (int i = 0; i < numFloats; ++i)
+        dst[i] = qFromBigEndian(src[i]);
+
+    // Build TCI IQ binary frame (type=0, channels=2 for I/Q pair)
+    const int iqFrames = numFloats / 2;  // I/Q pairs
+    QByteArray frame = buildAudioFrame(trx, 0 /*IQ*/, sampleRate, 2,
+                                       reinterpret_cast<const float*>(swapped.constData()),
+                                       iqFrames);
+
+    for (auto& cs : m_clients) {
+        if (cs.iqEnabled && cs.iqChannel == trx)
+            cs.socket->sendBinaryMessage(frame);
     }
 }
 

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -41,10 +41,12 @@ public:
     void wireSpotModel();
 
 public slots:
-    // RX audio from main audio pipeline (int16 stereo, 24 kHz, LE)
+    // RX audio from main audio pipeline (float32 stereo, 24 kHz)
     void onRxAudioReady(const QByteArray& pcm);
-    // RX audio from DAX pipeline (int16 stereo, 24 kHz, LE)
+    // RX audio from DAX pipeline (float32 stereo, 24 kHz)
     void onDaxAudioReady(int channel, const QByteArray& pcm);
+    // IQ data from DAX IQ stream (big-endian float32 I/Q pairs)
+    void onIqDataReady(int channel, const QByteArray& rawPayload, int sampleRate);
 
 signals:
     void clientCountChanged(int count);
@@ -78,6 +80,8 @@ private:
         Resampler*   resampler{nullptr};    // null if rate == 24000 (native)
         bool         rxSensorsEnabled{false};
         bool         txSensorsEnabled{false};
+        bool         iqEnabled{false};       // client sent IQ_START
+        int          iqChannel{0};           // TCI TRX → DAX IQ channel (0-based)
     };
 
     RadioModel*       m_model;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1872,6 +1872,8 @@ MainWindow::MainWindow(QWidget* parent)
                 m_tciServer, &TciServer::onRxAudioReady);
         connect(m_radioModel.panStream(), &PanadapterStream::daxAudioReady,
                 m_tciServer, &TciServer::onDaxAudioReady);
+        connect(m_radioModel.panStream(), &PanadapterStream::iqDataReady,
+                m_tciServer, &TciServer::onIqDataReady);
     }
 
     // TCI client count changes no longer auto-create/remove the audio stream.


### PR DESCRIPTION
## Summary
- Add iq_start/iq_stop command handling in TCI server
- Stream DAX IQ data to TCI clients for panadapter/waterfall display
- Clean up IQ streams on client disconnect

Fixes #1182. From AetherClaude PR #1247, rebased with #1264 audio fixes resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)