### PR TITLE
Fix Autotune label leaking to non-CW modes and show marker row always

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -3052,10 +3052,15 @@ void VfoWidget::rebuildFilterButtons()
 {
     for (auto* btn : m_filterBtns) delete btn;
     m_filterBtns.clear();
-    // Remove autotune buttons if they exist (they'll be re-added for CW)
-    if (m_autotuneOnceBtn) { delete m_autotuneOnceBtn; m_autotuneOnceBtn = nullptr; }
-    if (m_autotuneLoopBtn) { delete m_autotuneLoopBtn; m_autotuneLoopBtn = nullptr; }
-    if (m_zeroBeatBtn) { delete m_zeroBeatBtn; m_zeroBeatBtn = nullptr; }
+    // Remove autotune row if it exists (re-added for CW). Delete the
+    // container — its children ("Autotune:" label, buttons) go with it.
+    if (m_autotuneContainer) {
+        delete m_autotuneContainer;
+        m_autotuneContainer = nullptr;
+        m_autotuneOnceBtn = nullptr;
+        m_autotuneLoopBtn = nullptr;
+        m_zeroBeatBtn = nullptr;
+    }
     // Remove marker-style buttons if they exist (re-added for CW only, #1526)
     if (m_markerThinBtn)  { delete m_markerThinBtn;  m_markerThinBtn = nullptr; }
     if (m_markerThickBtn) { delete m_markerThickBtn; m_markerThickBtn = nullptr; }
@@ -3103,11 +3108,13 @@ void VfoWidget::rebuildFilterButtons()
         m_filterGrid->addWidget(btn, i / 4, i % 4);
     }
 
-    // Per-slice VFO marker style row: Thin/Thick line + Edges/Hide filter edges (#1526)
-    // CW/CWL only — the original issue was specifically about CW, and other
-    // modes typically have wide enough filters that the 3-line cluster is not
-    // visually problematic.
-    if (m_slice && (m_slice->mode() == "CW" || m_slice->mode() == "CWL")) {
+    // Per-slice VFO marker style row: Thin/Thick line + Edges/Hide filter
+    // edges (#1526). Shown in every mode — narrow filters aren't CW-exclusive
+    // (narrow DIGL, RTTY, CWL, etc. all benefit from hiding the overlapping
+    // edge lines), and users who want a thicker center marker on any mode
+    // can set it. Cleanup in the rebuildFilterButtons header ensures we
+    // don't accumulate duplicate rows on mode change.
+    {
         int row = (m_filterWidths.size() + 3) / 4;
 
         m_markerThinBtn = new QPushButton("Thin");
@@ -3151,7 +3158,8 @@ void VfoWidget::rebuildFilterButtons()
     if (m_slice && (m_slice->mode() == "CW" || m_slice->mode() == "CWL")) {
         int row = (m_filterWidths.size() + 3) / 4 + 1;
 
-        auto* container = new QWidget;
+        m_autotuneContainer = new QWidget;
+        auto* container = m_autotuneContainer;
         auto* hbox = new QHBoxLayout(container);
         hbox->setContentsMargins(0, 0, 0, 0);
         hbox->setSpacing(4);

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -269,7 +269,10 @@ private:
     QGridLayout* m_filterGrid{nullptr};
     QVector<QPushButton*> m_filterBtns;
     QVector<int> m_filterWidths;
-    // CW autotune buttons (only visible in CW mode)
+    // CW autotune row (only visible in CW mode). The container holds the
+    // "Autotune:" label + buttons; deleting it on rebuild also removes the
+    // label, which is not tracked as its own member.
+    class QWidget* m_autotuneContainer{nullptr};
     QPushButton* m_autotuneOnceBtn{nullptr};
     QPushButton* m_autotuneLoopBtn{nullptr};
     QPushButton* m_zeroBeatBtn{nullptr};


### PR DESCRIPTION
Two small VFO flag fixes on top of #1614/#1615:

1. The CW autotune row ("Autotune:" label + Once/Loop/Zero Beat
   buttons) was built inside a QWidget container and added to the
   filter grid, but only the buttons were tracked as members for
   cleanup — the container itself was leaked on rebuild. Switching
   away from CW left the "Autotune:" label visible under USB/AM/FM.
   Track the container as m_autotuneContainer and delete it at the
   top of rebuildFilterButtons; its children (label + buttons) get
   reaped with it.

2. The Thin/Thick/Edges/Hide marker-style row was previously
   restricted to CW/CWL (#1615). Narrow filters aren't CW-exclusive
   (DIGL, RTTY, CWL at narrow widths all cluster the edges the same
   way) and the per-slice setting is useful regardless of mode.
   Drop the CW-only gate. The same single code path in
   rebuildFilterButtons now runs for every mode — no per-mode
   duplication, just existing pointer members reinitialized on each
   mode change, cleanup still suppresses duplicate rows.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
