### PR TITLE
Map WWV/GEN to their band-stack slot indexes (#1540/#1211 follow-up)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5996,23 +5996,54 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // One command handles everything.
         m_bandSettings.setCurrentBand(bandName);
 
-        // Translate XVTR display names ("2m", "70cm", "23cm") to their band-stack
-        // key ("X0", "X1", "X2"). SmartSDR pcap shows this is what the radio's
-        // band stack expects — sending band=<xvtr_name> clears the slice because
-        // the name isn't a valid stack key, whereas band=X<idx> restores the
-        // saved XVTR slice correctly (#1540/#1211).
-        QString stackKey = bandName;
-        for (auto it = m_radioModel.xvtrList().constBegin();
-             it != m_radioModel.xvtrList().constEnd(); ++it) {
-            if (it.value().isValid && it.value().name == bandName) {
-                stackKey = QString("X%1").arg(it.key());
-                qDebug() << "  ↳ XVTR match:" << bandName << "->" << stackKey;
-                break;
+        // Translate the UI band label to the radio's band-stack key. Mapping
+        // determined from SmartSDR pcap captures (#1540/#1211):
+        //   - Standard HF names (160, 80, ..., 6, 2200, 630): pass through
+        //   - XVTR display names ("2m"): send band=X<idx> (xvtr index)
+        //   - WWV / GEN: send numeric band-stack slot 33 / 34 (per pcap)
+        //   - Anything else: fall back to tuning the slice directly
+        static const QSet<QString> kPassThroughBands = {
+            "160", "80", "60", "40", "30", "20", "17", "15", "12", "10", "6",
+            "2200", "630"
+        };
+        static const QMap<QString, int> kNumericBandSlots = {
+            { QStringLiteral("WWV"), 33 },
+            { QStringLiteral("GEN"), 34 },
+        };
+
+        QString stackKey;
+        if (kPassThroughBands.contains(bandName)) {
+            stackKey = bandName;
+        } else if (kNumericBandSlots.contains(bandName)) {
+            stackKey = QString::number(kNumericBandSlots.value(bandName));
+            qDebug() << "  ↳ numeric band slot:" << bandName << "->" << stackKey;
+        } else {
+            for (auto it = m_radioModel.xvtrList().constBegin();
+                 it != m_radioModel.xvtrList().constEnd(); ++it) {
+                if (it.value().isValid && it.value().name == bandName) {
+                    stackKey = QString("X%1").arg(it.key());
+                    qDebug() << "  ↳ XVTR match:" << bandName << "->" << stackKey;
+                    break;
+                }
             }
         }
 
-        m_radioModel.sendCommand(
-            QString("display pan set %1 band=%2").arg(applet->panId()).arg(stackKey));
+        if (stackKey.isEmpty()) {
+            // Unrecognized band — tune slice directly as a safety net.
+            qDebug() << "  ↳ unrecognized band" << bandName << "— tuning slice directly";
+            SliceModel* s = nullptr;
+            for (auto* sl : m_radioModel.slices()) {
+                if (sl->panId() == applet->panId()) { s = sl; break; }
+            }
+            if (!s) s = activeSlice();
+            if (s) {
+                if (!mode.isEmpty() && s->mode() != mode) s->setMode(mode);
+                s->tuneAndRecenter(freqMhz);
+            }
+        } else {
+            m_radioModel.sendCommand(
+                QString("display pan set %1 band=%2").arg(applet->panId()).arg(stackKey));
+        }
     });
 
     // XVTR button → open Radio Setup XVTR tab (#571)


### PR DESCRIPTION
The previous fix fell back to direct slice tuning for WWV and GEN
because the radio rejects band=WWV / band=GEN with error 0x5000002D.
Pcap capture of SmartSDR shows it actually uses numeric band-stack
slot indexes for these labels:

  WWV -> band=33
  GEN -> band=34

These slots are outside the interlock band range (which ends at
29 = 23cm) and aren't exposed via any status message, so they're
hardcoded from the pcap. The radio maintains persistent band-stack
state for these slots, so users get proper save/restore on
WWV/GEN just like on standard HF bands.

2200 and 630 pass through as band=<name> unchanged — those were
already working against the existing HF code path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
