### PR TITLE
Add QSO audio recorder with auto-record on TX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,6 +408,7 @@ set(CORE_SOURCES
     src/core/PgxlConnection.cpp
     src/core/FirmwareUploader.cpp
     src/core/DvkWavTransfer.cpp
+    src/core/QsoRecorder.cpp
     src/core/FirmwareStager.cpp
     src/core/RNNoiseFilter.cpp
     src/core/SpecbleachFilter.cpp

--- a/src/core/QsoRecorder.cpp
+++ b/src/core/QsoRecorder.cpp
@@ -1,0 +1,269 @@
+#include "QsoRecorder.h"
+#include "AppSettings.h"
+#include "LogManager.h"
+#include "../models/SliceModel.h"
+
+#include <QDir>
+#include <QStandardPaths>
+#include <QtEndian>
+
+namespace AetherSDR {
+
+QsoRecorder::QsoRecorder(QObject* parent)
+    : QObject(parent)
+{
+    // Default recording directory: ~/Documents/AetherSDR/Recordings
+    m_recordingDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)
+                     + "/AetherSDR/Recordings";
+
+    // Restore settings
+    auto& s = AppSettings::instance();
+    m_recordingDir = s.value("QsoRecordingDir", m_recordingDir).toString();
+    m_idleTimeoutSecs = s.value("QsoRecordingIdleTimeout", 120).toInt();
+    m_autoRecord = s.value("QsoRecordingAutoRecord", false).toBool();
+    m_includeDate = s.value("QsoRecordingIncludeDate", true).toBool();
+    m_includeTime = s.value("QsoRecordingIncludeTime", true).toBool();
+    m_includeFreq = s.value("QsoRecordingIncludeFreq", true).toBool();
+    m_includeMode = s.value("QsoRecordingIncludeMode", true).toBool();
+
+    // Idle timer — fires when no TX activity for m_idleTimeoutSecs
+    m_idleTimer = new QTimer(this);
+    m_idleTimer->setSingleShot(true);
+    connect(m_idleTimer, &QTimer::timeout, this, [this]() {
+        if (m_recording) {
+            qCInfo(lcAudio) << "QsoRecorder: idle timeout, stopping recording";
+            stopRecording();
+        }
+    });
+}
+
+QsoRecorder::~QsoRecorder()
+{
+    if (m_recording)
+        finalizeFile();
+}
+
+void QsoRecorder::setRecordingDir(const QString& path)
+{
+    m_recordingDir = path;
+    AppSettings::instance().setValue("QsoRecordingDir", path);
+}
+
+void QsoRecorder::setIdleTimeoutSecs(int secs)
+{
+    m_idleTimeoutSecs = qBound(10, secs, 3600);
+    AppSettings::instance().setValue("QsoRecordingIdleTimeout", m_idleTimeoutSecs);
+}
+
+void QsoRecorder::setAutoRecordEnabled(bool on)
+{
+    m_autoRecord = on;
+    AppSettings::instance().setValue("QsoRecordingAutoRecord", on);
+}
+
+void QsoRecorder::setCallsign(const QString& call)
+{
+    m_callsign = call.trimmed().toUpper();
+}
+
+void QsoRecorder::setSlice(SliceModel* slice)
+{
+    m_slice = slice;
+}
+
+int QsoRecorder::recordingDurationSecs() const
+{
+    if (!m_recording) return 0;
+    return static_cast<int>(m_startTime.secsTo(QDateTime::currentDateTimeUtc()));
+}
+
+// ── Manual control ──────────────────────────────────────────────────────────
+
+void QsoRecorder::startRecording()
+{
+    if (m_recording) return;
+    startFile();
+}
+
+void QsoRecorder::stopRecording()
+{
+    if (!m_recording) return;
+    m_idleTimer->stop();
+    finalizeFile();
+}
+
+// ── Audio feeds ─────────────────────────────────────────────────────────────
+
+void QsoRecorder::feedRxAudio(const QByteArray& pcm)
+{
+    std::lock_guard<std::mutex> lock(m_writeMutex);
+    if (!m_recording || !m_file) return;
+    m_file->write(pcm);
+    m_dataBytes += static_cast<quint32>(pcm.size());
+}
+
+void QsoRecorder::feedTxAudio(const QByteArray& pcm)
+{
+    std::lock_guard<std::mutex> lock(m_writeMutex);
+    if (!m_recording || !m_file) return;
+    m_file->write(pcm);
+    m_dataBytes += static_cast<quint32>(pcm.size());
+}
+
+// ── TX state tracking ───────────────────────────────────────────────────────
+
+void QsoRecorder::onMoxChanged(bool mox)
+{
+    if (mox) {
+        // TX started — begin recording if auto-record is on and not already recording
+        if (m_autoRecord && !m_recording)
+            startFile();
+
+        // Reset idle timer on each TX
+        m_idleTimer->stop();
+    } else {
+        // TX ended — start idle countdown
+        if (m_recording)
+            m_idleTimer->start(m_idleTimeoutSecs * 1000);
+    }
+}
+
+// ── File management ─────────────────────────────────────────────────────────
+
+void QsoRecorder::startFile()
+{
+    // Capture metadata from active slice at recording start
+    if (m_slice) {
+        m_freqMhz = m_slice->frequency();
+        m_mode = m_slice->mode();
+    } else {
+        m_freqMhz = 0.0;
+        m_mode.clear();
+    }
+
+    m_startTime = QDateTime::currentDateTimeUtc();
+    m_dataBytes = 0;
+
+    // Ensure directory exists
+    QDir dir(m_recordingDir);
+    if (!dir.exists()) {
+        if (!dir.mkpath(".")) {
+            emit recordingError("Cannot create recording directory: " + m_recordingDir);
+            return;
+        }
+    }
+
+    QString filePath = m_recordingDir + "/" + buildFilename();
+
+    m_file = new QFile(filePath, this);
+    if (!m_file->open(QIODevice::WriteOnly)) {
+        emit recordingError("Cannot create recording file: " + m_file->errorString());
+        delete m_file;
+        m_file = nullptr;
+        return;
+    }
+
+    writeWavHeader();
+    m_recording = true;
+
+    qCInfo(lcAudio) << "QsoRecorder: started recording to" << filePath;
+    emit recordingStarted(filePath);
+}
+
+void QsoRecorder::finalizeFile()
+{
+    {
+        std::lock_guard<std::mutex> lock(m_writeMutex);
+        m_recording = false;
+    }
+
+    if (!m_file) return;
+
+    patchWavHeader();
+    QString filePath = m_file->fileName();
+    int durationSecs = static_cast<int>(m_startTime.secsTo(QDateTime::currentDateTimeUtc()));
+
+    m_file->close();
+    m_file->deleteLater();
+    m_file = nullptr;
+
+    qCInfo(lcAudio) << "QsoRecorder: stopped recording," << durationSecs << "seconds,"
+                     << m_dataBytes << "bytes";
+    emit recordingStopped(filePath, durationSecs);
+}
+
+QString QsoRecorder::buildFilename() const
+{
+    QStringList parts;
+
+    if (m_includeDate)
+        parts << m_startTime.toString("yyyy-MM-dd");
+
+    if (m_includeTime)
+        parts << m_startTime.toString("HHmmss") + "Z";
+
+    if (m_includeFreq && m_freqMhz > 0.0) {
+        // Format frequency: e.g. 14.200 MHz → "14.200"
+        parts << QString::number(m_freqMhz, 'f', 3) + "MHz";
+    }
+
+    if (m_includeMode && !m_mode.isEmpty())
+        parts << m_mode;
+
+    if (!m_callsign.isEmpty())
+        parts << m_callsign;
+
+    if (parts.isEmpty())
+        parts << "QSO";
+
+    return parts.join("_") + ".wav";
+}
+
+void QsoRecorder::writeWavHeader()
+{
+    // Write a placeholder WAV header (44 bytes). The data size fields
+    // will be patched in finalizeFile() once we know the total size.
+    char header[WAV_HEADER_SIZE] = {};
+
+    const int byteRate = SAMPLE_RATE * NUM_CHANNELS * (BITS_PER_SAMPLE / 8);
+    const int blockAlign = NUM_CHANNELS * (BITS_PER_SAMPLE / 8);
+
+    // RIFF header
+    memcpy(header + 0, "RIFF", 4);
+    // header[4..7] = file size - 8 (patched later)
+    memcpy(header + 8, "WAVE", 4);
+
+    // fmt sub-chunk
+    memcpy(header + 12, "fmt ", 4);
+    qToLittleEndian<quint32>(16, header + 16);               // sub-chunk size
+    qToLittleEndian<quint16>(1, header + 20);                 // audio format (1 = PCM)
+    qToLittleEndian<quint16>(NUM_CHANNELS, header + 22);      // channels
+    qToLittleEndian<quint32>(SAMPLE_RATE, header + 24);       // sample rate
+    qToLittleEndian<quint32>(byteRate, header + 28);          // byte rate
+    qToLittleEndian<quint16>(blockAlign, header + 32);        // block align
+    qToLittleEndian<quint16>(BITS_PER_SAMPLE, header + 34);   // bits per sample
+
+    // data sub-chunk
+    memcpy(header + 36, "data", 4);
+    // header[40..43] = data size (patched later)
+
+    m_file->write(header, WAV_HEADER_SIZE);
+}
+
+void QsoRecorder::patchWavHeader()
+{
+    if (!m_file || !m_file->isOpen()) return;
+
+    // Seek back and patch the two size fields in the WAV header
+    m_file->seek(4);
+    quint32 riffSize = m_dataBytes + WAV_HEADER_SIZE - 8;
+    char buf[4];
+    qToLittleEndian<quint32>(riffSize, buf);
+    m_file->write(buf, 4);
+
+    m_file->seek(40);
+    qToLittleEndian<quint32>(m_dataBytes, buf);
+    m_file->write(buf, 4);
+}
+
+} // namespace AetherSDR

--- a/src/core/QsoRecorder.h
+++ b/src/core/QsoRecorder.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <QObject>
+#include <QFile>
+#include <QTimer>
+#include <QDateTime>
+#include <QString>
+#include <mutex>
+
+namespace AetherSDR {
+
+class SliceModel;
+class TransmitModel;
+
+// Records QSO audio (both RX and TX sides) to WAV files.
+//
+// Usage:
+//   - Connect feedRxAudio() to AudioEngine::feedAudioData() (or post-DSP tap)
+//   - Connect feedTxAudio() to AudioEngine::txRawPcmReady()
+//   - Connect onMoxChanged() to TransmitModel::moxChanged()
+//   - Set the active slice for frequency/mode metadata via setSlice()
+//
+// Recording triggers:
+//   - Auto: starts when MOX goes true (first TX), stops after idle timeout
+//   - Manual: startRecording() / stopRecording()
+//
+// Output: 24 kHz stereo int16 WAV (matches AudioEngine native format).
+
+class QsoRecorder : public QObject {
+    Q_OBJECT
+
+public:
+    explicit QsoRecorder(QObject* parent = nullptr);
+    ~QsoRecorder() override;
+
+    // Configuration
+    void setRecordingDir(const QString& path);
+    QString recordingDir() const { return m_recordingDir; }
+
+    void setIdleTimeoutSecs(int secs);
+    int idleTimeoutSecs() const { return m_idleTimeoutSecs; }
+
+    void setAutoRecordEnabled(bool on);
+    bool autoRecordEnabled() const { return m_autoRecord; }
+
+    void setCallsign(const QString& call);
+    QString callsign() const { return m_callsign; }
+
+    // Filename component toggles
+    void setIncludeDate(bool on) { m_includeDate = on; }
+    void setIncludeTime(bool on) { m_includeTime = on; }
+    void setIncludeFrequency(bool on) { m_includeFreq = on; }
+    void setIncludeMode(bool on) { m_includeMode = on; }
+
+    // Active slice (provides frequency + mode for filename)
+    void setSlice(SliceModel* slice);
+
+    bool isRecording() const { return m_recording; }
+
+    // Duration of current recording in seconds (0 if not recording)
+    int recordingDurationSecs() const;
+
+public slots:
+    // Manual control
+    void startRecording();
+    void stopRecording();
+
+    // Audio feeds — thread-safe, called from audio thread
+    void feedRxAudio(const QByteArray& pcm);
+    void feedTxAudio(const QByteArray& pcm);
+
+    // TX state tracking (connect to TransmitModel::moxChanged)
+    void onMoxChanged(bool mox);
+
+signals:
+    void recordingStarted(const QString& filePath);
+    void recordingStopped(const QString& filePath, int durationSecs);
+    void recordingError(const QString& error);
+
+private:
+    void startFile();
+    void finalizeFile();
+    QString buildFilename() const;
+    void writeWavHeader();
+    void patchWavHeader();
+
+    // Recording state
+    bool        m_recording{false};
+    QFile*      m_file{nullptr};
+    QDateTime   m_startTime;
+    quint32     m_dataBytes{0};    // PCM data bytes written (for WAV header patching)
+
+    // Configuration
+    QString     m_recordingDir;
+    int         m_idleTimeoutSecs{120};  // 2 minutes default
+    bool        m_autoRecord{false};
+    QString     m_callsign;
+    bool        m_includeDate{true};
+    bool        m_includeTime{true};
+    bool        m_includeFreq{true};
+    bool        m_includeMode{true};
+
+    // Slice metadata (captured at recording start)
+    SliceModel* m_slice{nullptr};
+    double      m_freqMhz{0.0};
+    QString     m_mode;
+
+    // Idle timeout
+    QTimer*     m_idleTimer{nullptr};
+
+    // Thread safety for audio feed paths
+    std::mutex  m_writeMutex;
+
+    // WAV format constants (matching AudioEngine native format)
+    static constexpr int SAMPLE_RATE = 24000;
+    static constexpr int NUM_CHANNELS = 2;
+    static constexpr int BITS_PER_SAMPLE = 16;
+    static constexpr int WAV_HEADER_SIZE = 44;
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -269,6 +269,9 @@ MainWindow::MainWindow(QWidget* parent)
     m_audio->moveToThread(m_audioThread);
     m_audioThread->start();
 
+    // QSO audio recorder (#1297) — lives on main thread, audio feeds are thread-safe
+    m_qsoRecorder = new QsoRecorder(this);
+
     // Band plan manager — must be created before buildMenuBar() which references it
     m_bandPlanMgr = new BandPlanManager(this);
     m_bandPlanMgr->loadPlans();
@@ -1126,6 +1129,14 @@ MainWindow::MainWindow(QWidget* parent)
     // audioDataReady(); we feed that directly to the QAudioSink.
     connect(m_radioModel.panStream(), &PanadapterStream::audioDataReady,
             m_audio, &AudioEngine::feedAudioData);
+
+    // ── QSO recorder: tap RX and TX audio, trigger on MOX (#1297) ───────
+    connect(m_radioModel.panStream(), &PanadapterStream::audioDataReady,
+            m_qsoRecorder, &QsoRecorder::feedRxAudio);
+    connect(m_audio, &AudioEngine::txRawPcmReady,
+            m_qsoRecorder, &QsoRecorder::feedTxAudio);
+    connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
+            m_qsoRecorder, &QsoRecorder::onMoxChanged);
 
     // ── BNR container autostart ─────────────────────────────────────────
 #ifdef HAVE_BNR
@@ -4911,6 +4922,9 @@ void MainWindow::setActiveSlice(int sliceId)
             sl->mode(), sl->rttyMark(), sl->rttyShift(),
             sl->ritOn(), sl->ritFreq(), sl->xitOn(), sl->xitFreq());
     }
+
+    // QSO recorder: track active slice for frequency/mode metadata (#1297)
+    m_qsoRecorder->setSlice(s);
 
     // Re-wire applet panel, overlay menu to the new active slice
     if (m_panStack) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -13,6 +13,7 @@
 #include "core/SmartLinkClient.h"
 #include "core/WanConnection.h"
 #include "core/CwDecoder.h"
+#include "core/QsoRecorder.h"
 #include "core/DxClusterClient.h"
 #ifdef HAVE_MQTT
 #include "core/MqttClient.h"
@@ -151,6 +152,7 @@ private:
     DxccColorProvider m_dxccProvider;
     AudioEngine*      m_audio{nullptr};
     QThread*          m_audioThread{nullptr};
+    QsoRecorder*      m_qsoRecorder{nullptr};
     BandSettings      m_bandSettings;
     // 8-channel CAT: each channel (A-H) binds to a slice index (0-7)
     static constexpr int kCatChannels = 8;


### PR DESCRIPTION
## Summary
- New QsoRecorder class: captures RX+TX audio to WAV files client-side
- Auto-record triggered by MOX, idle timeout stops recording
- Filenames include date, time, frequency, mode, callsign (configurable)
- Recording directory configurable, defaults to ~/Documents/AetherSDR/Recordings
- Backend engine only — UI for browsing/playback is follow-up work

Fixes #1297 (partial — items 1-5, 9). From AetherClaude PR #1298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)