### PR TITLE
Fix SIGSEGV in SpectrumOverlayMenu::setSlice on band change with 2 pans

### DIFF
--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -4,6 +4,7 @@
 #include <QVector>
 #include <QStringList>
 #include <QPoint>
+#include <QPointer>
 #include <QWheelEvent>
 #include <QMouseEvent>
 
@@ -210,7 +211,7 @@ private:
     QLabel*      m_bgOpacityLabel{nullptr};
 
     QStringList  m_antList;
-    SliceModel*  m_slice{nullptr};
+    QPointer<SliceModel> m_slice;
     bool         m_updatingFromModel{false};
 };
 


### PR DESCRIPTION
Crash reproduced by: open two panadapters, tune on Slice A, use the Band
button to switch Slice A to 40 m, then return focus to Slice A.

## Root cause

`SpectrumOverlayMenu` stored the previous slice as a raw `SliceModel*
m_slice`. When a band change destroyed the slice model, `setActiveSlice`
triggered `setSlice()` which called `m_slice->disconnect(this)` on the
now-dangling pointer → SIGSEGV (access violation in Qt6Core on Windows,
SIGSEGV on Linux).

## Fix

Changed `SliceModel* m_slice{nullptr}` to `QPointer<SliceModel> m_slice`
in `SpectrumOverlayMenu.h`. `QPointer` is a Qt weak observer that
auto-nulls when the tracked `QObject` is destroyed, so the existing
`if (m_slice)` guard on line 364 of `SpectrumOverlayMenu.cpp` correctly
short-circuits before calling `disconnect()` on a dead object. No changes
required in the `.cpp` implementation.

## Files changed

| File | Change |
|---|---|
| `src/gui/SpectrumOverlayMenu.h` | Add `#include <QPointer>`; change `SliceModel* m_slice{nullptr}` to `QPointer<SliceModel> m_slice` |

Co-Authored-By: Claude Sonnet 4.6 & CJ WT2P

Tested on Windows and Linux.