### PR TITLE
Smooth slice flag S-meter bar

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -188,6 +188,13 @@ VfoWidget::VfoWidget(QWidget* parent)
     setAttribute(Qt::WA_TranslucentBackground);
     setAutoFillBackground(false);
     setStyleSheet(kBgStyle);
+
+    m_signalMeterFraction = signalDbmToMeterFraction(m_signalDbm);
+    m_targetSignalMeterFraction = m_signalMeterFraction;
+    m_signalMeterAnimation.setTimerType(Qt::PreciseTimer);
+    m_signalMeterAnimation.setInterval(kSignalMeterAnimationIntervalMs);
+    connect(&m_signalMeterAnimation, &QTimer::timeout, this, &VfoWidget::animateSignalMeter);
+
     buildUI();
 }
 
@@ -2063,23 +2070,10 @@ void VfoWidget::paintEvent(QPaintEvent* event)
 
     // S-meter scale: S0=-127, S9=-73 (6 dB per S-unit), S9+60=-13
     // S0–S9 occupies left 60%, S9–S9+60 occupies right 40%
-    constexpr float S0_DBM  = -127.0f;
-    constexpr float S9_DBM  = -73.0f;
-    constexpr float S9P60   = -13.0f;
     const int s9X = barX + barW * 60 / 100;  // S9 boundary pixel
 
     // Signal fill — blue up to S9, red beyond
-    float frac;
-    if (m_signalDbm <= S0_DBM) {
-        frac = 0.0f;
-    } else if (m_signalDbm <= S9_DBM) {
-        frac = (m_signalDbm - S0_DBM) / (S9_DBM - S0_DBM) * 0.6f;
-    } else if (m_signalDbm <= S9P60) {
-        frac = 0.6f + (m_signalDbm - S9_DBM) / (S9P60 - S9_DBM) * 0.4f;
-    } else {
-        frac = 1.0f;
-    }
-    int fillW = static_cast<int>(frac * barW);
+    const int fillW = static_cast<int>(m_signalMeterFraction * barW);
 
     if (fillW > 0) {
         p.fillRect(barX, barY, fillW, barH, QColor(0x00, 0xc0, 0x40));
@@ -2157,7 +2151,67 @@ void VfoWidget::setSignalLevel(float dbm)
 {
     m_signalDbm = dbm;
     m_dbmLabel->setText(QString("%1 dBm").arg(static_cast<int>(dbm)));
-    update();  // repaint S-meter bar
+    updateSignalMeterTarget();
+}
+
+float VfoWidget::signalDbmToMeterFraction(float dbm)
+{
+    constexpr float kS0Dbm = -127.0f;
+    constexpr float kS9Dbm = -73.0f;
+    constexpr float kS9Plus60Dbm = -13.0f;
+
+    if (dbm <= kS0Dbm) {
+        return 0.0f;
+    }
+    if (dbm <= kS9Dbm) {
+        return (dbm - kS0Dbm) / (kS9Dbm - kS0Dbm) * 0.6f;
+    }
+    if (dbm <= kS9Plus60Dbm) {
+        return 0.6f + (dbm - kS9Dbm) / (kS9Plus60Dbm - kS9Dbm) * 0.4f;
+    }
+    return 1.0f;
+}
+
+void VfoWidget::updateSignalMeterTarget()
+{
+    m_targetSignalMeterFraction = signalDbmToMeterFraction(m_signalDbm);
+
+    if (qAbs(m_targetSignalMeterFraction - m_signalMeterFraction) <= kSignalMeterSnapEpsilon) {
+        m_signalMeterFraction = m_targetSignalMeterFraction;
+        if (m_signalMeterAnimation.isActive()) {
+            m_signalMeterAnimation.stop();
+        }
+        update();
+        return;
+    }
+
+    if (!m_signalMeterAnimation.isActive()) {
+        m_signalMeterElapsed.restart();
+        m_signalMeterAnimation.start();
+    }
+}
+
+void VfoWidget::animateSignalMeter()
+{
+    const qint64 elapsedMs = m_signalMeterElapsed.restart();
+    if (elapsedMs <= 0) {
+        return;
+    }
+
+    const float delta = m_targetSignalMeterFraction - m_signalMeterFraction;
+    const float elapsedSeconds = static_cast<float>(elapsedMs) / 1000.0f;
+    const float timeConstant = (delta >= 0.0f) ? kSignalMeterAttackTimeSeconds
+                                               : kSignalMeterReleaseTimeSeconds;
+    const float alpha = 1.0f - std::exp(-elapsedSeconds / timeConstant);
+
+    if (qAbs(delta) <= kSignalMeterSnapEpsilon) {
+        m_signalMeterFraction = m_targetSignalMeterFraction;
+        m_signalMeterAnimation.stop();
+    } else {
+        m_signalMeterFraction += delta * alpha;
+    }
+
+    update();
 }
 
 // ── Slice connection ──────────────────────────────────────────────────────────

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -7,6 +7,8 @@
 #include <QVector>
 #include <QStringList>
 #include <QSet>
+#include <QTimer>
+#include <QElapsedTimer>
 
 class QPushButton;
 class ScrollableLabel;
@@ -108,6 +110,10 @@ protected:
     void mouseReleaseEvent(QMouseEvent* ev) override;
 
 private:
+    void updateSignalMeterTarget();
+    void animateSignalMeter();
+    static float signalDbmToMeterFraction(float dbm);
+
     void buildUI();
     void buildTabContent();
     void updateTxBadgeStyle(bool isTx);
@@ -128,6 +134,10 @@ private:
     bool           m_updatingFromModel{false};
     bool           m_lastOnLeft{true};
     float          m_signalDbm{-130.0f};
+    QTimer         m_signalMeterAnimation;
+    QElapsedTimer  m_signalMeterElapsed;
+    float          m_signalMeterFraction{0.0f};
+    float          m_targetSignalMeterFraction{0.0f};
     bool           m_collapsed{false};
     bool           m_collapseToggled{false};  // guard: absorb release after toggle
     QPointer<QLabel> m_collapsedFreqLabel;
@@ -145,6 +155,11 @@ private:
     QPointer<QPushButton> m_recordBtn;
     QPointer<QPushButton> m_playBtn;
     QTimer* m_recordPulse{nullptr};
+
+    static constexpr int kSignalMeterAnimationIntervalMs = 8;
+    static constexpr float kSignalMeterAttackTimeSeconds = 0.045f;
+    static constexpr float kSignalMeterReleaseTimeSeconds = 0.180f;
+    static constexpr float kSignalMeterSnapEpsilon = 0.001f;
 
     // Frequency / meter
     QLabel* m_freqLabel{nullptr};


### PR DESCRIPTION
## Summary
- Apply asymmetric attack/decay smoothing to the VFO slice flag S-meter bar
- dBm label updates immediately, only bar fill animates
- Same timing constants as the analog S-meter (45ms attack, 180ms release)

Based on work by @rfoust in #1367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)