### PR TITLE
[crash] Handle Bluetooth audio hotplug safely

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -26,6 +26,17 @@ namespace AetherSDR {
 
 namespace {
 constexpr qint64 kTxAutoRestartMinRuntimeMs = 60000;
+
+bool devicePresent(const QList<QAudioDevice>& devices, const QAudioDevice& target)
+{
+    if (target.isNull()) {
+        return false;
+    }
+
+    return std::any_of(devices.begin(), devices.end(), [&target](const QAudioDevice& device) {
+        return device.id() == target.id();
+    });
+}
 }
 
 void AudioEngine::updateRxBufferStats()
@@ -59,9 +70,16 @@ AudioEngine::AudioEngine(QObject* parent)
     // Windows/macOS only: PipeWire on Linux crashes in pw_stream_connect when
     // audioOutputsChanged fires during device enumeration. The zombie sink
     // watchdog and stateChanged handlers cover Linux recovery instead.
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     m_mediaDevices = new QMediaDevices(this);
     connect(m_mediaDevices, &QMediaDevices::audioOutputsChanged, this, [this]() {
+        if (!m_outputDevice.isNull()) {
+            const auto outputs = QMediaDevices::audioOutputs();
+            if (!devicePresent(outputs, m_outputDevice)) {
+                qCWarning(lcAudio) << "AudioEngine: selected output device is no longer available, falling back to the system default";
+                m_outputDevice = QAudioDevice{};
+            }
+        }
         if (!m_audioSink) return;
         qCWarning(lcAudio) << "AudioEngine: audio output device list changed, restarting RX (#1361)";
         QMetaObject::invokeMethod(this, [this]() {
@@ -191,8 +209,16 @@ bool AudioEngine::startRxStream()
     m_lastAudioFeedTime.start();  // initialize liveness watchdog (#1411)
 
     QAudioFormat fmt = makeFormat();
-    QAudioDevice dev = m_outputDevice.isNull()
-        ? QMediaDevices::defaultAudioOutput() : m_outputDevice;
+    QAudioDevice dev = QMediaDevices::defaultAudioOutput();
+    if (!m_outputDevice.isNull()) {
+        const auto outputs = QMediaDevices::audioOutputs();
+        if (devicePresent(outputs, m_outputDevice)) {
+            dev = m_outputDevice;
+        } else {
+            qCWarning(lcAudio) << "AudioEngine: saved output device is unavailable, using the system default output instead";
+            m_outputDevice = QAudioDevice{};
+        }
+    }
 
 #ifdef Q_OS_MAC
     if (!m_allowBluetoothTelephonyOutput.load()) {
@@ -262,6 +288,7 @@ bool AudioEngine::startRxStream()
         if (state != QAudio::StoppedState) {
             return;
         }
+        m_audioDevice = nullptr;
         if (!m_audioSink) {
             return;   // intentional stop (stopRxStream nulls this)
         }
@@ -351,6 +378,7 @@ bool AudioEngine::startRxStream()
         if (state != QAudio::StoppedState) {
             return;
         }
+        m_audioDevice = nullptr;
         if (!m_audioSink) {
             return;   // intentional stop (stopRxStream nulls this)
         }

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -13,6 +13,7 @@
 #include <QBuffer>
 #include <QByteArray>
 #include <QElapsedTimer>
+#include <QPointer>
 
 class QMediaDevices;
 
@@ -203,12 +204,12 @@ private:
 
     // RX
     QAudioSink*   m_audioSink{nullptr};
-    QIODevice*    m_audioDevice{nullptr};   // raw device from QAudioSink
+    QPointer<QIODevice> m_audioDevice;   // sink-owned device, may vanish on hot-unplug
 
     // TX
     QUdpSocket    m_txSocket;
     QAudioSource* m_audioSource{nullptr};
-    QIODevice*    m_micDevice{nullptr};
+    QPointer<QIODevice> m_micDevice;
 #ifdef Q_OS_MAC
     QTimer*       m_txPollTimer{nullptr};
     QBuffer*      m_micBuffer{nullptr};


### PR DESCRIPTION
## Summary

Fix a macOS crash that can happen when the active Bluetooth audio output disappears while RX audio is running.

## Root Cause

When a Bluetooth headset powers down, disconnects, or otherwise vanishes while AetherSDR is actively playing RX audio, two related things can happen in very quick succession:

1. CoreAudio publishes an output-device change on the main side of the app.
2. Qt's `QAudioSink` transitions to `StoppedState` and tears down the sink-owned `QIODevice` backing the RX stream.

At the same time, `AudioEngine` still has a timer-driven RX liveness path running on the audio thread that checks whether the current audio device is open. Before this fix, that path kept a raw `QIODevice*` borrowed from `QAudioSink`.

That created a race during headset power-down / hot-unplug:

- the Bluetooth device disappears
- `QAudioSink` stops and destroys its internal device object
- `AudioEngine` still holds the old raw pointer
- the RX timer fires and calls `isOpen()` on a pointer that is no longer valid

That matches the observed macOS crash, where the faulting thread is `AudioEngine` and the crash occurs in `QIODevice::isOpen()` after the output device is removed.

There was a second recovery problem too: if the selected output device disappeared, AetherSDR could continue holding onto a stale saved output selection instead of cleanly falling back to the system default output and restarting RX.

## What Changed

- Replace the sink/mic device handles in `AudioEngine` with `QPointer<QIODevice>` so they automatically null out if Qt destroys the underlying object.
- Clear the RX device handle immediately when `QAudioSink` enters `StoppedState`, so the timer path cannot keep probing a dead sink-owned device.
- On macOS and Windows, listen for output-device list changes and restart RX when the output topology changes.
- If the previously selected output device is no longer present, clear that stale selection and fall back to the current system default output before starting RX again.
- Keep the fix scoped to the audio hotplug lifecycle in `AudioEngine`.

## User Impact

- Removing or powering down a Bluetooth headset while AetherSDR is running should no longer crash the app.
- RX audio should recover cleanly by falling back to another available output when the active headset disappears.
- If the Bluetooth headset comes back, Qt output switching can recover cleanly instead of leaving the app in a broken audio state.

## Validation

- Built locally with:
  - `cmake -S . -B build -G Ninja`
  - `cmake --build build -j10`
- Tested on macOS by:
  - starting RX with a Bluetooth headset active
  - removing / powering down the headset
  - verifying AetherSDR no longer crashes
  - reconnecting the headset
  - verifying audio switches back cleanly

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.4 Pro) and tested by @jensenpat
