### PR TITLE
Add configurable frequency grid spacing option

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5366,6 +5366,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             sw, &SpectrumWidget::setFftHeatMap);
     connect(menu, &SpectrumOverlayMenu::showGridChanged,
             sw, &SpectrumWidget::setShowGrid);
+    connect(menu, &SpectrumOverlayMenu::freqGridSpacingChanged,
+            sw, &SpectrumWidget::setFreqGridSpacing);
     connect(menu, &SpectrumOverlayMenu::fftLineWidthChanged,
             sw, &SpectrumWidget::setFftLineWidth);
     connect(menu, &SpectrumOverlayMenu::noiseFloorPositionChanged,
@@ -5517,6 +5519,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setBackgroundOpacity(80);
         sw->setNoiseFloorEnable(false);
         sw->setNoiseFloorPosition(75);
+        sw->setFreqGridSpacing(0);  // Auto (#1390)
 
         // Radio commands for radio-authoritative display settings
         m_radioModel.sendCommand(
@@ -5554,12 +5557,13 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         s.setValue(sw->settingsKey("CursorFreqLabel"),            "False");
         s.setValue(sw->settingsKey("BackgroundImage"),            ":/bg-default.jpg");
         s.setValue(sw->settingsKey("BackgroundOpacity"),          "80");
+        s.setValue(sw->settingsKey("DisplayFreqGridSpacing"),     "0");
         s.save();
 
         // Sync all Display panel UI controls
         menu->syncDisplaySettings(0, 25, 70, false, QColor(0x00, 0xe5, 0xff),
                                   50, 15, true, 100, 75, false, true, 0);
-        menu->syncExtraDisplaySettings(false, 1.15f, 80);
+        menu->syncExtraDisplaySettings(false, 1.15f, 80, 0);
     });
 
     // ── Click-to-tune ────────────────────────────────────────────────────

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1161,6 +1161,25 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         });
     }
 
+    // ── Freq Grid Spacing dropdown (#1390) ──────────────────────────────
+    {
+        auto* lbl = new QLabel("Grid:");
+        lbl->setStyleSheet(labelStyle);
+        grid->addWidget(lbl, row, 0);
+        m_freqGridSpacingCmb = new QComboBox;
+        m_freqGridSpacingCmb->setFixedHeight(18);
+        m_freqGridSpacingCmb->setStyleSheet(comboStyleSheet());
+        m_freqGridSpacingCmb->addItem("Auto", 0);
+        for (int khz : {1, 2, 5, 10, 25, 50, 100})
+            m_freqGridSpacingCmb->addItem(QString("%1 kHz").arg(khz), khz);
+        grid->addWidget(m_freqGridSpacingCmb, row, 1, 1, 3);
+        connect(m_freqGridSpacingCmb, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this](int idx) {
+            emit freqGridSpacingChanged(m_freqGridSpacingCmb->itemData(idx).toInt());
+        });
+        ++row;
+    }
+
     // ── Scheme dropdown ───────────────────────────────────────────────────
     {
         auto* lbl = new QLabel("Scheme:");
@@ -1201,6 +1220,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     if (m_autoBlackBtn) m_autoBlackBtn->setToolTip("Automatically adjusts the waterfall black level to match the current noise floor.");
     m_rateSlider->setToolTip("Waterfall line duration. Higher values scroll faster.");
     if (m_wfBlankerThreshSlider) m_wfBlankerThreshSlider->setToolTip("Waterfall noise blanking threshold. Higher values blank more aggressively.");
+    if (m_freqGridSpacingCmb) m_freqGridSpacingCmb->setToolTip("Frequency grid line spacing. Auto adapts to the current span.");
     if (m_colorSchemeCmb) m_colorSchemeCmb->setToolTip("Selects the waterfall color palette.");
     if (m_bgOpacitySlider) m_bgOpacitySlider->setToolTip("Opacity of the background image overlay.");
     if (m_floorEnableBtn) m_floorEnableBtn->setToolTip("Shows a noise floor reference line on the spectrum display.");
@@ -1272,8 +1292,15 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
 }
 
 void SpectrumOverlayMenu::syncExtraDisplaySettings(bool blankerOn, float blankerThresh,
-                                                    int bgOpacity)
+                                                    int bgOpacity,
+                                                    int freqGridSpacingKhz)
 {
+    if (m_freqGridSpacingCmb) {
+        QSignalBlocker b(m_freqGridSpacingCmb);
+        int idx = m_freqGridSpacingCmb->findData(freqGridSpacingKhz);
+        if (idx >= 0) m_freqGridSpacingCmb->setCurrentIndex(idx);
+        else          m_freqGridSpacingCmb->setCurrentIndex(0);  // Auto
+    }
     if (m_wfBlankerBtn) {
         QSignalBlocker b(m_wfBlankerBtn);
         m_wfBlankerBtn->setChecked(blankerOn);

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -41,7 +41,8 @@ public:
                              float lineWidth = 2.0f);
     // Sync blanker/cursor/opacity controls not covered by syncDisplaySettings.
     void syncExtraDisplaySettings(bool blankerOn, float blankerThresh,
-                                  int bgOpacity);
+                                  int bgOpacity,
+                                  int freqGridSpacingKhz = 0);
 
     // Set the panadapter ID this overlay belongs to (for +RX routing).
     void setPanId(const QString& id) { m_panId = id; }
@@ -92,6 +93,7 @@ signals:
     void fftFillColorChanged(const QColor& color);
     void fftHeatMapChanged(bool on);
     void showGridChanged(bool on);
+    void freqGridSpacingChanged(int khz);
     void fftLineWidthChanged(float width);
     void wfColorGainChanged(int gain);
     void wfBlackLevelChanged(int level);
@@ -206,6 +208,7 @@ private:
     QLabel*      m_floorLabel{nullptr};
     QPushButton* m_floorEnableBtn{nullptr};
 
+    QComboBox*   m_freqGridSpacingCmb{nullptr};
     QSlider*     m_bgOpacitySlider{nullptr};
     QLabel*      m_bgOpacityLabel{nullptr};
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -251,6 +251,7 @@ void SpectrumWidget::loadSettings()
     }
     m_fftHeatMap     = s.value(settingsKey("DisplayFftHeatMap"), "True").toString() == "True";
     m_showGrid       = s.value(settingsKey("DisplayShowGrid"), "True").toString() == "True";
+    m_freqGridSpacingKhz = s.value(settingsKey("DisplayFreqGridSpacing"), "0").toInt();
     m_fftLineWidth   = s.value(settingsKey("DisplayFftLineWidth"), "2.0").toFloat();
     m_wfColorScheme  = static_cast<WfColorScheme>(
         std::clamp(s.value(settingsKey("DisplayWfColorScheme"), "0").toInt(),
@@ -265,12 +266,15 @@ void SpectrumWidget::loadSettings()
     m_bgOpacity = s.value(settingsKey("BackgroundOpacity"), "80").toInt();
 
     // Sync overlay menu sliders with restored settings
-    if (m_overlayMenu)
+    if (m_overlayMenu) {
         m_overlayMenu->syncDisplaySettings(m_fftAverage, m_fftFps,
             static_cast<int>(m_fftFillAlpha * 100), m_fftWeightedAvg, m_fftFillColor,
             m_wfColorGain, m_wfBlackLevel, m_wfAutoBlack, m_wfLineDuration,
             75, false, m_fftHeatMap, static_cast<int>(m_wfColorScheme), m_showGrid,
             m_fftLineWidth);
+        m_overlayMenu->syncExtraDisplaySettings(m_wfBlankerEnabled,
+            m_wfBlankerThreshold, m_bgOpacity, m_freqGridSpacingKhz);
+    }
 }
 
 VfoWidget* SpectrumWidget::addVfoWidget(int sliceId)
@@ -340,6 +344,13 @@ void SpectrumWidget::setShowGrid(bool on) {
     m_showGrid = on;
     auto& s = AppSettings::instance();
     s.setValue(settingsKey("DisplayShowGrid"), on ? "True" : "False");
+    s.save();
+    markOverlayDirty();
+}
+void SpectrumWidget::setFreqGridSpacing(int khz) {
+    m_freqGridSpacingKhz = khz;
+    auto& s = AppSettings::instance();
+    s.setValue(settingsKey("DisplayFreqGridSpacing"), QString::number(khz));
     s.save();
     markOverlayDirty();
 }
@@ -3233,6 +3244,45 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
 
 // ─── Grid ─────────────────────────────────────────────────────────────────────
 
+// Compute the effective frequency grid step in MHz, honouring user override (#1390).
+// When m_freqGridSpacingKhz is 0 (Auto), uses the 1-2-5 sequence for ~5 grid lines.
+// When a manual value is set, clamps up to the next valid option if labels would overlap.
+double SpectrumWidget::effectiveGridStepMhz(int widgetWidth) const
+{
+    // 1-2-5 auto algorithm
+    auto autoStep = [&]() {
+        const double rawStep = m_bandwidthMhz / 5.0;
+        const double mag = std::pow(10.0, std::floor(std::log10(rawStep)));
+        const double norm = rawStep / mag;
+        if      (norm >= 5.0) return 5.0 * mag;
+        else if (norm >= 2.0) return 2.0 * mag;
+        else                  return 1.0 * mag;
+    };
+
+    if (m_freqGridSpacingKhz <= 0)
+        return autoStep();
+
+    // Manual spacing — check that labels won't overlap (~60px minimum per label)
+    static const int validKhz[] = { 1, 2, 5, 10, 25, 50, 100 };
+    const double minStepMhz = (widgetWidth > 0)
+        ? m_bandwidthMhz / (widgetWidth / 60.0)
+        : 0.0;
+
+    // Start from the user's chosen value; clamp up if too dense
+    double manualMhz = m_freqGridSpacingKhz * 0.001;
+    if (manualMhz >= minStepMhz)
+        return manualMhz;
+
+    // Find the smallest valid option that fits
+    for (int khz : validKhz) {
+        double mhz = khz * 0.001;
+        if (mhz >= minStepMhz && mhz > manualMhz)
+            return mhz;
+    }
+    // All manual options too dense — fall back to auto
+    return autoStep();
+}
+
 void SpectrumWidget::drawGrid(QPainter& p, const QRect& r)
 {
     if (!m_showGrid) return;
@@ -3256,16 +3306,10 @@ void SpectrumWidget::drawGrid(QPainter& p, const QRect& r)
         p.drawLine(0, y, w, y);
     }
 
-    // Vertical frequency grid lines — adaptive step matching the scale bar
+    // Vertical frequency grid lines (#1390: honour user spacing override)
     const double startMhz = m_centerMhz - m_bandwidthMhz / 2.0;
     const double endMhz   = m_centerMhz + m_bandwidthMhz / 2.0;
-    const double rawStep  = m_bandwidthMhz / 5.0;
-    const double gridMag  = std::pow(10.0, std::floor(std::log10(rawStep)));
-    const double gridNorm = rawStep / gridMag;
-    double gridStep;
-    if      (gridNorm >= 5.0) gridStep = 5.0 * gridMag;
-    else if (gridNorm >= 2.0) gridStep = 2.0 * gridMag;
-    else                      gridStep = 1.0 * gridMag;
+    const double gridStep = effectiveGridStepMhz(w);
     const double firstLine = std::ceil(startMhz / gridStep) * gridStep;
 
     p.setPen(QPen(QColor(0x20, 0x30, 0x40), 1, Qt::DotLine));
@@ -3876,15 +3920,8 @@ void SpectrumWidget::drawFreqScale(QPainter& p, const QRect& r)
     const double startMhz = m_centerMhz - m_bandwidthMhz / 2.0;
     const double endMhz   = m_centerMhz + m_bandwidthMhz / 2.0;
 
-    // Pick a step using 1-2-5 sequence to give ~5-10 labels at any zoom level.
-    double rawStep = m_bandwidthMhz / 5.0;
-    const double mag = std::pow(10.0, std::floor(std::log10(rawStep)));
-    const double norm = rawStep / mag;
-    double stepMhz;
-    if      (norm >= 5.0) stepMhz = 5.0 * mag;
-    else if (norm >= 2.0) stepMhz = 2.0 * mag;
-    else                  stepMhz = 1.0 * mag;
-
+    // Grid step — honours user spacing override (#1390)
+    const double stepMhz = effectiveGridStepMhz(width());
     const double firstLine = std::ceil(startMhz / stepMhz) * stepMhz;
 
     QFont f = p.font();

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -196,11 +196,13 @@ public:
     void setFftFillColor(const QColor& c);
     void setFftHeatMap(bool on);
     void setShowGrid(bool on);
+    void setFreqGridSpacing(int khz);
     void setFftLineWidth(float w);
     float fftFillAlpha() const         { return m_fftFillAlpha; }
     QColor fftFillColor() const        { return m_fftFillColor; }
     bool fftHeatMap() const            { return m_fftHeatMap; }
     bool showGrid() const              { return m_showGrid; }
+    int  freqGridSpacing() const       { return m_freqGridSpacingKhz; }
     float fftLineWidth() const         { return m_fftLineWidth; }
     int   fftAverage() const           { return m_fftAverage; }
     int   fftFps() const               { return m_fftFps; }
@@ -361,6 +363,7 @@ public:
     void showAddSpotDialog(double freqMhz);
 
 private:
+    double effectiveGridStepMhz(int widgetWidth) const;
     void drawGrid(QPainter& p, const QRect& r);
     void drawSpectrum(QPainter& p, const QRect& r);
     void drawSliceMarkers(QPainter& p, const QRect& specRect, const QRect& wfRect);
@@ -431,6 +434,7 @@ private:
     QColor m_fftFillColor{0x00, 0xe5, 0xff};  // client-side fill color (default cyan)
     bool m_fftHeatMap{true};        // true = intensity heat map, false = solid color
     bool m_showGrid{true};          // false = hide grid lines
+    int  m_freqGridSpacingKhz{0};   // 0=Auto, or 1/2/5/10/25/50/100 kHz (#1390)
     float m_fftLineWidth{2.0f};     // spectrum trace width in pixels
 
     // ── Waterfall display controls (radio-side via "display panafall set") ─


### PR DESCRIPTION
## Summary
- Add Grid dropdown to Display panel: Auto, 1/2/5/10/25/50/100 kHz
- Centralize step calculation in effectiveGridStepMhz() (deduplicates grid + scale bar)
- Manual mode clamps to prevent label overlap
- Persisted per-pan via AppSettings

Fixes #1390. From AetherClaude PR #1391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)