### PR TITLE
Propagate late-arriving DIV eligibility to all VFOs (#1503)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1248,14 +1248,24 @@ MainWindow::MainWindow(QWidget* parent)
         m_appletPanel->setMaxSlices(m_radioModel.maxSlices());
     });
 
-    // Propagate late-arriving SmartSDR+ subscription to all existing VFOs (#1356)
+    // Propagate late-arriving SmartSDR+ subscription + dual-SCU diversity
+    // eligibility to all existing VFOs. Both depend on radio info (license
+    // subscription / model) that can arrive after a slice is created — in
+    // which case onSliceAdded reads empty strings and the VFO gets stuck in
+    // the wrong state (#1356 for SmartSDR+, #1503 for DIV).
     connect(&m_radioModel, &RadioModel::infoChanged, this, [this]() {
         const bool hasPlus = m_radioModel.licenseSubscription().contains("SmartSDR+");
+        const QString& model = m_radioModel.model();
+        const bool divAllowed = model.contains("6500") || model.contains("6600")
+                             || model.contains("6700") || model.contains("8600")
+                             || model.contains("AU-520");
         if (m_panStack) {
             for (auto* applet : m_panStack->allApplets()) {
                 auto* sw = applet->spectrumWidget();
-                for (auto* vfo : sw->findChildren<VfoWidget*>())
+                for (auto* vfo : sw->findChildren<VfoWidget*>()) {
                     vfo->setSmartSdrPlus(hasPlus);
+                    vfo->setDiversityAllowed(divAllowed);
+                }
             }
         }
     });


### PR DESCRIPTION
If the radio's model status arrives after Slice A is created,
onSliceAdded reads an empty m_radioModel.model() and permanently
hides the Diversity button on that VfoWidget. Later slices succeed
because model info is available by then. Identical race pattern
to the SmartSDR+ subscription issue fixed in #1356.

Extend the existing infoChanged handler — which already iterates
every VfoWidget for SmartSDR+ — to also re-apply setDiversityAllowed
using the dual-SCU model list. Deterministic regardless of protocol
message ordering; Linux tends to dodge the race via TCP arrival
ordering but Windows reliably trips it.

Closes #1503.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
