### PR TITLE
Schedule rigctld client sockets for deletion on server stop

### DIFF
--- a/src/core/RigctlServer.cpp
+++ b/src/core/RigctlServer.cpp
@@ -49,6 +49,7 @@ void RigctlServer::stop()
             // onClientDisconnected() while we're already tearing down clients.
             cs.socket->disconnect(this);
             cs.socket->close();
+            cs.socket->deleteLater();
         }
         delete cs.protocol;
     }


### PR DESCRIPTION
Follow-up to #1601: the swap-and-disconnect pattern prevents the
re-entrant double-free, but leaves socket lifetime tied to the
server's child-ownership. Restore the explicit deleteLater() that
was previously called in onClientDisconnected() so sockets are
reaped on the event loop turn after stop(), not only when the
server is destroyed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
