### PR TITLE
Fix WSJT-X DT drift on DAX RX audio after TX cycles

### DIFF
--- a/src/core/PipeWireAudioBridge.cpp
+++ b/src/core/PipeWireAudioBridge.cpp
@@ -77,6 +77,13 @@ bool PipeWireAudioBridge::open()
 
 void PipeWireAudioBridge::close()
 {
+    if (m_silenceTimer) {
+        m_silenceTimer->stop();
+        delete m_silenceTimer;
+        m_silenceTimer = nullptr;
+    }
+    m_transmitting = false;
+
     if (m_txReadTimer) {
         m_txReadTimer->stop();
         delete m_txReadTimer;
@@ -258,7 +265,12 @@ void PipeWireAudioBridge::feedDaxAudio(int channel, const QByteArray& pcm)
 {
     if (!m_open) return;
     if (channel < 1 || channel > NUM_CHANNELS) return;
-    if (m_transmitting) return;
+
+    // Real DAX audio has arrived — stop the silence fill timer if running.
+    if (m_transmitting && m_silenceTimer && m_silenceTimer->isActive()) {
+        m_silenceTimer->stop();
+        m_transmitting = false;
+    }
 
     auto& rx = m_rx[channel - 1];
     if (rx.fd < 0) return;
@@ -291,6 +303,49 @@ void PipeWireAudioBridge::feedDaxAudio(int channel, const QByteArray& pcm)
 void PipeWireAudioBridge::setTransmitting(bool tx)
 {
     m_transmitting = tx;
+
+    if (tx) {
+        // Start a timer that feeds silence into all RX pipes so the
+        // module-pipe-source clock keeps advancing during TX.  Without this,
+        // the pipe underruns and WSJT-X sees a timing gap equal to the TX
+        // duration, causing cumulative DT drift.
+        if (!m_silenceTimer) {
+            m_silenceTimer = new QTimer(this);
+            m_silenceTimer->setInterval(20);
+            m_silenceTimer->setTimerType(Qt::PreciseTimer);
+            connect(m_silenceTimer, &QTimer::timeout,
+                    this, &PipeWireAudioBridge::feedSilenceToAllPipes);
+        }
+        m_silenceElapsed.start();
+        m_silenceTimer->start();
+    }
+    // NOTE: silence timer is stopped in feedDaxAudio() when real RX audio
+    // arrives, not here — the radio hasn't resumed DAX RX audio yet at
+    // this point (interlock is still transitioning).
+}
+
+void PipeWireAudioBridge::feedSilenceToAllPipes()
+{
+    if (!m_open) return;
+
+    // Compute the exact number of mono int16 silence samples based on
+    // elapsed wall-clock time.  This avoids cumulative drift from QTimer
+    // jitter (same approach as the macOS VirtualAudioBridge fix).
+    const qint64 elapsedNs = m_silenceElapsed.nsecsElapsed();
+    m_silenceElapsed.start();
+
+    // mono samples = elapsed_s * sampleRate
+    const int monoSamples = static_cast<int>(
+        elapsedNs * SAMPLE_RATE / 1000000000LL);
+    if (monoSamples <= 0) return;
+
+    // Write silence (zero int16 samples) to each active RX pipe.
+    QByteArray silence(monoSamples * static_cast<int>(sizeof(int16_t)), '\0');
+    for (int i = 0; i < NUM_CHANNELS; ++i) {
+        if (m_rx[i].fd >= 0) {
+            ::write(m_rx[i].fd, silence.constData(), silence.size());
+        }
+    }
 }
 
 void PipeWireAudioBridge::readTxPipe()

--- a/src/core/PipeWireAudioBridge.h
+++ b/src/core/PipeWireAudioBridge.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QByteArray>
+#include <QElapsedTimer>
 #include <atomic>
 #include <array>
 
@@ -67,6 +68,12 @@ private:
 
     QTimer* m_txReadTimer{nullptr};
     void readTxPipe();
+
+    // Silence fill during TX — keeps pipe-source clock advancing so
+    // WSJT-X / VARA don't see a stalled audio source.
+    QTimer*       m_silenceTimer{nullptr};
+    QElapsedTimer m_silenceElapsed;
+    void feedSilenceToAllPipes();
 
     bool m_open{false};
     float m_gain{0.5f};

--- a/src/core/VirtualAudioBridge.cpp
+++ b/src/core/VirtualAudioBridge.cpp
@@ -183,6 +183,7 @@ void VirtualAudioBridge::setTransmitting(bool tx)
             connect(m_silenceTimer, &QTimer::timeout,
                     this, &VirtualAudioBridge::feedSilenceToAllChannels);
         }
+        m_silenceElapsed.start();
         m_silenceTimer->start();
     }
     // NOTE: we do NOT stop the silence timer on TX→RX here.
@@ -194,13 +195,24 @@ void VirtualAudioBridge::setTransmitting(bool tx)
 void VirtualAudioBridge::feedSilenceToAllChannels()
 {
     if (!m_open) return;
-    // 20ms of silence @ 24 kHz stereo = 480 frames = 960 float samples
-    static constexpr int SILENCE_SAMPLES = 960;
+
+    // Compute the exact number of stereo samples needed based on elapsed
+    // wall-clock time since the last tick.  This eliminates cumulative drift
+    // caused by QTimer jitter (the old code wrote a fixed 960 samples per
+    // 20 ms tick, but late ticks produced fewer samples than real-time).
+    const qint64 elapsedNs = m_silenceElapsed.nsecsElapsed();
+    m_silenceElapsed.start();
+
+    // stereo samples = elapsed_s * sampleRate * 2 channels
+    const int silenceSamples = static_cast<int>(
+        elapsedNs * 24000LL * 2 / 1000000000LL);
+    if (silenceSamples <= 0) return;
+
     for (int i = 0; i < NUM_CHANNELS; ++i) {
         auto* block = m_blocks[i];
         if (!block || !block->active) continue;
         uint32_t wp = block->writePos.load(std::memory_order_relaxed);
-        for (int s = 0; s < SILENCE_SAMPLES; ++s) {
+        for (int s = 0; s < silenceSamples; ++s) {
             block->ringBuffer[wp % DaxShmBlock::RING_SIZE] = 0.0f;
             ++wp;
         }

--- a/src/core/VirtualAudioBridge.h
+++ b/src/core/VirtualAudioBridge.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QByteArray>
+#include <QElapsedTimer>
 #include <atomic>
 #include <algorithm>
 #include <cstdint>
@@ -89,6 +90,7 @@ private:
 
     bool     m_transmitting{false};
     QTimer*  m_silenceTimer{nullptr};
+    QElapsedTimer m_silenceElapsed;   // tracks wall-clock time for accurate silence fill
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
## Summary
- PipeWireAudioBridge: add silence fill timer during TX to keep pipe clock advancing
- VirtualAudioBridge: improve existing silence fill with wall-clock-accurate sample count
- Prevents cumulative DT drift in WSJT-X/VARA after TX cycles

Fixes #537. From AetherClaude PR #1340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)