### PR TITLE
[network] Improve radio connection UX and panadapter feedback

### DIFF
--- a/resources/help/aethersdr-help.md
+++ b/resources/help/aethersdr-help.md
@@ -46,7 +46,7 @@ This is the best place to look when you want to answer, "Is this a station probl
 This is the operational configuration menu. It contains most dialogs that affect station behavior, radio setup, control surfaces, and external integrations.
 
 - `Radio Setup...`: the main multi-tab radio configuration dialog.
-- `Choose Radio / SmartLink Setup...`: opens the floating Connection panel.
+- `Connect to Radio...`: opens the radio connection dialog.
 - `FlexControl...`: jumps directly into the serial and FlexControl setup area when serial support is available.
 - `Network...`: opens network diagnostics.
 - `Memory...`: opens the memory channel manager.
@@ -357,15 +357,15 @@ If you are operating quickly, this row helps prevent "silent failures" where the
 
 ### Connection panel
 
-The floating Connection panel is the gateway to the radio. It includes:
+The `Connect to Radio` dialog is the gateway to the radio. It includes:
 
-- discovered radio list
-- `Low Bandwidth` mode
-- connect or disconnect button
-- SmartLink login section
-- manual IP connection section
+- `On This Network` for beginner-friendly LAN discovery
+- `Remote with SmartLink` for internet-connected stations
+- `Connect by IP` for VPN or routed access when you already know the radio IP
+- contextual `Low Bandwidth` mode for SmartLink or VPN links
+- diagnostics and recovery actions when discovery does not find a radio
 
-This panel is meant to be simple enough for initial connection but detailed enough to support remote and manual workflows.
+The dialog is meant to keep the novice path obvious while still exposing manual routing controls only when a station actually needs them.
 
 ### multiFLEX dashboard
 

--- a/resources/help/getting-started.md
+++ b/resources/help/getting-started.md
@@ -25,26 +25,27 @@ Make sure:
 ### Local LAN connection
 
 1. Start AetherSDR.
-2. Wait for the Connection panel to show discovered radios.
-3. If the panel is not visible, open `Settings -> Choose Radio / SmartLink Setup...`.
+2. Wait for the `Connect to Radio` dialog to show radios on the `On This Network` page.
+3. If the dialog is not visible, open `Settings -> Connect to Radio...`.
 4. Select the radio you want.
-5. Leave `Low Bandwidth` off for normal local use unless you are intentionally reducing display traffic.
-6. Click `Connect`.
+5. Click `Connect`.
 
 If nothing appears in the discovered list:
 
 1. Confirm the radio and computer are on the same network segment.
 2. Check that guest Wi-Fi isolation, VPN software, or firewall rules are not blocking discovery.
-3. Try the manual IP field in the `Manual Connection` section if you know the radio's address.
+3. Try `Connect by IP` if you know the radio's address or are reaching it through a VPN.
 4. Open `Settings -> Network...` for diagnostics if discovery still fails.
 
 ### SmartLink remote connection
 
-1. Open `Settings -> Choose Radio / SmartLink Setup...`.
-2. Use the SmartLink section to sign in.
-3. Select the WAN radio or station entry you want to use.
-4. Click `Connect`.
-5. Give the audio and panadapter streams a few extra seconds to settle, especially on slower links.
+1. Open `Settings -> Connect to Radio...`.
+2. Switch to `Remote with SmartLink`.
+3. Sign in to SmartLink.
+4. Select the remote radio you want to use.
+5. Turn on `Low Bandwidth` first if you are on a slower internet path.
+6. Click `Connect`.
+7. Give the audio and panadapter streams a few extra seconds to settle, especially on slower links.
 
 Remote operation depends more heavily on Internet quality, latency, and firewall setup than LAN operation. If the display or audio feels rough, simplify the session first by using fewer panadapters and avoiding unnecessary visual load.
 

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -2,17 +2,18 @@
 #include "core/AppSettings.h"
 #include "core/NetworkPathResolver.h"
 
-#include <QVBoxLayout>
-#include <QHBoxLayout>
+#include <QAbstractItemView>
+#include <QFormLayout>
+#include <QFrame>
 #include <QGroupBox>
-#include <QCheckBox>
-#include <QEvent>
-#include <QPainter>
-#include <QPainterPath>
-#include <QDebug>
+#include <QHBoxLayout>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QPainter>
 #include <QSignalBlocker>
+#include <QTcpSocket>
+#include <QTimer>
+#include <QVBoxLayout>
 
 namespace AetherSDR {
 
@@ -23,6 +24,10 @@ constexpr int kSourceInterfaceIdRole = Qt::UserRole + 11;
 constexpr int kSourceInterfaceNameRole = Qt::UserRole + 12;
 constexpr int kSourceAddressRole = Qt::UserRole + 13;
 constexpr int kSourceStaleRole = Qt::UserRole + 14;
+
+const char* kHintLabelStyle = "QLabel { color: #8aa8c0; font-size: 11px; }";
+const char* kInfoLabelStyle = "QLabel { color: #9bd1ff; font-size: 11px; }";
+const char* kErrorLabelStyle = "QLabel { color: #ff8f8f; font-size: 11px; }";
 
 QJsonObject loadRoutedProfiles()
 {
@@ -66,168 +71,460 @@ QString staleSelectionText(const RadioBindSettings& settings)
     return QStringLiteral("%1 (unavailable, last %2)").arg(iface, addr);
 }
 
+QLabel* makeWrappedLabel(const QString& text, const char* style = nullptr)
+{
+    auto* label = new QLabel(text);
+    label->setWordWrap(true);
+    if (style)
+        label->setStyleSheet(style);
+    return label;
+}
+
+QString smartLinkUserText(const SmartLinkClient* client)
+{
+    if (!client)
+        return QStringLiteral("Sign in to see radios at remote stations.");
+
+    if (!client->firstName().isEmpty()) {
+        const QString call = client->callsign().trimmed();
+        if (!call.isEmpty()) {
+            return QStringLiteral("%1 %2 (%3)")
+                .arg(client->firstName().trimmed(),
+                     client->lastName().trimmed(),
+                     call);
+        }
+        return QStringLiteral("%1 %2")
+            .arg(client->firstName().trimmed(), client->lastName().trimmed());
+    }
+
+    if (!client->callsign().trimmed().isEmpty())
+        return QStringLiteral("Signed in as %1").arg(client->callsign().trimmed());
+
+    return QStringLiteral("Signed in to SmartLink");
+}
+
+QString normalizedStatus(QString status)
+{
+    status.replace('_', ' ');
+    return status.trimmed();
+}
+
 }
 
 ConnectionPanel::ConnectionPanel(QWidget* parent)
     : QWidget(parent)
 {
-    setStyleSheet("ConnectionPanel { background: #0f0f1a; }");
+    setStyleSheet(
+        "ConnectionPanel { background: #0f0f1a; }"
+        "QGroupBox { border: 1px solid #304050; border-radius: 7px; margin-top: 10px; "
+        "color: #c8d8e8; font-weight: bold; }"
+        "QGroupBox::title { subcontrol-origin: margin; left: 10px; padding: 0 4px; }"
+        "QListWidget { background: #09111b; border: 1px solid #304050; border-radius: 4px; "
+        "color: #d7e4f2; padding: 2px; }"
+        "QPushButton { padding: 5px 12px; }");
+
     const QString editStyle =
-        "QLineEdit { border: 1px solid #304050; "
-        "border-radius: 3px; padding: 2px 4px; }";
+        "QLineEdit { border: 1px solid #304050; border-radius: 4px; padding: 4px 6px; "
+        "background: #09111b; color: #d7e4f2; }";
+    const QString modeCardStyle =
+        "QCommandLinkButton { text-align: left; border: 1px solid #304050; border-radius: 8px; "
+        "padding: 10px 12px; background: #121a25; color: #d7e4f2; }"
+        "QCommandLinkButton:hover { border-color: #4e6a86; background: #172334; }"
+        "QCommandLinkButton:checked { border-color: #66a8ff; background: #1a3046; }";
+    const QString calloutStyle =
+        "QFrame { border: 1px solid #304050; border-radius: 8px; background: #121a25; }";
+    const QString lowBandwidthCheckStyle =
+        "QCheckBox { color: #d7e4f2; spacing: 8px; padding: 2px 0; }"
+        "QCheckBox::indicator { width: 16px; height: 16px; "
+        "border: 2px solid #5d748d; border-radius: 3px; background: #0b1520; }"
+        "QCheckBox::indicator:hover { border-color: #81abd9; background: #142130; }"
+        "QCheckBox::indicator:checked { border: 2px solid #8cc8ff; background: #2f71b6; }"
+        "QCheckBox::indicator:disabled { border-color: #405262; background: #10161d; }";
 
-    auto* vbox = new QVBoxLayout(this);
-    vbox->setContentsMargins(8, 8, 8, 8);
-    vbox->setSpacing(6);
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(12, 12, 12, 12);
+    root->setSpacing(10);
 
-    // Status label (shows connection state text)
-    m_statusLabel = new QLabel("Not connected", this);
-    m_statusLabel->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; }");
-    m_statusLabel->setAlignment(Qt::AlignCenter);
-    vbox->addWidget(m_statusLabel);
+    auto* titleLabel = new QLabel("Connect to a Radio", this);
+    titleLabel->setStyleSheet("QLabel { color: #e7f1fb; font-size: 18px; font-weight: bold; }");
+    root->addWidget(titleLabel);
 
-    // Discovered radios list
-    m_radioGroup = new QGroupBox("Discovered Radios", this);
-    auto* gbox  = new QVBoxLayout(m_radioGroup);
-    m_radioList = new QListWidget(m_radioGroup);
+    auto* introLabel = makeWrappedLabel(
+        "Pick the simplest path for your station. Most first-time users should start with "
+        "\"On This Network\" and only use the IP path for VPN or routed connections.",
+        kHintLabelStyle);
+    root->addWidget(introLabel);
+
+    m_modeButtons = new QButtonGroup(this);
+    m_modeButtons->setExclusive(true);
+
+    auto configureModeButton = [&](QCommandLinkButton* button,
+                                   const QString& title,
+                                   const QString& description,
+                                   ConnectionMode mode) {
+        button->setText(title);
+        button->setDescription(description);
+        button->setCheckable(true);
+        button->setStyleSheet(modeCardStyle);
+        button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+        button->setMinimumHeight(84);
+        m_modeButtons->addButton(button, static_cast<int>(mode));
+    };
+
+    auto* modeRow = new QHBoxLayout;
+    modeRow->setSpacing(8);
+
+    m_localModeBtn = new QCommandLinkButton(this);
+    configureModeButton(m_localModeBtn,
+                        "On This Network",
+                        "Recommended for new users when the radio and computer are on the same LAN.",
+                        LocalMode);
+    modeRow->addWidget(m_localModeBtn);
+
+    m_smartLinkModeBtn = new QCommandLinkButton(this);
+    configureModeButton(m_smartLinkModeBtn,
+                        "Remote with SmartLink",
+                        "Use FlexRadio SmartLink when the radio is away from this computer.",
+                        SmartLinkMode);
+    modeRow->addWidget(m_smartLinkModeBtn);
+
+    m_manualModeBtn = new QCommandLinkButton(this);
+    configureModeButton(m_manualModeBtn,
+                        "Connect by IP",
+                        "Best for VPN or routed station access when you already know the radio IP.",
+                        ManualMode);
+    modeRow->addWidget(m_manualModeBtn);
+
+    root->addLayout(modeRow);
+
+    m_modeStack = new QStackedWidget(this);
+    root->addWidget(m_modeStack, 1);
+
+    // ── Local page ────────────────────────────────────────────────────────
+    auto* localPage = new QWidget(m_modeStack);
+    auto* localLayout = new QVBoxLayout(localPage);
+    localLayout->setContentsMargins(0, 0, 0, 0);
+    localLayout->setSpacing(8);
+    localLayout->addWidget(makeWrappedLabel(
+        "Discovery finds radios automatically on your local network. If nothing appears, "
+        "guest Wi-Fi isolation, VPN software, or firewall rules may be blocking discovery.",
+        kHintLabelStyle));
+
+    m_localStateStack = new QStackedWidget(localPage);
+    localLayout->addWidget(m_localStateStack, 1);
+
+    auto* localListPage = new QWidget(m_localStateStack);
+    auto* localListLayout = new QVBoxLayout(localListPage);
+    localListLayout->setContentsMargins(0, 0, 0, 0);
+    localListLayout->setSpacing(8);
+    auto* localGroup = new QGroupBox("Available radios", localListPage);
+    auto* localGroupLayout = new QVBoxLayout(localGroup);
+    m_radioList = new QListWidget(localGroup);
     m_radioList->setSelectionMode(QAbstractItemView::SingleSelection);
-    gbox->addWidget(m_radioList);
-    vbox->addWidget(m_radioGroup, 1);
+    m_radioList->setWordWrap(true);
+    m_radioList->setSpacing(2);
+    m_radioList->setMinimumHeight(220);
+    localGroupLayout->addWidget(m_radioList);
+    localListLayout->addWidget(localGroup, 1);
 
-    // Low bandwidth checkbox
-    m_lowBwCheck = new QCheckBox("Low Bandwidth", this);
-    m_lowBwCheck->setChecked(
-        AppSettings::instance().value("LowBandwidthConnect", "False").toString() == "True");
-    m_lowBwCheck->setToolTip("Reduces FFT/waterfall data from the radio.\n"
-                             "Recommended for VPN, LTE, or other metered/limited links.");
-    m_lowBwCheck->setStyleSheet("QCheckBox { color: #8aa8c0; font-size: 11px; }");
-    vbox->addWidget(m_lowBwCheck);
+    auto* localActionRow = new QHBoxLayout;
+    localActionRow->addStretch();
+    m_localConnectBtn = new QPushButton("Connect Selected Radio", localListPage);
+    m_localConnectBtn->setEnabled(false);
+    localActionRow->addWidget(m_localConnectBtn);
+    localListLayout->addLayout(localActionRow);
+    m_localStateStack->addWidget(localListPage);
 
-    // Connect/disconnect button
-    m_connectBtn = new QPushButton("Connect", this);
-    m_connectBtn->setEnabled(false);
-    vbox->addWidget(m_connectBtn);
+    m_localEmptyState = new QWidget(m_localStateStack);
+    auto* emptyLayout = new QVBoxLayout(m_localEmptyState);
+    emptyLayout->setContentsMargins(0, 0, 0, 0);
+    emptyLayout->setSpacing(8);
+    auto* emptyCallout = new QFrame(m_localEmptyState);
+    emptyCallout->setStyleSheet(calloutStyle);
+    auto* emptyCalloutLayout = new QVBoxLayout(emptyCallout);
+    emptyCalloutLayout->setContentsMargins(14, 14, 14, 14);
+    emptyCalloutLayout->setSpacing(8);
+    auto* emptyTitle = new QLabel("No local radios found yet", emptyCallout);
+    emptyTitle->setStyleSheet("QLabel { color: #e7f1fb; font-size: 15px; font-weight: bold; }");
+    emptyCalloutLayout->addWidget(emptyTitle);
+    emptyCalloutLayout->addWidget(makeWrappedLabel(
+        "AetherSDR is still listening for discovery packets. If your station is on a VPN "
+        "or another routed network, switch to \"Connect by IP\" instead.",
+        kHintLabelStyle));
 
-    // ── SmartLink login section ──────────────────────────────────────────
-    m_smartLinkGroup = new QGroupBox("SmartLink", this);
-    auto* slBox = new QVBoxLayout(m_smartLinkGroup);
-    slBox->setSpacing(4);
+    auto* retryBtn = new QPushButton("Retry Discovery", emptyCallout);
+    auto* useSmartLinkBtn = new QPushButton("Remote with SmartLink", emptyCallout);
+    auto* connectByIpBtn = new QPushButton("Connect by IP", emptyCallout);
+    auto* diagnosticsBtn = new QPushButton("Open Network Diagnostics", emptyCallout);
+    emptyCalloutLayout->addWidget(retryBtn);
+    emptyCalloutLayout->addWidget(connectByIpBtn);
+    emptyCalloutLayout->addWidget(useSmartLinkBtn);
+    emptyCalloutLayout->addWidget(diagnosticsBtn);
+    emptyLayout->addWidget(emptyCallout);
+    emptyLayout->addStretch();
+    m_localStateStack->addWidget(m_localEmptyState);
 
-    // Login form container (hidden after successful login)
-    m_loginForm = new QWidget(m_smartLinkGroup);
-    auto* loginLayout = new QVBoxLayout(m_loginForm);
+    m_modeStack->addWidget(localPage);
+
+    // ── SmartLink page ────────────────────────────────────────────────────
+    auto* smartLinkPage = new QWidget(m_modeStack);
+    auto* smartLinkLayout = new QVBoxLayout(smartLinkPage);
+    smartLinkLayout->setContentsMargins(0, 0, 0, 0);
+    smartLinkLayout->setSpacing(8);
+    smartLinkLayout->addWidget(makeWrappedLabel(
+        "Use SmartLink when the radio is at another location. Sign in, choose a remote radio, "
+        "then connect over the internet.",
+        kHintLabelStyle));
+
+    auto* accountGroup = new QGroupBox("SmartLink account", smartLinkPage);
+    auto* accountLayout = new QVBoxLayout(accountGroup);
+    accountLayout->setSpacing(6);
+
+    m_loginForm = new QWidget(accountGroup);
+    auto* loginLayout = new QFormLayout(m_loginForm);
     loginLayout->setContentsMargins(0, 0, 0, 0);
-    loginLayout->setSpacing(4);
-
-    auto* emailRow = new QHBoxLayout;
-    emailRow->addWidget(new QLabel("Email:", m_loginForm));
+    loginLayout->setHorizontalSpacing(8);
+    loginLayout->setVerticalSpacing(6);
     m_emailEdit = new QLineEdit(m_loginForm);
     m_emailEdit->setStyleSheet(editStyle);
     m_emailEdit->setPlaceholderText("flexradio account email");
     QString storedEmail = AppSettings::instance().value("SmartLinkEmail").toString();
     if (!storedEmail.isEmpty())
         m_emailEdit->setText(QString::fromUtf8(QByteArray::fromBase64(storedEmail.toUtf8())));
-    emailRow->addWidget(m_emailEdit, 1);
-    loginLayout->addLayout(emailRow);
-
-    auto* passRow = new QHBoxLayout;
-    passRow->addWidget(new QLabel("Pass:", m_loginForm));
     m_passwordEdit = new QLineEdit(m_loginForm);
     m_passwordEdit->setStyleSheet(editStyle);
     m_passwordEdit->setEchoMode(QLineEdit::Password);
     m_passwordEdit->setPlaceholderText("password");
-    passRow->addWidget(m_passwordEdit, 1);
-    loginLayout->addLayout(passRow);
+    loginLayout->addRow("Email:", m_emailEdit);
+    loginLayout->addRow("Password:", m_passwordEdit);
+    m_loginBtn = new QPushButton("Sign In", m_loginForm);
+    loginLayout->addRow(QString(), m_loginBtn);
+    accountLayout->addWidget(m_loginForm);
 
-    m_loginBtn = new QPushButton("Log In", m_loginForm);
-    loginLayout->addWidget(m_loginBtn);
+    m_logoutBtn = new QPushButton("Sign Out", accountGroup);
+    m_logoutBtn->setVisible(false);
+    accountLayout->addWidget(m_logoutBtn, 0, Qt::AlignLeft);
 
-    slBox->addWidget(m_loginForm);
+    m_slUserLabel = makeWrappedLabel("Sign in to see radios at remote stations.", kHintLabelStyle);
+    accountLayout->addWidget(m_slUserLabel);
+    smartLinkLayout->addWidget(accountGroup);
 
-    // User info (shown after login)
-    m_slUserLabel = new QLabel("", m_smartLinkGroup);
-    m_slUserLabel->setStyleSheet("QLabel { color: #00b4d8; font-size: 10px; }");
-    m_slUserLabel->setVisible(false);
-    slBox->addWidget(m_slUserLabel);
+    auto* remoteGroup = new QGroupBox("Remote radios", smartLinkPage);
+    auto* remoteLayout = new QVBoxLayout(remoteGroup);
+    remoteLayout->setSpacing(10);
+    m_wanList = new QListWidget(remoteGroup);
+    m_wanList->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_wanList->setWordWrap(true);
+    m_wanList->setSpacing(2);
+    m_wanList->setMinimumHeight(220);
+    remoteLayout->addWidget(m_wanList);
+    m_smartLinkEmptyLabel = makeWrappedLabel(
+        "Remote radios appear here after SmartLink sign-in.",
+        kHintLabelStyle);
+    remoteLayout->addWidget(m_smartLinkEmptyLabel);
+    auto* wanActionBar = new QWidget(remoteGroup);
+    auto* wanActionRow = new QHBoxLayout(wanActionBar);
+    wanActionRow->setContentsMargins(0, 6, 18, 0);
+    wanActionRow->setSpacing(10);
+    wanActionRow->addStretch();
+    m_wanConnectBtn = new QPushButton("Connect Remote Radio", wanActionBar);
+    m_wanConnectBtn->setEnabled(false);
+    m_wanConnectBtn->setMinimumWidth(190);
+    wanActionRow->addWidget(m_wanConnectBtn);
+    remoteLayout->addWidget(wanActionBar);
+    smartLinkLayout->addWidget(remoteGroup, 1);
 
-    vbox->addWidget(m_smartLinkGroup);
+    m_modeStack->addWidget(smartLinkPage);
 
-    // ── Manual (routed) connection ───────────────────────────────────────
-    m_manualGroup = new QGroupBox("Manual Connection", this);
-    auto* manBox = new QVBoxLayout(m_manualGroup);
-    manBox->setContentsMargins(4, 8, 4, 4);
-    manBox->setSpacing(4);
+    // ── Manual / VPN page ────────────────────────────────────────────────
+    auto* manualPage = new QWidget(m_modeStack);
+    auto* manualLayout = new QVBoxLayout(manualPage);
+    manualLayout->setContentsMargins(0, 0, 0, 0);
+    manualLayout->setSpacing(8);
+    manualLayout->addWidget(makeWrappedLabel(
+        "Use this path for VPN or other routed networks where discovery broadcasts cannot reach "
+        "the radio. Enter the radio IP address and AetherSDR will take care of the probe.",
+        kHintLabelStyle));
 
-    auto* manRow = new QHBoxLayout;
-    manRow->setContentsMargins(0, 0, 0, 0);
-    m_manualIpEdit = new QLineEdit(m_manualGroup);
+    auto* manualGroup = new QGroupBox("Radio IP address", manualPage);
+    auto* manualGroupLayout = new QVBoxLayout(manualGroup);
+    manualGroupLayout->setSpacing(8);
+    auto* manualForm = new QFormLayout;
+    manualForm->setHorizontalSpacing(8);
+    manualForm->setVerticalSpacing(6);
+    m_manualIpEdit = new QLineEdit(manualGroup);
     m_manualIpEdit->setStyleSheet(editStyle);
-    m_manualIpEdit->setPlaceholderText("IP address");
-    m_manualIpEdit->setFixedWidth(150);
-    m_manualProbeBtn = new QPushButton("Go", m_manualGroup);
-    m_manualProbeBtn->setFixedWidth(70);
-    manRow->addWidget(m_manualIpEdit);
-    manRow->addWidget(m_manualProbeBtn);
-    manBox->addLayout(manRow);
+    m_manualIpEdit->setPlaceholderText("Example: 10.0.0.25");
+    manualForm->addRow("Radio IP:", m_manualIpEdit);
+    manualGroupLayout->addLayout(manualForm);
 
+    auto* manualActionRow = new QHBoxLayout;
+    auto* manualDiagnosticsBtn = new QPushButton("Network Diagnostics", manualGroup);
+    manualActionRow->addWidget(manualDiagnosticsBtn);
+    manualActionRow->addStretch();
+    m_manualConnectBtn = new QPushButton("Connect by IP", manualGroup);
+    manualActionRow->addWidget(m_manualConnectBtn);
+    manualGroupLayout->addLayout(manualActionRow);
+
+    m_manualResultLabel = makeWrappedLabel(QString(), kHintLabelStyle);
+    m_manualResultLabel->setVisible(false);
+    manualGroupLayout->addWidget(m_manualResultLabel);
+
+    m_manualAdvancedToggle = new QToolButton(manualGroup);
+    m_manualAdvancedToggle->setText("Advanced: choose the VPN source path");
+    m_manualAdvancedToggle->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+    m_manualAdvancedToggle->setCheckable(true);
+    m_manualAdvancedToggle->setArrowType(Qt::RightArrow);
+    m_manualAdvancedToggle->setVisible(false);
+    manualGroupLayout->addWidget(m_manualAdvancedToggle, 0, Qt::AlignLeft);
+
+    m_manualAdvancedWidget = new QWidget(manualGroup);
+    auto* manualAdvancedLayout = new QVBoxLayout(m_manualAdvancedWidget);
+    manualAdvancedLayout->setContentsMargins(8, 4, 8, 4);
+    manualAdvancedLayout->setSpacing(6);
+    manualAdvancedLayout->addWidget(makeWrappedLabel(
+        "Most users can leave this on Auto. Pick a source path only if your VPN creates more "
+        "than one active network adapter or a saved path is no longer available.",
+        kHintLabelStyle));
     auto* sourceRow = new QHBoxLayout;
     sourceRow->setContentsMargins(0, 0, 0, 0);
-    sourceRow->addWidget(new QLabel("Source:", m_manualGroup));
-    m_manualSourceCombo = new QComboBox(m_manualGroup);
+    sourceRow->addWidget(new QLabel("Source path:", m_manualAdvancedWidget));
+    m_manualSourceCombo = new QComboBox(m_manualAdvancedWidget);
     sourceRow->addWidget(m_manualSourceCombo, 1);
-    manBox->addLayout(sourceRow);
-
-    m_manualSourceWarningLabel = new QLabel(m_manualGroup);
+    manualAdvancedLayout->addLayout(sourceRow);
+    m_manualSourceWarningLabel = makeWrappedLabel(QString(), kErrorLabelStyle);
     m_manualSourceWarningLabel->setVisible(false);
-    m_manualSourceWarningLabel->setWordWrap(true);
-    m_manualSourceWarningLabel->setStyleSheet("QLabel { color: #ffbb66; font-size: 10px; }");
-    manBox->addWidget(m_manualSourceWarningLabel);
+    manualAdvancedLayout->addWidget(m_manualSourceWarningLabel);
+    m_manualAdvancedWidget->setVisible(false);
+    manualGroupLayout->addWidget(m_manualAdvancedWidget);
+    manualLayout->addWidget(manualGroup);
+    manualLayout->addStretch();
+
+    m_modeStack->addWidget(manualPage);
+
+    // ── Contextual options ────────────────────────────────────────────────
+    m_linkOptionsWidget = new QFrame(this);
+    m_linkOptionsWidget->setStyleSheet(calloutStyle);
+    auto* optionsLayout = new QVBoxLayout(m_linkOptionsWidget);
+    optionsLayout->setContentsMargins(12, 10, 12, 10);
+    optionsLayout->setSpacing(6);
+    auto* optionsTitle = new QLabel("Connection options for slower links", m_linkOptionsWidget);
+    optionsTitle->setStyleSheet("QLabel { color: #e7f1fb; font-weight: bold; }");
+    optionsLayout->addWidget(optionsTitle);
+    m_lowBwHintLabel = makeWrappedLabel(QString(), kHintLabelStyle);
+    optionsLayout->addWidget(m_lowBwHintLabel);
+    m_lowBwCheck = new QCheckBox("Use low bandwidth mode", m_linkOptionsWidget);
+    const auto remoteLowBandwidth = AppSettings::instance()
+        .value("LowBandwidthRemotePreferred",
+               AppSettings::instance().value("LowBandwidthConnect", "False"))
+        .toString();
+    m_lowBwCheck->setChecked(remoteLowBandwidth == "True");
+    m_lowBwCheck->setToolTip("Reduces FFT and waterfall traffic from the radio.");
+    m_lowBwCheck->setStyleSheet(lowBandwidthCheckStyle);
+    optionsLayout->addWidget(m_lowBwCheck);
+    root->addWidget(m_linkOptionsWidget);
+
+    // ── Footer ────────────────────────────────────────────────────────────
+    auto* footerRow = new QHBoxLayout;
+    footerRow->setSpacing(8);
+    m_statusLabel = makeWrappedLabel("Choose how you want to connect.", kHintLabelStyle);
+    footerRow->addWidget(m_statusLabel, 1);
+    m_disconnectBtn = new QPushButton("Disconnect", this);
+    m_disconnectBtn->setVisible(false);
+    footerRow->addWidget(m_disconnectBtn, 0, Qt::AlignRight);
+    root->addLayout(footerRow);
+
     refreshManualSourceOptions();
 
-    connect(m_manualProbeBtn, &QPushButton::clicked, this, [this] {
-        const QString ip = m_manualIpEdit->text().trimmed();
-        if (!ip.isEmpty()) probeRadio(ip);
+    connect(m_modeButtons, QOverload<int>::of(&QButtonGroup::idClicked),
+            this, &ConnectionPanel::onConnectionModeClicked);
+
+    connect(retryBtn, &QPushButton::clicked, this, [this] {
+        setStatusText("Refreshing local discovery…");
+        emit retryDiscoveryRequested();
     });
-    connect(m_manualIpEdit, &QLineEdit::returnPressed, this, [this] {
-        const QString ip = m_manualIpEdit->text().trimmed();
-        if (!ip.isEmpty()) probeRadio(ip);
+    connect(connectByIpBtn, &QPushButton::clicked, this, [this] {
+        setCurrentMode(ManualMode);
+        m_manualIpEdit->setFocus();
+        m_manualIpEdit->selectAll();
     });
+    connect(useSmartLinkBtn, &QPushButton::clicked, this, [this] {
+        setCurrentMode(SmartLinkMode);
+        if (m_loginForm->isVisible())
+            m_emailEdit->setFocus();
+    });
+    connect(diagnosticsBtn, &QPushButton::clicked,
+            this, &ConnectionPanel::networkDiagnosticsRequested);
+    connect(manualDiagnosticsBtn, &QPushButton::clicked,
+            this, &ConnectionPanel::networkDiagnosticsRequested);
+
+    connect(m_radioList, &QListWidget::itemSelectionChanged,
+            this, &ConnectionPanel::onListSelectionChanged);
+    connect(m_wanList, &QListWidget::itemSelectionChanged,
+            this, &ConnectionPanel::onWanSelectionChanged);
+    connect(m_localConnectBtn, &QPushButton::clicked,
+            this, &ConnectionPanel::onLocalConnectClicked);
+    connect(m_wanConnectBtn, &QPushButton::clicked,
+            this, &ConnectionPanel::onWanConnectClicked);
+    connect(m_disconnectBtn, &QPushButton::clicked,
+            this, &ConnectionPanel::disconnectRequested);
+    connect(m_radioList, &QListWidget::itemDoubleClicked, this, [this](QListWidgetItem*) {
+        if (!m_connected)
+            onLocalConnectClicked();
+    });
+    connect(m_wanList, &QListWidget::itemDoubleClicked, this, [this](QListWidgetItem*) {
+        if (!m_connected)
+            onWanConnectClicked();
+    });
+
+    connect(m_manualConnectBtn, &QPushButton::clicked,
+            this, &ConnectionPanel::onManualConnectClicked);
+    connect(m_manualIpEdit, &QLineEdit::returnPressed,
+            this, &ConnectionPanel::onManualConnectClicked);
     connect(m_manualIpEdit, &QLineEdit::textChanged,
             this, &ConnectionPanel::onManualIpChanged);
+    connect(m_manualAdvancedToggle, &QToolButton::toggled,
+            this, &ConnectionPanel::onManualAdvancedToggled);
+    connect(m_manualSourceCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            [this](int) {
+                updateManualAdvancedVisibility();
+                setManualMessage(QString());
+            });
 
-    vbox->addWidget(m_manualGroup);
-
-    // Login action (button click or Enter in password field)
-    auto doLogin = [this] {
+    const auto doLogin = [this] {
         const QString email = m_emailEdit->text().trimmed();
-        const QString pass  = m_passwordEdit->text();
-        if (email.isEmpty() || pass.isEmpty()) return;
+        const QString pass = m_passwordEdit->text();
+        if (email.isEmpty() || pass.isEmpty())
+            return;
         m_loginBtn->setEnabled(false);
-        m_loginBtn->setText("Logging in...");
+        m_loginBtn->setText("Signing In...");
         emit smartLinkLoginRequested(email, pass);
     };
     connect(m_loginBtn, &QPushButton::clicked, this, doLogin);
     connect(m_passwordEdit, &QLineEdit::returnPressed, this, doLogin);
+    connect(m_logoutBtn, &QPushButton::clicked, this, [this] {
+        if (!m_smartLink)
+            return;
+        m_smartLink->logout();
+        m_wanRadios.clear();
+        m_wanList->clear();
+        m_slUserLabel->setText("Signed out of SmartLink.");
+        m_slUserLabel->setStyleSheet(kHintLabelStyle);
+        updateSmartLinkUi();
+    });
 
-    // All widgets now exist — safe to call setConnected for initial state
     setConnected(false);
-
-    connect(m_radioList, &QListWidget::itemSelectionChanged,
-            this, &ConnectionPanel::onListSelectionChanged);
-    connect(m_connectBtn, &QPushButton::clicked,
-            this, &ConnectionPanel::onConnectClicked);
-    connect(m_radioList, &QListWidget::itemDoubleClicked,
-            this, [this](QListWidgetItem*) {
-                if (!m_connected)
-                    onConnectClicked();
-            });
+    setCurrentMode(LocalMode);
+    updateLocalPageState();
+    updateSmartLinkUi();
+    updateManualAdvancedVisibility();
 }
 
 void ConnectionPanel::setConnected(bool connected)
 {
     m_connected = connected;
-    m_connectBtn->setText(connected ? "Disconnect" : "Connect");
-    m_connectBtn->setEnabled(connected || m_radioList->currentItem() != nullptr);
+    m_disconnectBtn->setVisible(connected);
+    updateActionState();
 }
 
 void ConnectionPanel::setStatusText(const QString& text)
@@ -235,15 +532,230 @@ void ConnectionPanel::setStatusText(const QString& text)
     m_statusLabel->setText(text);
 }
 
-// ─── Radio list management ────────────────────────────────────────────────────
+void ConnectionPanel::saveLowBandwidthPreference(bool enabled)
+{
+    auto& settings = AppSettings::instance();
+    const QString value = enabled ? QStringLiteral("True") : QStringLiteral("False");
+    settings.setValue("LowBandwidthConnect", value);
+    settings.setValue("LowBandwidthRemotePreferred", value);
+    settings.save();
+}
+
+QString ConnectionPanel::formatLocalRadioLabel(const RadioInfo& radio) const
+{
+    QString title = radio.model.trimmed();
+    if (!radio.nickname.trimmed().isEmpty())
+        title += QStringLiteral("  %1").arg(radio.nickname.trimmed());
+    if (!radio.callsign.trimmed().isEmpty())
+        title += QStringLiteral("  %1").arg(radio.callsign.trimmed());
+    if (title.trimmed().isEmpty())
+        title = QStringLiteral("Radio");
+    if (title == radio.model.trimmed() && !radio.address.isNull())
+        title += QStringLiteral("  %1").arg(radio.address.toString());
+
+    QString detail;
+    if (!radio.guiClientStations.isEmpty()) {
+        const QString station = radio.guiClientStations.first().trimmed();
+        detail = station.isEmpty()
+            ? QStringLiteral("Shared radio on your network via multiFLEX")
+            : QStringLiteral("Shared radio on your network via multiFLEX at %1").arg(station);
+    } else if (!radio.address.isNull()) {
+        detail = QStringLiteral("Ready on your local network • %1").arg(radio.address.toString());
+    } else {
+        detail = QStringLiteral("Ready on your local network");
+    }
+
+    return title + QLatin1Char('\n') + detail;
+}
+
+QString ConnectionPanel::formatWanRadioLabel(const WanRadioInfo& radio) const
+{
+    QString title = radio.model.trimmed();
+    if (!radio.nickname.trimmed().isEmpty())
+        title += QStringLiteral("  %1").arg(radio.nickname.trimmed());
+    if (!radio.callsign.trimmed().isEmpty())
+        title += QStringLiteral("  %1").arg(radio.callsign.trimmed());
+    if (title.trimmed().isEmpty())
+        title = QStringLiteral("SmartLink radio");
+
+    QString detail = QStringLiteral("Remote via SmartLink");
+    const QString status = normalizedStatus(radio.status);
+    if (!status.isEmpty() && status.compare(QStringLiteral("Available"), Qt::CaseInsensitive) != 0)
+        detail += QStringLiteral(" • %1").arg(status);
+    else
+        detail += QStringLiteral(" • Ready to connect");
+
+    if (!radio.guiClientStations.trimmed().isEmpty())
+        detail += QStringLiteral(" • station %1").arg(radio.guiClientStations.trimmed());
+
+    return title + QLatin1Char('\n') + detail;
+}
+
+void ConnectionPanel::setManualMessage(const QString& text, bool error)
+{
+    if (text.trimmed().isEmpty()) {
+        m_manualResultLabel->clear();
+        m_manualResultLabel->setVisible(false);
+        return;
+    }
+
+    m_manualResultLabel->setText(text);
+    m_manualResultLabel->setStyleSheet(error ? kErrorLabelStyle : kInfoLabelStyle);
+    m_manualResultLabel->setVisible(true);
+}
+
+void ConnectionPanel::updateLocalPageState()
+{
+    const bool hasRadios = !m_radios.isEmpty();
+    m_localStateStack->setCurrentIndex(hasRadios ? 0 : 1);
+
+    if (hasRadios && !m_radioList->currentItem())
+        m_radioList->setCurrentRow(0);
+
+    updateActionState();
+}
+
+void ConnectionPanel::updateSmartLinkUi()
+{
+    const bool authed = m_smartLink && m_smartLink->isAuthenticated();
+    const bool hasWanRadios = authed && !m_wanRadios.isEmpty();
+
+    m_loginForm->setVisible(!authed);
+    m_logoutBtn->setVisible(authed);
+    m_wanList->setVisible(hasWanRadios);
+    m_wanConnectBtn->setVisible(authed);
+
+    if (authed) {
+        if (m_slUserLabel->text().trimmed().isEmpty()
+            || m_slUserLabel->styleSheet() == QString::fromLatin1(kHintLabelStyle)) {
+            m_slUserLabel->setText(smartLinkUserText(m_smartLink));
+            m_slUserLabel->setStyleSheet(kInfoLabelStyle);
+        }
+        if (hasWanRadios) {
+            m_smartLinkEmptyLabel->setVisible(false);
+        } else {
+            m_smartLinkEmptyLabel->setText(
+                "No SmartLink radios are available right now. If the station is on your current "
+                "LAN, it will appear on the local page instead.");
+            m_smartLinkEmptyLabel->setVisible(true);
+        }
+    } else {
+        if (m_slUserLabel->text().trimmed().isEmpty())
+            m_slUserLabel->setText("Sign in to see radios at remote stations.");
+        if (m_slUserLabel->styleSheet().isEmpty())
+            m_slUserLabel->setStyleSheet(kHintLabelStyle);
+        m_smartLinkEmptyLabel->setText("Remote radios appear here after SmartLink sign-in.");
+        m_smartLinkEmptyLabel->setVisible(true);
+    }
+
+    if (hasWanRadios && !m_wanList->currentItem())
+        m_wanList->setCurrentRow(0);
+
+    updateActionState();
+}
+
+void ConnectionPanel::updateActionState()
+{
+    m_localConnectBtn->setEnabled(!m_connected && m_radioList->currentItem() != nullptr);
+
+    const bool smartLinkReady = !m_connected
+        && m_smartLink
+        && m_smartLink->isAuthenticated()
+        && m_wanList->currentItem() != nullptr;
+    m_wanConnectBtn->setEnabled(smartLinkReady);
+
+    const bool manualReady = !m_connected && !m_manualIpEdit->text().trimmed().isEmpty();
+    m_manualConnectBtn->setEnabled(manualReady);
+}
+
+void ConnectionPanel::updateLowBandwidthVisibility()
+{
+    const auto mode = static_cast<ConnectionMode>(m_modeStack->currentIndex());
+    const bool visible = mode == SmartLinkMode || mode == ManualMode;
+    m_linkOptionsWidget->setVisible(visible);
+
+    if (!visible)
+        return;
+
+    if (mode == SmartLinkMode) {
+        m_lowBwHintLabel->setText(
+            "Recommended for SmartLink, hotel Wi-Fi, LTE, or other internet paths where "
+            "waterfall and FFT traffic may feel heavy.");
+    } else {
+        m_lowBwHintLabel->setText(
+            "Helpful on VPN or routed links when the radio is reachable by IP but the network "
+            "feels slower than a normal local LAN.");
+    }
+}
+
+void ConnectionPanel::updateManualAdvancedVisibility()
+{
+    const auto candidates = NetworkPathResolver::enumerateIpv4Candidates();
+    const RadioBindSettings settings = currentManualBindSettings();
+    const bool hasExplicitSelection = settings.mode == RadioBindMode::Explicit;
+    const bool showToggle = candidates.size() > 1
+        || hasExplicitSelection
+        || m_manualSourceWarningLabel->isVisible();
+
+    m_manualAdvancedToggle->setVisible(showToggle);
+    if (!showToggle) {
+        if (m_manualAdvancedToggle->isChecked()) {
+            const QSignalBlocker blocker(m_manualAdvancedToggle);
+            m_manualAdvancedToggle->setChecked(false);
+        }
+        m_manualAdvancedToggle->setArrowType(Qt::RightArrow);
+        m_manualAdvancedWidget->setVisible(false);
+        return;
+    }
+
+    if (hasExplicitSelection || m_manualSourceWarningLabel->isVisible()) {
+        const QSignalBlocker blocker(m_manualAdvancedToggle);
+        m_manualAdvancedToggle->setChecked(true);
+        m_manualAdvancedToggle->setArrowType(Qt::DownArrow);
+        m_manualAdvancedWidget->setVisible(true);
+        return;
+    }
+
+    m_manualAdvancedWidget->setVisible(m_manualAdvancedToggle->isChecked());
+    m_manualAdvancedToggle->setArrowType(
+        m_manualAdvancedToggle->isChecked() ? Qt::DownArrow : Qt::RightArrow);
+}
+
+void ConnectionPanel::setCurrentMode(ConnectionMode mode)
+{
+    if (m_modeButtons->checkedId() != static_cast<int>(mode)) {
+        const QSignalBlocker blocker(m_modeButtons);
+        if (auto* button = m_modeButtons->button(static_cast<int>(mode)))
+            button->setChecked(true);
+    }
+
+    m_modeStack->setCurrentIndex(static_cast<int>(mode));
+    updateLowBandwidthVisibility();
+    updateActionState();
+}
+
+void ConnectionPanel::onConnectionModeClicked(int id)
+{
+    setCurrentMode(static_cast<ConnectionMode>(id));
+}
 
 void ConnectionPanel::onRadioDiscovered(const RadioInfo& radio)
 {
+    for (int i = 0; i < m_radios.size(); ++i) {
+        if (m_radios[i].serial == radio.serial) {
+            m_radios[i] = radio;
+            if (auto* item = m_radioList->item(i))
+                item->setText(formatLocalRadioLabel(radio));
+            updateLocalPageState();
+            return;
+        }
+    }
+
     m_radios.append(radio);
-    m_radioList->addItem(radio.displayName());
-    // Auto-select first discovered radio so new users don't get stuck
+    m_radioList->addItem(formatLocalRadioLabel(radio));
     if (m_radioList->count() == 1)
         m_radioList->setCurrentRow(0);
+    updateLocalPageState();
 }
 
 void ConnectionPanel::onRadioUpdated(const RadioInfo& radio)
@@ -251,7 +763,8 @@ void ConnectionPanel::onRadioUpdated(const RadioInfo& radio)
     for (int i = 0; i < m_radios.size(); ++i) {
         if (m_radios[i].serial == radio.serial) {
             m_radios[i] = radio;
-            m_radioList->item(i)->setText(radio.displayName());
+            if (auto* item = m_radioList->item(i))
+                item->setText(formatLocalRadioLabel(radio));
             return;
         }
     }
@@ -263,147 +776,127 @@ void ConnectionPanel::onRadioLost(const QString& serial)
         if (m_radios[i].serial == serial) {
             delete m_radioList->takeItem(i);
             m_radios.removeAt(i);
-            return;
+            break;
         }
     }
+
+    updateLocalPageState();
 }
 
 void ConnectionPanel::onListSelectionChanged()
 {
-    // When connected, Disconnect is always available. When disconnected,
-    // Connect requires a radio to be selected. (#561)
-    m_connectBtn->setEnabled(m_connected || m_radioList->currentItem() != nullptr);
+    updateActionState();
 }
 
-void ConnectionPanel::onConnectClicked()
+void ConnectionPanel::onWanSelectionChanged()
 {
-    if (m_connected) {
-        emit disconnectRequested();
-        return;
-    }
+    updateActionState();
+}
 
+void ConnectionPanel::onLocalConnectClicked()
+{
     const int row = m_radioList->currentRow();
-    if (row < 0) return;
-
-    // Check if this is a WAN entry (stored in item data)
-    auto* item = m_radioList->item(row);
-    if (!item) return;
-
-    int wanIdx = item->data(Qt::UserRole + 1).toInt();
-    if (wanIdx > 0 && wanIdx <= m_wanRadios.size()) {
-        emit wanConnectRequested(m_wanRadios[wanIdx - 1]);  // 1-based index
+    if (m_connected || row < 0 || row >= m_radios.size())
         return;
-    }
 
-    // Save low bandwidth preference before connecting
-    auto& s = AppSettings::instance();
-    s.setValue("LowBandwidthConnect", m_lowBwCheck->isChecked() ? "True" : "False");
-    s.save();
+    auto& settings = AppSettings::instance();
+    settings.setValue("LowBandwidthConnect", "False");
+    settings.save();
 
-    // LAN radio
-    if (row < m_radios.size())
-        emit connectRequested(m_radios[row]);
+    emit connectRequested(m_radios[row]);
+}
+
+void ConnectionPanel::onWanConnectClicked()
+{
+    const int row = m_wanList->currentRow();
+    if (m_connected || row < 0 || row >= m_wanRadios.size())
+        return;
+
+    saveLowBandwidthPreference(m_lowBwCheck->isChecked());
+    emit wanConnectRequested(m_wanRadios[row]);
 }
 
 void ConnectionPanel::setSmartLinkClient(SmartLinkClient* client)
 {
     m_smartLink = client;
-    if (!client) return;
+    if (!client)
+        return;
 
     connect(client, &SmartLinkClient::authenticated, this, [this] {
-        // Clear password from memory immediately
         m_passwordEdit->clear();
-
-        // Hide login form, show logout button
-        m_loginForm->setVisible(false);
-
-        // Add logout button below user label
-        m_loginBtn = new QPushButton("Log Out", m_smartLinkGroup);
-        qobject_cast<QVBoxLayout*>(m_smartLinkGroup->layout())->insertWidget(1, m_loginBtn);
-        connect(m_loginBtn, &QPushButton::clicked, this, [this] {
-            m_smartLink->logout();
-            // Remove logout button, show login form
-            m_loginBtn->deleteLater();
-            m_loginForm->setVisible(true);
-            m_loginBtn = m_loginForm->findChild<QPushButton*>();
-            m_slUserLabel->setVisible(false);
-            // Remove WAN entries from unified list
-            for (int i = m_radioList->count() - 1; i >= 0; --i) {
-                if (m_radioList->item(i)->data(Qt::UserRole + 1).toInt() > 0)
-                    delete m_radioList->takeItem(i);
-            }
-            m_wanRadios.clear();
-        });
-
-        // User info may not be available yet — show placeholder
-        m_slUserLabel->setText("Connected to SmartLink");
-        m_slUserLabel->setStyleSheet("QLabel { color: #00b4d8; font-size: 10px; }");
-        m_slUserLabel->setVisible(true);
+        m_loginBtn->setEnabled(true);
+        m_loginBtn->setText("Sign In");
+        m_slUserLabel->setText(smartLinkUserText(m_smartLink));
+        m_slUserLabel->setStyleSheet(kInfoLabelStyle);
+        updateSmartLinkUi();
     });
 
-    // Update user label when server sends user_settings (after authenticated)
     connect(client, &SmartLinkClient::serverConnected, this, [this] {
-        // User settings arrive shortly after server connect
         QTimer::singleShot(500, this, [this] {
-            if (!m_smartLink->firstName().isEmpty()) {
-                m_slUserLabel->setText(QString("%1 %2 (%3)")
-                    .arg(m_smartLink->firstName(), m_smartLink->lastName(),
-                         m_smartLink->callsign()));
+            if (m_smartLink && m_smartLink->isAuthenticated()) {
+                m_slUserLabel->setText(smartLinkUserText(m_smartLink));
+                m_slUserLabel->setStyleSheet(kInfoLabelStyle);
+                updateSmartLinkUi();
             }
         });
+    });
+
+    connect(client, &SmartLinkClient::serverDisconnected, this, [this] {
+        if (!m_smartLink || !m_smartLink->isAuthenticated()) {
+            if (m_slUserLabel->text().trimmed().isEmpty()) {
+                m_slUserLabel->setText("Sign in to see radios at remote stations.");
+                m_slUserLabel->setStyleSheet(kHintLabelStyle);
+            }
+        }
+        updateSmartLinkUi();
     });
 
     connect(client, &SmartLinkClient::authFailed, this, [this](const QString& err) {
         m_passwordEdit->clear();
-        m_loginBtn->setText("Log In");
+        m_loginBtn->setText("Sign In");
         m_loginBtn->setEnabled(true);
-        m_slUserLabel->setText("Login failed: " + err);
-        m_slUserLabel->setStyleSheet("QLabel { color: #ff4444; font-size: 10px; }");
-        m_slUserLabel->setVisible(true);
+        m_slUserLabel->setText("SmartLink sign-in failed: " + err);
+        m_slUserLabel->setStyleSheet(kErrorLabelStyle);
+        updateSmartLinkUi();
     });
-
-    // Attempt auto-login from stored keychain credentials
-    client->tryAutoLogin();
 
     connect(client, &SmartLinkClient::radioListReceived, this,
             [this](const QList<WanRadioInfo>& radios) {
-        // Remove old WAN entries from unified list
-        for (int i = m_radioList->count() - 1; i >= 0; --i) {
-            if (m_radioList->item(i)->data(Qt::UserRole + 1).toInt() > 0)
-                delete m_radioList->takeItem(i);
-        }
+        m_wanRadios.clear();
+        m_wanList->clear();
 
-        m_wanRadios = radios;
-        for (int i = 0; i < radios.size(); ++i) {
-            const auto& r = radios[i];
-            // Skip if already in LAN list (same serial)
-            bool isLan = false;
+        for (const auto& radio : radios) {
+            bool isLanRadio = false;
             for (const auto& lan : m_radios) {
-                if (lan.serial == r.serial) { isLan = true; break; }
+                if (lan.serial == radio.serial) {
+                    isLanRadio = true;
+                    break;
+                }
             }
-            if (isLan) continue;
+            if (isLanRadio)
+                continue;
 
-            QString display = QString("%1  %2  %3\nAvailable (SmartLink)")
-                .arg(r.model, r.nickname, r.callsign);
-            auto* item = new QListWidgetItem(display);
-            item->setData(Qt::UserRole + 1, i + 1);  // 1-based WAN index
-            m_radioList->addItem(item);
+            m_wanRadios.append(radio);
+            m_wanList->addItem(formatWanRadioLabel(radio));
         }
+
+        if (m_wanList->count() > 0 && !m_wanList->currentItem())
+            m_wanList->setCurrentRow(0);
+
+        updateSmartLinkUi();
     });
+
+    client->tryAutoLogin();
+    updateSmartLinkUi();
 }
 
 bool ConnectionPanel::event(QEvent* e)
 {
-    if (e->type() == QEvent::WindowDeactivate) {
-        hide();
-        return true;
-    }
     return QWidget::event(e);
 }
 
 void ConnectionPanel::paintEvent(QPaintEvent*)
 {
-    // Solid fill — system window frame handles border/decorations (#574)
     QPainter p(this);
     p.fillRect(rect(), QColor(15, 15, 26));
 }
@@ -428,20 +921,21 @@ void ConnectionPanel::refreshManualSourceOptions(const RadioBindSettings* select
         m_manualSourceCombo->setItemData(idx, candidate.address.toString(), kSourceAddressRole);
         m_manualSourceCombo->setItemData(idx, false, kSourceStaleRole);
 
-        if (selected &&
-            selected->mode == RadioBindMode::Explicit &&
-            ((!selected->interfaceId.isEmpty() && selected->interfaceId == candidate.interfaceId) ||
-             (!selected->bindAddress.isNull() && selected->bindAddress == candidate.address))) {
+        if (selected
+            && selected->mode == RadioBindMode::Explicit
+            && ((!selected->interfaceId.isEmpty() && selected->interfaceId == candidate.interfaceId)
+                || (!selected->bindAddress.isNull() && selected->bindAddress == candidate.address))) {
             selectedIndex = idx;
         }
     }
 
-    if (selected &&
-        selected->mode == RadioBindMode::Explicit &&
-        selectedIndex == 0) {
+    if (selected
+        && selected->mode == RadioBindMode::Explicit
+        && selectedIndex == 0) {
         selectedIndex = m_manualSourceCombo->count();
         m_manualSourceCombo->addItem(staleSelectionText(*selected));
-        m_manualSourceCombo->setItemData(selectedIndex, static_cast<int>(RadioBindMode::Explicit), kSourceModeRole);
+        m_manualSourceCombo->setItemData(
+            selectedIndex, static_cast<int>(RadioBindMode::Explicit), kSourceModeRole);
         m_manualSourceCombo->setItemData(selectedIndex, selected->interfaceId, kSourceInterfaceIdRole);
         m_manualSourceCombo->setItemData(selectedIndex, selected->interfaceName, kSourceInterfaceNameRole);
         m_manualSourceCombo->setItemData(selectedIndex, selected->bindAddress.toString(), kSourceAddressRole);
@@ -449,6 +943,7 @@ void ConnectionPanel::refreshManualSourceOptions(const RadioBindSettings* select
     }
 
     m_manualSourceCombo->setCurrentIndex(selectedIndex);
+    updateManualAdvancedVisibility();
 }
 
 void ConnectionPanel::applySavedSourceSelection(const QString& ip)
@@ -460,6 +955,7 @@ void ConnectionPanel::applySavedSourceSelection(const QString& ip)
 
     if (trimmedIp.isEmpty()) {
         refreshManualSourceOptions();
+        updateManualAdvancedVisibility();
         return;
     }
 
@@ -467,6 +963,7 @@ void ConnectionPanel::applySavedSourceSelection(const QString& ip)
     const QJsonObject profile = profiles.value(trimmedIp).toObject();
     if (profile.isEmpty()) {
         refreshManualSourceOptions();
+        updateManualAdvancedVisibility();
         return;
     }
 
@@ -480,13 +977,15 @@ void ConnectionPanel::applySavedSourceSelection(const QString& ip)
             settings.bindAddress = resolved.address;
         } else {
             m_manualSourceWarningLabel->setText(
-                QStringLiteral("Saved source path for %1 is unavailable. Re-select a live IPv4 source before connecting.")
+                QStringLiteral("Saved VPN source path for %1 is unavailable. Pick a live path "
+                               "below before connecting.")
                     .arg(trimmedIp));
             m_manualSourceWarningLabel->setVisible(true);
         }
     }
 
     refreshManualSourceOptions(&settings);
+    updateManualAdvancedVisibility();
 }
 
 RadioBindSettings ConnectionPanel::currentManualBindSettings(bool* staleSelection) const
@@ -532,117 +1031,147 @@ void ConnectionPanel::saveManualProfile(const QString& targetIp,
 void ConnectionPanel::onManualIpChanged(const QString& ip)
 {
     const QString trimmed = ip.trimmed();
-    if (trimmed == m_manualProfileIp)
+    m_manualConnectPending = false;
+    if (trimmed != m_manualProfileIp)
+        applySavedSourceSelection(trimmed);
+    setManualMessage(QString());
+    updateActionState();
+}
+
+void ConnectionPanel::onManualConnectClicked()
+{
+    const QString ip = m_manualIpEdit->text().trimmed();
+    if (m_connected || ip.isEmpty())
         return;
-    applySavedSourceSelection(trimmed);
+
+    m_manualConnectPending = true;
+    setManualMessage(QStringLiteral("Checking %1…").arg(ip));
+    probeRadio(ip);
+}
+
+void ConnectionPanel::onManualAdvancedToggled(bool checked)
+{
+    m_manualAdvancedToggle->setArrowType(checked ? Qt::DownArrow : Qt::RightArrow);
+    m_manualAdvancedWidget->setVisible(checked);
 }
 
 void ConnectionPanel::probeRadio(const QString& ip)
 {
-    if (m_manualIpEdit->text().trimmed() != ip) {
-        m_manualIpEdit->setText(ip);
-        applySavedSourceSelection(ip);
-    } else if (m_manualProfileIp != ip) {
-        applySavedSourceSelection(ip);
+    const QString trimmedIp = ip.trimmed();
+    if (trimmedIp.isEmpty())
+        return;
+
+    if (m_manualIpEdit->text().trimmed() != trimmedIp) {
+        m_manualIpEdit->setText(trimmedIp);
+        applySavedSourceSelection(trimmedIp);
+    } else if (m_manualProfileIp != trimmedIp) {
+        applySavedSourceSelection(trimmedIp);
     }
 
     bool staleSelection = false;
     const RadioBindSettings bindSettings = currentManualBindSettings(&staleSelection);
     if (bindSettings.mode == RadioBindMode::Explicit && staleSelection) {
         m_manualSourceWarningLabel->setText(
-            QStringLiteral("Selected source path is unavailable. Choose a live IPv4 source before probing."));
+            QStringLiteral("The selected VPN source path is unavailable. Choose a live path "
+                           "before connecting."));
         m_manualSourceWarningLabel->setVisible(true);
+        updateManualAdvancedVisibility();
+        setManualMessage("Choose a live source path before trying again.", true);
+        m_manualConnectPending = false;
         return;
     }
 
-    m_manualProbeBtn->setEnabled(false);
-    m_manualProbeBtn->setText("Probing...");
+    const QString busyText = m_manualConnectPending
+        ? QStringLiteral("Connecting...")
+        : QStringLiteral("Checking...");
+    m_manualConnectBtn->setEnabled(false);
+    m_manualConnectBtn->setText(busyText);
     m_manualSourceWarningLabel->setVisible(false);
+    updateManualAdvancedVisibility();
 
     auto* sock = new QTcpSocket(this);
-    if (bindSettings.mode == RadioBindMode::Explicit &&
-        !sock->bind(bindSettings.bindAddress, 0)) {
+    if (bindSettings.mode == RadioBindMode::Explicit
+        && !sock->bind(bindSettings.bindAddress, 0)) {
         m_manualSourceWarningLabel->setText(
-            QStringLiteral("Failed to bind source %1: %2")
+            QStringLiteral("Failed to bind %1: %2")
                 .arg(bindSettings.bindAddress.toString(), sock->errorString()));
         m_manualSourceWarningLabel->setVisible(true);
+        updateManualAdvancedVisibility();
+        setManualMessage("AetherSDR could not use that VPN source path. Try Auto or choose another path.", true);
         sock->deleteLater();
-        m_manualProbeBtn->setEnabled(true);
-        m_manualProbeBtn->setText("Connect");
+        m_manualConnectPending = false;
+        m_manualConnectBtn->setText("Connect by IP");
+        updateActionState();
         return;
     }
-    sock->connectToHost(ip, 4992);
 
-    // 3-second timeout
-    QTimer::singleShot(3000, sock, [this, sock] {
+    sock->connectToHost(trimmedIp, 4992);
+
+    QTimer::singleShot(3000, sock, [this, sock, trimmedIp] {
         if (sock->state() != QAbstractSocket::ConnectedState) {
             sock->abort();
             sock->deleteLater();
-            m_manualProbeBtn->setEnabled(true);
-            m_manualProbeBtn->setText("Connect");
+            m_manualConnectPending = false;
+            m_manualConnectBtn->setText("Connect by IP");
+            updateActionState();
+            setManualMessage(
+                QStringLiteral("No radio responded at %1. If this is a VPN path, confirm the IP "
+                               "address and try Advanced only if your VPN exposes multiple adapters.")
+                    .arg(trimmedIp),
+                true);
         }
     });
 
-    connect(sock, &QTcpSocket::connected, this, [this, sock, ip, bindSettings] {
-        // Connected — read V/H lines, then disconnect
-        auto* buf = new QByteArray;
-        connect(sock, &QTcpSocket::readyRead, this, [this, sock, ip, buf, bindSettings] {
-            buf->append(sock->readAll());
+    connect(sock, &QTcpSocket::connected, this, [this, sock, trimmedIp, bindSettings] {
+        auto* buffer = new QByteArray;
+        connect(sock, &QTcpSocket::readyRead, this,
+                [this, sock, trimmedIp, bindSettings, buffer] {
+            buffer->append(sock->readAll());
 
-            // We need V<version>\n and H<handle>\n
             QString version;
-            while (buf->contains('\n')) {
-                int idx = buf->indexOf('\n');
-                QString line = QString::fromUtf8(buf->left(idx)).trimmed();
-                buf->remove(0, idx + 1);
+            while (buffer->contains('\n')) {
+                const int idx = buffer->indexOf('\n');
+                const QString line = QString::fromUtf8(buffer->left(idx)).trimmed();
+                buffer->remove(0, idx + 1);
 
-                if (line.startsWith('V'))
+                if (line.startsWith('V')) {
                     version = line.mid(1);
-                else if (line.startsWith('H')) {
-                    // Got both V and H — we have enough info
+                } else if (line.startsWith('H')) {
                     const QHostAddress localSource = sock->localAddress();
                     sock->disconnectFromHost();
                     sock->deleteLater();
-                    delete buf;
+                    delete buffer;
 
-                    // Build a RadioInfo for this routed radio
                     RadioInfo info;
-                    info.address = QHostAddress(ip);
+                    info.address = QHostAddress(trimmedIp);
                     info.port = 4992;
                     info.version = version;
                     info.status = "Available";
                     info.model = "FLEX";
                     info.name = "FLEX";
-                    info.serial = ip;  // use IP as unique ID for routed radios
+                    info.serial = trimmedIp;
                     info.isRouted = true;
                     info.bindSettings = bindSettings;
                     info.sessionBindAddress = localSource;
 
-                    saveManualProfile(ip, bindSettings, info.sessionBindAddress);
+                    saveManualProfile(trimmedIp, bindSettings, info.sessionBindAddress);
 
-                    // Check if already in list
-                    for (int i = 0; i < m_radios.size(); ++i) {
-                        if (m_radios[i].address == info.address) {
-                            m_radios[i] = info;
-                            m_radioList->item(i)->setText(info.displayName());
-                            m_manualProbeBtn->setEnabled(true);
-                            m_manualProbeBtn->setText("Connect");
-                            emit routedRadioFound(info);
-                            return;
-                        }
+                    m_manualConnectBtn->setText("Connect by IP");
+                    updateActionState();
+
+                    if (m_manualConnectPending) {
+                        saveLowBandwidthPreference(m_lowBwCheck->isChecked());
+                        setManualMessage(
+                            QStringLiteral("Found a radio at %1. Connecting now…").arg(trimmedIp));
+                        m_manualConnectPending = false;
+                        emit connectRequested(info);
+                    } else {
+                        setManualMessage(
+                            QStringLiteral("Found a radio at %1 and saved the path for later.")
+                                .arg(trimmedIp));
+                        emit routedRadioFound(info);
                     }
 
-                    m_radios.append(info);
-                    m_radioList->addItem(info.displayName());
-
-                    m_manualProbeBtn->setEnabled(true);
-                    m_manualProbeBtn->setText("Connect");
-                    emit routedRadioFound(info);
-
-                    qDebug() << "ConnectionPanel: routed radio found at" << ip
-                             << "version:" << version
-                             << "localSource:" << info.sessionBindAddress.toString()
-                             << "mode:" << info.bindSettings.modeString();
                     return;
                 }
             }
@@ -650,11 +1179,14 @@ void ConnectionPanel::probeRadio(const QString& ip)
     });
 
     connect(sock, &QTcpSocket::errorOccurred, this,
-            [this, sock](QAbstractSocket::SocketError) {
-        qWarning() << "ConnectionPanel: probe failed:" << sock->errorString();
+            [this, sock, trimmedIp](QAbstractSocket::SocketError) {
+        setManualMessage(
+            QStringLiteral("Could not reach %1: %2").arg(trimmedIp, sock->errorString()),
+            true);
         sock->deleteLater();
-        m_manualProbeBtn->setEnabled(true);
-        m_manualProbeBtn->setText("Connect");
+        m_manualConnectPending = false;
+        m_manualConnectBtn->setText("Connect by IP");
+        updateActionState();
     });
 }
 

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -10,12 +10,14 @@
 #include <QComboBox>
 #include <QCheckBox>
 #include <QLineEdit>
-#include <QTcpSocket>
+#include <QButtonGroup>
+#include <QCommandLinkButton>
+#include <QStackedWidget>
+#include <QToolButton>
 
 namespace AetherSDR {
 
-// Floating panel that shows discovered radios, SmartLink, and manual connection.
-// Displayed as a popup anchored to the station label in the status bar.
+// Novice-first dialog for local, SmartLink, and manual/VPN radio connections.
 class ConnectionPanel : public QWidget {
     Q_OBJECT
 
@@ -43,47 +45,88 @@ signals:
     void wanConnectRequested(const WanRadioInfo& radio);
     void disconnectRequested();
     void routedRadioFound(const RadioInfo& radio);
+    void retryDiscoveryRequested();
+    void networkDiagnosticsRequested();
     void smartLinkLoginRequested(const QString& email, const QString& password);
 
 private slots:
-    void onConnectClicked();
+    void onConnectionModeClicked(int id);
     void onListSelectionChanged();
+    void onWanSelectionChanged();
+    void onLocalConnectClicked();
+    void onWanConnectClicked();
     void onManualIpChanged(const QString& ip);
+    void onManualConnectClicked();
+    void onManualAdvancedToggled(bool checked);
 
 private:
+    enum ConnectionMode {
+        LocalMode = 0,
+        SmartLinkMode = 1,
+        ManualMode = 2
+    };
+
+    void setCurrentMode(ConnectionMode mode);
+    void updateLocalPageState();
+    void updateSmartLinkUi();
+    void updateActionState();
+    void updateLowBandwidthVisibility();
+    void updateManualAdvancedVisibility();
     void refreshManualSourceOptions(const RadioBindSettings* selected = nullptr);
     void applySavedSourceSelection(const QString& ip);
     RadioBindSettings currentManualBindSettings(bool* staleSelection = nullptr) const;
     void saveManualProfile(const QString& targetIp,
                            const RadioBindSettings& settings,
                            const QHostAddress& lastSuccessfulLocalIp);
+    void saveLowBandwidthPreference(bool enabled);
+    void setManualMessage(const QString& text, bool error = false);
+    QString formatLocalRadioLabel(const RadioInfo& radio) const;
+    QString formatWanRadioLabel(const WanRadioInfo& radio) const;
 
-    QListWidget* m_radioList;
-    QPushButton* m_connectBtn;
-    QCheckBox*   m_lowBwCheck;
+    QButtonGroup* m_modeButtons{nullptr};
+    QStackedWidget* m_modeStack{nullptr};
+    QCommandLinkButton* m_localModeBtn{nullptr};
+    QCommandLinkButton* m_smartLinkModeBtn{nullptr};
+    QCommandLinkButton* m_manualModeBtn{nullptr};
+
     QLabel*      m_statusLabel;
-    QWidget*     m_radioGroup;       // "Discovered Radios" group box
+    QPushButton* m_disconnectBtn{nullptr};
 
-    QList<RadioInfo> m_radios;   // mirror of what's in the list
+    QListWidget* m_radioList{nullptr};
+    QStackedWidget* m_localStateStack{nullptr};
+    QWidget* m_localEmptyState{nullptr};
+    QPushButton* m_localConnectBtn{nullptr};
+
+    QList<RadioInfo> m_radios;   // LAN radios only
     bool m_connected{false};
 
     // SmartLink UI
     SmartLinkClient* m_smartLink{nullptr};
-    QWidget*     m_smartLinkGroup{nullptr};
     QWidget*     m_loginForm{nullptr};
     QLineEdit*   m_emailEdit{nullptr};
     QLineEdit*   m_passwordEdit{nullptr};
     QPushButton* m_loginBtn{nullptr};
+    QPushButton* m_logoutBtn{nullptr};
     QLabel*      m_slUserLabel{nullptr};
+    QListWidget* m_wanList{nullptr};
+    QLabel*      m_smartLinkEmptyLabel{nullptr};
+    QPushButton* m_wanConnectBtn{nullptr};
     QList<WanRadioInfo> m_wanRadios;
 
-    // Manual (routed) connection
-    QWidget*     m_manualGroup{nullptr};
+    // Manual (VPN / routed) connection
     QLineEdit*   m_manualIpEdit{nullptr};
+    QLabel*      m_manualResultLabel{nullptr};
+    QToolButton* m_manualAdvancedToggle{nullptr};
+    QWidget*     m_manualAdvancedWidget{nullptr};
     QComboBox*   m_manualSourceCombo{nullptr};
     QLabel*      m_manualSourceWarningLabel{nullptr};
-    QPushButton* m_manualProbeBtn{nullptr};
+    QPushButton* m_manualConnectBtn{nullptr};
     QString      m_manualProfileIp;
+    bool         m_manualConnectPending{false};
+
+    QWidget*     m_linkOptionsWidget{nullptr};
+    QLabel*      m_lowBwHintLabel{nullptr};
+    QCheckBox*   m_lowBwCheck{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -63,11 +63,13 @@
 #include <functional>
 #include <QApplication>
 #include <QProcess>
+#include <QScreen>
 #include <QTimer>
 #include <QDateTime>
 #include <QPropertyAnimation>
 #include <QIcon>
 #include <QKeyEvent>
+#include <QWindow>
 #include <QPixmap>
 #include <QWidgetAction>
 #include <QPainter>
@@ -343,6 +345,14 @@ MainWindow::MainWindow(QWidget* parent)
             m_connPanel, &ConnectionPanel::onRadioUpdated);
     connect(&m_discovery, &RadioDiscovery::radioLost,
             m_connPanel, &ConnectionPanel::onRadioLost);
+    connect(m_connPanel, &ConnectionPanel::retryDiscoveryRequested, this, [this] {
+        m_connPanel->setStatusText("Searching your local network…");
+        if (m_titleBar) m_titleBar->setDiscovering(true);
+        m_discovery.stopListening();
+        m_discovery.startListening();
+    });
+    connect(m_connPanel, &ConnectionPanel::networkDiagnosticsRequested,
+            this, &MainWindow::showNetworkDiagnosticsDialog);
 
     // ── Heartbeat indicator + disconnect detection via TCP ping ─────────
     m_heartbeatMissTimer = new QTimer(this);
@@ -363,6 +373,7 @@ MainWindow::MainWindow(QWidget* parent)
             this, [this](const RadioInfo& info){
         m_connPanel->setStatusText("Connecting…");
         m_userDisconnected = false;
+        setPanadapterConnectionAnimation(true, "Connecting to radio…");
         m_radioModel.connectToRadio(info);
         auto& s = AppSettings::instance();
         s.setValue("LastConnectedRadioSerial", info.serial);
@@ -384,12 +395,14 @@ MainWindow::MainWindow(QWidget* parent)
             && !m_radioModel.isConnected()) {
             qDebug() << "Auto-connecting to" << info.displayName();
             m_connPanel->setStatusText("Auto-connecting…");
+            setPanadapterConnectionAnimation(true, "Connecting to radio…");
             m_radioModel.connectToRadio(info);
         }
     });
     connect(m_connPanel, &ConnectionPanel::disconnectRequested,
             this, [this]{
         m_userDisconnected = true;
+        setPanadapterConnectionAnimation(false);
         auto& s = AppSettings::instance();
         s.remove("LastConnectedRadioSerial");
         s.remove("LastRoutedRadioIp");
@@ -409,6 +422,7 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_connPanel, &ConnectionPanel::wanConnectRequested,
             this, [this](const WanRadioInfo& info) {
         m_connPanel->setStatusText("Requesting SmartLink connection…");
+        setPanadapterConnectionAnimation(true, "Connecting to remote radio…");
         // Store WAN radio info for when connect_ready arrives
         m_pendingWanRadio = info;
 
@@ -435,6 +449,7 @@ MainWindow::MainWindow(QWidget* parent)
             this, [this](const QString& handle, const QString& serial) {
         if (serial != m_pendingWanRadio.serial) return;
         m_connPanel->setStatusText("TLS connecting to radio…");
+        setPanadapterConnectionAnimation(true, "Connecting to remote radio…");
         m_wanConnection.connectToRadio(
             m_pendingWanRadio.publicIp,
             static_cast<quint16>(m_pendingWanRadio.publicTlsPort),
@@ -459,9 +474,12 @@ MainWindow::MainWindow(QWidget* parent)
         qDebug() << "MainWindow: WAN connection lost";
         m_connPanel->setStatusText("SmartLink disconnected");
         m_connPanel->setConnected(false);
+        setPanadapterConnectionAnimation(false);
     });
     connect(&m_wanConnection, &WanConnection::errorOccurred, this, [this](const QString& err) {
         m_connPanel->setStatusText("SmartLink error: " + err);
+        if (!m_reconnectDlg)
+            setPanadapterConnectionAnimation(false);
     });
 
     // ── DX Cluster — forward parsed spots to radio ──────────────────────
@@ -896,25 +914,35 @@ MainWindow::MainWindow(QWidget* parent)
             this, [this](quint32 streamId, const QVector<float>& bins) {
         for (auto* pan : m_radioModel.panadapters()) {
             if (pan->panStreamId() == streamId) {
-                if (auto* sw = m_panStack->spectrum(pan->panId()))
+                if (auto* sw = m_panStack->spectrum(pan->panId())) {
                     sw->updateSpectrum(bins);
+                    finishPanadapterConnectionAnimation();
+                }
                 return;
             }
         }
         // Fallback: active spectrum (covers "default" pan before radio connects)
-        if (auto* sw = spectrum()) sw->updateSpectrum(bins);
+        if (auto* sw = spectrum()) {
+            sw->updateSpectrum(bins);
+            finishPanadapterConnectionAnimation();
+        }
     });
     connect(m_radioModel.panStream(), &PanadapterStream::waterfallRowReady,
             this, [this](quint32 streamId, const QVector<float>& bins,
                          double low, double high, quint32 tc) {
         for (auto* pan : m_radioModel.panadapters()) {
             if (pan->wfStreamId() == streamId) {
-                if (auto* sw = m_panStack->spectrum(pan->panId()))
+                if (auto* sw = m_panStack->spectrum(pan->panId())) {
                     sw->updateWaterfallRow(bins, low, high, tc);
+                    finishPanadapterConnectionAnimation();
+                }
                 return;
             }
         }
-        if (auto* sw = spectrum()) sw->updateWaterfallRow(bins, low, high, tc);
+        if (auto* sw = spectrum()) {
+            sw->updateWaterfallRow(bins, low, high, tc);
+            finishPanadapterConnectionAnimation();
+        }
     });
     connect(m_radioModel.panStream(), &PanadapterStream::waterfallAutoBlackLevel,
             this, [this](quint32 streamId, quint32 autoBlack) {
@@ -1011,6 +1039,10 @@ MainWindow::MainWindow(QWidget* parent)
         }
         setActivePanApplet(applet);
         wirePanadapter(applet);
+        if (m_panadapterConnectionAnimationVisible) {
+            applet->spectrumWidget()->setConnectionAnimationVisible(
+                true, m_panadapterConnectionAnimationLabel);
+        }
         connect(pan, &PanadapterModel::infoChanged,
                 applet->spectrumWidget(), &SpectrumWidget::setFrequencyRange);
         // NOTE: levelChanged → setDbmRange is wired in wirePanadapter() above;
@@ -2023,6 +2055,13 @@ MainWindow::MainWindow(QWidget* parent)
     if (m_titleBar) m_titleBar->setDiscovering(true);
     m_discovery.startListening();
 
+    const QString startupLastSerial =
+        AppSettings::instance().value("LastConnectedRadioSerial").toString();
+    if (!startupLastSerial.isEmpty()) {
+        m_connPanel->setStatusText("Looking for your radio…");
+        setPanadapterConnectionAnimation(true, "Looking for your radio…");
+    }
+
     // Auto-connect to routed radios (probed, not broadcast-discovered)
     connect(m_connPanel, &ConnectionPanel::routedRadioFound,
             this, [this](const RadioInfo& info) {
@@ -2032,6 +2071,7 @@ MainWindow::MainWindow(QWidget* parent)
         if (!lastSerial.isEmpty() && info.serial == lastSerial) {
             qDebug() << "Auto-connecting to routed radio" << info.address.toString();
             m_connPanel->setStatusText("Auto-connecting…");
+            setPanadapterConnectionAnimation(true, "Connecting to radio…");
             m_radioModel.connectToRadio(info);
         }
     });
@@ -2041,6 +2081,8 @@ MainWindow::MainWindow(QWidget* parent)
         auto& s = AppSettings::instance();
         const QString routedIp = s.value("LastRoutedRadioIp").toString();
         if (!routedIp.isEmpty() && !m_userDisconnected) {
+            m_connPanel->setStatusText("Looking for your radio…");
+            setPanadapterConnectionAnimation(true, "Looking for your radio…");
             QTimer::singleShot(500, this, [this, routedIp] {
                 m_connPanel->probeRadio(routedIp);
             });
@@ -2417,17 +2459,33 @@ void MainWindow::toggleConnectionDialog()
         m_connPanel->hide();
         return;
     }
-    // Position above the status bar, centered on station label
+
+    // Position above the status bar, centered on the station label, while staying on-screen.
     QPoint statusBarTop = statusBar()->mapToGlobal(QPoint(0, 0));
     QPoint labelCenter = m_stationNickLabel->mapToGlobal(
         QPoint(m_stationNickLabel->width() / 2, 0));
-    int dlgW = m_connPanel->width();
-    int dlgH = m_connPanel->height();
-    QPoint pos(labelCenter.x() - dlgW / 2,
-               statusBarTop.y() - dlgH - 4);
+    QScreen* screen = QApplication::screenAt(labelCenter);
+    if (!screen && windowHandle())
+        screen = windowHandle()->screen();
+    if (!screen)
+        screen = QApplication::primaryScreen();
+
+    const QSize dlgSize = m_connPanel->size();
+    QPoint pos(labelCenter.x() - dlgSize.width() / 2,
+               statusBarTop.y() - dlgSize.height() - 8);
+
+    if (screen) {
+        const QRect available = screen->availableGeometry();
+        const int maxX = available.left() + available.width() - dlgSize.width();
+        const int maxY = available.top() + available.height() - dlgSize.height();
+        pos.setX(qMax(available.left(), qMin(pos.x(), maxX)));
+        pos.setY(qMax(available.top(), qMin(pos.y(), maxY)));
+    }
+
     m_connPanel->move(pos);
     m_connPanel->show();
     m_connPanel->raise();
+    m_connPanel->activateWindow();
 }
 
 void MainWindow::showMemoryDialog()
@@ -2575,7 +2633,7 @@ void MainWindow::buildMenuBar()
         dlg->show();
     });
 
-    auto* chooseRadio = settingsMenu->addAction("Choose Radio / SmartLink Setup...");
+    auto* chooseRadio = settingsMenu->addAction("Connect to Radio...");
     chooseRadio->setMenuRole(QAction::NoRole);      // prevent macOS auto-reparenting (#883)
     connect(chooseRadio, &QAction::triggered, this, [this] {
         toggleConnectionDialog();
@@ -3567,8 +3625,9 @@ void MainWindow::buildUI()
     // Connection panel — modeless dialog with standard decorations (#560, #574)
     m_connPanel = new ConnectionPanel(this);
     m_connPanel->setWindowFlags(Qt::Dialog);
-    m_connPanel->setWindowTitle("Choose Radio / SmartLink Setup");
-    m_connPanel->setFixedSize(300, 420);
+    m_connPanel->setWindowTitle("Connect to Radio");
+    m_connPanel->setMinimumSize(640, 520);
+    m_connPanel->resize(760, 580);
     m_connPanel->hide();
 
     // CWX panel — left of spectrum, hidden by default
@@ -4390,6 +4449,8 @@ void MainWindow::onConnectionStateChanged(bool connected)
         for (auto* applet : m_panStack->allApplets())
             applet->spectrumWidget()->clearDisplay();
 
+        setPanadapterConnectionAnimation(!m_userDisconnected, "Reconnecting to radio…");
+
         // Show reconnect dialog on unexpected disconnect (only one at a time)
         if (!m_userDisconnected && !m_reconnectDlg) {
             m_reconnectDlg = new QDialog(this);
@@ -4413,6 +4474,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
             layout->addWidget(dismissBtn, 0, Qt::AlignCenter);
             connect(dismissBtn, &QPushButton::clicked, this, [this]() {
                 m_userDisconnected = true;
+                setPanadapterConnectionAnimation(false);
                 m_reconnectDlg->close();
                 m_reconnectDlg->deleteLater();
                 m_reconnectDlg = nullptr;
@@ -4432,6 +4494,36 @@ void MainWindow::onConnectionError(const QString& msg)
     m_connPanel->setStatusText("Error: " + msg);
     m_connStatusLabel->setText("Error");
     statusBar()->showMessage("Connection error: " + msg, 5000);
+    if (!m_reconnectDlg)
+        setPanadapterConnectionAnimation(false);
+}
+
+void MainWindow::setPanadapterConnectionAnimation(bool visible, const QString& label)
+{
+    const QString nextLabel = label.trimmed().isEmpty()
+        ? QStringLiteral("Connecting to radio…")
+        : label.trimmed();
+    m_panadapterConnectionAnimationVisible = visible;
+    m_waitingForFirstPanadapterFrame = visible;
+    m_panadapterConnectionAnimationLabel = visible ? nextLabel : QString();
+
+    if (!m_panStack)
+        return;
+
+    for (auto* applet : m_panStack->allApplets()) {
+        if (!applet)
+            continue;
+        if (auto* spectrumWidget = applet->spectrumWidget())
+            spectrumWidget->setConnectionAnimationVisible(visible, nextLabel);
+    }
+}
+
+void MainWindow::finishPanadapterConnectionAnimation()
+{
+    if (!m_waitingForFirstPanadapterFrame || !m_panadapterConnectionAnimationVisible)
+        return;
+
+    setPanadapterConnectionAnimation(false);
 }
 
 void MainWindow::syncMemorySpot(int memoryIndex)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -141,6 +141,8 @@ private:
     void showNetworkDiagnosticsDialog();
     void showPropDashboard();
     void setPaTempDisplayUnit(bool useFahrenheit);
+    void setPanadapterConnectionAnimation(bool visible, const QString& label = {});
+    void finishPanadapterConnectionAnimation();
     void syncMemorySpot(int memoryIndex);
     void removeMemorySpot(int memoryIndex);
     void clearMemorySpotFeed();
@@ -311,6 +313,9 @@ private:
     bool m_spacePttActive{false};          // true while Space is held for PTT
     bool m_minimalMode{false};             // true when spectrum is hidden (#208)
     QAction* m_minimalModeAction{nullptr};
+    bool m_panadapterConnectionAnimationVisible{false};
+    bool m_waitingForFirstPanadapterFrame{false};
+    QString m_panadapterConnectionAnimationLabel;
     ShortcutManager m_shortcutManager;
 
 #ifdef HAVE_RADE

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -725,12 +725,9 @@ void SpectrumWidget::drawConnectionAnimation(QPainter& p, const QRect& contentRe
     }
 
     const qreal seconds = m_connectionAnimationClock.elapsed() / 1000.0;
-    const qreal towerHeight = qMin(available.height() * 0.32, 106.0);
+    const qreal towerHeight = qMin(available.height() * 0.27, 90.0);
     const qreal towerWidth = towerHeight * 0.34;
-    const SliceOverlay* anchorOverlay = activeOverlay();
-    const qreal anchorX = anchorOverlay
-        ? static_cast<qreal>(mhzToX(anchorOverlay->freqMhz))
-        : static_cast<qreal>(mhzToX(m_centerMhz));
+    const qreal anchorX = static_cast<qreal>(mhzToX(m_centerMhz));
     const qreal centerX = qBound(available.left() + towerWidth * 1.5,
                                  anchorX,
                                  available.right() - towerWidth * 1.5);
@@ -746,22 +743,23 @@ void SpectrumWidget::drawConnectionAnimation(QPainter& p, const QRect& contentRe
     p.save();
     p.setRenderHint(QPainter::Antialiasing, true);
 
-    QRadialGradient glow(QPointF(centerX, topY + towerHeight * 0.32),
-                         towerHeight * 1.18);
+    QRadialGradient glow(QPointF(centerX, topY + towerHeight * 0.42),
+                         towerHeight * 1.05);
     glow.setColorAt(0.0, withAlpha(kAetherBrandBlue, 48));
     glow.setColorAt(0.55, withAlpha(kAetherBrandGreen, 22));
     glow.setColorAt(1.0, QColor(0, 0, 0, 0));
     p.setPen(Qt::NoPen);
     p.setBrush(glow);
-    p.drawEllipse(QPointF(centerX, topY + towerHeight * 0.34),
-                  towerHeight * 1.05, towerHeight * 0.82);
+    p.drawEllipse(QPointF(centerX, topY + towerHeight * 0.44),
+                  towerHeight * 0.98, towerHeight * 0.72);
 
     static constexpr qreal kTau = 6.28318530717958647692;
     const qreal pulse = 0.55 + 0.45 * std::sin(seconds * kTau);
+    const qreal waveCenterY = topY + towerHeight * 0.38;
     for (int ring = 0; ring < 3; ++ring) {
         const qreal ringProgress = std::fmod(phase + ring * 0.24, 1.0);
-        const qreal radiusX = towerWidth * 0.85 + ringProgress * towerHeight * 0.92;
-        const qreal radiusY = radiusX * 0.74;
+        const qreal radiusX = towerWidth * 0.50 + ringProgress * towerHeight * 0.68;
+        const qreal radiusY = radiusX * 0.86;
         QColor waveColor = (ring % 2 == 0) ? kAetherBrandBlue : kAetherBrandGreen;
         const qreal fade = 1.0 - ringProgress;
         waveColor.setAlphaF(qBound(0.10, 0.16 + fade * 0.48 * pulse, 0.70));
@@ -770,9 +768,14 @@ void SpectrumWidget::drawConnectionAnimation(QPainter& p, const QRect& contentRe
                      Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
         p.setPen(wavePen);
         p.setBrush(Qt::NoBrush);
-        const QRectF arcRect(centerX - radiusX, topY - radiusY + towerHeight * 0.12,
-                             radiusX * 2.0, radiusY * 2.0);
-        p.drawArc(arcRect, 28 * 16, 124 * 16);
+        const QRectF leftArcRect(centerX - towerWidth * 0.16 - radiusX * 2.0,
+                                 waveCenterY - radiusY,
+                                 radiusX * 2.0, radiusY * 2.0);
+        const QRectF rightArcRect(centerX + towerWidth * 0.16,
+                                  waveCenterY - radiusY,
+                                  radiusX * 2.0, radiusY * 2.0);
+        p.drawArc(leftArcRect, 100 * 16, 160 * 16);
+        p.drawArc(rightArcRect, -80 * 16, 160 * 16);
     }
 
     QLinearGradient towerGradient(QPointF(centerX, topY), QPointF(centerX, baseY));

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -41,6 +41,10 @@
 
 namespace AetherSDR {
 
+static const QColor kAetherBrandBlue(0x00, 0xb4, 0xd8);
+static const QColor kAetherBrandGreen(0x20, 0xc0, 0x60);
+static const QColor kConnectionTextColor(0xd8, 0xe6, 0xf0);
+
 // ─── Waterfall color scheme gradient presets ─────────────────────────────────
 
 static constexpr WfGradientStop kDefaultStops[] = {
@@ -156,6 +160,13 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     connect(m_tuneGuideTimer, &QTimer::timeout, this, [this]() {
         m_tuneGuideVisible = false;
         markOverlayDirty();
+    });
+
+    m_connectionAnimationTimer = new QTimer(this);
+    m_connectionAnimationTimer->setInterval(40);
+    connect(m_connectionAnimationTimer, &QTimer::timeout, this, [this]() {
+        if (m_connectionAnimationVisible)
+            markOverlayDirty();
     });
 
     // Load display settings (panIndex 0 by default — loadSettings() can be
@@ -673,6 +684,182 @@ void SpectrumWidget::clearDisplay()
     m_wfHistoryOffsetRows = 0;
     m_wfLive = true;
     markOverlayDirty();
+}
+
+void SpectrumWidget::setConnectionAnimationVisible(bool on, const QString& label)
+{
+    const QString nextLabel = label.trimmed().isEmpty()
+        ? QStringLiteral("Connecting to radio…")
+        : label.trimmed();
+    const bool changed = (m_connectionAnimationVisible != on)
+        || (on && m_connectionAnimationLabel != nextLabel);
+
+    if (!changed) {
+        return;
+    }
+
+    m_connectionAnimationVisible = on;
+    if (on) {
+        m_connectionAnimationLabel = nextLabel;
+        m_connectionAnimationClock.restart();
+        m_connectionAnimationTimer->start();
+    } else {
+        m_connectionAnimationLabel.clear();
+        m_connectionAnimationTimer->stop();
+    }
+    markOverlayDirty();
+}
+
+void SpectrumWidget::drawConnectionAnimation(QPainter& p, const QRect& contentRect)
+{
+    if (!m_connectionAnimationVisible || !m_connectionAnimationClock.isValid()) {
+        return;
+    }
+
+    const qreal insetX = qMin(40.0, contentRect.width() * 0.10);
+    const qreal insetTop = qMin(18.0, contentRect.height() * 0.08);
+    const qreal insetBottom = qMin(22.0, contentRect.height() * 0.10);
+    const QRectF available = QRectF(contentRect).adjusted(insetX, insetTop, -insetX, -insetBottom);
+    if (available.width() < 140.0 || available.height() < 96.0) {
+        return;
+    }
+
+    const qreal seconds = m_connectionAnimationClock.elapsed() / 1000.0;
+    const qreal towerHeight = qMin(available.height() * 0.32, 106.0);
+    const qreal towerWidth = towerHeight * 0.34;
+    const SliceOverlay* anchorOverlay = activeOverlay();
+    const qreal anchorX = anchorOverlay
+        ? static_cast<qreal>(mhzToX(anchorOverlay->freqMhz))
+        : static_cast<qreal>(mhzToX(m_centerMhz));
+    const qreal centerX = qBound(available.left() + towerWidth * 1.5,
+                                 anchorX,
+                                 available.right() - towerWidth * 1.5);
+    const qreal baseY = available.top() + available.height() * 0.66;
+    const qreal topY = baseY - towerHeight;
+    const qreal phase = std::fmod(seconds * 0.7, 1.0);
+
+    auto withAlpha = [](QColor color, int alpha) {
+        color.setAlpha(alpha);
+        return color;
+    };
+
+    p.save();
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    QRadialGradient glow(QPointF(centerX, topY + towerHeight * 0.32),
+                         towerHeight * 1.18);
+    glow.setColorAt(0.0, withAlpha(kAetherBrandBlue, 48));
+    glow.setColorAt(0.55, withAlpha(kAetherBrandGreen, 22));
+    glow.setColorAt(1.0, QColor(0, 0, 0, 0));
+    p.setPen(Qt::NoPen);
+    p.setBrush(glow);
+    p.drawEllipse(QPointF(centerX, topY + towerHeight * 0.34),
+                  towerHeight * 1.05, towerHeight * 0.82);
+
+    static constexpr qreal kTau = 6.28318530717958647692;
+    const qreal pulse = 0.55 + 0.45 * std::sin(seconds * kTau);
+    for (int ring = 0; ring < 3; ++ring) {
+        const qreal ringProgress = std::fmod(phase + ring * 0.24, 1.0);
+        const qreal radiusX = towerWidth * 0.85 + ringProgress * towerHeight * 0.92;
+        const qreal radiusY = radiusX * 0.74;
+        QColor waveColor = (ring % 2 == 0) ? kAetherBrandBlue : kAetherBrandGreen;
+        const qreal fade = 1.0 - ringProgress;
+        waveColor.setAlphaF(qBound(0.10, 0.16 + fade * 0.48 * pulse, 0.70));
+        QPen wavePen(waveColor,
+                     qMax(1.8, towerWidth * (0.075 + fade * 0.05)),
+                     Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
+        p.setPen(wavePen);
+        p.setBrush(Qt::NoBrush);
+        const QRectF arcRect(centerX - radiusX, topY - radiusY + towerHeight * 0.12,
+                             radiusX * 2.0, radiusY * 2.0);
+        p.drawArc(arcRect, 28 * 16, 124 * 16);
+    }
+
+    QLinearGradient towerGradient(QPointF(centerX, topY), QPointF(centerX, baseY));
+    towerGradient.setColorAt(0.0, kAetherBrandBlue.lighter(115));
+    towerGradient.setColorAt(0.55, kAetherBrandBlue);
+    towerGradient.setColorAt(1.0, kAetherBrandGreen);
+
+    QPainterPath towerFill;
+    towerFill.moveTo(centerX - towerWidth * 0.48, baseY);
+    towerFill.lineTo(centerX, topY + towerHeight * 0.08);
+    towerFill.lineTo(centerX + towerWidth * 0.48, baseY);
+    towerFill.closeSubpath();
+    QLinearGradient fillGradient(QPointF(centerX, topY), QPointF(centerX, baseY));
+    fillGradient.setColorAt(0.0, withAlpha(kAetherBrandBlue, 28));
+    fillGradient.setColorAt(1.0, withAlpha(kAetherBrandGreen, 12));
+    p.fillPath(towerFill, fillGradient);
+
+    QPen towerPen(QBrush(towerGradient), qMax(2.2, towerWidth * 0.11),
+                  Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
+    p.setPen(towerPen);
+    p.drawLine(QPointF(centerX - towerWidth * 0.48, baseY),
+               QPointF(centerX, topY));
+    p.drawLine(QPointF(centerX + towerWidth * 0.48, baseY),
+               QPointF(centerX, topY));
+
+    const qreal mastBottomY = topY + towerHeight * 0.28;
+    p.drawLine(QPointF(centerX, topY - towerHeight * 0.10),
+               QPointF(centerX, mastBottomY));
+
+    for (qreal t : {0.25, 0.45, 0.66, 0.84}) {
+        const qreal y = topY + towerHeight * t;
+        const qreal halfWidth = towerWidth * 0.48 * t;
+        p.drawLine(QPointF(centerX - halfWidth, y), QPointF(centerX + halfWidth, y));
+        if (t < 0.8) {
+            const qreal nextT = qMin(t + 0.16, 0.98);
+            const qreal nextY = topY + towerHeight * nextT;
+            const qreal nextHalfWidth = towerWidth * 0.48 * nextT;
+            p.drawLine(QPointF(centerX - halfWidth, y),
+                       QPointF(centerX + nextHalfWidth, nextY));
+            p.drawLine(QPointF(centerX + halfWidth, y),
+                       QPointF(centerX - nextHalfWidth, nextY));
+        }
+    }
+
+    p.drawLine(QPointF(centerX - towerWidth * 0.72, baseY),
+               QPointF(centerX + towerWidth * 0.72, baseY));
+    p.setBrush(kAetherBrandBlue);
+    p.setPen(Qt::NoPen);
+    p.drawEllipse(QPointF(centerX, topY - towerHeight * 0.10),
+                  towerWidth * 0.10, towerWidth * 0.10);
+
+    QFont titleFont = p.font();
+    titleFont.setPointSizeF(qBound(10.5, available.height() * 0.078, 18.0));
+    titleFont.setBold(true);
+    p.setFont(titleFont);
+    QFontMetricsF titleFm(titleFont);
+
+    QString subtitle = QStringLiteral("Getting everything ready");
+    if (m_connectionAnimationLabel.contains(QStringLiteral("remote"), Qt::CaseInsensitive)
+        || m_connectionAnimationLabel.contains(QStringLiteral("smartlink"), Qt::CaseInsensitive)) {
+        subtitle = QStringLiteral("Establishing a secure radio link");
+    } else if (m_connectionAnimationLabel.contains(QStringLiteral("reconnect"), Qt::CaseInsensitive)) {
+        subtitle = QStringLiteral("Restoring your session");
+    }
+
+    QFont subtitleFont = titleFont;
+    subtitleFont.setPointSizeF(qMax(9.0, titleFont.pointSizeF() - 2.5));
+    subtitleFont.setBold(false);
+    QFontMetricsF subtitleFm(subtitleFont);
+
+    const qreal titleY = baseY + towerHeight * 0.18;
+    const QRectF titleRect(available.left(), titleY, available.width(), titleFm.height() + 6.0);
+    const QRectF subtitleRect(available.left(), titleRect.bottom() + 4.0,
+                              available.width(), subtitleFm.height() + 4.0);
+
+    QLinearGradient titleGradient(titleRect.topLeft(), titleRect.topRight());
+    titleGradient.setColorAt(0.0, kAetherBrandBlue.lighter(108));
+    titleGradient.setColorAt(1.0, kAetherBrandGreen.lighter(105));
+    p.setFont(titleFont);
+    p.setPen(QPen(QBrush(titleGradient), 1.0));
+    p.drawText(titleRect, Qt::AlignHCenter | Qt::AlignTop, m_connectionAnimationLabel);
+
+    p.setFont(subtitleFont);
+    p.setPen(withAlpha(kConnectionTextColor, 180));
+    p.drawText(subtitleRect, Qt::AlignHCenter | Qt::AlignTop, subtitle);
+
+    p.restore();
 }
 
 void SpectrumWidget::resetGpuResources()
@@ -2984,6 +3171,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                 p.drawText(lx + 4, ly + fm.ascent() + 2, label);
             }
 
+            drawConnectionAnimation(p, specRect);
+
             m_overlayStaticDirty = false;
             m_overlayNeedsUpload = true;
         }
@@ -3387,6 +3576,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         if (m_showSpots) drawSpotMarkers(p, specRect);
         drawSliceMarkers(p, specRect, wfRect);
         drawOffScreenSlices(p, specRect);
+        drawConnectionAnimation(p, specRect);
     }
 
     // Reposition all VFO widgets — deconflict flags so they fly away from each other

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -7,6 +7,7 @@
 #include <QImage>
 #include <QColor>
 #include <QDateTime>
+#include <QElapsedTimer>
 #include <QTimer>
 
 class QVariantAnimation;
@@ -75,6 +76,7 @@ public:
     void setFrequencyRange(double centerMhz, double bandwidthMhz);
     void clearDisplay();  // blank spectrum and waterfall on disconnect
     void resetGpuResources();  // tear down GPU pipelines for reparenting (#1240)
+    void setConnectionAnimationVisible(bool on, const QString& label = {});
 
     // Feed a new FFT frame. bins are scaled dBm values.
     void updateSpectrum(const QVector<float>& binsDbm);
@@ -380,6 +382,7 @@ private:
     void drawFreqScale(QPainter& p, const QRect& r);
     void drawDbmScale(QPainter& p, const QRect& specRect);
     void drawTimeScale(QPainter& p, const QRect& wfRect);
+    void drawConnectionAnimation(QPainter& p, const QRect& contentRect);
     int waterfallStripWidth() const;
     QRect waterfallLiveButtonRect(const QRect& wfRect) const;
     QRect waterfallTimeScaleRect(const QRect& wfRect) const;
@@ -556,6 +559,10 @@ private:
     bool    m_isFloating{false};
     bool    m_tuneGuideVisible{false};
     QTimer* m_tuneGuideTimer{nullptr};
+    bool    m_connectionAnimationVisible{false};
+    QString m_connectionAnimationLabel;
+    QTimer* m_connectionAnimationTimer{nullptr};
+    QElapsedTimer m_connectionAnimationClock;
 
     // State change detector cache (per-instance, NOT static — multiple
     // panadapters have different values and static vars cause an infinite


### PR DESCRIPTION

<img width="872" height="724" alt="image" src="https://github.com/user-attachments/assets/39b95175-327e-403c-b224-1faf3ae6ed5c" />

## Summary

This PR reworks AetherSDR's radio connection experience around beginner tasks instead of transport jargon, then adds branded panadapter connection feedback so connect and reconnect flows feel alive from discovery through first pan data.

## What changed

- Rebuilt the connection dialog around three clear paths:
  - `On This Network`
  - `Remote with SmartLink`
  - `Connect by IP`
- Reframed manual IP entry as the VPN/routed-radio path so new users understand when to use it.
- Replaced the old probe-first manual workflow with a more direct `Connect by IP` flow and clearer routed-radio guidance.
- Added stronger empty-state UX for local discovery, including retry, SmartLink, IP-connect, and diagnostics actions.
- Moved `Low Bandwidth` into the remote/manual contexts where it matters, and improved its checkbox visibility in dark mode.
- Increased overall dialog usability on Linux, Windows, and macOS by enlarging the window, clamping placement on-screen, and reorganizing spacing/alignment for the novice path.
- Added SmartLink account/status cleanup and extra spacing for the remote radio action area so the remote connect button no longer crowds the scrollbar.
- Updated the help content to match the new connection model and menu naming.
- Added a panadapter connection animation using the AetherSDR blue/green brand colors.
- Kept that animation active across more of the actual lifecycle:
  - while looking for a remembered radio on startup
  - while probing a saved routed/VPN radio
  - during explicit connect and SmartLink connect
  - during reconnect after unexpected disconnect
  - until the first spectrum or waterfall frame arrives, instead of stopping at raw socket connection time
- Tuned the tower animation placement and anchoring so it sits inside the panadapter and lines up with the actual pan/slice frequency line instead of a generic widget midpoint.

## Why this changed

The old dialog asked users to understand discovered radios, manual/static radios, SmartLink, and other transport concepts before they could simply answer "How am I trying to reach my radio?" That was especially confusing for novice users and for VPN/routed access, where the right path was not obvious.

There was also a separate feedback gap during connect and reconnect: the panadapter could remain blank for a few seconds with no meaningful visual indication that the application was still actively progressing. That made successful connects feel stalled or ambiguous.

## User impact

- First-time users now get clearer choices that map to their station setup instead of internal networking terminology.
- VPN and routed-radio users are explicitly guided toward the IP workflow.
- SmartLink and remote users get a cleaner action layout and contextual low-bandwidth controls.
- Discovery failures now lead to recovery actions instead of a dead-end blank list.
- Connect and reconnect feel more polished because the panadapter provides branded, in-context visual feedback until live pan data arrives.

## Implementation notes

- `ConnectionPanel` now owns a stacked, task-based flow with dedicated local, SmartLink, and manual/VPN pages.
- `MainWindow` now drives panadapter connection animation state across startup search, local/remote connect, reconnect, error, and first-frame handoff.
- `SpectrumWidget` renders the new antenna animation in both software and GPU paths so the experience stays consistent across supported desktop platforms.
- The connection dialog menu/title/help text were renamed from the older `Choose Radio / SmartLink Setup...` wording to `Connect to Radio...`.

## Validation

- `cmake --build build -j10`
- Iterative manual UI validation during development for:
  - novice local discovery flow
  - SmartLink remote flow
  - VPN/routed `Connect by IP` flow
  - reconnect blank-state handoff into first live pan data
  - animation sizing, placement, and alignment on the panadapter

## Notes

This PR intentionally bundles the connection-dialog redesign and the panadapter connection-feedback work because they solve the same broader problem: making radio connection behavior more obvious, reassuring, and beginner-friendly from the first decision through reconnect recovery.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.4 Pro) and tested by @jensenpat
