### PR TITLE
Fix K-index regex capturing UTC time instead of actual value

### DIFF
--- a/src/core/PropForecastClient.cpp
+++ b/src/core/PropForecastClient.cpp
@@ -97,7 +97,7 @@ void PropForecastClient::fetch()
 
         // K-index: fractional value from WWV, rounded to nearest int (#1232, #1255)
         static const QRegularExpression reK(
-            QStringLiteral("K-index[^\\d]+(\\d+\\.?\\d*)"));
+            QStringLiteral("K-index.*\\bwas\\s+(\\d+\\.?\\d*)"));
         auto mK = reK.match(text);
         if (mK.hasMatch())
             fc.kIndex = qRound(mK.captured(1).toDouble());


### PR DESCRIPTION
## Summary
- Anchor K-index regex on "was" keyword to skip the UTC time in the WWV bulletin
- Old regex captured 1800 (time), new one captures the actual K value

Fixes #1401. From AetherClaude PR #1402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)