### PR TITLE
Fix RF Gain slider wiring and keyboard shortcut yield for all sliders

### DIFF
--- a/src/core/ShortcutManager.cpp
+++ b/src/core/ShortcutManager.cpp
@@ -138,6 +138,12 @@ void ShortcutManager::rebuildShortcuts(QWidget* parent,
     }
 }
 
+void ShortcutManager::setShortcutsEnabled(bool enabled)
+{
+    for (auto* sc : m_shortcuts)
+        sc->setEnabled(enabled);
+}
+
 ShortcutManager::Action* ShortcutManager::action(const QString& id)
 {
     for (auto& a : m_actions) {

--- a/src/core/ShortcutManager.h
+++ b/src/core/ShortcutManager.h
@@ -44,6 +44,11 @@ public:
     void rebuildShortcuts(QWidget* parent,
                           std::function<bool()> guardFn = nullptr);
 
+    // Enable or disable all active QShortcut objects. Used to yield key
+    // events to focused child widgets (e.g. sliders) that would otherwise
+    // have their arrow keys stolen by window-level shortcuts.
+    void setShortcutsEnabled(bool enabled);
+
     // Query
     const QVector<Action>& actions() const { return m_actions; }
     Action* action(const QString& id);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -245,7 +245,7 @@ static bool isTextInputFocused()
     if (!w) return false;
     return qobject_cast<QLineEdit*>(w) || qobject_cast<QTextEdit*>(w)
         || qobject_cast<QPlainTextEdit*>(w) || qobject_cast<QSpinBox*>(w)
-        || qobject_cast<QComboBox*>(w);
+        || qobject_cast<QComboBox*>(w) || qobject_cast<QAbstractSlider*>(w);
 }
 
 static bool shortcutGuard() {
@@ -2262,6 +2262,24 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
                 }
             }
             return true;  // always consume Space to prevent button activation
+        }
+
+        // Arrow keys on focused sliders: intercept here (before QShortcut processing)
+        // so the slider's singleStep/pageStep movement isn't stolen by frequency-tune
+        // shortcuts. The application event filter runs before Qt's shortcut map.
+        if (event->type() == QEvent::KeyPress) {
+            auto* slider = qobject_cast<QAbstractSlider*>(QApplication::focusWidget());
+            if (slider) {
+                int k = ke->key();
+                if (k == Qt::Key_Left || k == Qt::Key_Right
+                    || k == Qt::Key_Up || k == Qt::Key_Down) {
+                    bool increase = (k == Qt::Key_Right || k == Qt::Key_Up);
+                    int step = (ke->modifiers() & Qt::ControlModifier)
+                                   ? slider->pageStep() : slider->singleStep();
+                    slider->setValue(slider->value() + (increase ? step : -step));
+                    return true;
+                }
+            }
         }
     }
 
@@ -6683,6 +6701,16 @@ void MainWindow::registerShortcutActions()
     m_shortcutManager.loadBindings();
     s_keyboardShortcutsEnabled = m_keyboardShortcutsEnabled;
     m_shortcutManager.rebuildShortcuts(this, shortcutGuard);
+
+    // Disable all QShortcuts while a slider has keyboard focus so arrow keys
+    // (and other slider keys) reach the slider instead of being consumed by
+    // window-level shortcuts (e.g. frequency tune left/right). Qt processes
+    // shortcuts before dispatching key events to focused widgets.
+    connect(qApp, &QApplication::focusChanged, this,
+            [this](QWidget* /*old*/, QWidget* now) {
+        m_shortcutManager.setShortcutsEnabled(
+            !qobject_cast<QAbstractSlider*>(now));
+    });
 }
 
 void MainWindow::showNr2ParamPopup(const QPoint& globalPos)

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -303,8 +303,11 @@ void SpectrumOverlayMenu::buildAntPanel()
             m_rfGainSlider->setValue(snapped);
         }
         m_rfGainLabel->setText(QString("%1 dB").arg(snapped));
-        if (!m_updatingFromModel)
+        if (!m_updatingFromModel) {
             emit rfGainChanged(snapped);
+            if (m_slice)
+                m_slice->setRfGain(static_cast<float>(snapped));
+        }
     });
 
     // WNB row: toggle button + level slider
@@ -369,6 +372,14 @@ void SpectrumOverlayMenu::setSlice(SliceModel* slice)
     connect(m_slice, &SliceModel::rxAntennaChanged, this, [this](const QString& ant) {
         m_updatingFromModel = true;
         m_rxAntCmb->setCurrentText(ant);
+        m_updatingFromModel = false;
+    });
+
+    connect(m_slice, &SliceModel::rfGainChanged, this, [this](float gain) {
+        m_updatingFromModel = true;
+        QSignalBlocker sb(m_rfGainSlider);
+        m_rfGainSlider->setValue(static_cast<int>(gain));
+        m_rfGainLabel->setText(QString("%1 dB").arg(static_cast<int>(gain)));
         m_updatingFromModel = false;
     });
 
@@ -532,6 +543,11 @@ void SpectrumOverlayMenu::syncAntPanel()
     if (!m_slice) return;
     m_updatingFromModel = true;
     m_rxAntCmb->setCurrentText(m_slice->rxAntenna());
+    {
+        QSignalBlocker sb(m_rfGainSlider);
+        m_rfGainSlider->setValue(static_cast<int>(m_slice->rfGain()));
+    }
+    m_rfGainLabel->setText(QString("%1 dB").arg(static_cast<int>(m_slice->rfGain())));
     m_updatingFromModel = false;
 }
 

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -414,7 +414,7 @@ void SliceModel::setAudioGain(float gain)
 void SliceModel::setRfGain(float gain)
 {
     m_rfGain = gain;
-    sendCommand(QString("slice set %1 rf_gain=%2").arg(m_id).arg(static_cast<int>(gain)));
+    sendCommand(QString("slice set %1 rfgain=%2").arg(m_id).arg(static_cast<int>(gain)));
 }
 
 void SliceModel::setAudioMute(bool mute)
@@ -547,8 +547,8 @@ void SliceModel::applyStatus(const QMap<QString, QString>& kvs)
             emit txSliceChanged(tx);
         }
     }
-    if (kvs.contains("rf_gain")) {
-        float g = kvs["rf_gain"].toFloat();
+    if (kvs.contains("rfgain")) {
+        float g = kvs["rfgain"].toFloat();
         if (m_rfGain != g) { m_rfGain = g; emit rfGainChanged(g); }
     }
     if (kvs.contains("audio_level")) {


### PR DESCRIPTION
## Summary

- **RF Gain key name**: `rf_gain` → `rfgain` in `SliceModel` command and status parser. Firmware v1.4.0.0 uses `rfgain` (no underscore); the old key was silently ignored.
- **Direct slice command**: Slider now sends `slice set <id> rfgain=<val>` directly. Previously only the pan-level `display pan set rfgain=` fired (works on FLEX-8600/v1.4.0.0 as a side effect, but is incorrect per protocol).
- **Model→UI sync**: Added `SliceModel::rfGainChanged` → slider connection in `setSlice()` so radio-initiated gain changes reflect in the UI. Added initial sync in `syncAntPanel()` so the slider shows the correct value on first open.
- **Arrow keys on sliders (global)**: Qt's `QShortcut` objects with `Qt::WindowShortcut` context consume key events before they reach the focused widget. Arrow-key frequency-tune shortcuts were stealing `Key_Left`/`Key_Right` from any focused `QSlider`. Added `ShortcutManager::setShortcutsEnabled()` and a `QApplication::focusChanged` connection in `MainWindow` to disable all shortcuts while a `QAbstractSlider` holds focus. Fixes RF Gain, AF Gain, squelch, NR, EQ, and all other `GuardedSlider` instances globally.

## Test results

| # | Test | Result |
|---|------|--------|
| 1 | Drag slider — `slice set rfgain=` and `display pan set rfgain=` both accepted (`R\|0\|`) | Pass |
| 2 | Radio status echo updates slider position | Pass |
| 3 | dB label updates with slider | Pass |
| 4 | No new feedback loop introduced | Pass — pre-existing ~33ms echo loop present before these changes; root cause in `PanadapterModel::setPreamp()` emitting stale rfGain before `applyPanStatus` updates `m_rfGain`; separate issue/PR planned |
| 5 | Slice A and B gain consistent | Pass on FLEX-8400 (single SCU — both slices share one hardware gain, expected). **Multi-SCU radios (e.g. FLEX-6700) not tested** — independent per-slice gains expected to work via the `slice set rfgain=` path but unverified. |
| 6 | Click slider, arrow keys step gain | Pass — fixed by the shortcut yield change; works globally on all sliders |

## Notes

The `display pan set rfgain=` command still fires via `MainWindow` in addition to the new `slice set rfgain=` command. This is redundant but harmless; removing it is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)