### PR TITLE
Fix waterfall black level and rate tooltip descriptions

### DIFF
--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1197,9 +1197,9 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     if (m_showGridBtn) m_showGridBtn->setToolTip("Show or hide the frequency and dB grid lines on the panadapter.");
     if (m_weightedAvgBtn) m_weightedAvgBtn->setToolTip("Weights recent FFT frames more heavily for faster response to signal changes.");
     m_gainSlider->setToolTip("Waterfall color gain. Higher values brighten weak signals.");
-    m_blackSlider->setToolTip("Waterfall black level. Increase to darken the noise floor.");
+    m_blackSlider->setToolTip("Waterfall black level. Decrease to darken the noise floor.");
     if (m_autoBlackBtn) m_autoBlackBtn->setToolTip("Automatically adjusts the waterfall black level to match the current noise floor.");
-    m_rateSlider->setToolTip("Waterfall line duration. Lower values scroll faster.");
+    m_rateSlider->setToolTip("Waterfall line duration. Higher values scroll faster.");
     if (m_wfBlankerThreshSlider) m_wfBlankerThreshSlider->setToolTip("Waterfall noise blanking threshold. Higher values blank more aggressively.");
     if (m_colorSchemeCmb) m_colorSchemeCmb->setToolTip("Selects the waterfall color palette.");
     if (m_bgOpacitySlider) m_bgOpacitySlider->setToolTip("Opacity of the background image overlay.");


### PR DESCRIPTION
## Summary
- Black level: "Increase to darken" → "Decrease to darken"
- Rate: "Lower values scroll faster" → "Higher values scroll faster"

Fixes #1365. From AetherClaude PR #1368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)