### PR TITLE
Fix SIGSEGV in SpectrumOverlayMenu::setSlice on band change with 2 pans

### DIFF
--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -4,6 +4,7 @@
 #include <QVector>
 #include <QStringList>
 #include <QPoint>
+#include <QPointer>
 #include <QWheelEvent>
 #include <QMouseEvent>
 
@@ -213,7 +214,7 @@ private:
     QLabel*      m_bgOpacityLabel{nullptr};
 
     QStringList  m_antList;
-    SliceModel*  m_slice{nullptr};
+    QPointer<SliceModel> m_slice;
     bool         m_updatingFromModel{false};
 };
 


### PR DESCRIPTION
## Summary
- Replace raw SliceModel* with QPointer<SliceModel> in SpectrumOverlayMenu
- Prevents dangling pointer crash when band change destroys a slice model

Based on work by @chibondking in #1429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)