### PR TITLE
Add per-slice VFO marker style toggles to filter panel (#1526)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6301,6 +6301,17 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     });
 #endif
 
+    // Per-slice VFO marker style (#1526): push user's saved line thickness and
+    // filter-edge visibility preferences to this slice's overlay whenever they
+    // change. Also fires once on setSlice() below to apply loaded defaults.
+    connect(w, &VfoWidget::markerStyleChanged, this,
+            [this, sliceId](bool thin, bool hideEdges) {
+        auto* sl = m_radioModel.slice(sliceId);
+        if (!sl) return;
+        if (auto* sw = spectrumForSlice(sl))
+            sw->setSliceOverlayMarkerStyle(sliceId, thin, hideEdges);
+    });
+
     // Wire slice data into widget
     w->setSlice(s);
     w->setAntennaList(m_radioModel.antennaList());

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1160,6 +1160,17 @@ void SpectrumWidget::setSliceOverlay(int sliceId, double freq, int fLow, int fHi
     }
 }
 
+void SpectrumWidget::setSliceOverlayMarkerStyle(int sliceId, bool markerThin, bool filterEdgesHidden)
+{
+    int idx = overlayIndex(sliceId);
+    if (idx < 0) return;
+    auto& o = m_sliceOverlays[idx];
+    if (o.markerThin == markerThin && o.filterEdgesHidden == filterEdgesHidden) return;
+    o.markerThin = markerThin;
+    o.filterEdgesHidden = filterEdgesHidden;
+    markOverlayDirty();
+}
+
 void SpectrumWidget::setSliceOverlayFreq(int sliceId, double freqMhz)
 {
     for (auto& so : m_sliceOverlays) {
@@ -4395,10 +4406,12 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
         p.fillRect(QRect(fX1, wfRect.top(), fW, wfRect.height()),
                    QColor(col.red(), col.green(), col.blue(), 25));
 
-        // Filter edge lines
-        p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 130), 1));
-        p.drawLine(fX1, specRect.top(), fX1, specRect.bottom());
-        p.drawLine(fX2, specRect.top(), fX2, specRect.bottom());
+        // Filter edge lines — user-hidden via per-slice VFO flag toggle (#1526)
+        if (!so.filterEdgesHidden) {
+            p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 130), 1));
+            p.drawLine(fX1, specRect.top(), fX1, specRect.bottom());
+            p.drawLine(fX2, specRect.top(), fX2, specRect.bottom());
+        }
 
         // ── RTTY/DIGL: mark/space lines replace the VFO center line ────
         const bool isRttyMode = (so.mode == "RTTY" || so.mode == "DIGL");
@@ -4438,8 +4451,8 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
             // ── Standard VFO center line ─────────────────────────────────
             int markerX = vfoX;
 
-            // Reduce line width when a filter edge is very close (e.g. CW mode) (#764)
-            const qreal vfoLineW = (std::abs(vfoX - fX1) <= 4 || std::abs(vfoX - fX2) <= 4) ? 1.0 : 2.0;
+            // Per-slice VFO marker thickness — user-toggled via VFO flag (#1526)
+            const qreal vfoLineW = so.markerThin ? 1.0 : 2.0;
             p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 220), vfoLineW));
             p.drawLine(markerX, specRect.top(), markerX, freqLineBottom);
 

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -246,6 +246,9 @@ public:
         int    ritFreq{0};          // Hz offset
         bool   xitOn{false};
         int    xitFreq{0};          // Hz offset
+        // Per-slice VFO marker display preferences (#1526)
+        bool   markerThin{false};         // 1px center line instead of 2px
+        bool   filterEdgesHidden{false};  // skip drawing filter-edge vertical lines
     };
 
     // Add or update a slice overlay (called per-slice on any state change).
@@ -257,6 +260,8 @@ public:
                          bool xitOn = false, int xitFreq = 0);
     // Update just the frequency on an existing overlay (for optimistic scroll-to-tune)
     void setSliceOverlayFreq(int sliceId, double freqMhz);
+    // Update per-slice marker display style (#1526)
+    void setSliceOverlayMarkerStyle(int sliceId, bool markerThin, bool filterEdgesHidden);
     // Remove a slice overlay.
     void removeSliceOverlay(int sliceId);
 

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1891,6 +1891,51 @@ void VfoWidget::setSmartSdrPlus(bool has)
     if (m_slice) rebuildFilterButtons();
 }
 
+// ── Per-slice VFO marker display prefs (#1526) ───────────────────────────────
+
+void VfoWidget::setMarkerThin(bool thin)
+{
+    if (m_markerThin != thin) {
+        m_markerThin = thin;
+        saveDisplayPrefs();
+        emit markerStyleChanged(m_markerThin, m_filterEdgesHidden);
+    }
+    if (m_markerThinBtn)  m_markerThinBtn->setChecked(thin);
+    if (m_markerThickBtn) m_markerThickBtn->setChecked(!thin);
+}
+
+void VfoWidget::setFilterEdgesHidden(bool hide)
+{
+    if (m_filterEdgesHidden != hide) {
+        m_filterEdgesHidden = hide;
+        saveDisplayPrefs();
+        emit markerStyleChanged(m_markerThin, m_filterEdgesHidden);
+    }
+    if (m_edgesShowBtn) m_edgesShowBtn->setChecked(!hide);
+    if (m_edgesHideBtn) m_edgesHideBtn->setChecked(hide);
+}
+
+void VfoWidget::loadDisplayPrefs()
+{
+    if (!m_slice) return;
+    auto& s = AppSettings::instance();
+    const QString keyT = QStringLiteral("Slice%1_MarkerThin").arg(m_slice->sliceId());
+    const QString keyH = QStringLiteral("Slice%1_FilterEdgesHidden").arg(m_slice->sliceId());
+    m_markerThin        = s.value(keyT, "False").toString() == "True";
+    m_filterEdgesHidden = s.value(keyH, "False").toString() == "True";
+}
+
+void VfoWidget::saveDisplayPrefs()
+{
+    if (!m_slice) return;
+    auto& s = AppSettings::instance();
+    const QString keyT = QStringLiteral("Slice%1_MarkerThin").arg(m_slice->sliceId());
+    const QString keyH = QStringLiteral("Slice%1_FilterEdgesHidden").arg(m_slice->sliceId());
+    s.setValue(keyT, m_markerThin ? "True" : "False");
+    s.setValue(keyH, m_filterEdgesHidden ? "True" : "False");
+    s.save();
+}
+
 void VfoWidget::setEscLevel(float dbm)
 {
     m_escLevelDbm = dbm;
@@ -2239,6 +2284,12 @@ void VfoWidget::setSlice(SliceModel* slice)
         m_slice->disconnect(this);
     m_slice = slice;
     if (!m_slice) return;
+
+    // Load per-slice display prefs now that we know the slice ID, then push
+    // them out so the SpectrumWidget's overlay picks up the saved style. This
+    // runs after wireVfoWidget() has connected markerStyleChanged (#1526).
+    loadDisplayPrefs();
+    emit markerStyleChanged(m_markerThin, m_filterEdgesHidden);
 
     // Frequency
     connect(m_slice, &SliceModel::frequencyChanged, this, [this](double) { updateFreqLabel(); });
@@ -3047,9 +3098,50 @@ void VfoWidget::rebuildFilterButtons()
         m_filterGrid->addWidget(btn, i / 4, i % 4);
     }
 
+    // Per-slice VFO marker style row: Thin/Thick line + Edges/Hide filter edges (#1526)
+    {
+        int row = (m_filterWidths.size() + 3) / 4;
+
+        m_markerThinBtn = new QPushButton("Thin");
+        m_markerThinBtn->setCheckable(true);
+        m_markerThinBtn->setChecked(m_markerThin);
+        m_markerThinBtn->setFixedHeight(26);
+        m_markerThinBtn->setStyleSheet(kModeBtn);
+        m_markerThinBtn->setToolTip("Thin VFO center line");
+        connect(m_markerThinBtn, &QPushButton::clicked, this, [this]() { setMarkerThin(true); });
+        m_filterGrid->addWidget(m_markerThinBtn, row, 0);
+
+        m_markerThickBtn = new QPushButton("Thick");
+        m_markerThickBtn->setCheckable(true);
+        m_markerThickBtn->setChecked(!m_markerThin);
+        m_markerThickBtn->setFixedHeight(26);
+        m_markerThickBtn->setStyleSheet(kModeBtn);
+        m_markerThickBtn->setToolTip("Thick VFO center line");
+        connect(m_markerThickBtn, &QPushButton::clicked, this, [this]() { setMarkerThin(false); });
+        m_filterGrid->addWidget(m_markerThickBtn, row, 1);
+
+        m_edgesShowBtn = new QPushButton("Edges");
+        m_edgesShowBtn->setCheckable(true);
+        m_edgesShowBtn->setChecked(!m_filterEdgesHidden);
+        m_edgesShowBtn->setFixedHeight(26);
+        m_edgesShowBtn->setStyleSheet(kModeBtn);
+        m_edgesShowBtn->setToolTip("Show filter edge lines");
+        connect(m_edgesShowBtn, &QPushButton::clicked, this, [this]() { setFilterEdgesHidden(false); });
+        m_filterGrid->addWidget(m_edgesShowBtn, row, 2);
+
+        m_edgesHideBtn = new QPushButton("Hide");
+        m_edgesHideBtn->setCheckable(true);
+        m_edgesHideBtn->setChecked(m_filterEdgesHidden);
+        m_edgesHideBtn->setFixedHeight(26);
+        m_edgesHideBtn->setStyleSheet(kModeBtn);
+        m_edgesHideBtn->setToolTip("Hide filter edge lines");
+        connect(m_edgesHideBtn, &QPushButton::clicked, this, [this]() { setFilterEdgesHidden(true); });
+        m_filterGrid->addWidget(m_edgesHideBtn, row, 3);
+    }
+
     // Add CW autotune row spanning all 4 columns when in CW mode
     if (m_slice && (m_slice->mode() == "CW" || m_slice->mode() == "CWL")) {
-        int row = (m_filterWidths.size() + 3) / 4;
+        int row = (m_filterWidths.size() + 3) / 4 + 1;
 
         auto* container = new QWidget;
         auto* hbox = new QHBoxLayout(container);

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -104,6 +104,8 @@ Q_SIGNALS:
     // Emitted when the wheel tunes by step (autopan=0 path) — MainWindow uses
     // this to explicitly re-center the pan if the new freq is outside the window.
     void stepTuned(double mhz);
+    // Per-slice VFO marker style changed (#1526)
+    void markerStyleChanged(bool markerThin, bool filterEdgesHidden);
 
 protected:
     void paintEvent(QPaintEvent* event) override;
@@ -199,7 +201,22 @@ private:
 public:
     void setDiversityAllowed(bool allowed);
     void setSmartSdrPlus(bool has);
+
+    // Per-slice VFO marker display prefs, persisted by slice ID (#1526)
+    bool markerThin() const { return m_markerThin; }
+    bool filterEdgesHidden() const { return m_filterEdgesHidden; }
+    void setMarkerThin(bool thin);
+    void setFilterEdgesHidden(bool hide);
 private:
+    bool m_markerThin{false};
+    bool m_filterEdgesHidden{false};
+    class QPushButton* m_markerThinBtn{nullptr};
+    class QPushButton* m_markerThickBtn{nullptr};
+    class QPushButton* m_edgesShowBtn{nullptr};
+    class QPushButton* m_edgesHideBtn{nullptr};
+    void loadDisplayPrefs();
+    void saveDisplayPrefs();
+
     QSlider* m_sqlSlider{nullptr};
     QComboBox* m_agcCmb{nullptr};
     QSlider* m_agcTSlider{nullptr};


### PR DESCRIPTION
Reporter's CW complaint was that the center VFO line and two filter
edge lines merge visually at narrow filter widths, making the marker
look too thick. Previous auto-thin heuristic (#764) adjusted line
width based on edge proximity but left no user control.

Replace the heuristic with explicit, per-slice user toggles in the
VFO flag's filter panel, inserted between the filter width buttons
and the CW autotune row:

  [Thin]  [Thick]  [Edges]  [Hide]

- Thin/Thick: 1px vs 2px center VFO line
- Edges/Hide: show or suppress the two filter-edge vertical lines

State is per-VfoWidget and persists across restarts via AppSettings
keyed by slice ID (Slice<N>_MarkerThin, Slice<N>_FilterEdgesHidden).
Settings on Slice A do not affect Slice B or vice versa.

Wiring: VfoWidget::markerStyleChanged(bool, bool) → MainWindow →
SpectrumWidget::setSliceOverlayMarkerStyle(sliceId, thin, hideEdges)
which updates the per-slice SliceOverlay fields consulted during
drawSliceMarkers().

Closes #1526.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
