### PR TITLE
Fix popout panadapter frozen after reparent

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2866,7 +2866,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
 
 void SpectrumWidget::render(QRhiCommandBuffer* cb)
 {
-    if (!m_rhiInitialized) return;
+    if (!m_rhiInitialized) {
+        initialize(cb);
+        if (!m_rhiInitialized) return;
+    }
     renderGpuFrame(cb);
 }
 


### PR DESCRIPTION
## Summary
- Re-initialize GPU pipelines lazily in render() when m_rhiInitialized is false
- Self-healing: after releaseResources() on reparent, next render frame rebuilds pipelines
- Complements the #1266 releaseResources() fix

Fixes #1381. From AetherClaude PR #1382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)