### PR TITLE
[memory] Improve memory dialog navigation, bulk selection, and editing flow

### DIFF
--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -21,7 +21,6 @@
 #include <QItemSelectionModel>
 #include <QDebug>
 #include <QMessageBox>
-#include <QMouseEvent>
 #include <QPointer>
 #include <QShortcut>
 #include <QSaveFile>
@@ -178,9 +177,9 @@ QList<MemoryCsvRecord> currentExportRecords(const QMap<int, MemoryEntry>& memori
 QString selectionHintText()
 {
 #if defined(Q_OS_MACOS)
-    return "Tip: Double-click tunes. Command-click adds or removes rows from the selection.";
+    return "Tip: Double-click tunes. Shift-click selects a range. Command-click adds or removes rows.";
 #else
-    return "Tip: Double-click tunes. Shift-click or Ctrl-click selects multiple rows.";
+    return "Tip: Double-click tunes. Shift-click selects a range. Ctrl-click adds or removes rows.";
 #endif
 }
 
@@ -373,27 +372,6 @@ void MemoryDialog::keyPressEvent(QKeyEvent* event)
 
 bool MemoryDialog::eventFilter(QObject* watched, QEvent* event)
 {
-    if (m_table && watched == m_table->viewport() && event->type() == QEvent::MouseButtonPress) {
-#if !defined(Q_OS_MACOS)
-        auto* mouseEvent = static_cast<QMouseEvent*>(event);
-        if (mouseEvent->button() == Qt::LeftButton
-            && (mouseEvent->modifiers() & Qt::ShiftModifier)) {
-            const QModelIndex index = m_table->indexAt(mouseEvent->position().toPoint());
-            if (index.isValid()) {
-                auto* selectionModel = m_table->selectionModel();
-                const bool wasSelected = selectionModel->isRowSelected(index.row(), QModelIndex());
-                const QModelIndex firstColumn = m_table->model()->index(index.row(), 0);
-                selectionModel->select(firstColumn, (wasSelected
-                    ? QItemSelectionModel::Deselect
-                    : QItemSelectionModel::Select) | QItemSelectionModel::Rows);
-                m_table->setCurrentCell(index.row(), 0, QItemSelectionModel::NoUpdate);
-                updateSelectionActions();
-                return true;
-            }
-        }
-#endif
-    }
-
     if (event->type() == QEvent::KeyPress) {
         auto* keyEvent = static_cast<QKeyEvent*>(event);
         const int key = keyEvent->key();

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -18,13 +18,18 @@
 #include <QLineEdit>
 #include <QLabel>
 #include <QHeaderView>
+#include <QItemSelectionModel>
 #include <QDebug>
 #include <QMessageBox>
+#include <QMouseEvent>
 #include <QPointer>
+#include <QShortcut>
 #include <QSaveFile>
+#include <QSharedPointer>
 #include <QTimer>
 #include <QCloseEvent>
 #include <QKeyEvent>
+#include <QtGlobal>
 
 namespace AetherSDR {
 
@@ -170,6 +175,23 @@ QList<MemoryCsvRecord> currentExportRecords(const QMap<int, MemoryEntry>& memori
     return records;
 }
 
+QString selectionHintText()
+{
+#if defined(Q_OS_MACOS)
+    return "Tip: Double-click tunes. Command-click adds or removes rows from the selection.";
+#else
+    return "Tip: Double-click tunes. Shift-click or Ctrl-click selects multiple rows.";
+#endif
+}
+
+QString describeMemory(const MemoryEntry& memory)
+{
+    const QString label = memory.name.trimmed().isEmpty()
+        ? QString("Memory %1").arg(memory.index)
+        : memory.name.trimmed();
+    return QString("%1 (%2 MHz)").arg(label, QString::number(memory.freq, 'f', 6));
+}
+
 } // namespace
 
 static const QStringList COLUMNS = {
@@ -206,7 +228,7 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     connect(m_searchEdit, &QLineEdit::textChanged,
             this, [this](const QString&) { populateTable(); });
     connect(m_searchEdit, &QLineEdit::returnPressed,
-            this, [this]() { activateMemoryRow(m_table->currentRow()); });
+            this, [this]() { activateMemoryRow(m_table ? m_table->currentRow() : -1); });
     connect(m_filterCombo, &QComboBox::currentIndexChanged,
             this, [this](int) { populateTable(); });
 
@@ -214,13 +236,14 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     m_table = new QTableWidget(0, COLUMNS.size());
     m_table->setHorizontalHeaderLabels(COLUMNS);
     m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
-    m_table->setSelectionMode(QAbstractItemView::SingleSelection);
-    m_table->setEditTriggers(QAbstractItemView::DoubleClicked);
+    m_table->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
     m_table->horizontalHeader()->setStretchLastSection(true);
     m_table->verticalHeader()->setVisible(false);
     m_table->setAlternatingRowColors(true);
     m_table->setSortingEnabled(false);
     m_table->installEventFilter(this);
+    m_table->viewport()->installEventFilter(this);
     m_table->setStyleSheet(
         "QTableWidget { alternate-background-color: #1a1a2e; }"
         "QTableWidget::item:selected { background: #2060a0; }");
@@ -242,24 +265,56 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
         m_table->sortItems(m_sortColumn, m_sortOrder);
     });
     root->addWidget(m_table);
+    root->addWidget(new QLabel(selectionHintText()));
 
     // ── Buttons ───────────────────────────────────────────────────────────
     auto* btnRow = new QHBoxLayout;
     auto* exportBtn = new QPushButton("Export...");
     auto* addBtn = new QPushButton("Add");
-    auto* selectBtn = new QPushButton("Select");
-    auto* removeBtn = new QPushButton("Remove");
+    m_selectionLabel = new QLabel("0 selected");
+    m_editBtn = new QPushButton("Edit");
+    m_selectBtn = new QPushButton("Tune");
+    m_selectAllBtn = new QPushButton("Select All");
+    m_removeBtn = new QPushButton("Remove");
     btnRow->addWidget(addBtn);
-    btnRow->addWidget(selectBtn);
+    btnRow->addWidget(m_editBtn);
+    btnRow->addWidget(m_selectBtn);
+    btnRow->addWidget(m_selectAllBtn);
     btnRow->addWidget(exportBtn);
     btnRow->addStretch();
-    btnRow->addWidget(removeBtn);
+    btnRow->addWidget(m_selectionLabel);
+    btnRow->addWidget(m_removeBtn);
     root->addLayout(btnRow);
+
+    for (QPushButton* button : {addBtn, m_editBtn, m_selectBtn, m_selectAllBtn, exportBtn, m_removeBtn}) {
+        button->setAutoDefault(false);
+        button->setDefault(false);
+    }
 
     connect(exportBtn, &QPushButton::clicked, this, &MemoryDialog::onExport);
     connect(addBtn, &QPushButton::clicked, this, &MemoryDialog::onAdd);
-    connect(selectBtn, &QPushButton::clicked, this, &MemoryDialog::onSelect);
-    connect(removeBtn, &QPushButton::clicked, this, &MemoryDialog::onRemove);
+    connect(m_editBtn, &QPushButton::clicked, this, &MemoryDialog::onEdit);
+    connect(m_selectBtn, &QPushButton::clicked, this, &MemoryDialog::onSelect);
+    connect(m_selectAllBtn, &QPushButton::clicked, this, &MemoryDialog::onSelectAll);
+    connect(m_removeBtn, &QPushButton::clicked, this, &MemoryDialog::onRemove);
+    connect(m_table, &QTableWidget::cellDoubleClicked,
+            this, [this](int row, int) { activateMemoryRow(row); });
+    connect(m_table->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, &MemoryDialog::updateSelectionActions);
+    connect(m_table->selectionModel(), &QItemSelectionModel::currentRowChanged,
+            this, [this](const QModelIndex&, const QModelIndex&) {
+        updateSelectionActions();
+    });
+    new QShortcut(QKeySequence::Find, this, [this]() {
+        if (!m_searchEdit)
+            return;
+        m_searchEdit->setFocus(Qt::ShortcutFocusReason);
+        m_searchEdit->selectAll();
+    });
+    new QShortcut(QKeySequence::New, this, [this]() { onAdd(); });
+    new QShortcut(QKeySequence(Qt::Key_F2), this, [this]() { onEdit(); });
+    new QShortcut(QKeySequence(QStringLiteral("Ctrl+E")), this, [this]() { onEdit(); });
+    new QShortcut(QKeySequence(QStringLiteral("Ctrl+Shift+A")), this, [this]() { onSelectAll(); });
 
     // Rebuild filter combo when profile lists change
     connect(model, &RadioModel::globalProfilesChanged,
@@ -285,8 +340,8 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     connect(m_table, &QTableWidget::cellChanged, this, [this](int row, int col) {
         submitCellEdit(row, col);
     });
-    // Note: double-click starts inline cell editing (DoubleClicked edit trigger).
-    // Memory apply uses Enter key or the Select button — not double-click.
+    // Double-click tunes to the selected memory.
+    // Editing is explicit via the Edit button to avoid accidental cell mutations.
 
     // The radio doesn't support "sub memory all" or "memory list".
     // Populate from RadioModel cache (filled from status pushes during connect).
@@ -301,11 +356,57 @@ void MemoryDialog::closeEvent(QCloseEvent* event)
     QDialog::closeEvent(event);
 }
 
+void MemoryDialog::keyPressEvent(QKeyEvent* event)
+{
+    if (event->key() == Qt::Key_Escape) {
+        if (m_searchEdit && !m_searchEdit->text().isEmpty()) {
+            m_searchEdit->clear();
+            m_searchEdit->setFocus(Qt::ShortcutFocusReason);
+        } else {
+            reject();
+        }
+        return;
+    }
+
+    QDialog::keyPressEvent(event);
+}
+
 bool MemoryDialog::eventFilter(QObject* watched, QEvent* event)
 {
+    if (m_table && watched == m_table->viewport() && event->type() == QEvent::MouseButtonPress) {
+#if !defined(Q_OS_MACOS)
+        auto* mouseEvent = static_cast<QMouseEvent*>(event);
+        if (mouseEvent->button() == Qt::LeftButton
+            && (mouseEvent->modifiers() & Qt::ShiftModifier)) {
+            const QModelIndex index = m_table->indexAt(mouseEvent->position().toPoint());
+            if (index.isValid()) {
+                auto* selectionModel = m_table->selectionModel();
+                const bool wasSelected = selectionModel->isRowSelected(index.row(), QModelIndex());
+                const QModelIndex firstColumn = m_table->model()->index(index.row(), 0);
+                selectionModel->select(firstColumn, (wasSelected
+                    ? QItemSelectionModel::Deselect
+                    : QItemSelectionModel::Select) | QItemSelectionModel::Rows);
+                m_table->setCurrentCell(index.row(), 0, QItemSelectionModel::NoUpdate);
+                updateSelectionActions();
+                return true;
+            }
+        }
+#endif
+    }
+
     if (event->type() == QEvent::KeyPress) {
         auto* keyEvent = static_cast<QKeyEvent*>(event);
         const int key = keyEvent->key();
+
+        if ((watched == m_searchEdit || watched == m_table) && key == Qt::Key_Escape) {
+            if (m_searchEdit && !m_searchEdit->text().isEmpty()) {
+                m_searchEdit->clear();
+                m_searchEdit->setFocus(Qt::ShortcutFocusReason);
+            } else {
+                reject();
+            }
+            return true;
+        }
 
         if (watched == m_searchEdit) {
             if (key == Qt::Key_Up || key == Qt::Key_Down) {
@@ -322,20 +423,41 @@ bool MemoryDialog::eventFilter(QObject* watched, QEvent* event)
                 return true;
             }
             if (key == Qt::Key_Return || key == Qt::Key_Enter) {
-                activateMemoryRow(m_table ? m_table->currentRow() : -1);
+                int row = m_table ? m_table->currentRow() : -1;
+                if (m_table && row < 0 && m_table->rowCount() > 0) {
+                    row = 0;
+                    m_table->selectRow(row);
+                    m_table->setCurrentCell(row, 0);
+                }
+                activateMemoryRow(row);
                 return true;
             }
         }
 
-        if (watched == m_table && (key == Qt::Key_Return || key == Qt::Key_Enter)) {
+        if (m_table && watched == m_table && (key == Qt::Key_Return || key == Qt::Key_Enter)) {
             // Don't intercept Enter while editing a cell — let the delegate handle it.
             // QAbstractItemView::state() is protected, so check for an active editor
             // via indexWidget on the current index instead.
             QModelIndex idx = m_table->currentIndex();
-            if (!m_table->indexWidget(idx) && !m_table->isPersistentEditorOpen(m_table->currentItem())) {
+            if (selectedMemoryIndices().size() == 1
+                && !m_table->indexWidget(idx)
+                && !m_table->isPersistentEditorOpen(m_table->currentItem())) {
                 activateMemoryRow(m_table->currentRow());
                 return true;
             }
+        }
+
+        if (m_table && watched == m_table && (key == Qt::Key_Delete || key == Qt::Key_Backspace)) {
+            if (!selectedMemoryIndices().isEmpty()) {
+                onRemove();
+                return true;
+            }
+        }
+
+        if (m_table && watched == m_table && key == Qt::Key_A
+            && (keyEvent->modifiers() & (Qt::ControlModifier | Qt::MetaModifier))) {
+            onSelectAll();
+            return true;
         }
     }
 
@@ -363,14 +485,66 @@ void MemoryDialog::activateMemoryRow(int row)
     if (memoryIt == m_model->memories().constEnd())
         return;
 
+    setInlineEditMode(false);
     m_table->setCurrentCell(row, 0);
+    focusTableOnCurrentRow();
     m_model->sendCommand(QString("memory apply %1").arg(idx));
     m_model->setPanCenter(memoryIt->freq);
+}
+
+void MemoryDialog::beginEditingMemoryName(int memoryIndex)
+{
+    if (!m_table)
+        return;
+
+    for (int row = 0; row < m_table->rowCount(); ++row) {
+        auto* indexItem = m_table->item(row, 0);
+        auto* nameItem = m_table->item(row, 3);
+        if (!indexItem || !nameItem)
+            continue;
+        if (indexItem->data(Qt::UserRole).toInt() != memoryIndex)
+            continue;
+
+        if (auto* selectionModel = m_table->selectionModel()) {
+            selectionModel->select(
+                m_table->model()->index(row, 0),
+                QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+        }
+        setInlineEditMode(true);
+        m_table->setCurrentCell(row, 3, QItemSelectionModel::NoUpdate);
+        m_table->scrollToItem(nameItem, QAbstractItemView::PositionAtCenter);
+        m_table->setFocus(Qt::OtherFocusReason);
+        updateSelectionActions();
+        m_table->editItem(nameItem);
+        return;
+    }
+}
+
+void MemoryDialog::focusTableOnCurrentRow()
+{
+    if (!m_table)
+        return;
+
+    if (m_table->currentRow() < 0 && m_table->rowCount() > 0)
+        m_table->setCurrentCell(0, 0, QItemSelectionModel::NoUpdate);
+    m_table->setFocus(Qt::OtherFocusReason);
+}
+
+void MemoryDialog::setInlineEditMode(bool enabled)
+{
+    m_inlineEditMode = enabled;
+    if (!m_table)
+        return;
+
+    m_table->setEditTriggers(enabled
+        ? (QAbstractItemView::SelectedClicked | QAbstractItemView::EditKeyPressed)
+        : QAbstractItemView::NoEditTriggers);
 }
 
 void MemoryDialog::populateTable()
 {
     const QSignalBlocker blocker(m_table);
+    const QSet<int> previousSelection = selectedMemoryIndices();
     const int currentMemoryIndex = (m_table->currentRow() >= 0 && m_table->item(m_table->currentRow(), 0))
         ? m_table->item(m_table->currentRow(), 0)->data(Qt::UserRole).toInt()
         : -1;
@@ -447,6 +621,8 @@ void MemoryDialog::populateTable()
 
     m_table->resizeColumnsToContents();
     m_table->setColumnWidth(2, std::max(m_table->columnWidth(2), 105));
+    const int minNameWidth = fontMetrics().horizontalAdvance(QString(20, QChar('M')));
+    m_table->setColumnWidth(3, std::max(m_table->columnWidth(3), minNameWidth));
     if (isSortableColumn(m_sortColumn)) {
         auto* header = m_table->horizontalHeader();
         header->setSortIndicatorShown(true);
@@ -456,18 +632,48 @@ void MemoryDialog::populateTable()
     m_table->setSortingEnabled(true);
 
     if (hasRows) {
-        int selectedRow = 0;
-        if (currentMemoryIndex >= 0) {
-            for (int row = 0; row < m_table->rowCount(); ++row) {
-                auto* item = m_table->item(row, 0);
-                if (item && item->data(Qt::UserRole).toInt() == currentMemoryIndex) {
-                    selectedRow = row;
-                    break;
-                }
+        bool restoredSelection = false;
+        int currentRow = -1;
+        int firstSelectedRow = -1;
+        for (int row = 0; row < m_table->rowCount(); ++row) {
+            auto* item = m_table->item(row, 0);
+            if (!item)
+                continue;
+
+            const int memoryIndex = item->data(Qt::UserRole).toInt();
+            if (previousSelection.contains(memoryIndex)) {
+                m_table->selectionModel()->select(
+                    m_table->model()->index(row, 0),
+                    QItemSelectionModel::Select | QItemSelectionModel::Rows);
+                restoredSelection = true;
+                if (firstSelectedRow < 0)
+                    firstSelectedRow = row;
             }
+            if (memoryIndex == currentMemoryIndex)
+                currentRow = row;
         }
-        m_table->selectRow(selectedRow);
-        m_table->setCurrentCell(selectedRow, 0);
+
+        if (!restoredSelection) {
+            currentRow = currentRow >= 0 ? currentRow : 0;
+            m_table->selectRow(currentRow);
+        } else if (currentRow < 0) {
+            currentRow = firstSelectedRow;
+        }
+
+        if (currentRow >= 0)
+            m_table->setCurrentCell(currentRow, 0, QItemSelectionModel::NoUpdate);
+    }
+
+    updateSelectionActions();
+
+    if (m_pendingEditMemoryIndex >= 0 && m_pendingEditRetries > 0) {
+        const int pendingMemoryIndex = m_pendingEditMemoryIndex;
+        --m_pendingEditRetries;
+        QTimer::singleShot(0, this, [this, pendingMemoryIndex]() {
+            beginEditingMemoryName(pendingMemoryIndex);
+        });
+        if (m_pendingEditRetries == 0)
+            m_pendingEditMemoryIndex = -1;
     }
 }
 
@@ -489,6 +695,10 @@ void MemoryDialog::submitCellEdit(int row, int col)
         return;
 
     const int memIdx = indexItem->data(Qt::UserRole).toInt();
+    if (col == 3 && memIdx == m_pendingEditMemoryIndex) {
+        m_pendingEditMemoryIndex = -1;
+        m_pendingEditRetries = 0;
+    }
     RadioModel* const model = m_model;
     const QPointer<MemoryDialog> dialogGuard(this);
     model->sendCmdPublic(QString("memory set %1 %2").arg(memIdx).arg(commandSuffix),
@@ -599,8 +809,11 @@ void MemoryDialog::onAdd()
         kvs["digu_offset"] = QString::number(m.diguOffset);
         model->handleMemoryStatus(idx, kvs);
 
-        if (dialogGuard)
+        if (dialogGuard) {
+            dialogGuard->m_pendingEditMemoryIndex = idx;
+            dialogGuard->m_pendingEditRetries = 3;
             dialogGuard->populateTable();
+        }
     });
 }
 
@@ -665,27 +878,111 @@ void MemoryDialog::onExport()
 
 void MemoryDialog::onSelect()
 {
+    if (selectedMemoryIndices().size() != 1)
+        return;
+
     activateMemoryRow(m_table->currentRow());
+}
+
+void MemoryDialog::onEdit()
+{
+    if (!m_table || selectedMemoryIndices().size() != 1)
+        return;
+
+    auto* indexItem = m_table->item(m_table->currentRow(), 0);
+    if (!indexItem)
+        return;
+
+    beginEditingMemoryName(indexItem->data(Qt::UserRole).toInt());
+}
+
+void MemoryDialog::onSelectAll()
+{
+    if (!m_table || m_table->rowCount() <= 0)
+        return;
+
+    setInlineEditMode(false);
+    m_table->selectAll();
+    if (m_table->currentRow() < 0)
+        m_table->setCurrentCell(0, 0, QItemSelectionModel::NoUpdate);
+    focusTableOnCurrentRow();
+    updateSelectionActions();
 }
 
 void MemoryDialog::onRemove()
 {
-    const int row = m_table->currentRow();
-    if (row < 0) return;
-    const int idx = m_table->item(row, 0)->data(Qt::UserRole).toInt();
+    const QSet<int> selectedIndices = selectedMemoryIndices();
+    if (selectedIndices.isEmpty())
+        return;
+
+    setInlineEditMode(false);
+    QList<int> indices = selectedIndices.values();
+    std::sort(indices.begin(), indices.end());
+
+    QStringList memoryDescriptions;
+    memoryDescriptions.reserve(indices.size());
+    for (int idx : indices) {
+        const auto it = m_model->memories().constFind(idx);
+        memoryDescriptions << (it != m_model->memories().constEnd()
+            ? describeMemory(it.value())
+            : QString("Memory %1").arg(idx));
+    }
+
+    QMessageBox confirm(this);
+    confirm.setIcon(QMessageBox::Warning);
+    confirm.setWindowTitle(indices.size() == 1 ? "Delete Memory" : "Delete Memories");
+    confirm.setText(indices.size() == 1
+        ? QString("Delete %1?").arg(memoryDescriptions.value(0, "the selected memory"))
+        : QString("Delete %1 selected memories?").arg(indices.size()));
+    confirm.setInformativeText("This can't be undone.");
+    if (memoryDescriptions.size() > 1)
+        confirm.setDetailedText(memoryDescriptions.join('\n'));
+    confirm.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
+    confirm.setDefaultButton(QMessageBox::Cancel);
+    if (confirm.exec() != QMessageBox::Yes) {
+        focusTableOnCurrentRow();
+        return;
+    }
+
     RadioModel* const model = m_model;
     const QPointer<MemoryDialog> dialogGuard(this);
-    m_model->sendCmdPublic(QString("memory remove %1").arg(idx),
-        [model, dialogGuard, idx](int code, const QString&) {
-        if (code == 0) {
-            QMap<QString, QString> kvs;
-            kvs["removed"] = QString{};
-            model->handleMemoryStatus(idx, kvs);
-            return;
-        }
-        if (dialogGuard)
-            dialogGuard->populateTable();
-    });
+    struct RemovalState {
+        int remaining{0};
+        int failed{0};
+        QStringList failedDescriptions;
+    };
+    const auto state = QSharedPointer<RemovalState>::create();
+    state->remaining = indices.size();
+
+    for (int i = 0; i < indices.size(); ++i) {
+        const int idx = indices.at(i);
+        const QString description = memoryDescriptions.value(i, QString("Memory %1").arg(idx));
+        m_model->sendCmdPublic(QString("memory remove %1").arg(idx),
+            [model, dialogGuard, idx, description, state](int code, const QString&) {
+            if (code == 0) {
+                QMap<QString, QString> kvs;
+                kvs["removed"] = QString{};
+                model->handleMemoryStatus(idx, kvs);
+            } else {
+                ++state->failed;
+                state->failedDescriptions << description;
+            }
+
+            --state->remaining;
+            if (state->remaining == 0 && dialogGuard) {
+                dialogGuard->populateTable();
+                if (state->failed > 0) {
+                    QMessageBox::warning(
+                        dialogGuard,
+                        state->failed == 1 ? "Delete Memory" : "Delete Memories",
+                        state->failed == 1
+                            ? QString("Couldn't delete %1.").arg(state->failedDescriptions.value(0))
+                            : QString("Couldn't delete %1 memories.").arg(state->failed));
+                }
+                dialogGuard->focusTableOnCurrentRow();
+            }
+        });
+    }
 }
 
 void MemoryDialog::rebuildFilterCombo()
@@ -719,6 +1016,51 @@ void MemoryDialog::rebuildFilterCombo()
     int idx = m_filterCombo->findData(previous);
     if (idx >= 0) {
         m_filterCombo->setCurrentIndex(idx);
+    }
+}
+
+QSet<int> MemoryDialog::selectedMemoryIndices() const
+{
+    QSet<int> indices;
+    if (!m_table || !m_table->selectionModel())
+        return indices;
+
+    const QModelIndexList rows = m_table->selectionModel()->selectedRows(0);
+    for (const QModelIndex& row : rows)
+        indices.insert(row.data(Qt::UserRole).toInt());
+    return indices;
+}
+
+void MemoryDialog::updateSelectionActions()
+{
+    const int selectedCount = selectedMemoryIndices().size();
+    const int visibleCount = m_table ? m_table->rowCount() : 0;
+    if (selectedCount != 1 && m_inlineEditMode)
+        setInlineEditMode(false);
+    if (m_selectionLabel) {
+        m_selectionLabel->setText(QString("%1 of %2 selected").arg(selectedCount).arg(visibleCount));
+    }
+    if (m_editBtn) {
+        m_editBtn->setEnabled(selectedCount == 1);
+        m_editBtn->setToolTip(selectedCount == 1
+            ? "Edit the highlighted memory fields."
+            : "Edit is available when exactly one memory is highlighted.");
+    }
+    if (m_selectBtn) {
+        m_selectBtn->setEnabled(selectedCount == 1);
+        m_selectBtn->setToolTip(selectedCount == 1
+            ? QString()
+            : "Tune is available when exactly one memory is highlighted.");
+    }
+    if (m_selectAllBtn) {
+        m_selectAllBtn->setEnabled(visibleCount > 0 && selectedCount < visibleCount);
+        m_selectAllBtn->setToolTip(visibleCount > 0
+            ? "Select every memory in the current search/filter result."
+            : QString());
+    }
+    if (m_removeBtn) {
+        m_removeBtn->setEnabled(selectedCount > 0);
+        m_removeBtn->setText(selectedCount > 1 ? "Remove Selected" : "Remove");
     }
 }
 

--- a/src/gui/MemoryDialog.h
+++ b/src/gui/MemoryDialog.h
@@ -3,12 +3,16 @@
 #include <QDialog>
 #include <QCloseEvent>
 #include <QEvent>
+#include <QKeyEvent>
 #include <QShowEvent>
+#include <QSet>
 #include <QTableWidget>
 #include <QMap>
 
 class QComboBox;
+class QLabel;
 class QLineEdit;
+class QPushButton;
 
 namespace AetherSDR {
 
@@ -23,23 +27,39 @@ public:
 protected:
     void closeEvent(QCloseEvent* event) override;
     bool eventFilter(QObject* watched, QEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
     void showEvent(QShowEvent* event) override;
 
 private:
     void activateMemoryRow(int row);
+    void beginEditingMemoryName(int memoryIndex);
+    void focusTableOnCurrentRow();
     void populateTable();
+    void setInlineEditMode(bool enabled);
     void submitCellEdit(int row, int col);
     void onAdd();
     void onExport();
+    void onEdit();
     void onSelect();
+    void onSelectAll();
     void onRemove();
     bool isSortableColumn(int column) const;
     void rebuildFilterCombo();
+    QSet<int> selectedMemoryIndices() const;
+    void updateSelectionActions();
 
     RadioModel* m_model;
     QTableWidget* m_table;
     QLineEdit* m_searchEdit;
     QComboBox* m_filterCombo;
+    QLabel* m_selectionLabel{nullptr};
+    QPushButton* m_editBtn{nullptr};
+    QPushButton* m_selectBtn{nullptr};
+    QPushButton* m_selectAllBtn{nullptr};
+    QPushButton* m_removeBtn{nullptr};
+    int m_pendingEditMemoryIndex{-1};
+    int m_pendingEditRetries{0};
+    bool m_inlineEditMode{false};
     int m_sortColumn{2};
     Qt::SortOrder m_sortOrder{Qt::AscendingOrder};
 };


### PR DESCRIPTION
<img width="1083" height="644" alt="image" src="https://github.com/user-attachments/assets/cd99f41e-b256-419f-b820-a18884b8920a" />

## Summary

This PR reworks the `MemoryDialog` interaction model so tuning and editing are clearly separated, bulk actions are first-class, and the dialog behaves predictably for both mouse and keyboard users.

The original memory table leaned toward inline editing as the default interaction. In practice that made it too easy to mutate a memory while the user was trying to navigate to it, and in some cases it could leave behind confusing or unintended frequency state after an accidental edit. This change makes tuning/navigation the default behavior and moves editing behind an explicit `Edit` action, while also adding multi-selection and bulk delete support with confirmation.

## Why This Changed

The main goals behind this update were:

- make the primary user action in the memories dialog "go there / tune there"
- prevent accidental inline edits from mouse double-clicks
- support safe bulk memory cleanup with an explicit confirmation step
- improve the keyboard-only workflow so the dialog is efficient without a mouse
- make focus and selection state more predictable after each action

## What Changed

### 1. Tuning is now the default interaction

- Double-clicking a memory now tunes/applies that memory instead of opening an editor.
- Pressing `Enter` in the table still tunes the current memory when a single row is active.
- Pressing `Enter` in the search field now tunes the current filtered result again, with a fallback to the first visible row if needed.
- The primary action button is now labeled `Tune` instead of `Select`.

This keeps the dialog aligned with the common operator expectation that activating a memory should navigate to it, not start mutating it.

### 2. Editing is explicit and safer

- Added an `Edit` button to enter inline editing intentionally.
- `Edit` always opens the `Name` column first, since that is the most common field to adjust.
- `Add` now behaves the same way: after creating a memory, the dialog reselects the new row, opens the `Name` field, and keeps retrying through the first refreshes so the editor stays available.
- Once editing is explicitly entered, clicking other editable fields in that row works naturally again instead of forcing the user to tab across columns.

This keeps accidental edits out of the tune path while still preserving fast inline editing once the user has clearly entered edit mode.

### 3. Bulk selection and bulk delete

- The table now supports native extended row selection.
- On macOS, `Shift`-click selects a range and `Command`-click adds or removes rows from the selection.
- On Windows/Linux, `Shift`-click selects a range and `Ctrl`-click adds or removes rows from the selection.
- Added `Select All` for the current visible search/filter result.
- Added a live selection counter (`X of Y selected`).
- Bulk delete now confirms the entire set before removing anything.
- Delete failures are aggregated and reported after the batch finishes.

This makes memory cleanup practical without having to remove rows one at a time.

### 4. Focus and selection behavior

- The dialog now restores focus to the table after actions like `Tune`, `Select All`, and delete completion/cancellation.
- The "new memory name editing" flow now clears the old selection and selects only the new row, so the UI matches the active editing target.
- Buttons are no longer allowed to behave as implicit default `Enter` targets, which reduces accidental activation when a button has focus.

This is mostly polish, but it materially improves how predictable the dialog feels during repeated use.

### 5. Keyboard workflow improvements

Added shortcuts and behaviors intended to make the dialog efficient without requiring the mouse:

- `Cmd/Ctrl+F` focuses and selects the search field
- `Cmd/Ctrl+N` adds a new memory
- `F2` and `Cmd/Ctrl+E` begin editing the selected memory name
- `Cmd/Ctrl+Shift+A` selects all visible rows
- `Esc` clears the search field first, then closes the dialog if search is already empty
- `Delete` / `Backspace` triggers the delete-confirm flow from the table
- Up/Down from the search field moves the current row in the table

### 6. Small usability improvements

- Added a cross-platform hint label that reflects the new interaction model:
  - double-click tunes
  - macOS uses `Shift`-click for range selection and `Command`-click to add/remove rows
  - Windows/Linux use `Shift`-click for range selection and `Ctrl`-click to add/remove rows
- Widened the `Name` column to a more useful default width so quick naming/editing does not open into a tiny field.

## User Impact

From an operator point of view, the memories dialog should now feel much more intentional:

- browsing memories is safer because activating a row tunes instead of edits
- naming a new memory is faster because `Add` drops directly into the `Name` field
- bulk cleanup is possible and guarded by confirmation
- the dialog works better as a keyboard-driven tool instead of only as a mouse-driven editor

## Root Cause Addressed

The underlying UX problem was that the dialog mixed two high-frequency but conflicting actions:

1. "take me to this memory"
2. "edit this memory"

Because inline editing was easy to enter accidentally, the tune/navigation path could be disrupted by unintended edits. This PR fixes that by making navigation the default activation path and requiring an explicit transition into edit mode.

## Validation

Validated locally with:

- `cmake -S . -B build -G Ninja`
- `cmake --build build -j10`

Interactive smoke testing covered:

- opening the memory dialog
- search + `Enter` tuning
- double-click tuning
- explicit editing through `Edit`
- `Add` focusing the new row's `Name`
- native range/toggle multi-selection and confirmed bulk delete
- selection count and focus restoration after actions
- keyboard shortcuts and `Esc` behavior

## Notes For Review

- The implementation intentionally keeps all changes localized to `MemoryDialog.{h,cpp}`.
- The dialog now uses a controlled inline-edit mode so we can preserve tune-first behavior while still allowing natural multi-field editing after explicit entry into edit mode.
- Multi-selection now follows each platform's native extended-selection semantics instead of redefining `Shift`-click behavior.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.4 Pro) and tested by @jensenpat
