### PR TITLE
Restrict VFO marker-style buttons to CW/CWL modes and clean up on rebuild

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5995,8 +5995,24 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // stack (frequency, mode, filters, pan center, bandwidth, antennas).
         // One command handles everything.
         m_bandSettings.setCurrentBand(bandName);
+
+        // Translate XVTR display names ("2m", "70cm", "23cm") to their band-stack
+        // key ("X0", "X1", "X2"). SmartSDR pcap shows this is what the radio's
+        // band stack expects — sending band=<xvtr_name> clears the slice because
+        // the name isn't a valid stack key, whereas band=X<idx> restores the
+        // saved XVTR slice correctly (#1540/#1211).
+        QString stackKey = bandName;
+        for (auto it = m_radioModel.xvtrList().constBegin();
+             it != m_radioModel.xvtrList().constEnd(); ++it) {
+            if (it.value().isValid && it.value().name == bandName) {
+                stackKey = QString("X%1").arg(it.key());
+                qDebug() << "  ↳ XVTR match:" << bandName << "->" << stackKey;
+                break;
+            }
+        }
+
         m_radioModel.sendCommand(
-            QString("display pan set %1 band=%2").arg(applet->panId()).arg(bandName));
+            QString("display pan set %1 band=%2").arg(applet->panId()).arg(stackKey));
     });
 
     // XVTR button → open Radio Setup XVTR tab (#571)

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -3056,6 +3056,11 @@ void VfoWidget::rebuildFilterButtons()
     if (m_autotuneOnceBtn) { delete m_autotuneOnceBtn; m_autotuneOnceBtn = nullptr; }
     if (m_autotuneLoopBtn) { delete m_autotuneLoopBtn; m_autotuneLoopBtn = nullptr; }
     if (m_zeroBeatBtn) { delete m_zeroBeatBtn; m_zeroBeatBtn = nullptr; }
+    // Remove marker-style buttons if they exist (re-added for CW only, #1526)
+    if (m_markerThinBtn)  { delete m_markerThinBtn;  m_markerThinBtn = nullptr; }
+    if (m_markerThickBtn) { delete m_markerThickBtn; m_markerThickBtn = nullptr; }
+    if (m_edgesShowBtn)   { delete m_edgesShowBtn;   m_edgesShowBtn = nullptr; }
+    if (m_edgesHideBtn)   { delete m_edgesHideBtn;   m_edgesHideBtn = nullptr; }
 
     for (int i = 0; i < m_filterWidths.size(); ++i) {
         const int w = m_filterWidths[i];
@@ -3099,7 +3104,10 @@ void VfoWidget::rebuildFilterButtons()
     }
 
     // Per-slice VFO marker style row: Thin/Thick line + Edges/Hide filter edges (#1526)
-    {
+    // CW/CWL only — the original issue was specifically about CW, and other
+    // modes typically have wide enough filters that the 3-line cluster is not
+    // visually problematic.
+    if (m_slice && (m_slice->mode() == "CW" || m_slice->mode() == "CWL")) {
         int row = (m_filterWidths.size() + 3) / 4;
 
         m_markerThinBtn = new QPushButton("Thin");


### PR DESCRIPTION
- Fix XVTR band switching by translating names to band-stack keys (#1540)
- Restrict VFO marker-style buttons to CW/CWL modes and clean up on rebuild
