### PR TITLE
Audit and update CLAUDE.md against current project state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 Replicate the **Windows-only FlexRadio SmartSDR client** (written in C#) as a
 **Linux-native C++ application** using Qt6 and C++20. The aim is to mirror the
 look, feel, and every function SmartSDR is capable of. The reference radio is a
-**FLEX-8600 running firmware v1.4.0.0**.
+**FLEX-8600 running firmware 4.1.5**, which speaks **SmartSDR protocol v1.4.0.0**.
 
 ## AI Agent Guidelines
 
@@ -49,7 +49,7 @@ is the sole authority on visual design and UX direction.
 - **Braces on all control flow** — even single-line `if`/`else`/`for`/`while`
 - **`auto` sparingly** — use explicit types unless the type is obvious from context (e.g. `auto* ptr = new Foo` is fine, `auto x = foo()` is not)
 - **Naming**: classes `PascalCase`, methods/variables `camelCase`, constants `kPascalCase`, member variables `m_camelCase`
-- **Platform guards**: use `#ifdef Q_OS_WIN` / `Q_OS_MAC` / `Q_OS_LINUX`, not `_WIN32` or `__APPLE__`
+- **Platform guards**: prefer `Q_OS_WIN` / `Q_OS_MAC` / `Q_OS_LINUX` for new code. Existing `_WIN32`/`__APPLE__` guards can be migrated opportunistically — don't do a blanket rewrite.
 - **Don't remove code you didn't add** — if rebasing, ensure upstream changes are preserved. Review the diff before submitting.
 - **Atomic parameters for cross-thread DSP** — main thread writes via `std::atomic`, audio thread reads. Never hold a mutex in the audio callback for parameter updates.
 - **Error handling**: log with `qCWarning(lcCategory)`, don't throw exceptions
@@ -62,43 +62,26 @@ cmake --build build -j$(nproc)
 ./build/AetherSDR
 ```
 
-Dependencies (Arch): `qt6-base qt6-multimedia cmake ninja pkgconf autoconf automake libtool`
+Full dependency list is in `README.md` — don't duplicate it here.
 
-Current version: **0.8.15** (set in both `CMakeLists.txt` and `README.md`).
+Current version: **0.8.16** (set in both `CMakeLists.txt` and `README.md`).
 
 ---
 
 ## CI/CD Workflow
 
-### CI (GitHub Actions)
+CI runs in Docker image `ghcr.io/ten9876/aethersdr-ci:latest` (~3.5 min builds).
+**If you add a new `find_package(...)` to CMakeLists.txt, also add the
+corresponding `-dev` package to `.github/docker/Dockerfile` and push.** The
+`docker-ci-image.yml` workflow rebuilds the image automatically (~3 min); wait
+for that before the next CI run can use it.
 
-CI uses a Docker container (`ghcr.io/ten9876/aethersdr-ci:latest`) with all
-build dependencies pre-installed. Build time is ~3.5 minutes consistently.
+**`git ship`** alias — squashes local commits ahead of origin/main, creates a
+branch, pushes, opens a PR with auto-squash-merge enabled. Commit freely
+locally, then ship once.
 
-**When adding a new system dependency:**
-1. Add the package to `.github/docker/Dockerfile`
-2. Push the Dockerfile change — `docker-ci-image.yml` triggers automatically
-3. Wait for the image to build (~3 min) before the next CI run can use it
-
-### Git Aliases
-
-**`git ship`** — Squashes all local commits ahead of origin/main into one,
-creates a PR branch, pushes, opens a PR with auto-squash-merge enabled.
-Use this to batch multiple commits into a single PR.
-
-```bash
-# Accumulate work locally, then ship once:
-git commit -m "Fix A"
-git commit -m "Fix B"
-git ship   # squashes both into one PR
-```
-
-### Branch Protection
-
-- All commits to `main` require GPG signatures
-- CI build must pass before merge
-- CODEOWNERS requires project owner review on all PRs
-- Branches auto-delete after PR merge
+Branch protection: signed commits required on main, CI must pass, CODEOWNERS
+review required, branches auto-delete after merge.
 
 ---
 
@@ -106,17 +89,16 @@ git ship   # squashes both into one PR
 
 Key source directories: `src/core/` (protocol, audio, DSP), `src/models/`
 (RadioModel, SliceModel, etc.), `src/gui/` (MainWindow, SpectrumWidget, applets).
-Use `ls src/core/`, `ls src/models/`, `ls src/gui/` to explore.
 
 **Key classes:**
 - `RadioModel` — central state, owns connection + all sub-models
-- `AudioEngine` — RX/TX audio, NR2/RN2/NR4/BNR DSP pipeline
+- `AudioEngine` — RX/TX audio, NR2/RN2/NR4/BNR/DFNR DSP pipeline
 - `SpectrumWidget` — GPU-accelerated FFT spectrum + waterfall (QRhiWidget)
 - `MainWindow` — wires everything together, signal routing hub
 - `PanadapterStream` — VITA-49 UDP parsing, routes FFT/waterfall/audio/meters
 
-**Threading:** 11 threads — see `docs/architecture-pipelines.md` for full
-thread diagram, data flow ASCII art, cross-thread signal map, and GPU rendering notes.
+**Threading:** up to 11 threads — see `docs/architecture-pipelines.md` for the
+full thread diagram, data flow, cross-thread signal map, and GPU rendering notes.
 
 **Design principle:** RadioModel owns all sub-models on the main thread.
 Worker threads communicate exclusively via auto-queued signals. Never hold
@@ -124,7 +106,7 @@ a mutex in the audio callback.
 
 ---
 
-## SmartSDR Protocol (Firmware v1.4.0.0)
+## SmartSDR Protocol (v1.4.0.0)
 
 ### Message Types
 
@@ -137,18 +119,15 @@ a mutex in the audio callback.
 | `S` | Radio→Client | Status: `S<handle>\|<object> key=val ...` |
 | `M` | Radio→Client | Informational message |
 
-### Status Object Names
-
-Object names are **multi-word**: `slice 0`, `display pan 0x40000000`,
-`display waterfall 0x42000000`, `interlock band 9`. The parser finds the split
-between object name and key=value pairs by locating the last space before the
-first `=` sign.
+Status object names are **multi-word** (`slice 0`, `display pan 0x40000000`,
+`interlock band 9`). The parser finds the split between object name and
+key=value pairs by locating the last space before the first `=` sign.
 
 ### Connection Sequence
 
 1. TCP connect → radio sends `V<version>` then `H<handle>`
-2. Subscribe: `sub slice all`, `sub pan all`, `sub tx all`, `sub atu all`,
-   `sub meter all`, `sub audio all`
+2. `sub <topic> all` for each of: `slice`, `pan`, `tx`, `amplifier`, `atu`,
+   `meter`, `audio`, `gps`, `apd`, `client`, `xvtr`
 3. `client gui` + `client program AetherSDR` + `client station AetherSDR`
 4. Bind UDP socket, send `\x00` to radio:4992 (port registration)
 5. `client udpport <port>` (returns error 0x50001000 on v1.4.0.0 — expected)
@@ -169,10 +148,8 @@ first `=` sign.
 - `cw key immediate` not supported — use netcw UDP stream for CW keying
 - `transmit set break_in=1` wrong — correct: `cw break_in 1`
 
-### VITA-49 Packet Format
-
-See `docs/vita49-format.md` for full packet format, PCC codes, FFT bin
-conversion, waterfall tile format, audio payload, and meter data parsing.
+VITA-49 packet format, PCC codes, FFT bin conversion, waterfall tile format,
+audio payload, meter data — see `docs/vita49-format.md`.
 
 ---
 
@@ -192,6 +169,22 @@ s.setValue("MyFeatureEnabled", "True");
 bool on = s.value("MyFeatureEnabled", "False").toString() == "True";
 ```
 
+### Settings Migration
+
+One-time migrations when renaming or restructuring keys (e.g. `Applet_DIGI` →
+`Applet_CAT`, `DaxTxGain` → `TciTxGain`):
+
+```cpp
+auto& s = AppSettings::instance();
+if (s.contains("OldKey") && !s.contains("NewKey")) {
+    s.setValue("NewKey", s.value("OldKey", "default").toString());
+    s.remove("OldKey");
+    s.save();
+}
+```
+
+Run once at app or feature startup, not on every access.
+
 ### Radio-Authoritative Settings Policy
 
 **The radio is always authoritative for any setting it stores.** AetherSDR
@@ -199,13 +192,15 @@ must never save, recall, or override radio-side settings from client-side
 persistence. Only save client-side settings for things the radio does NOT save.
 
 **Radio-authoritative (do NOT persist):** frequency, mode, filter, step size,
-AGC, squelch, DSP flags, antennas, TX power, panadapter count/assignments.
+AGC, squelch, DSP flags, antennas, TX power, panadapter *count* and per-pan
+state (center, bandwidth, min/max dBm, etc.).
 
-**Client-authoritative (persist in AppSettings):** layout arrangement, client-side
-DSP (NR2/RN2/NR4), UI preferences, display preferences, spot settings.
+**Client-authoritative (persist in AppSettings):** window geometry, layout
+arrangement (`PanadapterLayout`, applet order/visibility), client-side DSP
+(NR2/RN2/NR4/DFNR), UI preferences, display preferences, spot settings.
 
-**Why:** When both persist the same setting, they fight on reconnect. The radio's
-GUIClientID session restore is always more current than our saved state.
+**Why:** When both persist the same setting, they fight on reconnect. The
+radio's GUIClientID session restore is always more current than our saved state.
 
 ### GUI↔Radio Sync (No Feedback Loops)
 
@@ -226,13 +221,6 @@ for each missing status echo — optimistic updates break Multi-Flex.
 
 ---
 
-## Known Bugs
-
-- **Tuner applet SWR capture**: race between tuning=0 (TCP) and final SWR
-  meter (UDP). See `TunerApplet::updateMeters()`.
-
----
-
 ## Multi-Panadapter Support
 
 **Architecture:** PanadapterModel (per-pan state), PanadapterStream (VITA-49
@@ -245,9 +233,7 @@ signal wiring), spectrumForSlice() (overlay routing).
 - Push `xpixels`/`ypixels` on pan creation (radio defaults to 50×20)
 - FFT stream ID = pan ID (0x40xx), waterfall stream ID = waterfall ID (0x42xx)
 
-**Implementation pitfalls:** See `docs/multi-pan-pitfalls.md` for 20 numbered
-lessons learned (Qt parsing, status dispatch, waterfall timing, feedback loops,
-filter polarity, preamp sharing, band changes, etc.).
+See `docs/multi-pan-pitfalls.md` for 20 numbered lessons learned.
 
 ---
 


### PR DESCRIPTION
Findings from a systematic audit against the v0.8.16 codebase:

- Version bumped to 0.8.16
- Clarified firmware (4.1.5) vs protocol (v1.4.0.0) distinction; they are
  different things that CLAUDE.md was conflating
- Removed stale "Tuner applet SWR capture" known bug (fixed in #1531)
- Moved PanadapterLayout to client-authoritative (we do persist it); kept
  panadapter count and per-pan state on the radio-authoritative list
- Expanded connection subscribe list to match RadioModel.cpp: added
  amplifier, gps, apd, client, xvtr (five missing from prior doc)
- DSP pipeline updated to include DFNR (DeepFilterNet3)
- Relaxed platform-guard rule to match reality ("prefer Q_OS_* for new
  code, migrate existing _WIN32/__APPLE__ opportunistically")
- Build section now defers the dep list to README.md
- Added Settings Migration pattern with code snippet (we keep doing these
  and they weren't documented — e.g. Applet_DIGI→Applet_CAT,
  DaxTxGain→TciTxGain)
- Added Docker CI rule: new find_package calls require corresponding
  -dev package in .github/docker/Dockerfile

Net effect: 263 -> 248 lines, tighter and more accurate. All load-bearing
guidance (AppSettings, radio-authoritative policy, feedback-loop guards,
protocol quirks, multi-pan/multi-client layers) preserved.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
