### PR TITLE
Fix RF Gain echo-driven command loop (#1498)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1074,7 +1074,7 @@ MainWindow::MainWindow(QWidget* parent)
                 applet->spectrumWidget()->overlayMenu(),
                 &SpectrumOverlayMenu::setRfGainRange);
         connect(pan, &PanadapterModel::rfGainChanged,
-                this, [applet](int gain, const QString&) {
+                this, [applet](int gain) {
             applet->spectrumWidget()->setRfGain(gain);
             applet->spectrumWidget()->overlayMenu()->setRfGain(gain);
         });

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -303,7 +303,13 @@ void SpectrumOverlayMenu::buildAntPanel()
             m_rfGainSlider->setValue(snapped);
         }
         m_rfGainLabel->setText(QString("%1 dB").arg(snapped));
-        if (!m_updatingFromModel) {
+        // Only emit when the snapped value actually differs from the last
+        // emitted one. Mouse drags within a single step fire valueChanged
+        // with many unsnapped values that all round to the same snapped
+        // value — without this guard we'd spam rfgain commands to the
+        // radio on every drag tick (#1498).
+        if (!m_updatingFromModel && snapped != m_lastEmittedRfGain) {
+            m_lastEmittedRfGain = snapped;
             emit rfGainChanged(snapped);
             if (m_slice)
                 m_slice->setRfGain(static_cast<float>(snapped));
@@ -1366,6 +1372,7 @@ void SpectrumOverlayMenu::setRfGain(int gain)
     QSignalBlocker b(m_rfGainSlider);
     m_rfGainSlider->setValue(gain);
     m_rfGainLabel->setText(QString("%1 dB").arg(gain));
+    m_lastEmittedRfGain = gain;  // keep emit-dedupe in sync with external updates
 }
 
 void SpectrumOverlayMenu::setRfGainRange(int low, int high, int step)

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -2,6 +2,7 @@
 
 #include <QWidget>
 #include <QVector>
+#include <climits>
 #include <QStringList>
 #include <QPoint>
 #include <QPointer>
@@ -216,6 +217,7 @@ private:
     QStringList  m_antList;
     QPointer<SliceModel> m_slice;
     bool         m_updatingFromModel{false};
+    int          m_lastEmittedRfGain{INT_MIN};  // dedupe rfgain emits across drag snap ticks (#1498)
 };
 
 } // namespace AetherSDR

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -68,14 +68,14 @@ void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
         int g = kvs["rfgain"].toInt();
         if (g != m_rfGain) {
             m_rfGain = g;
-            emit rfGainChanged(m_rfGain, m_preamp);
+            emit rfGainChanged(m_rfGain);
         }
     }
     if (kvs.contains("pre")) {
         QString pre = kvs["pre"];
         if (pre != m_preamp) {
+            // Preamp is internal state only — no UI listeners, no emit.
             m_preamp = pre;
-            emit rfGainChanged(m_rfGain, m_preamp);
         }
     }
     if (kvs.contains("wnb")) {

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -41,7 +41,11 @@ public:
     bool wideActive() const { return m_wideActive; }
     QString preamp() const { return m_preamp; }
     void setPreamp(const QString& pre) {
-        if (m_preamp != pre) { m_preamp = pre; emit rfGainChanged(m_rfGain, m_preamp); }
+        // Preamp is internal state only — no UI listeners. Do not emit
+        // rfGainChanged here; doing so caused a ~33ms echo loop because the
+        // gain display listener would re-assert the current rfgain back to
+        // the radio on every status cycle (#1498).
+        if (m_preamp != pre) { m_preamp = pre; }
     }
     int daxiqChannel() const { return m_daxiqChannel; }
 
@@ -59,7 +63,7 @@ signals:
     void infoChanged(double centerMhz, double bandwidthMhz);
     void levelChanged(float minDbm, float maxDbm);
     void antListChanged(const QStringList& ants);
-    void rfGainChanged(int gain, const QString& preamp);
+    void rfGainChanged(int gain);
     void rfGainInfoChanged(int low, int high, int step);
     void wnbChanged(bool active, int level);
     void wideChanged(bool active);


### PR DESCRIPTION
Root cause: SpectrumOverlayMenu's slider valueChanged handler fires
on every pixel of mouse interaction with the slider, producing many
unsnapped values that all round to the same step-aligned value. It
then unconditionally emitted rfGainChanged(snapped), firing redundant
display pan set + slice set commands on every tick — ~350 commands
in 16 seconds of cursor activity on the slider.

Fix: dedupe emits against the last snapped value. Idle hover no
longer spams; one command per actual step crossing during drag.

Also tighten PanadapterModel::rfGainChanged: the signal bundled a
preamp argument no listener consumed (MainWindow.cpp:1076 handler
took it as an unnamed const QString&). Drop the argument, stop
emitting from setPreamp/applyPanStatus preamp branch entirely —
preamp is internal state with no UI listeners, and firing the
signal on preamp changes was creating the potential for confusion
without any benefit.

Closes #1498.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
