### PR TITLE
[memory] Add searchable memory dialog navigation and arrow controls

### DIFF
--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -9,12 +9,14 @@
 #include <QHBoxLayout>
 #include <QPushButton>
 #include <QComboBox>
+#include <QLineEdit>
 #include <QLabel>
 #include <QHeaderView>
 #include <QDebug>
 #include <QPointer>
 #include <QTimer>
 #include <QCloseEvent>
+#include <QKeyEvent>
 
 namespace AetherSDR {
 
@@ -149,15 +151,26 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
 
     auto* root = new QVBoxLayout(this);
 
-    // ── Profile filter ───────────────────────────────────────────────────
+    // ── Search + profile filter ──────────────────────────────────────────
     auto* filterRow = new QHBoxLayout;
-    filterRow->addWidget(new QLabel("Filter by Profile:"));
+    filterRow->addWidget(new QLabel("Search:"));
+    m_searchEdit = new QLineEdit;
+    m_searchEdit->setPlaceholderText("Type a memory name and press Enter");
+    m_searchEdit->setClearButtonEnabled(true);
+    m_searchEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    m_searchEdit->installEventFilter(this);
+    filterRow->addWidget(m_searchEdit, 1);
+    filterRow->addWidget(new QLabel("Profile:"));
     m_filterCombo = new QComboBox;
-    m_filterCombo->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    m_filterCombo->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     rebuildFilterCombo();
     filterRow->addWidget(m_filterCombo);
     root->addLayout(filterRow);
 
+    connect(m_searchEdit, &QLineEdit::textChanged,
+            this, [this](const QString&) { populateTable(); });
+    connect(m_searchEdit, &QLineEdit::returnPressed,
+            this, [this]() { activateMemoryRow(m_table->currentRow()); });
     connect(m_filterCombo, &QComboBox::currentIndexChanged,
             this, [this](int) { populateTable(); });
 
@@ -171,6 +184,7 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     m_table->verticalHeader()->setVisible(false);
     m_table->setAlternatingRowColors(true);
     m_table->setSortingEnabled(false);
+    m_table->installEventFilter(this);
     m_table->setStyleSheet(
         "QTableWidget { alternate-background-color: #1a1a2e; }"
         "QTableWidget::item:selected { background: #2060a0; }");
@@ -232,6 +246,8 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     connect(m_table, &QTableWidget::cellChanged, this, [this](int row, int col) {
         submitCellEdit(row, col);
     });
+    connect(m_table, &QTableWidget::cellDoubleClicked,
+            this, [this](int row, int) { activateMemoryRow(row); });
 
     // The radio doesn't support "sub memory all" or "memory list".
     // Populate from RadioModel cache (filled from status pushes during connect).
@@ -246,13 +262,79 @@ void MemoryDialog::closeEvent(QCloseEvent* event)
     QDialog::closeEvent(event);
 }
 
+bool MemoryDialog::eventFilter(QObject* watched, QEvent* event)
+{
+    if (event->type() == QEvent::KeyPress) {
+        auto* keyEvent = static_cast<QKeyEvent*>(event);
+        const int key = keyEvent->key();
+
+        if (watched == m_searchEdit) {
+            if (key == Qt::Key_Up || key == Qt::Key_Down) {
+                const int rowCount = m_table ? m_table->rowCount() : 0;
+                if (rowCount <= 0)
+                    return true;
+
+                const int currentRow = qMax(0, m_table->currentRow());
+                const int nextRow = (key == Qt::Key_Down)
+                    ? qMin(currentRow + 1, rowCount - 1)
+                    : qMax(currentRow - 1, 0);
+                m_table->selectRow(nextRow);
+                m_table->setCurrentCell(nextRow, 0);
+                return true;
+            }
+            if (key == Qt::Key_Return || key == Qt::Key_Enter) {
+                activateMemoryRow(m_table ? m_table->currentRow() : -1);
+                return true;
+            }
+        }
+
+        if (watched == m_table && (key == Qt::Key_Return || key == Qt::Key_Enter)) {
+            activateMemoryRow(m_table ? m_table->currentRow() : -1);
+            return true;
+        }
+    }
+
+    return QDialog::eventFilter(watched, event);
+}
+
+void MemoryDialog::showEvent(QShowEvent* event)
+{
+    QDialog::showEvent(event);
+    if (m_searchEdit)
+        m_searchEdit->setFocus(Qt::OtherFocusReason);
+}
+
+void MemoryDialog::activateMemoryRow(int row)
+{
+    if (row < 0)
+        return;
+
+    auto* indexItem = m_table->item(row, 0);
+    if (!indexItem)
+        return;
+
+    const int idx = indexItem->data(Qt::UserRole).toInt();
+    const auto memoryIt = m_model->memories().constFind(idx);
+    if (memoryIt == m_model->memories().constEnd())
+        return;
+
+    m_table->setCurrentCell(row, 0);
+    m_model->sendCommand(QString("memory apply %1").arg(idx));
+    m_model->setPanCenter(memoryIt->freq);
+}
+
 void MemoryDialog::populateTable()
 {
     const QSignalBlocker blocker(m_table);
+    const int currentMemoryIndex = (m_table->currentRow() >= 0 && m_table->item(m_table->currentRow(), 0))
+        ? m_table->item(m_table->currentRow(), 0)->data(Qt::UserRole).toInt()
+        : -1;
     m_table->setSortingEnabled(false);
     m_table->setRowCount(0);
     const auto& memories = m_model->memories();
     const QString filterProfile = m_filterCombo->currentData().toString();
+    const QString nameFilter = m_searchEdit ? m_searchEdit->text().trimmed() : QString();
+    bool hasRows = false;
 
     for (auto it = memories.begin(); it != memories.end(); ++it) {
         const auto& m = it.value();
@@ -261,8 +343,12 @@ void MemoryDialog::populateTable()
         if (!filterProfile.isEmpty() && m.group != filterProfile) {
             continue;
         }
+        if (!nameFilter.isEmpty() && !m.name.contains(nameFilter, Qt::CaseInsensitive)) {
+            continue;
+        }
         int row = m_table->rowCount();
         m_table->insertRow(row);
+        hasRows = true;
 
         int col = 0;
         m_table->setItem(row, col++, new QTableWidgetItem(m.group));
@@ -323,6 +409,21 @@ void MemoryDialog::populateTable()
         m_table->sortItems(m_sortColumn, m_sortOrder);
     }
     m_table->setSortingEnabled(true);
+
+    if (hasRows) {
+        int selectedRow = 0;
+        if (currentMemoryIndex >= 0) {
+            for (int row = 0; row < m_table->rowCount(); ++row) {
+                auto* item = m_table->item(row, 0);
+                if (item && item->data(Qt::UserRole).toInt() == currentMemoryIndex) {
+                    selectedRow = row;
+                    break;
+                }
+            }
+        }
+        m_table->selectRow(selectedRow);
+        m_table->setCurrentCell(selectedRow, 0);
+    }
 }
 
 bool MemoryDialog::isSortableColumn(int column) const
@@ -460,10 +561,7 @@ void MemoryDialog::onAdd()
 
 void MemoryDialog::onSelect()
 {
-    const int row = m_table->currentRow();
-    if (row < 0) return;
-    const int idx = m_table->item(row, 0)->data(Qt::UserRole).toInt();
-    m_model->sendCommand(QString("memory apply %1").arg(idx));
+    activateMemoryRow(m_table->currentRow());
 }
 
 void MemoryDialog::onRemove()

--- a/src/gui/MemoryDialog.h
+++ b/src/gui/MemoryDialog.h
@@ -2,10 +2,13 @@
 
 #include <QDialog>
 #include <QCloseEvent>
+#include <QEvent>
+#include <QShowEvent>
 #include <QTableWidget>
 #include <QMap>
 
 class QComboBox;
+class QLineEdit;
 
 namespace AetherSDR {
 
@@ -19,8 +22,11 @@ public:
 
 protected:
     void closeEvent(QCloseEvent* event) override;
+    bool eventFilter(QObject* watched, QEvent* event) override;
+    void showEvent(QShowEvent* event) override;
 
 private:
+    void activateMemoryRow(int row);
     void populateTable();
     void submitCellEdit(int row, int col);
     void onAdd();
@@ -31,6 +37,7 @@ private:
 
     RadioModel* m_model;
     QTableWidget* m_table;
+    QLineEdit* m_searchEdit;
     QComboBox* m_filterCombo;
     int m_sortColumn{2};
     Qt::SortOrder m_sortOrder{Qt::AscendingOrder};


### PR DESCRIPTION
## Summary
- Add a memory-name search field at the top of the Memory Channels dialog and keep the profile filter to its right
- Filter the memory table character-by-character, keep a visible row highlighted, and make the search field the default focus
- Let Up/Down move through filtered results and have Enter apply the highlighted memory and recenter the pan
- Use keyboard shortcut '/' followed by memory name for instant tuning.

## Validation
- cmake --build build -j10

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.4 Pro) and tested by @jensenpat