### PR TITLE
Add option to inhibit system sleep while connected to radio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,14 @@ if(Qt6WebSockets_FOUND)
 else()
     message(STATUS "Qt6::WebSockets not found — FreeDV Reporter spot source disabled")
 endif()
+if(UNIX AND NOT APPLE)
+    find_package(Qt6 QUIET COMPONENTS DBus)
+    if(Qt6DBus_FOUND)
+        message(STATUS "Qt6::DBus found — sleep inhibition via D-Bus enabled")
+    else()
+        message(STATUS "Qt6::DBus not found — sleep inhibition disabled on Linux")
+    endif()
+endif()
 find_package(Qt6Keychain QUIET)
 if(Qt6Keychain_FOUND)
     message(STATUS "Qt6Keychain found — SmartLink credential persistence enabled")
@@ -430,6 +438,7 @@ set(CORE_SOURCES
     src/core/AdifParser.cpp
     src/core/DxccWorkedStatus.cpp
     src/core/DxccColorProvider.cpp
+    src/core/SleepInhibitor.cpp
 )
 
 if(APPLE)
@@ -657,6 +666,11 @@ if(Qt6Keychain_FOUND)
     target_link_libraries(AetherSDR PRIVATE Qt6Keychain::Qt6Keychain)
 endif()
 
+if(Qt6DBus_FOUND)
+    target_compile_definitions(AetherSDR PRIVATE HAVE_DBUS)
+    target_link_libraries(AetherSDR PRIVATE Qt6::DBus)
+endif()
+
 if(AETHER_GPU_SPECTRUM)
     target_compile_definitions(AetherSDR PRIVATE AETHER_GPU_SPECTRUM)
 
@@ -696,7 +710,7 @@ target_sources(AetherSDR PRIVATE
 target_include_directories(AetherSDR PRIVATE third_party/rtmidi)
 if(APPLE)
     target_compile_definitions(AetherSDR PRIVATE __MACOSX_CORE__)
-    target_link_libraries(AetherSDR PRIVATE "-framework CoreMIDI" "-framework CoreAudio" "-framework CoreFoundation")
+    target_link_libraries(AetherSDR PRIVATE "-framework CoreMIDI" "-framework CoreAudio" "-framework CoreFoundation" "-framework IOKit")
 elseif(WIN32)
     target_compile_definitions(AetherSDR PRIVATE __WINDOWS_MM__)
     target_link_libraries(AetherSDR PRIVATE winmm)

--- a/src/core/SleepInhibitor.cpp
+++ b/src/core/SleepInhibitor.cpp
@@ -1,0 +1,104 @@
+#include "SleepInhibitor.h"
+#include <QDebug>
+
+#ifdef Q_OS_MAC
+#include <IOKit/pwr_mgt/IOPMLib.h>
+#endif
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
+#if defined(Q_OS_LINUX) && defined(HAVE_DBUS)
+#include <QDBusInterface>
+#include <QDBusReply>
+#endif
+
+namespace AetherSDR {
+
+SleepInhibitor::~SleepInhibitor()
+{
+    release();
+}
+
+void SleepInhibitor::acquire(const QString& reason)
+{
+    if (m_held)
+        return;
+
+#ifdef Q_OS_MAC
+    CFStringRef cfReason = reason.toCFString();
+    IOReturn ret = IOPMAssertionCreateWithName(
+        kIOPMAssertionTypeNoIdleSleep,
+        kIOPMAssertionLevelOn,
+        cfReason,
+        &m_assertionId);
+    CFRelease(cfReason);
+    if (ret == kIOReturnSuccess) {
+        m_held = true;
+        qDebug() << "SleepInhibitor: acquired (macOS IOPMAssertion)";
+    } else {
+        qWarning() << "SleepInhibitor: IOPMAssertionCreate failed:" << ret;
+    }
+#endif
+
+#ifdef Q_OS_WIN
+    EXECUTION_STATE prev = SetThreadExecutionState(
+        ES_CONTINUOUS | ES_SYSTEM_REQUIRED);
+    if (prev != 0 || true) { // SetThreadExecutionState returns previous state, 0 only on error
+        m_held = true;
+        qDebug() << "SleepInhibitor: acquired (Windows SetThreadExecutionState)";
+    }
+#endif
+
+#if defined(Q_OS_LINUX) && defined(HAVE_DBUS)
+    QDBusInterface iface("org.freedesktop.ScreenSaver",
+                         "/org/freedesktop/ScreenSaver",
+                         "org.freedesktop.ScreenSaver");
+    if (iface.isValid()) {
+        QDBusReply<uint32_t> reply = iface.call("Inhibit", "AetherSDR", reason);
+        if (reply.isValid()) {
+            m_cookie = reply.value();
+            m_held = true;
+            qDebug() << "SleepInhibitor: acquired (D-Bus ScreenSaver.Inhibit)";
+        } else {
+            qWarning() << "SleepInhibitor: D-Bus Inhibit failed:" << reply.error().message();
+        }
+    } else {
+        qWarning() << "SleepInhibitor: D-Bus ScreenSaver interface not available";
+    }
+#endif
+
+    Q_UNUSED(reason);
+}
+
+void SleepInhibitor::release()
+{
+    if (!m_held)
+        return;
+
+#ifdef Q_OS_MAC
+    IOPMAssertionRelease(m_assertionId);
+    m_assertionId = 0;
+    qDebug() << "SleepInhibitor: released (macOS)";
+#endif
+
+#ifdef Q_OS_WIN
+    SetThreadExecutionState(ES_CONTINUOUS);
+    qDebug() << "SleepInhibitor: released (Windows)";
+#endif
+
+#if defined(Q_OS_LINUX) && defined(HAVE_DBUS)
+    QDBusInterface iface("org.freedesktop.ScreenSaver",
+                         "/org/freedesktop/ScreenSaver",
+                         "org.freedesktop.ScreenSaver");
+    if (iface.isValid())
+        iface.call("UnInhibit", m_cookie);
+    m_cookie = 0;
+    qDebug() << "SleepInhibitor: released (Linux D-Bus)";
+#endif
+
+    m_held = false;
+}
+
+} // namespace AetherSDR

--- a/src/core/SleepInhibitor.h
+++ b/src/core/SleepInhibitor.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR {
+
+// Prevents the operating system from entering idle sleep while an assertion
+// is held. Used to keep TCP/UDP/audio streams alive during radio connections.
+//
+// Platform backends:
+//   macOS:   IOPMAssertionCreateWithName (kIOPMAssertionTypeNoIdleSleep)
+//   Linux:   org.freedesktop.ScreenSaver.Inhibit via D-Bus
+//   Windows: SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED)
+class SleepInhibitor {
+public:
+    SleepInhibitor() = default;
+    ~SleepInhibitor();
+
+    // Acquire the power assertion. No-op if already held.
+    void acquire(const QString& reason = "Connected to radio");
+
+    // Release the power assertion. No-op if not held.
+    void release();
+
+    bool isHeld() const { return m_held; }
+
+private:
+    bool m_held{false};
+
+#ifdef Q_OS_MAC
+    uint32_t m_assertionId{0};
+#endif
+#if defined(Q_OS_LINUX) && defined(HAVE_DBUS)
+    uint32_t m_cookie{0};
+#endif
+};
+
+} // namespace AetherSDR

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1507,6 +1507,23 @@ QWidget* RadioSetupDialog::buildAudioTab()
         vbox->addWidget(compGroup);
     }
 
+    // ── Prevent Sleep ───────────────────────────────────────────────────
+    {
+        auto* sleepCheck = new QCheckBox("Prevent system sleep while connected");
+        sleepCheck->setStyleSheet("QCheckBox { color: #c8d8e8; font-size: 11px; }");
+        sleepCheck->setToolTip("Hold a system power assertion to prevent idle sleep\n"
+                               "while connected to a radio. Keeps TCP/UDP/audio\n"
+                               "streams alive during long sessions.");
+        sleepCheck->setChecked(
+            AppSettings::instance().value("InhibitSleepWhileConnected", "False").toString() == "True");
+        connect(sleepCheck, &QCheckBox::toggled, this, [](bool on) {
+            auto& s = AppSettings::instance();
+            s.setValue("InhibitSleepWhileConnected", on ? "True" : "False");
+            s.save();
+        });
+        vbox->addWidget(sleepCheck);
+    }
+
     // ── PC Audio Devices ────────────────────────────────────────────────
     auto* pcGroup = new QGroupBox("PC Audio Devices");
     pcGroup->setStyleSheet(kGroupStyle);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -745,6 +745,11 @@ void RadioModel::onConnected()
 {
     qCDebug(lcProtocol) << "RadioModel: connected";
     setActivePanResized(false);
+
+    // Inhibit system sleep while connected if the user has opted in (#1420)
+    if (AppSettings::instance().value("InhibitSleepWhileConnected", "False").toString() == "True")
+        m_sleepInhibitor.acquire("AetherSDR connected to radio");
+
     emit connectionStateChanged(true);
     // Delay network monitor until after client gui registration
     // (pings sent before registration cause "Malformed command" on WAN)
@@ -1169,6 +1174,9 @@ void RadioModel::restoreTuneInhibit()
 void RadioModel::onDisconnected()
 {
     qCDebug(lcProtocol) << "RadioModel: disconnected";
+
+    // Release sleep inhibition on disconnect (#1420)
+    m_sleepInhibitor.release();
 
     // Safety: restore TX outputs if we were inhibiting during tune
     if (m_tuneInhibitActive && m_tuneInhibitBandId >= 0)

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -3,6 +3,7 @@
 #include "core/RadioConnection.h"
 #include "core/WanConnection.h"
 #include "core/PanadapterStream.h"
+#include "core/SleepInhibitor.h"
 #include <QThread>
 #include "SliceModel.h"
 #include "MeterModel.h"
@@ -576,6 +577,7 @@ private:
     QMap<quint32, ClientInfo> m_clientInfoMap; // handle → full client info
     QMap<quint32, QString> m_clientStations;   // handle → station name (legacy, kept in sync)
 
+    SleepInhibitor m_sleepInhibitor;     // prevents OS idle sleep while connected
     RadioInfo m_lastInfo;               // stored for auto-reconnect
     bool      m_intentionalDisconnect{false};
     QTimer    m_reconnectTimer;


### PR DESCRIPTION
## Summary
- New SleepInhibitor class with platform-specific implementations:
  - macOS: IOPMAssertionCreateWithName
  - Windows: SetThreadExecutionState
  - Linux: org.freedesktop.ScreenSaver.Inhibit via D-Bus
- Toggle in Radio Setup → Audio: "Prevent sleep while connected"
- Acquires on connect, releases on disconnect, RAII destructor

Fixes #1420. From AetherClaude PR #1421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)