### PR TITLE
[crash] Fix rigctld shutdown crash with active CAT clients

### DIFF
--- a/src/core/RigctlServer.cpp
+++ b/src/core/RigctlServer.cpp
@@ -39,12 +39,19 @@ void RigctlServer::stop()
 {
     if (!m_server) return;
 
-    for (auto& cs : m_clients) {
-        cs.socket->disconnectFromHost();
+    QList<ClientState> clients;
+    clients.swap(m_clients);
+    emit clientCountChanged(0);
+
+    for (auto& cs : clients) {
+        if (cs.socket) {
+            // Prevent synchronous disconnected() delivery from re-entering
+            // onClientDisconnected() while we're already tearing down clients.
+            cs.socket->disconnect(this);
+            cs.socket->close();
+        }
         delete cs.protocol;
     }
-    m_clients.clear();
-    emit clientCountChanged(0);
 
     m_server->close();
     delete m_server;


### PR DESCRIPTION
## Summary
- fix a crash when disabling rigctld autostart while a CAT TCP client is still connected
- make `RigctlServer::stop()` detach tracked clients before socket shutdown so cleanup only happens once

## Root Cause
`RigctlServer::stop()` disconnected live sockets while those sockets were still connected to `onClientDisconnected()`. That allowed shutdown to re-enter client cleanup and tear down the same protocol twice, matching the invalid free seen in the crash report.

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j10`
- reproduced the autostart toggle flow with an active WSJT-X CAT connection and verified the app no longer aborts

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.4 Pro) and tested by @jensenpat
