### PR TITLE
[memory] Add memory CSV bulk import and progress feedback

### DIFF
--- a/src/core/MemoryCsvCompat.cpp
+++ b/src/core/MemoryCsvCompat.cpp
@@ -63,6 +63,18 @@ QString csvEscape(const QString& value)
     return value;
 }
 
+QString describeCsvRow(const QStringList& fields, int lineNumber)
+{
+    const QString name = fields.size() > 4 ? fields.at(4).trimmed() : QString();
+    const QString freq = fields.size() > 3 ? fields.at(3).trimmed() : QString();
+
+    if (!name.isEmpty())
+        return QString("Line %1 (%2)").arg(lineNumber).arg(name);
+    if (!freq.isEmpty())
+        return QString("Line %1 (%2 MHz)").arg(lineNumber).arg(freq);
+    return QString("Line %1").arg(lineNumber);
+}
+
 QStringList parseCsvLine(const QString& line, bool* ok)
 {
     QStringList fields;
@@ -244,14 +256,19 @@ bool parseRecord(const QStringList& fields,
     }
 
     if (normalizedFields.size() != kExpectedColumnCount) {
-        error = QString("Line %1: expected %2 columns, got %3.")
-            .arg(lineNumber).arg(kExpectedColumnCount).arg(normalizedFields.size());
+        error = QString("%1: expected %2 columns, got %3.")
+            .arg(describeCsvRow(normalizedFields, lineNumber))
+            .arg(kExpectedColumnCount)
+            .arg(normalizedFields.size());
         return false;
     }
 
+    const QString rowLabel = describeCsvRow(normalizedFields, lineNumber);
+
     if (normalizedFields.at(0).trimmed().compare("MEMORY", Qt::CaseInsensitive) != 0) {
-        error = QString("Line %1: unsupported record type '%2'.")
-            .arg(lineNumber).arg(normalizedFields.at(0));
+        error = QString("%1: unsupported record type '%2'.")
+            .arg(rowLabel)
+            .arg(normalizedFields.at(0));
         return false;
     }
 
@@ -262,98 +279,98 @@ bool parseRecord(const QStringList& fields,
     memory.mode = normalizedFields.at(5).trimmed().toUpper();
 
     if (!parseDoubleField(normalizedFields.at(3), memory.freq) || !validateRange(memory.freq, 0.0, 10000.0)) {
-        error = QString("Line %1: invalid frequency '%2'.").arg(lineNumber).arg(normalizedFields.at(3));
+        error = QString("%1: invalid frequency '%2'.").arg(rowLabel).arg(normalizedFields.at(3));
         return false;
     }
 
     if (!parseIntField(normalizedFields.at(6), memory.step) || !validateRange(memory.step, 1, 1000000)) {
-        error = QString("Line %1: invalid step '%2'.").arg(lineNumber).arg(normalizedFields.at(6));
+        error = QString("%1: invalid step '%2'.").arg(rowLabel).arg(normalizedFields.at(6));
         return false;
     }
 
     memory.offsetDir = normalizeOffsetDirection(normalizedFields.at(7));
     if (memory.offsetDir.isEmpty()) {
-        error = QString("Line %1: invalid offset direction '%2'.").arg(lineNumber).arg(normalizedFields.at(7));
+        error = QString("%1: invalid offset direction '%2'.").arg(rowLabel).arg(normalizedFields.at(7));
         return false;
     }
 
     if (!parseDoubleField(normalizedFields.at(8), memory.repeaterOffset)
             || !validateRange(memory.repeaterOffset, -100.0, 100.0)) {
-        error = QString("Line %1: invalid repeater offset '%2'.").arg(lineNumber).arg(normalizedFields.at(8));
+        error = QString("%1: invalid repeater offset '%2'.").arg(rowLabel).arg(normalizedFields.at(8));
         return false;
     }
 
     memory.toneMode = normalizeToneMode(normalizedFields.at(9));
     if (memory.toneMode.isEmpty()) {
-        error = QString("Line %1: invalid tone mode '%2'.").arg(lineNumber).arg(normalizedFields.at(9));
+        error = QString("%1: invalid tone mode '%2'.").arg(rowLabel).arg(normalizedFields.at(9));
         return false;
     }
 
     if (!parseDoubleField(normalizedFields.at(10), memory.toneValue)
             || !validateRange(memory.toneValue, 0.0, 300.0)) {
-        error = QString("Line %1: invalid tone value '%2'.").arg(lineNumber).arg(normalizedFields.at(10));
+        error = QString("%1: invalid tone value '%2'.").arg(rowLabel).arg(normalizedFields.at(10));
         return false;
     }
 
     if (!parseIntField(normalizedFields.at(11), record.rfPower) || !validateRange(record.rfPower, 0, kMaxRfPower)) {
-        error = QString("Line %1: invalid RF power '%2'.").arg(lineNumber).arg(normalizedFields.at(11));
+        error = QString("%1: invalid RF power '%2'.").arg(rowLabel).arg(normalizedFields.at(11));
         return false;
     }
 
     if (!parseIntField(normalizedFields.at(12), memory.rxFilterLow)
             || !validateRange(memory.rxFilterLow, kMinFilterHz, kMaxFilterHz)) {
-        error = QString("Line %1: invalid RX filter low '%2'.").arg(lineNumber).arg(normalizedFields.at(12));
+        error = QString("%1: invalid RX filter low '%2'.").arg(rowLabel).arg(normalizedFields.at(12));
         return false;
     }
 
     if (!parseIntField(normalizedFields.at(13), memory.rxFilterHigh)
             || !validateRange(memory.rxFilterHigh, kMinFilterHz, kMaxFilterHz)) {
-        error = QString("Line %1: invalid RX filter high '%2'.").arg(lineNumber).arg(normalizedFields.at(13));
+        error = QString("%1: invalid RX filter high '%2'.").arg(rowLabel).arg(normalizedFields.at(13));
         return false;
     }
 
     if (!parseBool01Field(normalizedFields.at(14), record.highlight)) {
-        error = QString("Line %1: invalid highlight flag '%2'.").arg(lineNumber).arg(normalizedFields.at(14));
+        error = QString("%1: invalid highlight flag '%2'.").arg(rowLabel).arg(normalizedFields.at(14));
         return false;
     }
 
     if (!parseIntField(normalizedFields.at(15), record.highlightColor) || record.highlightColor < 0) {
-        error = QString("Line %1: invalid highlight color '%2'.").arg(lineNumber).arg(normalizedFields.at(15));
+        error = QString("%1: invalid highlight color '%2'.").arg(rowLabel).arg(normalizedFields.at(15));
         return false;
     }
 
     if (!parseBool01Field(normalizedFields.at(16), memory.squelch)) {
-        error = QString("Line %1: invalid squelch flag '%2'.").arg(lineNumber).arg(normalizedFields.at(16));
+        error = QString("%1: invalid squelch flag '%2'.").arg(rowLabel).arg(normalizedFields.at(16));
         return false;
     }
 
     if (!parseIntField(normalizedFields.at(17), memory.squelchLevel)
             || !validateRange(memory.squelchLevel, kMinSquelchLevel, kMaxSquelchLevel)) {
-        error = QString("Line %1: invalid squelch level '%2'.").arg(lineNumber).arg(normalizedFields.at(17));
+        error = QString("%1: invalid squelch level '%2'.").arg(rowLabel).arg(normalizedFields.at(17));
         return false;
     }
 
     if (!parseIntField(normalizedFields.at(18), memory.rttyMark)
             || !validateRange(memory.rttyMark, kMinRttyMarkHz, kMaxRttyMarkHz)) {
-        error = QString("Line %1: invalid RTTY mark '%2'.").arg(lineNumber).arg(normalizedFields.at(18));
+        error = QString("%1: invalid RTTY mark '%2'.").arg(rowLabel).arg(normalizedFields.at(18));
         return false;
     }
 
     if (!parseIntField(normalizedFields.at(19), memory.rttyShift)
             || !validateRange(memory.rttyShift, kMinRttyShiftHz, kMaxRttyShiftHz)) {
-        error = QString("Line %1: invalid RTTY shift '%2'.").arg(lineNumber).arg(normalizedFields.at(19));
+        error = QString("%1: invalid RTTY shift '%2'.").arg(rowLabel).arg(normalizedFields.at(19));
         return false;
     }
 
     if (!parseIntField(normalizedFields.at(20), memory.diglOffset)
             || !validateRange(memory.diglOffset, kMinDigitalOffsetHz, kMaxDigitalOffsetHz)) {
-        error = QString("Line %1: invalid DIGL offset '%2'.").arg(lineNumber).arg(normalizedFields.at(20));
+        error = QString("%1: invalid DIGL offset '%2'.").arg(rowLabel).arg(normalizedFields.at(20));
         return false;
     }
 
     if (!parseIntField(normalizedFields.at(21), memory.diguOffset)
             || !validateRange(memory.diguOffset, kMinDigitalOffsetHz, kMaxDigitalOffsetHz)) {
-        error = QString("Line %1: invalid DIGU offset '%2'.").arg(lineNumber).arg(normalizedFields.at(21));
+        error = QString("%1: invalid DIGU offset '%2'.").arg(rowLabel).arg(normalizedFields.at(21));
         return false;
     }
 

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -18,13 +18,18 @@
 #include <QLineEdit>
 #include <QLabel>
 #include <QHeaderView>
+#include <QItemSelectionModel>
 #include <QDebug>
 #include <QMessageBox>
+#include <QMouseEvent>
 #include <QPointer>
+#include <QShortcut>
 #include <QSaveFile>
+#include <QSharedPointer>
 #include <QTimer>
 #include <QCloseEvent>
 #include <QKeyEvent>
+#include <QtGlobal>
 
 namespace AetherSDR {
 
@@ -170,6 +175,23 @@ QList<MemoryCsvRecord> currentExportRecords(const QMap<int, MemoryEntry>& memori
     return records;
 }
 
+QString selectionHintText()
+{
+#if defined(Q_OS_MACOS)
+    return "Tip: Double-click tunes. Command-click adds or removes rows from the selection.";
+#else
+    return "Tip: Double-click tunes. Shift-click or Ctrl-click selects multiple rows.";
+#endif
+}
+
+QString describeMemory(const MemoryEntry& memory)
+{
+    const QString label = memory.name.trimmed().isEmpty()
+        ? QString("Memory %1").arg(memory.index)
+        : memory.name.trimmed();
+    return QString("%1 (%2 MHz)").arg(label, QString::number(memory.freq, 'f', 6));
+}
+
 } // namespace
 
 static const QStringList COLUMNS = {
@@ -206,7 +228,7 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     connect(m_searchEdit, &QLineEdit::textChanged,
             this, [this](const QString&) { populateTable(); });
     connect(m_searchEdit, &QLineEdit::returnPressed,
-            this, [this]() { activateMemoryRow(m_table->currentRow()); });
+            this, [this]() { activateMemoryRow(m_table ? m_table->currentRow() : -1); });
     connect(m_filterCombo, &QComboBox::currentIndexChanged,
             this, [this](int) { populateTable(); });
 
@@ -214,13 +236,14 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     m_table = new QTableWidget(0, COLUMNS.size());
     m_table->setHorizontalHeaderLabels(COLUMNS);
     m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
-    m_table->setSelectionMode(QAbstractItemView::SingleSelection);
-    m_table->setEditTriggers(QAbstractItemView::DoubleClicked);
+    m_table->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
     m_table->horizontalHeader()->setStretchLastSection(true);
     m_table->verticalHeader()->setVisible(false);
     m_table->setAlternatingRowColors(true);
     m_table->setSortingEnabled(false);
     m_table->installEventFilter(this);
+    m_table->viewport()->installEventFilter(this);
     m_table->setStyleSheet(
         "QTableWidget { alternate-background-color: #1a1a2e; }"
         "QTableWidget::item:selected { background: #2060a0; }");
@@ -242,24 +265,56 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
         m_table->sortItems(m_sortColumn, m_sortOrder);
     });
     root->addWidget(m_table);
+    root->addWidget(new QLabel(selectionHintText()));
 
     // ── Buttons ───────────────────────────────────────────────────────────
     auto* btnRow = new QHBoxLayout;
     auto* exportBtn = new QPushButton("Export...");
     auto* addBtn = new QPushButton("Add");
-    auto* selectBtn = new QPushButton("Select");
-    auto* removeBtn = new QPushButton("Remove");
+    m_selectionLabel = new QLabel("0 selected");
+    m_editBtn = new QPushButton("Edit");
+    m_selectBtn = new QPushButton("Tune");
+    m_selectAllBtn = new QPushButton("Select All");
+    m_removeBtn = new QPushButton("Remove");
     btnRow->addWidget(addBtn);
-    btnRow->addWidget(selectBtn);
+    btnRow->addWidget(m_editBtn);
+    btnRow->addWidget(m_selectBtn);
+    btnRow->addWidget(m_selectAllBtn);
     btnRow->addWidget(exportBtn);
     btnRow->addStretch();
-    btnRow->addWidget(removeBtn);
+    btnRow->addWidget(m_selectionLabel);
+    btnRow->addWidget(m_removeBtn);
     root->addLayout(btnRow);
+
+    for (QPushButton* button : {addBtn, m_editBtn, m_selectBtn, m_selectAllBtn, exportBtn, m_removeBtn}) {
+        button->setAutoDefault(false);
+        button->setDefault(false);
+    }
 
     connect(exportBtn, &QPushButton::clicked, this, &MemoryDialog::onExport);
     connect(addBtn, &QPushButton::clicked, this, &MemoryDialog::onAdd);
-    connect(selectBtn, &QPushButton::clicked, this, &MemoryDialog::onSelect);
-    connect(removeBtn, &QPushButton::clicked, this, &MemoryDialog::onRemove);
+    connect(m_editBtn, &QPushButton::clicked, this, &MemoryDialog::onEdit);
+    connect(m_selectBtn, &QPushButton::clicked, this, &MemoryDialog::onSelect);
+    connect(m_selectAllBtn, &QPushButton::clicked, this, &MemoryDialog::onSelectAll);
+    connect(m_removeBtn, &QPushButton::clicked, this, &MemoryDialog::onRemove);
+    connect(m_table, &QTableWidget::cellDoubleClicked,
+            this, [this](int row, int) { activateMemoryRow(row); });
+    connect(m_table->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, &MemoryDialog::updateSelectionActions);
+    connect(m_table->selectionModel(), &QItemSelectionModel::currentRowChanged,
+            this, [this](const QModelIndex&, const QModelIndex&) {
+        updateSelectionActions();
+    });
+    new QShortcut(QKeySequence::Find, this, [this]() {
+        if (!m_searchEdit)
+            return;
+        m_searchEdit->setFocus(Qt::ShortcutFocusReason);
+        m_searchEdit->selectAll();
+    });
+    new QShortcut(QKeySequence::New, this, [this]() { onAdd(); });
+    new QShortcut(QKeySequence(Qt::Key_F2), this, [this]() { onEdit(); });
+    new QShortcut(QKeySequence(QStringLiteral("Ctrl+E")), this, [this]() { onEdit(); });
+    new QShortcut(QKeySequence(QStringLiteral("Ctrl+Shift+A")), this, [this]() { onSelectAll(); });
 
     // Rebuild filter combo when profile lists change
     connect(model, &RadioModel::globalProfilesChanged,
@@ -285,8 +340,8 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     connect(m_table, &QTableWidget::cellChanged, this, [this](int row, int col) {
         submitCellEdit(row, col);
     });
-    // Note: double-click starts inline cell editing (DoubleClicked edit trigger).
-    // Memory apply uses Enter key or the Select button — not double-click.
+    // Double-click tunes to the selected memory.
+    // Editing is explicit via the Edit button to avoid accidental cell mutations.
 
     // The radio doesn't support "sub memory all" or "memory list".
     // Populate from RadioModel cache (filled from status pushes during connect).
@@ -301,11 +356,57 @@ void MemoryDialog::closeEvent(QCloseEvent* event)
     QDialog::closeEvent(event);
 }
 
+void MemoryDialog::keyPressEvent(QKeyEvent* event)
+{
+    if (event->key() == Qt::Key_Escape) {
+        if (m_searchEdit && !m_searchEdit->text().isEmpty()) {
+            m_searchEdit->clear();
+            m_searchEdit->setFocus(Qt::ShortcutFocusReason);
+        } else {
+            reject();
+        }
+        return;
+    }
+
+    QDialog::keyPressEvent(event);
+}
+
 bool MemoryDialog::eventFilter(QObject* watched, QEvent* event)
 {
+    if (m_table && watched == m_table->viewport() && event->type() == QEvent::MouseButtonPress) {
+#if !defined(Q_OS_MACOS)
+        auto* mouseEvent = static_cast<QMouseEvent*>(event);
+        if (mouseEvent->button() == Qt::LeftButton
+            && (mouseEvent->modifiers() & Qt::ShiftModifier)) {
+            const QModelIndex index = m_table->indexAt(mouseEvent->position().toPoint());
+            if (index.isValid()) {
+                auto* selectionModel = m_table->selectionModel();
+                const bool wasSelected = selectionModel->isRowSelected(index.row(), QModelIndex());
+                const QModelIndex firstColumn = m_table->model()->index(index.row(), 0);
+                selectionModel->select(firstColumn, (wasSelected
+                    ? QItemSelectionModel::Deselect
+                    : QItemSelectionModel::Select) | QItemSelectionModel::Rows);
+                m_table->setCurrentCell(index.row(), 0, QItemSelectionModel::NoUpdate);
+                updateSelectionActions();
+                return true;
+            }
+        }
+#endif
+    }
+
     if (event->type() == QEvent::KeyPress) {
         auto* keyEvent = static_cast<QKeyEvent*>(event);
         const int key = keyEvent->key();
+
+        if ((watched == m_searchEdit || watched == m_table) && key == Qt::Key_Escape) {
+            if (m_searchEdit && !m_searchEdit->text().isEmpty()) {
+                m_searchEdit->clear();
+                m_searchEdit->setFocus(Qt::ShortcutFocusReason);
+            } else {
+                reject();
+            }
+            return true;
+        }
 
         if (watched == m_searchEdit) {
             if (key == Qt::Key_Up || key == Qt::Key_Down) {
@@ -322,20 +423,41 @@ bool MemoryDialog::eventFilter(QObject* watched, QEvent* event)
                 return true;
             }
             if (key == Qt::Key_Return || key == Qt::Key_Enter) {
-                activateMemoryRow(m_table ? m_table->currentRow() : -1);
+                int row = m_table ? m_table->currentRow() : -1;
+                if (m_table && row < 0 && m_table->rowCount() > 0) {
+                    row = 0;
+                    m_table->selectRow(row);
+                    m_table->setCurrentCell(row, 0);
+                }
+                activateMemoryRow(row);
                 return true;
             }
         }
 
-        if (watched == m_table && (key == Qt::Key_Return || key == Qt::Key_Enter)) {
+        if (m_table && watched == m_table && (key == Qt::Key_Return || key == Qt::Key_Enter)) {
             // Don't intercept Enter while editing a cell — let the delegate handle it.
             // QAbstractItemView::state() is protected, so check for an active editor
             // via indexWidget on the current index instead.
             QModelIndex idx = m_table->currentIndex();
-            if (!m_table->indexWidget(idx) && !m_table->isPersistentEditorOpen(m_table->currentItem())) {
+            if (selectedMemoryIndices().size() == 1
+                && !m_table->indexWidget(idx)
+                && !m_table->isPersistentEditorOpen(m_table->currentItem())) {
                 activateMemoryRow(m_table->currentRow());
                 return true;
             }
+        }
+
+        if (m_table && watched == m_table && (key == Qt::Key_Delete || key == Qt::Key_Backspace)) {
+            if (!selectedMemoryIndices().isEmpty()) {
+                onRemove();
+                return true;
+            }
+        }
+
+        if (m_table && watched == m_table && key == Qt::Key_A
+            && (keyEvent->modifiers() & (Qt::ControlModifier | Qt::MetaModifier))) {
+            onSelectAll();
+            return true;
         }
     }
 
@@ -363,14 +485,66 @@ void MemoryDialog::activateMemoryRow(int row)
     if (memoryIt == m_model->memories().constEnd())
         return;
 
+    setInlineEditMode(false);
     m_table->setCurrentCell(row, 0);
+    focusTableOnCurrentRow();
     m_model->sendCommand(QString("memory apply %1").arg(idx));
     m_model->setPanCenter(memoryIt->freq);
+}
+
+void MemoryDialog::beginEditingMemoryName(int memoryIndex)
+{
+    if (!m_table)
+        return;
+
+    for (int row = 0; row < m_table->rowCount(); ++row) {
+        auto* indexItem = m_table->item(row, 0);
+        auto* nameItem = m_table->item(row, 3);
+        if (!indexItem || !nameItem)
+            continue;
+        if (indexItem->data(Qt::UserRole).toInt() != memoryIndex)
+            continue;
+
+        if (auto* selectionModel = m_table->selectionModel()) {
+            selectionModel->select(
+                m_table->model()->index(row, 0),
+                QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+        }
+        setInlineEditMode(true);
+        m_table->setCurrentCell(row, 3, QItemSelectionModel::NoUpdate);
+        m_table->scrollToItem(nameItem, QAbstractItemView::PositionAtCenter);
+        m_table->setFocus(Qt::OtherFocusReason);
+        updateSelectionActions();
+        m_table->editItem(nameItem);
+        return;
+    }
+}
+
+void MemoryDialog::focusTableOnCurrentRow()
+{
+    if (!m_table)
+        return;
+
+    if (m_table->currentRow() < 0 && m_table->rowCount() > 0)
+        m_table->setCurrentCell(0, 0, QItemSelectionModel::NoUpdate);
+    m_table->setFocus(Qt::OtherFocusReason);
+}
+
+void MemoryDialog::setInlineEditMode(bool enabled)
+{
+    m_inlineEditMode = enabled;
+    if (!m_table)
+        return;
+
+    m_table->setEditTriggers(enabled
+        ? (QAbstractItemView::SelectedClicked | QAbstractItemView::EditKeyPressed)
+        : QAbstractItemView::NoEditTriggers);
 }
 
 void MemoryDialog::populateTable()
 {
     const QSignalBlocker blocker(m_table);
+    const QSet<int> previousSelection = selectedMemoryIndices();
     const int currentMemoryIndex = (m_table->currentRow() >= 0 && m_table->item(m_table->currentRow(), 0))
         ? m_table->item(m_table->currentRow(), 0)->data(Qt::UserRole).toInt()
         : -1;
@@ -447,6 +621,8 @@ void MemoryDialog::populateTable()
 
     m_table->resizeColumnsToContents();
     m_table->setColumnWidth(2, std::max(m_table->columnWidth(2), 105));
+    const int minNameWidth = fontMetrics().horizontalAdvance(QString(20, QChar('M')));
+    m_table->setColumnWidth(3, std::max(m_table->columnWidth(3), minNameWidth));
     if (isSortableColumn(m_sortColumn)) {
         auto* header = m_table->horizontalHeader();
         header->setSortIndicatorShown(true);
@@ -456,18 +632,48 @@ void MemoryDialog::populateTable()
     m_table->setSortingEnabled(true);
 
     if (hasRows) {
-        int selectedRow = 0;
-        if (currentMemoryIndex >= 0) {
-            for (int row = 0; row < m_table->rowCount(); ++row) {
-                auto* item = m_table->item(row, 0);
-                if (item && item->data(Qt::UserRole).toInt() == currentMemoryIndex) {
-                    selectedRow = row;
-                    break;
-                }
+        bool restoredSelection = false;
+        int currentRow = -1;
+        int firstSelectedRow = -1;
+        for (int row = 0; row < m_table->rowCount(); ++row) {
+            auto* item = m_table->item(row, 0);
+            if (!item)
+                continue;
+
+            const int memoryIndex = item->data(Qt::UserRole).toInt();
+            if (previousSelection.contains(memoryIndex)) {
+                m_table->selectionModel()->select(
+                    m_table->model()->index(row, 0),
+                    QItemSelectionModel::Select | QItemSelectionModel::Rows);
+                restoredSelection = true;
+                if (firstSelectedRow < 0)
+                    firstSelectedRow = row;
             }
+            if (memoryIndex == currentMemoryIndex)
+                currentRow = row;
         }
-        m_table->selectRow(selectedRow);
-        m_table->setCurrentCell(selectedRow, 0);
+
+        if (!restoredSelection) {
+            currentRow = currentRow >= 0 ? currentRow : 0;
+            m_table->selectRow(currentRow);
+        } else if (currentRow < 0) {
+            currentRow = firstSelectedRow;
+        }
+
+        if (currentRow >= 0)
+            m_table->setCurrentCell(currentRow, 0, QItemSelectionModel::NoUpdate);
+    }
+
+    updateSelectionActions();
+
+    if (m_pendingEditMemoryIndex >= 0 && m_pendingEditRetries > 0) {
+        const int pendingMemoryIndex = m_pendingEditMemoryIndex;
+        --m_pendingEditRetries;
+        QTimer::singleShot(0, this, [this, pendingMemoryIndex]() {
+            beginEditingMemoryName(pendingMemoryIndex);
+        });
+        if (m_pendingEditRetries == 0)
+            m_pendingEditMemoryIndex = -1;
     }
 }
 
@@ -489,6 +695,10 @@ void MemoryDialog::submitCellEdit(int row, int col)
         return;
 
     const int memIdx = indexItem->data(Qt::UserRole).toInt();
+    if (col == 3 && memIdx == m_pendingEditMemoryIndex) {
+        m_pendingEditMemoryIndex = -1;
+        m_pendingEditRetries = 0;
+    }
     RadioModel* const model = m_model;
     const QPointer<MemoryDialog> dialogGuard(this);
     model->sendCmdPublic(QString("memory set %1 %2").arg(memIdx).arg(commandSuffix),
@@ -599,8 +809,11 @@ void MemoryDialog::onAdd()
         kvs["digu_offset"] = QString::number(m.diguOffset);
         model->handleMemoryStatus(idx, kvs);
 
-        if (dialogGuard)
+        if (dialogGuard) {
+            dialogGuard->m_pendingEditMemoryIndex = idx;
+            dialogGuard->m_pendingEditRetries = 3;
             dialogGuard->populateTable();
+        }
     });
 }
 
@@ -665,27 +878,111 @@ void MemoryDialog::onExport()
 
 void MemoryDialog::onSelect()
 {
+    if (selectedMemoryIndices().size() != 1)
+        return;
+
     activateMemoryRow(m_table->currentRow());
+}
+
+void MemoryDialog::onEdit()
+{
+    if (!m_table || selectedMemoryIndices().size() != 1)
+        return;
+
+    auto* indexItem = m_table->item(m_table->currentRow(), 0);
+    if (!indexItem)
+        return;
+
+    beginEditingMemoryName(indexItem->data(Qt::UserRole).toInt());
+}
+
+void MemoryDialog::onSelectAll()
+{
+    if (!m_table || m_table->rowCount() <= 0)
+        return;
+
+    setInlineEditMode(false);
+    m_table->selectAll();
+    if (m_table->currentRow() < 0)
+        m_table->setCurrentCell(0, 0, QItemSelectionModel::NoUpdate);
+    focusTableOnCurrentRow();
+    updateSelectionActions();
 }
 
 void MemoryDialog::onRemove()
 {
-    const int row = m_table->currentRow();
-    if (row < 0) return;
-    const int idx = m_table->item(row, 0)->data(Qt::UserRole).toInt();
+    const QSet<int> selectedIndices = selectedMemoryIndices();
+    if (selectedIndices.isEmpty())
+        return;
+
+    setInlineEditMode(false);
+    QList<int> indices = selectedIndices.values();
+    std::sort(indices.begin(), indices.end());
+
+    QStringList memoryDescriptions;
+    memoryDescriptions.reserve(indices.size());
+    for (int idx : indices) {
+        const auto it = m_model->memories().constFind(idx);
+        memoryDescriptions << (it != m_model->memories().constEnd()
+            ? describeMemory(it.value())
+            : QString("Memory %1").arg(idx));
+    }
+
+    QMessageBox confirm(this);
+    confirm.setIcon(QMessageBox::Warning);
+    confirm.setWindowTitle(indices.size() == 1 ? "Delete Memory" : "Delete Memories");
+    confirm.setText(indices.size() == 1
+        ? QString("Delete %1?").arg(memoryDescriptions.value(0, "the selected memory"))
+        : QString("Delete %1 selected memories?").arg(indices.size()));
+    confirm.setInformativeText("This can't be undone.");
+    if (memoryDescriptions.size() > 1)
+        confirm.setDetailedText(memoryDescriptions.join('\n'));
+    confirm.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
+    confirm.setDefaultButton(QMessageBox::Cancel);
+    if (confirm.exec() != QMessageBox::Yes) {
+        focusTableOnCurrentRow();
+        return;
+    }
+
     RadioModel* const model = m_model;
     const QPointer<MemoryDialog> dialogGuard(this);
-    m_model->sendCmdPublic(QString("memory remove %1").arg(idx),
-        [model, dialogGuard, idx](int code, const QString&) {
-        if (code == 0) {
-            QMap<QString, QString> kvs;
-            kvs["removed"] = QString{};
-            model->handleMemoryStatus(idx, kvs);
-            return;
-        }
-        if (dialogGuard)
-            dialogGuard->populateTable();
-    });
+    struct RemovalState {
+        int remaining{0};
+        int failed{0};
+        QStringList failedDescriptions;
+    };
+    const auto state = QSharedPointer<RemovalState>::create();
+    state->remaining = indices.size();
+
+    for (int i = 0; i < indices.size(); ++i) {
+        const int idx = indices.at(i);
+        const QString description = memoryDescriptions.value(i, QString("Memory %1").arg(idx));
+        m_model->sendCmdPublic(QString("memory remove %1").arg(idx),
+            [model, dialogGuard, idx, description, state](int code, const QString&) {
+            if (code == 0) {
+                QMap<QString, QString> kvs;
+                kvs["removed"] = QString{};
+                model->handleMemoryStatus(idx, kvs);
+            } else {
+                ++state->failed;
+                state->failedDescriptions << description;
+            }
+
+            --state->remaining;
+            if (state->remaining == 0 && dialogGuard) {
+                dialogGuard->populateTable();
+                if (state->failed > 0) {
+                    QMessageBox::warning(
+                        dialogGuard,
+                        state->failed == 1 ? "Delete Memory" : "Delete Memories",
+                        state->failed == 1
+                            ? QString("Couldn't delete %1.").arg(state->failedDescriptions.value(0))
+                            : QString("Couldn't delete %1 memories.").arg(state->failed));
+                }
+                dialogGuard->focusTableOnCurrentRow();
+            }
+        });
+    }
 }
 
 void MemoryDialog::rebuildFilterCombo()
@@ -719,6 +1016,51 @@ void MemoryDialog::rebuildFilterCombo()
     int idx = m_filterCombo->findData(previous);
     if (idx >= 0) {
         m_filterCombo->setCurrentIndex(idx);
+    }
+}
+
+QSet<int> MemoryDialog::selectedMemoryIndices() const
+{
+    QSet<int> indices;
+    if (!m_table || !m_table->selectionModel())
+        return indices;
+
+    const QModelIndexList rows = m_table->selectionModel()->selectedRows(0);
+    for (const QModelIndex& row : rows)
+        indices.insert(row.data(Qt::UserRole).toInt());
+    return indices;
+}
+
+void MemoryDialog::updateSelectionActions()
+{
+    const int selectedCount = selectedMemoryIndices().size();
+    const int visibleCount = m_table ? m_table->rowCount() : 0;
+    if (selectedCount != 1 && m_inlineEditMode)
+        setInlineEditMode(false);
+    if (m_selectionLabel) {
+        m_selectionLabel->setText(QString("%1 of %2 selected").arg(selectedCount).arg(visibleCount));
+    }
+    if (m_editBtn) {
+        m_editBtn->setEnabled(selectedCount == 1);
+        m_editBtn->setToolTip(selectedCount == 1
+            ? "Edit the highlighted memory fields."
+            : "Edit is available when exactly one memory is highlighted.");
+    }
+    if (m_selectBtn) {
+        m_selectBtn->setEnabled(selectedCount == 1);
+        m_selectBtn->setToolTip(selectedCount == 1
+            ? QString()
+            : "Tune is available when exactly one memory is highlighted.");
+    }
+    if (m_selectAllBtn) {
+        m_selectAllBtn->setEnabled(visibleCount > 0 && selectedCount < visibleCount);
+        m_selectAllBtn->setToolTip(visibleCount > 0
+            ? "Select every memory in the current search/filter result."
+            : QString());
+    }
+    if (m_removeBtn) {
+        m_removeBtn->setEnabled(selectedCount > 0);
+        m_removeBtn->setText(selectedCount > 1 ? "Remove Selected" : "Remove");
     }
 }
 

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -9,6 +9,7 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
+#include <QFile>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QVBoxLayout>
@@ -21,7 +22,8 @@
 #include <QItemSelectionModel>
 #include <QDebug>
 #include <QMessageBox>
-#include <QMouseEvent>
+#include <QProgressBar>
+#include <QProgressDialog>
 #include <QPointer>
 #include <QShortcut>
 #include <QSaveFile>
@@ -30,6 +32,8 @@
 #include <QCloseEvent>
 #include <QKeyEvent>
 #include <QtGlobal>
+
+#include <functional>
 
 namespace AetherSDR {
 
@@ -178,9 +182,9 @@ QList<MemoryCsvRecord> currentExportRecords(const QMap<int, MemoryEntry>& memori
 QString selectionHintText()
 {
 #if defined(Q_OS_MACOS)
-    return "Tip: Double-click tunes. Command-click adds or removes rows from the selection.";
+    return "Tip: Double-click tunes. Shift-click selects a range. Command-click adds or removes rows.";
 #else
-    return "Tip: Double-click tunes. Shift-click or Ctrl-click selects multiple rows.";
+    return "Tip: Double-click tunes. Shift-click selects a range. Ctrl-click adds or removes rows.";
 #endif
 }
 
@@ -190,6 +194,64 @@ QString describeMemory(const MemoryEntry& memory)
         ? QString("Memory %1").arg(memory.index)
         : memory.name.trimmed();
     return QString("%1 (%2 MHz)").arg(label, QString::number(memory.freq, 'f', 6));
+}
+
+QString describeImportedMemory(const MemoryEntry& memory)
+{
+    const QString label = memory.name.trimmed();
+    if (!label.isEmpty())
+        return QString("%1 (%2 MHz)").arg(label, QString::number(memory.freq, 'f', 6));
+    if (memory.freq > 0.0)
+        return QString("%1 MHz").arg(QString::number(memory.freq, 'f', 6));
+    return "Unnamed memory";
+}
+
+QString formatImportIssue(const QString& rowLabel,
+                          const QString& message,
+                          const QString& detail = QString())
+{
+    const QString normalizedDetail = detail.simplified();
+    return normalizedDetail.isEmpty()
+        ? QString("%1: %2").arg(rowLabel, message)
+        : QString("%1: %2 (%3)").arg(rowLabel, message, normalizedDetail);
+}
+
+struct MemoryUpdateData {
+    QString commandSuffix;
+    QMap<QString, QString> kvs;
+};
+
+MemoryUpdateData buildMemoryUpdateData(const MemoryEntry& memory)
+{
+    MemoryUpdateData update;
+
+    auto appendField = [&update](const QString& key, const QString& value) {
+        if (!update.commandSuffix.isEmpty())
+            update.commandSuffix += ' ';
+        update.commandSuffix += key + '=' + value;
+        update.kvs[key] = value;
+    };
+
+    appendField("group", encodeMemoryText(memory.group));
+    appendField("owner", encodeMemoryText(memory.owner));
+    appendField("freq", QString::number(memory.freq, 'f', 6));
+    appendField("name", encodeMemoryText(memory.name));
+    appendField("mode", memory.mode);
+    appendField("step", QString::number(memory.step));
+    appendField("repeater", memory.offsetDir);
+    appendField("repeater_offset", QString::number(memory.repeaterOffset, 'f', 6));
+    appendField("tone_mode", memory.toneMode);
+    appendField("tone_value", QString::number(memory.toneValue, 'f', 1));
+    appendField("squelch", memory.squelch ? "1" : "0");
+    appendField("squelch_level", QString::number(memory.squelchLevel));
+    appendField("rx_filter_low", QString::number(memory.rxFilterLow));
+    appendField("rx_filter_high", QString::number(memory.rxFilterHigh));
+    appendField("rtty_mark", QString::number(memory.rttyMark));
+    appendField("rtty_shift", QString::number(memory.rttyShift));
+    appendField("digl_offset", QString::number(memory.diglOffset));
+    appendField("digu_offset", QString::number(memory.diguOffset));
+
+    return update;
 }
 
 } // namespace
@@ -269,6 +331,7 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
 
     // ── Buttons ───────────────────────────────────────────────────────────
     auto* btnRow = new QHBoxLayout;
+    auto* importBtn = new QPushButton("Import...");
     auto* exportBtn = new QPushButton("Export...");
     auto* addBtn = new QPushButton("Add");
     m_selectionLabel = new QLabel("0 selected");
@@ -280,17 +343,19 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     btnRow->addWidget(m_editBtn);
     btnRow->addWidget(m_selectBtn);
     btnRow->addWidget(m_selectAllBtn);
+    btnRow->addWidget(importBtn);
     btnRow->addWidget(exportBtn);
     btnRow->addStretch();
     btnRow->addWidget(m_selectionLabel);
     btnRow->addWidget(m_removeBtn);
     root->addLayout(btnRow);
 
-    for (QPushButton* button : {addBtn, m_editBtn, m_selectBtn, m_selectAllBtn, exportBtn, m_removeBtn}) {
+    for (QPushButton* button : {addBtn, m_editBtn, m_selectBtn, m_selectAllBtn, importBtn, exportBtn, m_removeBtn}) {
         button->setAutoDefault(false);
         button->setDefault(false);
     }
 
+    connect(importBtn, &QPushButton::clicked, this, &MemoryDialog::onImport);
     connect(exportBtn, &QPushButton::clicked, this, &MemoryDialog::onExport);
     connect(addBtn, &QPushButton::clicked, this, &MemoryDialog::onAdd);
     connect(m_editBtn, &QPushButton::clicked, this, &MemoryDialog::onEdit);
@@ -373,27 +438,6 @@ void MemoryDialog::keyPressEvent(QKeyEvent* event)
 
 bool MemoryDialog::eventFilter(QObject* watched, QEvent* event)
 {
-    if (m_table && watched == m_table->viewport() && event->type() == QEvent::MouseButtonPress) {
-#if !defined(Q_OS_MACOS)
-        auto* mouseEvent = static_cast<QMouseEvent*>(event);
-        if (mouseEvent->button() == Qt::LeftButton
-            && (mouseEvent->modifiers() & Qt::ShiftModifier)) {
-            const QModelIndex index = m_table->indexAt(mouseEvent->position().toPoint());
-            if (index.isValid()) {
-                auto* selectionModel = m_table->selectionModel();
-                const bool wasSelected = selectionModel->isRowSelected(index.row(), QModelIndex());
-                const QModelIndex firstColumn = m_table->model()->index(index.row(), 0);
-                selectionModel->select(firstColumn, (wasSelected
-                    ? QItemSelectionModel::Deselect
-                    : QItemSelectionModel::Select) | QItemSelectionModel::Rows);
-                m_table->setCurrentCell(index.row(), 0, QItemSelectionModel::NoUpdate);
-                updateSelectionActions();
-                return true;
-            }
-        }
-#endif
-    }
-
     if (event->type() == QEvent::KeyPress) {
         auto* keyEvent = static_cast<QKeyEvent*>(event);
         const int key = keyEvent->key();
@@ -876,6 +920,198 @@ void MemoryDialog::onExport()
                                  .arg(QDir::toNativeSeparators(QFileInfo(path).fileName())));
 }
 
+void MemoryDialog::onImport()
+{
+    const QString path = QFileDialog::getOpenFileName(
+        this,
+        "Import Memories",
+        QDir::home().filePath("Documents"),
+        "CSV Files (*.csv)");
+    if (path.isEmpty())
+        return;
+
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        QMessageBox::warning(this, "Import Memories",
+                             QString("Couldn't open %1 for reading.")
+                                 .arg(QDir::toNativeSeparators(path)));
+        return;
+    }
+
+    const MemoryCsvParseResult parsed = MemoryCsvCompat::parse(file.readAll());
+
+    struct ImportState {
+        QList<MemoryCsvRecord> records;
+        QStringList issues;
+        QString fileName;
+        int nextRecord{0};
+        int processedCount{0};
+        int importedCount{0};
+    };
+
+    const auto state = QSharedPointer<ImportState>::create();
+    state->records = parsed.records;
+    state->issues = parsed.errors;
+    state->fileName = QFileInfo(path).fileName();
+
+    const QPointer<MemoryDialog> dialogGuard(this);
+    auto showSummary = [dialogGuard, state]() {
+        if (!dialogGuard)
+            return;
+
+        dialogGuard->populateTable();
+
+        QMessageBox summary(dialogGuard);
+        summary.setWindowTitle("Import Memories");
+        summary.setIcon(state->issues.isEmpty() ? QMessageBox::Information : QMessageBox::Warning);
+        summary.setText(QString("Imported %1 %2 from %3.")
+                            .arg(state->importedCount)
+                            .arg(state->importedCount == 1 ? "record" : "records")
+                            .arg(state->fileName));
+        if (!state->issues.isEmpty()) {
+            summary.setInformativeText(
+                QString("%1 %2 skipped or couldn't be imported. See Details for the row names and messages.")
+                    .arg(state->issues.size())
+                    .arg(state->issues.size() == 1 ? "row was" : "rows were"));
+            summary.setDetailedText(state->issues.join('\n'));
+        }
+        summary.exec();
+        if (dialogGuard)
+            dialogGuard->focusTableOnCurrentRow();
+    };
+
+    if (state->records.isEmpty()) {
+        showSummary();
+        return;
+    }
+
+    auto* progressDialog = new QProgressDialog(
+        QString("Importing 0 of %1 memories...").arg(state->records.size()),
+        QString(), 0, state->records.size(), this);
+    auto* progressBar = new QProgressBar(progressDialog);
+    progressBar->setTextVisible(false);
+    progressDialog->setBar(progressBar);
+    progressDialog->setWindowTitle("Import Memories");
+    progressDialog->setWindowModality(Qt::WindowModal);
+    progressDialog->setMinimumDuration(0);
+    progressDialog->setAutoClose(false);
+    progressDialog->setAutoReset(false);
+    progressDialog->setCancelButton(nullptr);
+    progressDialog->setWindowFlag(Qt::WindowCloseButtonHint, false);
+    progressDialog->setMinimumWidth(420);
+    progressDialog->setValue(0);
+    progressDialog->show();
+
+    RadioModel* const model = m_model;
+    const QPointer<QProgressDialog> progressGuard(progressDialog);
+    auto advanceProgress = [state, progressGuard]() {
+        ++state->processedCount;
+        if (progressGuard)
+            progressGuard->setValue(state->processedCount);
+    };
+    const auto runNext = QSharedPointer<std::function<void()>>::create();
+    *runNext = [model, dialogGuard, state, runNext, showSummary, progressGuard, advanceProgress]() {
+        if (!dialogGuard)
+            return;
+
+        if (state->nextRecord >= state->records.size()) {
+            if (progressGuard) {
+                progressGuard->setValue(progressGuard->maximum());
+                progressGuard->close();
+            }
+            showSummary();
+            return;
+        }
+
+        const MemoryCsvRecord record = state->records.at(state->nextRecord++);
+        const QString rowLabel = describeImportedMemory(record.memory);
+        const MemoryUpdateData update = buildMemoryUpdateData(record.memory);
+        if (progressGuard) {
+            const int currentRecord = state->processedCount + 1;
+            const int percent = state->records.isEmpty()
+                ? 0
+                : qRound((double(currentRecord) * 100.0) / double(state->records.size()));
+            const QString percentText = QString::number(percent) + QLatin1Char('%');
+            progressGuard->setLabelText(
+                QString("Importing %1 of %2 memories (%3)...\n\n%4")
+                    .arg(currentRecord)
+                    .arg(state->records.size())
+                    .arg(percentText)
+                    .arg(rowLabel));
+        }
+
+        model->sendCmdPublic("memory create",
+            [model, dialogGuard, state, runNext, rowLabel, update, advanceProgress](int code, const QString& body) {
+            if (!dialogGuard)
+                return;
+
+            if (code != 0) {
+                state->issues << formatImportIssue(
+                    rowLabel,
+                    "couldn't create a new memory on the radio",
+                    body);
+                advanceProgress();
+                (*runNext)();
+                return;
+            }
+
+            bool ok = false;
+            const int idx = body.trimmed().toInt(&ok);
+            if (!ok) {
+                state->issues << formatImportIssue(
+                    rowLabel,
+                    "the radio returned an unrecognized memory id",
+                    body);
+                advanceProgress();
+                (*runNext)();
+                return;
+            }
+
+            model->sendCmdPublic(
+                QString("memory set %1 %2").arg(idx).arg(update.commandSuffix),
+                [model, dialogGuard, state, runNext, rowLabel, update, idx, advanceProgress](int setCode, const QString& setBody) {
+                if (!dialogGuard)
+                    return;
+
+                if (setCode == 0) {
+                    model->handleMemoryStatus(idx, update.kvs);
+                    ++state->importedCount;
+                    advanceProgress();
+                    (*runNext)();
+                    return;
+                }
+
+                state->issues << formatImportIssue(
+                    rowLabel,
+                    "the radio rejected one or more imported fields",
+                    setBody);
+
+                model->sendCmdPublic(QString("memory remove %1").arg(idx),
+                    [model, dialogGuard, state, runNext, rowLabel, idx, advanceProgress](int removeCode, const QString& removeBody) {
+                    if (!dialogGuard)
+                        return;
+
+                    if (removeCode == 0) {
+                        QMap<QString, QString> kvs;
+                        kvs["removed"] = QString{};
+                        model->handleMemoryStatus(idx, kvs);
+                    } else {
+                        state->issues << formatImportIssue(
+                            rowLabel,
+                            "the partially created memory couldn't be cleaned up automatically",
+                            removeBody);
+                    }
+
+                    advanceProgress();
+                    (*runNext)();
+                });
+            });
+        });
+    };
+
+    (*runNext)();
+}
+
 void MemoryDialog::onSelect()
 {
     if (selectedMemoryIndices().size() != 1)
@@ -947,18 +1183,88 @@ void MemoryDialog::onRemove()
     RadioModel* const model = m_model;
     const QPointer<MemoryDialog> dialogGuard(this);
     struct RemovalState {
-        int remaining{0};
+        QList<int> indices;
+        QStringList descriptions;
+        int nextIndex{0};
+        int processedCount{0};
         int failed{0};
         QStringList failedDescriptions;
     };
     const auto state = QSharedPointer<RemovalState>::create();
-    state->remaining = indices.size();
+    state->indices = indices;
+    state->descriptions = memoryDescriptions;
 
-    for (int i = 0; i < indices.size(); ++i) {
-        const int idx = indices.at(i);
-        const QString description = memoryDescriptions.value(i, QString("Memory %1").arg(idx));
-        m_model->sendCmdPublic(QString("memory remove %1").arg(idx),
-            [model, dialogGuard, idx, description, state](int code, const QString&) {
+    auto* progressDialog = new QProgressDialog(
+        QString("Deleting 0 of %1 memories...").arg(indices.size()),
+        QString(), 0, indices.size(), this);
+    auto* progressBar = new QProgressBar(progressDialog);
+    progressBar->setTextVisible(false);
+    progressDialog->setBar(progressBar);
+    progressDialog->setWindowTitle(indices.size() == 1 ? "Delete Memory" : "Delete Memories");
+    progressDialog->setWindowModality(Qt::WindowModal);
+    progressDialog->setMinimumDuration(0);
+    progressDialog->setAutoClose(false);
+    progressDialog->setAutoReset(false);
+    progressDialog->setCancelButton(nullptr);
+    progressDialog->setWindowFlag(Qt::WindowCloseButtonHint, false);
+    progressDialog->setMinimumWidth(420);
+    progressDialog->setValue(0);
+    progressDialog->show();
+
+    const QPointer<QProgressDialog> progressGuard(progressDialog);
+    auto advanceProgress = [state, progressGuard]() {
+        ++state->processedCount;
+        if (progressGuard)
+            progressGuard->setValue(state->processedCount);
+    };
+
+    const auto runNext = QSharedPointer<std::function<void()>>::create();
+    *runNext = [model, dialogGuard, state, runNext, progressGuard, advanceProgress]() {
+        if (!dialogGuard)
+            return;
+
+        if (state->nextIndex >= state->indices.size()) {
+            if (progressGuard) {
+                progressGuard->setValue(progressGuard->maximum());
+                progressGuard->close();
+            }
+            dialogGuard->populateTable();
+            if (state->failed > 0) {
+                QMessageBox failure(dialogGuard);
+                failure.setIcon(QMessageBox::Warning);
+                failure.setWindowTitle(state->failed == 1 ? "Delete Memory" : "Delete Memories");
+                failure.setText(state->failed == 1
+                    ? QString("Couldn't delete %1.").arg(state->failedDescriptions.value(0))
+                    : QString("Couldn't delete %1 memories.").arg(state->failed));
+                if (state->failedDescriptions.size() > 1)
+                    failure.setDetailedText(state->failedDescriptions.join('\n'));
+                failure.exec();
+            }
+            dialogGuard->focusTableOnCurrentRow();
+            return;
+        }
+
+        const int idx = state->indices.at(state->nextIndex);
+        const QString description = state->descriptions.value(
+            state->nextIndex, QString("Memory %1").arg(idx));
+        ++state->nextIndex;
+
+        if (progressGuard) {
+            const int currentRecord = state->processedCount + 1;
+            const int percent = state->indices.isEmpty()
+                ? 0
+                : qRound((double(currentRecord) * 100.0) / double(state->indices.size()));
+            const QString percentText = QString::number(percent) + QLatin1Char('%');
+            progressGuard->setLabelText(
+                QString("Deleting %1 of %2 memories (%3)...\n\n%4")
+                    .arg(currentRecord)
+                    .arg(state->indices.size())
+                    .arg(percentText)
+                    .arg(description));
+        }
+
+        model->sendCmdPublic(QString("memory remove %1").arg(idx),
+            [model, dialogGuard, idx, description, state, runNext, advanceProgress](int code, const QString&) {
             if (code == 0) {
                 QMap<QString, QString> kvs;
                 kvs["removed"] = QString{};
@@ -967,22 +1273,13 @@ void MemoryDialog::onRemove()
                 ++state->failed;
                 state->failedDescriptions << description;
             }
-
-            --state->remaining;
-            if (state->remaining == 0 && dialogGuard) {
-                dialogGuard->populateTable();
-                if (state->failed > 0) {
-                    QMessageBox::warning(
-                        dialogGuard,
-                        state->failed == 1 ? "Delete Memory" : "Delete Memories",
-                        state->failed == 1
-                            ? QString("Couldn't delete %1.").arg(state->failedDescriptions.value(0))
-                            : QString("Couldn't delete %1 memories.").arg(state->failed));
-                }
-                dialogGuard->focusTableOnCurrentRow();
-            }
+            advanceProgress();
+            if (dialogGuard)
+                (*runNext)();
         });
-    }
+    };
+
+    (*runNext)();
 }
 
 void MemoryDialog::rebuildFilterCombo()

--- a/src/gui/MemoryDialog.h
+++ b/src/gui/MemoryDialog.h
@@ -38,6 +38,7 @@ private:
     void setInlineEditMode(bool enabled);
     void submitCellEdit(int row, int col);
     void onAdd();
+    void onImport();
     void onExport();
     void onEdit();
     void onSelect();

--- a/src/gui/MemoryDialog.h
+++ b/src/gui/MemoryDialog.h
@@ -3,12 +3,16 @@
 #include <QDialog>
 #include <QCloseEvent>
 #include <QEvent>
+#include <QKeyEvent>
 #include <QShowEvent>
+#include <QSet>
 #include <QTableWidget>
 #include <QMap>
 
 class QComboBox;
+class QLabel;
 class QLineEdit;
+class QPushButton;
 
 namespace AetherSDR {
 
@@ -23,23 +27,39 @@ public:
 protected:
     void closeEvent(QCloseEvent* event) override;
     bool eventFilter(QObject* watched, QEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
     void showEvent(QShowEvent* event) override;
 
 private:
     void activateMemoryRow(int row);
+    void beginEditingMemoryName(int memoryIndex);
+    void focusTableOnCurrentRow();
     void populateTable();
+    void setInlineEditMode(bool enabled);
     void submitCellEdit(int row, int col);
     void onAdd();
     void onExport();
+    void onEdit();
     void onSelect();
+    void onSelectAll();
     void onRemove();
     bool isSortableColumn(int column) const;
     void rebuildFilterCombo();
+    QSet<int> selectedMemoryIndices() const;
+    void updateSelectionActions();
 
     RadioModel* m_model;
     QTableWidget* m_table;
     QLineEdit* m_searchEdit;
     QComboBox* m_filterCombo;
+    QLabel* m_selectionLabel{nullptr};
+    QPushButton* m_editBtn{nullptr};
+    QPushButton* m_selectBtn{nullptr};
+    QPushButton* m_selectAllBtn{nullptr};
+    QPushButton* m_removeBtn{nullptr};
+    int m_pendingEditMemoryIndex{-1};
+    int m_pendingEditRetries{0};
+    bool m_inlineEditMode{false};
     int m_sortColumn{2};
     Qt::SortOrder m_sortOrder{Qt::AscendingOrder};
 };


### PR DESCRIPTION

<img width="1023" height="555" alt="image" src="https://github.com/user-attachments/assets/dc59e5ed-b40f-4bf9-a376-4d16ba3726a2" />

## Summary

This PR adds bulk memory CSV import to the Memories dialog and rounds out the batch-action UX with progress feedback for both import and delete.

The new import flow is designed around SmartSDR-compatible memory CSVs. Users can now import a file directly from the dialog, let valid rows import even when some rows are bad, and get a final summary that reports how many records were imported along with row-specific error details.

This branch is stacked on top of #1522. Until that PR merges, GitHub will show the memory-dialog interaction and bulk-selection commits from that branch in the combined diff. The net-new work in this PR is the CSV import path, improved CSV error reporting, and modal progress dialogs for long-running batch actions.

## What Changed

- Added an `Import...` button to the Memories dialog, positioned to the left of `Export...`.
- Added SmartSDR-compatible CSV import using the existing compatibility parser.
- Made import tolerant of mixed files:
  - valid rows are imported
  - invalid rows are skipped
  - the final results dialog lists row-specific failures
- Improved CSV parser error messages so invalid rows are identified by line number and, when possible, by memory name.
- Added modal progress dialogs for:
  - memory import
  - bulk memory delete
- Updated progress labels to show `Importing X of Y memories (Z%)...` / `Deleting X of Y memories (Z%)...` with the current row name.
- Carried forward the native row-selection behavior fix so the dialog follows platform-standard range/toggle selection semantics.

## Why This Changed

The export path already made it possible to move memories out of AetherSDR, but there was no corresponding import path to bring them back in or migrate them from SmartSDR-style CSVs. That made larger memory workflows tedious and forced users into one-at-a-time manual entry.

Once import existed, large files also exposed a UX gap: users could still interact with the dialog while rows were being imported or deleted asynchronously. The progress dialogs in this PR make those long-running operations feel intentional, visible, and safe.

## User Impact

Users can now:

- import large memory lists directly into the Memories dialog
- reuse exported AetherSDR memory CSVs as an import source
- see exactly which rows failed and why instead of only getting a generic failure
- watch progress during large imports and deletes instead of wondering whether the app is still working

## Root Cause Addressed

There were two underlying gaps:

1. The Memories dialog had a one-way CSV workflow: export only, no import.
2. Batch operations were asynchronous but not visually modal, so the dialog remained interactive during work that should have been treated as in-progress.

This PR addresses both by wiring a tolerant import pipeline into the dialog and adding modal progress feedback for long-running batch operations.

## Implementation Notes

- Import reuses `MemoryCsvCompat::parse()` and the existing memory create/set/remove command flow.
- When a combined row import fails after `memory create`, the temporary memory is removed so the radio is not left with a partially imported row.
- Parser diagnostics were upgraded so failures can name the offending row more clearly.
- The import and delete progress dialogs are window-modal, non-cancelable, and close into the existing completion/failure summaries.

## Validation

Validated locally with:

- `cmake -S . -B build -G Ninja`
- `cmake --build build -j10`

Manual smoke testing covered:

- importing a clean SmartSDR-compatible CSV
- importing a mixed CSV with named invalid rows and verifying detailed error reporting
- importing a larger CSV exported from AetherSDR
- verifying modal progress dialogs during import and bulk delete
- confirming import/deletion summary dialogs still report failures cleanly
- confirming the progress label percentage and row text update correctly

## Notes For Review

- Because this branch is stacked on #1522, I would review this PR commit-by-commit or after #1522 lands if you want the cleanest incremental diff.
- Local temporary smoke-test CSVs were not included in the commit.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.4 Pro) and tested by @jensenpat
