### PR TITLE
Guard m_hidCoalesceTimer reference behind HAVE_HIDAPI (Windows build)

### DIFF
--- a/src/core/RigctlServer.cpp
+++ b/src/core/RigctlServer.cpp
@@ -49,6 +49,7 @@ void RigctlServer::stop()
             // onClientDisconnected() while we're already tearing down clients.
             cs.socket->disconnect(this);
             cs.socket->close();
+            cs.socket->deleteLater();
         }
         delete cs.protocol;
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4800,7 +4800,10 @@ void MainWindow::onSliceAdded(SliceModel* s)
     connect(s, &SliceModel::frequencyChanged, this, [this, s](double mhz) {
         // Don't snap overlay back to stale radio-confirmed freq during active
         // encoder tuning — the optimistic VFO position is already ahead (#1524)
-        bool activeTuning = m_flexCoalesceTimer.isActive() || m_hidCoalesceTimer.isActive();
+        bool activeTuning = m_flexCoalesceTimer.isActive();
+#ifdef HAVE_HIDAPI
+        activeTuning = activeTuning || m_hidCoalesceTimer.isActive();
+#endif
         if (activeTuning && s->sliceId() == m_activeSliceId)
             return;
 


### PR DESCRIPTION
- Schedule rigctld client sockets for deletion on server stop
- Guard m_hidCoalesceTimer reference behind HAVE_HIDAPI (Windows build)
