### PR TITLE
Fix CW key/paddle not triggering TX in client interlock handler

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -387,12 +387,14 @@ QString RadioModel::audioCompressionParam() const
 
 void RadioModel::sendCwKey(bool down)
 {
+    m_cwKeyActive = down;
     QString cmd = QString("cw key %1").arg(down ? 1 : 0);
     sendNetCwCommand(cmd);
 }
 
 void RadioModel::sendCwPaddle(bool dit, bool dah)
 {
+    m_cwKeyActive = dit || dah;
     QString cmd = QString("cw key %1 %2").arg(dit ? 1 : 0).arg(dah ? 1 : 0);
     sendNetCwCommand(cmd);
 }
@@ -1173,6 +1175,7 @@ void RadioModel::onDisconnected()
         restoreTuneInhibit();
 
     m_txRequested = false;
+    m_cwKeyActive = false;
     if (m_txAudioGate) {
         m_txAudioGate = false;
         emit txAudioGateChanged(false);
@@ -2130,7 +2133,7 @@ void RadioModel::onStatusReceived(const QString& object,
             const bool radioTx = (state == "TRANSMITTING");
             emit radioTransmittingChanged(radioTx);
 
-            if (!m_txOwnedByUs || (!m_txRequested && !m_transmitModel.isTuning())) {
+            if (!m_txOwnedByUs || (!m_txRequested && !m_cwKeyActive && !m_transmitModel.isTuning())) {
                 // Another client owns TX, or local unkey requested:
                 // force local TX/audio gate off through all interlock states.
                 m_transmitModel.setTransmitting(false);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -463,6 +463,7 @@ private:
     bool        m_remoteOnEnabled{false};
     bool        m_multiFlexEnabled{true};
     bool        m_txRequested{false}; // local MOX command intent (for edge sync)
+    bool        m_cwKeyActive{false}; // true while CW key/paddle is held (#1379)
     bool        m_txAudioGate{false}; // actual TX audio gate state
     QStringList m_antList;
 


### PR DESCRIPTION
## Summary
- Track CW key/paddle state in m_cwKeyActive
- Include it in interlock guard so CW keying isn't killed by the unkey path
- Clear on disconnect for safety
- Radio break-in timeout remains authoritative TX timeout

Fixes #1379. From AetherClaude PR #1380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)