### PR TITLE
Fix audio input device combo showing system default instead of active device

### DIFF
--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1522,8 +1522,9 @@ QWidget* RadioSetupDialog::buildAudioTab()
     const auto inDevices = QMediaDevices::audioInputs();
     for (const auto& dev : inDevices)
         inCombo->addItem(dev.description(), dev.id());
-    const auto defaultIn = QMediaDevices::defaultAudioInput();
-    int inIdx = inCombo->findData(defaultIn.id());
+    const auto curIn = m_audio ? m_audio->inputDevice() : QAudioDevice();
+    const auto selIn = curIn.isNull() ? QMediaDevices::defaultAudioInput() : curIn;
+    int inIdx = inCombo->findData(selIn.id());
     if (inIdx >= 0) inCombo->setCurrentIndex(inIdx);
     inRow->addWidget(inLabel);
     inRow->addWidget(inCombo, 1);


### PR DESCRIPTION
## Summary
- Input device combo in Radio Setup → Audio now shows the actual active device instead of system default
- Mirrors the existing pattern used for the output device combo

Fixes #1334. From AetherClaude PR #1336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)