### PR TITLE
Fix FlexControl knob press not returning to frequency mode

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1604,6 +1604,11 @@ MainWindow::MainWindow(QWidget* parent)
 
     connect(m_flexControl, &FlexControlManager::buttonPressed,
             this, [this](int button, int action) {
+        // Knob press while wheel function is active → return to frequency mode (#1354)
+        if (button == 4 && action == 0 && m_flexWheelMode != FlexWheelMode::Frequency) {
+            m_flexWheelMode = FlexWheelMode::Frequency;
+            return;
+        }
         QString key = QString("FlexControlBtn%1Action%2").arg(button).arg(action);
         auto& settings = AppSettings::instance();
         static const char* defaults[4][3] = {


### PR DESCRIPTION
## Summary
- Knob press (X4S) while in Volume/Power wheel mode returns to Frequency mode
- Matches expected FlexControl behavior: press knob to go back to tuning

Fixes #1354. From AetherClaude PR #1355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)