### PR TITLE
Guard autoCatAction / autoDaxAction refs in placeholder-action loop (#1618)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3277,9 +3277,15 @@ void MainWindow::buildMenuBar()
             && action != midiAction
 #endif
             && action != multiFlexAction
-            && action != autoRigctlAction && action != autoCatAction
+            && action != autoRigctlAction
+#ifndef _WIN32
+            && action != autoCatAction
+#endif
             && action != autoTciAction
-            && action != autoDaxAction && action != lowLatencyDaxTxAction) {
+#if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
+            && action != autoDaxAction
+#endif
+            && action != lowLatencyDaxTxAction) {
             connect(action, &QAction::triggered, this, [this, action] {
                 statusBar()->showMessage(action->text().remove("...") + " — not yet implemented", 3000);
             });


### PR DESCRIPTION
Commit 870cb3e (#1557) wrapped the menu-action declarations in
platform guards but missed the same-variable references further down
in the placeholder-action loop.  On Windows, autoCatAction doesn't
exist (no _WIN32 branch of the #ifdef declares it) and autoDaxAction
doesn't exist (no Q_OS_MAC / HAVE_PIPEWIRE in scope), so compilation
fails with C2065: undeclared identifier.

Mirror the declaration guards at the reference sites.  Linux and
macOS builds unaffected — same conditions evaluate the same way.

Closes #1618.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
