### PR TITLE
Decouple TciServer TX gain from DaxTxGain (prep for #1627 applet split)

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -199,6 +199,16 @@ quint16 TciServer::port() const
     return m_server ? m_server->serverPort() : 0;
 }
 
+void TciServer::setTxGain(float gain)
+{
+    const float clamped = std::clamp(gain, 0.0f, 1.0f);
+    if (m_txGain == clamped) return;
+    m_txGain = clamped;
+    auto& s = AppSettings::instance();
+    s.setValue("TciTxGain", QString::number(clamped, 'f', 2));
+    s.save();
+}
+
 void TciServer::onNewConnection()
 {
     while (m_server->hasPendingConnections()) {
@@ -971,8 +981,18 @@ void TciServer::startTxChrono(QWebSocket* client, int trx)
     const bool lowLatencyRoute =
         AppSettings::instance().value("DaxTxLowLatency", "False").toString() == "True";
     m_txUseRadioRoute = !lowLatencyRoute;
+    // TCI has its own TX gain (decoupled from DaxTxGain) so users who split
+    // DAX and TCI routing get independent slider control.  On first read,
+    // copy DaxTxGain into TciTxGain so upgrading users see no behavior
+    // change — later the DAX/TCI applet split supplies separate UI.
+    auto& txGainSettings = AppSettings::instance();
+    if (!txGainSettings.contains("TciTxGain")) {
+        const QString legacy = txGainSettings.value("DaxTxGain", "0.5").toString();
+        txGainSettings.setValue("TciTxGain", legacy);
+        txGainSettings.save();
+    }
     m_txGain = std::clamp(
-        AppSettings::instance().value("DaxTxGain", "0.5").toString().toFloat(),
+        txGainSettings.value("TciTxGain", "0.5").toString().toFloat(),
         0.0f, 1.0f);
     m_txChronoAccumNs = 0;
     m_txChronoRequestedFrames = 0;

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -40,6 +40,12 @@ public:
 
     void setAudioEngine(AudioEngine* audio) { m_audio = audio; }
 
+    // TCI TX gain (0.0–1.0). Applied to outbound TX audio from WSJT-X/JTDX
+    // before the radio.  Decoupled from DaxTxGain (#1627) — the DAX bridge
+    // and TCI maintain independent gain settings.  Persists to TciTxGain.
+    void setTxGain(float gain);
+    float txGain() const { return m_txGain; }
+
     // Wire slice signals for state change broadcasts
     void wireSlice(int trx, SliceModel* slice);
     void wireSpotModel();


### PR DESCRIPTION
TciServer previously reused the DAX bridge's DaxTxGain setting for
TCI TX audio. With the upcoming DIGI-applet split (#1627), DAX and
TCI will have independent sliders, so the underlying settings need
to diverge.

Changes:
- TciServer reads TciTxGain instead of DaxTxGain.
- One-time migration: if TciTxGain is absent, copy DaxTxGain into
  it so upgrading users see no behavior change.
- Add TciServer::setTxGain(float) public setter so the future TCI
  applet's slider can apply changes at runtime + persist, without
  further server code modifications.

Zero user-visible change today; unlocks independent DAX/TCI gain
control in the applet-split work.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
