### PR TITLE
[cat] Add rigctl TX PWR and SWR meter levels for WSJT-X and JTDX

### DIFF
--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -3,9 +3,49 @@
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
 
+#include <QLocale>
 #include <QMetaObject>
+#include <QStringList>
+#include <QtGlobal>
 
 namespace AetherSDR {
+
+namespace {
+
+constexpr quint64 kRigLevelKeyspd            = (1ULL << 14);
+constexpr quint64 kRigLevelSwr               = (1ULL << 28);
+constexpr quint64 kRigLevelRfPowerMeter      = (1ULL << 32);
+constexpr quint64 kRigLevelRfPowerMeterWatts = (1ULL << 39);
+constexpr qint64  kTxMeterFreshMs            = 1500;
+constexpr quint64 kRigGetLevelMask = kRigLevelKeyspd
+                                   | kRigLevelSwr
+                                   | kRigLevelRfPowerMeter
+                                   | kRigLevelRfPowerMeterWatts;
+
+QStringList rigGetLevelTokens()
+{
+    return {
+        QStringLiteral("KEYSPD"),
+        QStringLiteral("SWR"),
+        QStringLiteral("RFPOWER_METER"),
+        QStringLiteral("RFPOWER_METER_WATTS"),
+    };
+}
+
+QStringList rigSetLevelTokens()
+{
+    return { QStringLiteral("KEYSPD") };
+}
+
+QString formatRigLevelValue(double value)
+{
+    QString text = QLocale::c().toString(value, 'g', 6);
+    if (text == "-0" || text == "-0.0")
+        text = "0";
+    return text;
+}
+
+} // namespace
 
 RigctlProtocol::RigctlProtocol(RadioModel* model)
     : m_model(model)
@@ -132,13 +172,13 @@ QString RigctlProtocol::processCommand(const QString& cmd)
         if (name == "set_split_freq") return cmdSetSplitFreq(args);
         if (name == "get_split_mode") return cmdGetSplitMode();
         if (name == "set_split_mode") return cmdSetSplitMode(args);
+        if (name == "get_level")      return cmdGetLevel(args);
+        if (name == "set_level")      return cmdSetLevel(args);
         if (name == "dump_state")     return cmdDumpState();
         if (name == "quit")           return {};  // caller handles disconnect
         if (name == "chk_vfo")        return QStringLiteral("0\n");  // VFO mode disabled
         if (name == "send_morse")    return cmdSendMorse(args);
         if (name == "stop_morse")    return cmdStopMorse();
-        if (name == "set_level" && args.startsWith("KEYSPD"))
-            return cmdSetKeySpeed(args.mid(7).trimmed());
 
         return rprt(-4);  // RIG_EINVAL
     }
@@ -160,6 +200,8 @@ QString RigctlProtocol::processCommand(const QString& cmd)
     case 'S': return cmdGetSplitVfo();
     case 'I': return cmdGetSplitFreq();
     case 'X': return cmdGetSplitMode();
+    case 'l': return cmdGetLevel(args);
+    case 'L': return cmdSetLevel(args);
     case '1': return cmdDumpState();       // \dump_state
     case 'b': return cmdSendMorse(args);    // send morse
     case 'q': return {};                   // quit
@@ -395,6 +437,78 @@ QString RigctlProtocol::cmdSetSplitMode(const QString& args)
     return rprt(0);
 }
 
+QString RigctlProtocol::cmdGetLevel(const QString& arg)
+{
+    if (!m_model) return rprt(-8);
+
+    const QString level = arg.trimmed().toUpper();
+    if (level.isEmpty())
+        return rprt(-1);
+
+    if (level == "?") {
+        const QString supported = rigGetLevelTokens().join(' ');
+        if (m_extended)
+            return QStringLiteral("get_level:\nLevels: %1\n").arg(supported) + rprt(0);
+        return supported + "\n";
+    }
+
+    auto makeResponse = [this, &level](const QString& value) {
+        if (m_extended) {
+            return QStringLiteral("get_level:\nLevel: %1\nLevel Value: %2\n")
+                .arg(level, value) + rprt(0);
+        }
+        return value + "\n";
+    };
+
+    const auto& txModel = m_model->transmitModel();
+    const bool txMetersActive = txModel.isTransmitting() || txModel.isMox() || txModel.isTuning();
+    const bool txMetersFresh = txMetersActive
+        && m_model->meterModel().hasRecentTxMeters(kTxMeterFreshMs);
+
+    if (level == "KEYSPD")
+        return makeResponse(QString::number(txModel.cwSpeed()));
+
+    if (level == "SWR") {
+        // WSJT-X polls immediately after PTT and treats 0 as "no valid reading".
+        // Suppress cached last-TX values until a fresh TX meter sample arrives.
+        const float swr = txMetersFresh ? qMax(0.0f, m_model->meterModel().swr()) : 0.0f;
+        return makeResponse(formatRigLevelValue(swr));
+    }
+
+    if (level == "RFPOWER_METER_WATTS") {
+        const float watts = txMetersFresh ? qMax(0.0f, m_model->meterModel().fwdPower()) : 0.0f;
+        return makeResponse(formatRigLevelValue(watts));
+    }
+
+    if (level == "RFPOWER_METER") {
+        const float watts = txMetersFresh ? qMax(0.0f, m_model->meterModel().fwdPower()) : 0.0f;
+        const int maxPower = qMax(1, txModel.maxPowerLevel());
+        float ratio = watts / static_cast<float>(maxPower);
+        ratio = qBound(0.0f, ratio, 1.0f);
+        return makeResponse(formatRigLevelValue(ratio));
+    }
+
+    return rprt(-11);  // RIG_ENAVAIL
+}
+
+QString RigctlProtocol::cmdSetLevel(const QString& args)
+{
+    QStringList parts = args.split(' ', Qt::SkipEmptyParts);
+    if (parts.isEmpty())
+        return rprt(-1);
+
+    const QString level = parts[0].trimmed().toUpper();
+    if (level == "?") {
+        const QString supported = rigSetLevelTokens().join(' ');
+        if (m_extended)
+            return QStringLiteral("set_level:\nLevels: %1\n").arg(supported) + rprt(0);
+        return supported + "\n";
+    }
+    if (level == "KEYSPD")
+        return cmdSetKeySpeed(parts.mid(1).join(' '));
+    return rprt(-11);  // RIG_ENAVAIL
+}
+
 QString RigctlProtocol::cmdDumpState()
 {
     // Mimic rigctld --model=2 (NET rigctl) output.
@@ -439,10 +553,11 @@ QString RigctlProtocol::cmdDumpState()
     dump += "\n";
     dump += "\n";
     // has get/set func/level/parm
+    // Levels: KEYSPD, SWR, RFPOWER_METER, RFPOWER_METER_WATTS
     dump += "0x0\n";
     dump += "0x0\n";
-    dump += "0x0\n";
-    dump += "0x0\n";
+    dump += QStringLiteral("0x%1\n").arg(kRigGetLevelMask, 0, 16);
+    dump += QStringLiteral("0x%1\n").arg(kRigLevelKeyspd, 0, 16);
     dump += "0x0\n";
     dump += "0x0\n";
     // Protocol v1 additional fields (required by netrigctl_open)

--- a/src/core/RigctlProtocol.h
+++ b/src/core/RigctlProtocol.h
@@ -48,6 +48,8 @@ private:
     QString cmdSetSplitFreq(const QString& args);
     QString cmdGetSplitMode();
     QString cmdSetSplitMode(const QString& args);
+    QString cmdGetLevel(const QString& arg);
+    QString cmdSetLevel(const QString& args);
     QString cmdDumpState();
     QString cmdSendMorse(const QString& text);  // b <text> / \send_morse
     QString cmdStopMorse();                     // \stop_morse

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -1,6 +1,7 @@
 #include "MeterModel.h"
 #include "core/LogManager.h"
 #include <QDebug>
+#include <QDateTime>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <cmath>
@@ -159,6 +160,15 @@ float MeterModel::convertRaw(const MeterDef& def, qint16 raw) const
     return static_cast<float>(raw);
 }
 
+bool MeterModel::hasRecentTxMeters(qint64 maxAgeMs) const
+{
+    if (m_lastTxMeterUpdateMs <= 0 || maxAgeMs < 0)
+        return false;
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    return now - m_lastTxMeterUpdateMs <= maxAgeMs;
+}
+
 void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>& vals)
 {
     const int n = qMin(ids.size(), vals.size());
@@ -200,6 +210,7 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
         if (isSliceLevel) {
             // no-op, already emitted
         } else if (idx == m_fwdPwrIdx) {
+            m_lastTxMeterUpdateMs = QDateTime::currentMSecsSinceEpoch();
             // FWDPWR meter reports in dBm — convert to watts for display.
             // watts = 10^(dBm/10) / 1000
             // e.g. 50 dBm = 100 W, 47 dBm ≈ 50 W, 40 dBm = 10 W
@@ -214,6 +225,7 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
             }
             txChanged = true;
         } else if (idx == m_swrIdx) {
+            m_lastTxMeterUpdateMs = QDateTime::currentMSecsSinceEpoch();
             m_swr = v;
             txChanged = true;
         } else if (idx == m_micPeakIdx) {

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -73,6 +73,10 @@ public:
     // Convenience: SWR.
     float swr() const { return m_swr; }
 
+    // Timestamp of the last TX meter sample (milliseconds since epoch).
+    qint64 txMetersUpdatedAtMs() const { return m_lastTxMeterUpdateMs; }
+    bool hasRecentTxMeters(qint64 maxAgeMs) const;
+
     // Convenience: mic peak level (dBFS) and compression peak (dB).
     float micPeak()  const { return m_micPeak; }
     float compPeak() const { return m_compPeak; }
@@ -151,6 +155,7 @@ private:
     float m_sLevel{-130.0f};
     float m_fwdPower{0.0f};
     float m_swr{1.0f};
+    qint64 m_lastTxMeterUpdateMs{0};
     float m_micPeak{-50.0f};
     float m_compPeak{0.0f};      // computed gain reduction (displayed)
     float m_compPeakRaw{-150.0f}; // smoothed COMPPEAK value


### PR DESCRIPTION

<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/55bdda96-e2f2-4fc0-943b-404607f01887" />

## Summary
- add rigctl `get_level` support for `SWR`, `RFPOWER_METER`, and `RFPOWER_METER_WATTS`, plus `set_level` handling for `KEYSPD`
- advertise the supported Hamlib level capability bitmasks in `dump_state`
- track fresh TX meter timestamps so rigctl clients do not see stale SWR or power values during PTT transitions
- format level values with C-locale, Hamlib-style floating-point output for WSJT-X/JTDX compatibility

## Why
WSJT-X and related rigctl-based clients poll `rigctld` for TX power and SWR while transmitting. Our CAT emulation was missing those level responses and capability advertisements, which prevented those clients from reading TX meter data reliably.

## Impact
WSJT-X and JTDX can now read transmit power and SWR from the AetherSDR rigctl emulation, and the responses are shaped to match the timing and numeric formatting those clients expect.

## Validation
- `cmake --build build -j 10`
- manual WSJT-X validation with test tones, CQ calls, and completed QSOs
- manual JTDX validation with test tones, CQ calls, and completed QSOs

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.4 Pro) and tested by @jensenpat
