### PR TITLE
Fix duplicate `display pan set` commands on level gesture and during tuning

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5170,6 +5170,16 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     auto* sw = applet->spectrumWidget();
     auto* menu = sw->overlayMenu();
 
+    // Guard: wirePanadapter() is called once at startup (for m_panApplet) and
+    // again from panadapterAdded for the same widget.  Without these disconnects
+    // every sw/menu/applet → this signal would be connected twice, causing each
+    // user gesture to fire two identical radio commands (e.g. duplicate
+    // "display pan set … min_dbm= max_dbm=").  Clearing prior connections here
+    // replaces the scattered per-signal disconnect guards below.
+    sw->disconnect(this);
+    menu->disconnect(this);
+    applet->disconnect(this);
+
     // Wire band plan manager to this spectrum widget
     sw->setBandPlanManager(m_bandPlanMgr);
 
@@ -5447,10 +5457,6 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             sw, &SpectrumWidget::setWfBlankerEnabled);
     connect(menu, &SpectrumOverlayMenu::wfBlankerThresholdChanged,
             sw, &SpectrumWidget::setWfBlankerThreshold);
-    disconnect(menu, &SpectrumOverlayMenu::backgroundImageRequested, this, nullptr);
-    disconnect(menu, &SpectrumOverlayMenu::backgroundImageCleared, this, nullptr);
-    disconnect(menu, &SpectrumOverlayMenu::backgroundOpacityChanged, this, nullptr);
-    disconnect(menu, &SpectrumOverlayMenu::displaySettingsReset, this, nullptr);
     connect(menu, &SpectrumOverlayMenu::backgroundImageRequested,
             this, [this, sw] {
         QString path = QFileDialog::getOpenFileName(sw, "Choose Background Image",
@@ -5672,10 +5678,6 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
 
     // ── Manual spot add/remove (#36)
-    // Note: wirePanadapter() can be called multiple times for the same widget
-    // (layout changes, reconnect), so disconnect first to avoid duplicate sends.
-    disconnect(sw, &SpectrumWidget::spotAddRequested, this, nullptr);
-    disconnect(sw, &SpectrumWidget::spotRemoveRequested, this, nullptr);
     connect(sw, &SpectrumWidget::spotAddRequested, this,
             [this](double freqMhz, const QString& callsign, const QString& comment,
                    int lifetimeSec, bool forwardToCluster) {
@@ -5723,8 +5725,6 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                     .arg(m_radioModel.model()).arg(limit), 4000);
         }
     });
-    // Disconnect first to avoid duplicate sends on re-wire (#381)
-    disconnect(menu, &SpectrumOverlayMenu::addTnfClicked, this, nullptr);
     connect(menu, &SpectrumOverlayMenu::addTnfClicked,
             this, [this]() {
         auto* s = activeSlice();
@@ -5768,7 +5768,6 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
 
     // XVTR button → open Radio Setup XVTR tab (#571)
-    disconnect(menu, &SpectrumOverlayMenu::xvtrSetupRequested, this, nullptr);
     connect(menu, &SpectrumOverlayMenu::xvtrSetupRequested,
             this, [this]() {
         auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, &m_tgxlConn, &m_pgxlConn, &m_antennaGenius, this);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -737,6 +737,11 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
                 // Only adjust if change is significant (> 1 dB)
                 float currentMin = m_refLevel - m_dynamicRange;
                 if (std::abs(newMin - currentMin) > 1.0f) {
+                    // Optimistic update: suppress re-firing on subsequent FFT frames
+                    // while waiting for the radio to confirm and echo the new range.
+                    // Without this, every FFT frame would re-emit until the echo-back
+                    // arrives, producing a burst of identical display pan set commands.
+                    m_dynamicRange = newRange;
                     emit dbmRangeChangeRequested(newMin, m_refLevel);
                 }
             }


### PR DESCRIPTION


Two independent causes produced back-to-back identical `display pan set
… min_dbm= max_dbm=` commands (visible in logs as consecutive C-sequence
numbers for the same content).

---

## Root causes fixed

### 1 — `wirePanadapter()` double-wiring (MainWindow.cpp)

`wirePanadapter()` is called twice for the initial panadapter: once at
startup (`line 1134`, for the default `m_panApplet`) and again from the
`panadapterAdded` lambda (`line 1010`) when the first real pan model
arrives and reuses that same applet.  Without disconnect guards, every
`sw/menu/applet → MainWindow` signal connection was made twice.  Each
user gesture that emitted `dbmRangeChangeRequested` would therefore
invoke the `sendCommand` lambda twice, sending two identical commands.

**Fix:** Add three bulk disconnect calls at the top of `wirePanadapter()`:

```cpp
sw->disconnect(this);
menu->disconnect(this);
applet->disconnect(this);
```

These clear all previous connections from those objects to `MainWindow`
before re-establishing them.  The scattered per-signal `disconnect()`
guards that were previously inline with each `connect()` call are removed
as they are now redundant.

### 2 — Noise floor auto-adjust command burst during VFO tuning (SpectrumWidget.cpp)

The noise floor auto-adjust in `updateSpectrum()` emitted
`dbmRangeChangeRequested(newMin, m_refLevel)` but did **not** update
`m_dynamicRange` before doing so.  Because the widget's stored range
never changed, every subsequent FFT frame recomputed the same `newMin`,
found `|newMin - currentMin| > 1 dB`, and re-emitted — producing a
continuous burst of commands (~25/s) until the radio's echo-back finally
arrived and `setDbmRange()` updated the stored range.

This is why duplicate commands appeared specifically during VFO tuning:
the radio sends frequent `display pan` status updates as the center
moves, each response including `min_dbm`/`max_dbm`, and the round-trip
latency gave the auto-adjust many frames to fire.

**Fix:** Update `m_dynamicRange` optimistically before emitting, matching
the same pattern used in the dBm strip arrow-click path
(`mousePressEvent`):

```cpp
m_dynamicRange = newRange;
emit dbmRangeChangeRequested(newMin, m_refLevel);
```

Subsequent frames compute `currentMin == newMin` and skip the emit.  The
radio echo-back arriving later calls `setDbmRange()`, which finds the
values already match and returns early via the existing equality guard —
so no feedback loop is introduced.

---

## Files changed

| File | Change |
|---|---|
| `src/gui/MainWindow.cpp` | Bulk `disconnect(this)` guard at top of `wirePanadapter()`; remove now-redundant per-signal `disconnect()` calls |
| `src/gui/SpectrumWidget.cpp` | Optimistic `m_dynamicRange` update before `dbmRangeChangeRequested` emit in noise floor auto-adjust |

---

## Verification checklist

- [ ] **Level gesture — no duplicate** — Adjust dBm floor/ceiling via
  scroll wheel or drag. Protocol log should show a single
  `C<N>|display pan set … min_dbm= max_dbm=` with no immediate duplicate.
- [ ] **VFO tuning — no burst** — Scroll VFO to trigger pan-follow.
  Level should not spam the log; at most one command per ≥ 10 FFT frames
  if the noise floor position actually needs adjusting.
- [ ] **Floor level persistence** — Adjust dBm floor, then step VFO
  outside the visible window. Floor level stays at user-set value.
- [ ] **Reconnect** — Disconnect and reconnect. All spectrum controls
  (dBm drag, bandwidth drag, spot add, TNF add) function correctly with
  no duplicate commands.
- [ ] **Multi-pan** — Level gesture on one pan does not send a command
  for the other pan.

Fixes #989

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
