### PR TITLE
Add Client EQ applet skeleton (PR B.1 of 3 for client-side parametric EQ)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,6 +504,8 @@ set(GUI_SOURCES
     src/gui/PhoneCwApplet.cpp
     src/gui/PhoneApplet.cpp
     src/gui/EqApplet.cpp
+    src/gui/ClientEqApplet.cpp
+    src/gui/ClientEqCurveWidget.cpp
     src/gui/CatControlApplet.cpp
     src/gui/DaxApplet.cpp
     src/gui/TciApplet.cpp

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -10,6 +10,7 @@
 #include "PhoneCwApplet.h"
 #include "PhoneApplet.h"
 #include "EqApplet.h"
+#include "ClientEqApplet.h"
 #include "CatControlApplet.h"
 #include "DaxApplet.h"
 #include "TciApplet.h"
@@ -51,7 +52,7 @@ static QString floatKey(const QString& id)
 }
 
 const QStringList AppletPanel::kDefaultOrder = {
-    "RX", "TUN", "AMP", "TX", "PHNE", "P/CW", "EQ", "CAT", "DAX", "TCI", "IQ", "MTR", "AG"
+    "RX", "TUN", "AMP", "TX", "PHNE", "P/CW", "EQ", "CEQ", "CAT", "DAX", "TCI", "IQ", "MTR", "AG"
 };
 
 // ── Drag-handle title bar ───────────────────────────────────────────────────
@@ -658,6 +659,9 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
     m_eqApplet = new EqApplet;
     m_appletOrder.append(makeEntry("EQ", "Equalizer", m_eqApplet, true, btnRow1, btnLayout1));
+
+    m_clientEqApplet = new ClientEqApplet;
+    m_appletOrder.append(makeEntry("CEQ", "Client EQ", m_clientEqApplet, false, btnRow2, btnLayout2));
 
     m_catControlApplet = new CatControlApplet;
     m_appletOrder.append(makeEntry("CAT", "CAT Control", m_catControlApplet, false, btnRow2, btnLayout2));

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -23,6 +23,7 @@ class TxApplet;
 class PhoneCwApplet;
 class PhoneApplet;
 class EqApplet;
+class ClientEqApplet;
 class CatControlApplet;
 class DaxApplet;
 class TciApplet;
@@ -54,6 +55,7 @@ public:
     PhoneCwApplet*  phoneCwApplet()  { return m_phoneCwApplet; }
     PhoneApplet*    phoneApplet()    { return m_phoneApplet; }
     EqApplet*       eqApplet()       { return m_eqApplet; }
+    ClientEqApplet* clientEqApplet() { return m_clientEqApplet; }
     CatControlApplet* catControlApplet() { return m_catControlApplet; }
     DaxApplet*      daxApplet()      { return m_daxApplet; }
     TciApplet*      tciApplet()      { return m_tciApplet; }
@@ -120,6 +122,7 @@ private:
     PhoneCwApplet* m_phoneCwApplet{nullptr};
     PhoneApplet*   m_phoneApplet{nullptr};
     EqApplet*      m_eqApplet{nullptr};
+    ClientEqApplet* m_clientEqApplet{nullptr};
     CatControlApplet* m_catControlApplet{nullptr};
     DaxApplet*     m_daxApplet{nullptr};
     TciApplet*     m_tciApplet{nullptr};

--- a/src/gui/ClientEqApplet.cpp
+++ b/src/gui/ClientEqApplet.cpp
@@ -1,0 +1,177 @@
+#include "ClientEqApplet.h"
+#include "ClientEqCurveWidget.h"
+#include "core/AudioEngine.h"
+#include "core/ClientEq.h"
+
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QSignalBlocker>
+
+namespace AetherSDR {
+
+namespace {
+
+// Tab button: small rectangle, checked state highlighted. Two of these
+// live at the top of the applet (RX / TX). Shared style to keep them
+// visually symmetric.
+constexpr const char* kTabStyle =
+    "QPushButton {"
+    "  background: #0e1b28;"
+    "  color: #8aa8c0;"
+    "  border: 1px solid #203040;"
+    "  border-radius: 3px;"
+    "  font-size: 10px;"
+    "  font-weight: bold;"
+    "  padding: 2px 10px;"
+    "}"
+    "QPushButton:checked {"
+    "  background: #0070c0;"
+    "  color: #ffffff;"
+    "  border-color: #0090e0;"
+    "}"
+    "QPushButton:hover { background: #1a2a3a; }"
+    "QPushButton:checked:hover { background: #0080d0; }";
+
+// Enable is the prominent green toggle. Matches other applet Enable toggles.
+const QString kEnableStyle =
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 11px; font-weight: bold; padding: 2px 10px;"
+    "}"
+    "QPushButton:hover { background: #204060; }"
+    "QPushButton:checked {"
+    "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
+    "}";
+
+constexpr const char* kEditStyle =
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 11px; padding: 2px 10px;"
+    "}"
+    "QPushButton:hover { background: #204060; }";
+
+} // namespace
+
+ClientEqApplet::ClientEqApplet(QWidget* parent) : QWidget(parent)
+{
+    buildUI();
+    hide();  // hidden until toggled on from the button tray
+}
+
+void ClientEqApplet::buildUI()
+{
+    setStyleSheet("QWidget { background: transparent; }");
+
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(4, 4, 4, 4);
+    outer->setSpacing(4);
+
+    // Tab row — RX / TX selector.
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(2);
+
+        m_rxTab = new QPushButton("RX");
+        m_rxTab->setCheckable(true);
+        m_rxTab->setChecked(true);
+        m_rxTab->setStyleSheet(kTabStyle);
+        m_rxTab->setFixedHeight(20);
+        row->addWidget(m_rxTab);
+
+        m_txTab = new QPushButton("TX");
+        m_txTab->setCheckable(true);
+        m_txTab->setStyleSheet(kTabStyle);
+        m_txTab->setFixedHeight(20);
+        row->addWidget(m_txTab);
+        row->addStretch();
+
+        connect(m_rxTab, &QPushButton::clicked, this, [this]() { setPath(Path::Rx); });
+        connect(m_txTab, &QPushButton::clicked, this, [this]() { setPath(Path::Tx); });
+
+        outer->addLayout(row);
+    }
+
+    // Curve / analyzer area. Phase B.1 draws just the grid; B.2 wires in
+    // the summed response from the current path's ClientEq; B.3 adds the
+    // live FFT analyzer overlay.
+    m_curve = new ClientEqCurveWidget;
+    m_curve->setMinimumHeight(90);
+    outer->addWidget(m_curve, 1);
+
+    // Bottom row — Enable toggle on the left, Edit… on the right.
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(4);
+
+        m_enable = new QPushButton("Enable");
+        m_enable->setCheckable(true);
+        m_enable->setStyleSheet(kEnableStyle);
+        m_enable->setFixedHeight(22);
+        row->addWidget(m_enable);
+
+        row->addStretch();
+
+        m_edit = new QPushButton("Edit…");
+        m_edit->setStyleSheet(kEditStyle);
+        m_edit->setFixedHeight(22);
+        m_edit->setToolTip("Open the client EQ editor for the selected path");
+        row->addWidget(m_edit);
+
+        connect(m_enable, &QPushButton::toggled, this,
+                &ClientEqApplet::onEnableToggled);
+        connect(m_edit, &QPushButton::clicked, this, [this]() {
+            emit editRequested(m_currentPath);
+        });
+
+        outer->addLayout(row);
+    }
+}
+
+void ClientEqApplet::setAudioEngine(AudioEngine* engine)
+{
+    m_audio = engine;
+    if (!m_audio) return;
+    // Bind the curve widget to the currently-selected path so it can
+    // render band state (meaningful once B.2 draws the summed curve).
+    m_curve->setEq(m_audio->clientEqRx());
+    syncEnableFromEngine();
+}
+
+void ClientEqApplet::setPath(Path p)
+{
+    m_currentPath = p;
+    if (m_rxTab) {
+        QSignalBlocker b1(m_rxTab);
+        QSignalBlocker b2(m_txTab);
+        m_rxTab->setChecked(p == Path::Rx);
+        m_txTab->setChecked(p == Path::Tx);
+    }
+    if (m_audio && m_curve) {
+        m_curve->setEq(p == Path::Rx ? m_audio->clientEqRx()
+                                     : m_audio->clientEqTx());
+    }
+    syncEnableFromEngine();
+}
+
+void ClientEqApplet::syncEnableFromEngine()
+{
+    if (!m_audio || !m_enable) return;
+    ClientEq* eq = (m_currentPath == Path::Rx)
+        ? m_audio->clientEqRx() : m_audio->clientEqTx();
+    QSignalBlocker b(m_enable);
+    m_enable->setChecked(eq && eq->isEnabled());
+}
+
+void ClientEqApplet::onEnableToggled(bool on)
+{
+    if (!m_audio) return;
+    ClientEq* eq = (m_currentPath == Path::Rx)
+        ? m_audio->clientEqRx() : m_audio->clientEqTx();
+    if (!eq) return;
+    eq->setEnabled(on);
+    m_audio->saveClientEqSettings();
+    if (m_curve) m_curve->update();
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientEqApplet.h
+++ b/src/gui/ClientEqApplet.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientEqCurveWidget;
+
+// Docked applet for client-side parametric EQ. Shows a compact live
+// analyzer with the summed EQ response overlaid; the separate floating
+// editor window (Edit… button) is where users add, remove, and configure
+// bands interactively.
+//
+// RX and TX share the applet — the tab at top selects which path is
+// being viewed. The Enable toggle controls the selected path's EQ.
+class ClientEqApplet : public QWidget {
+    Q_OBJECT
+
+public:
+    enum class Path { Rx = 0, Tx = 1 };
+
+    explicit ClientEqApplet(QWidget* parent = nullptr);
+
+    void setAudioEngine(AudioEngine* engine);
+
+    Path currentPath() const { return m_currentPath; }
+
+signals:
+    // Fired when the user clicks Edit…. MainWindow owns the single
+    // editor window instance and shows / raises it in response.
+    void editRequested(Path path);
+
+private:
+    void buildUI();
+    void setPath(Path p);
+    void syncEnableFromEngine();
+    void onEnableToggled(bool on);
+
+    AudioEngine* m_audio{nullptr};
+    Path         m_currentPath{Path::Rx};
+
+    QPushButton*         m_rxTab{nullptr};
+    QPushButton*         m_txTab{nullptr};
+    QPushButton*         m_enable{nullptr};
+    QPushButton*         m_edit{nullptr};
+    ClientEqCurveWidget* m_curve{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientEqCurveWidget.cpp
+++ b/src/gui/ClientEqCurveWidget.cpp
@@ -1,0 +1,161 @@
+#include "ClientEqCurveWidget.h"
+#include "core/ClientEq.h"
+
+#include <QPainter>
+#include <QPaintEvent>
+#include <QPen>
+#include <QFont>
+#include <QColor>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+// Gridlines at standard audio decades + halves. 20k is the right-hand bound.
+constexpr float kMinHz   = 20.0f;
+constexpr float kMaxHz   = 20000.0f;
+constexpr float kDbRange = 18.0f;   // ±18 dB vertical extent
+
+const float kGridFreqs[] = {
+    20.0f, 50.0f, 100.0f, 200.0f, 500.0f,
+    1000.0f, 2000.0f, 5000.0f, 10000.0f, 20000.0f
+};
+
+QString freqLabel(float hz)
+{
+    if (hz >= 1000.0f) {
+        const float k = hz / 1000.0f;
+        if (std::fabs(k - std::round(k)) < 0.01f) {
+            return QString::number(static_cast<int>(std::round(k))) + "k";
+        }
+        return QString::number(k, 'f', 1) + "k";
+    }
+    return QString::number(static_cast<int>(std::round(hz)));
+}
+
+} // namespace
+
+ClientEqCurveWidget::ClientEqCurveWidget(QWidget* parent) : QWidget(parent)
+{
+    setMinimumHeight(80);
+    setAttribute(Qt::WA_OpaquePaintEvent, false);
+}
+
+void ClientEqCurveWidget::setEq(ClientEq* eq)
+{
+    m_eq = eq;
+    update();
+}
+
+float ClientEqCurveWidget::freqToX(float hz) const
+{
+    const float logMin = std::log10(kMinHz);
+    const float logMax = std::log10(kMaxHz);
+    const float norm   = (std::log10(std::max(hz, 0.1f)) - logMin) / (logMax - logMin);
+    return norm * static_cast<float>(width());
+}
+
+float ClientEqCurveWidget::xToFreq(float x) const
+{
+    const float logMin = std::log10(kMinHz);
+    const float logMax = std::log10(kMaxHz);
+    const float norm   = std::clamp(x / static_cast<float>(width()), 0.0f, 1.0f);
+    return std::pow(10.0f, logMin + norm * (logMax - logMin));
+}
+
+float ClientEqCurveWidget::dbToY(float db) const
+{
+    const float h = static_cast<float>(height());
+    const float norm = (kDbRange - db) / (2.0f * kDbRange);  // +db = top
+    return std::clamp(norm * h, 0.0f, h);
+}
+
+float ClientEqCurveWidget::yToDb(float y) const
+{
+    const float h = static_cast<float>(height());
+    const float norm = std::clamp(y / h, 0.0f, 1.0f);
+    return kDbRange - norm * (2.0f * kDbRange);
+}
+
+void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+    p.setRenderHint(QPainter::TextAntialiasing, true);
+
+    const QRect r = rect();
+
+    // Background — deep navy matching our dark theme.
+    p.fillRect(r, QColor("#0a0a18"));
+
+    // Minor grid — dB lines at ±6, ±12 dB.
+    {
+        QPen pen(QColor("#1a2a38"));
+        pen.setWidth(1);
+        p.setPen(pen);
+        for (float db : { -12.0f, -6.0f, 0.0f, 6.0f, 12.0f }) {
+            const float y = dbToY(db);
+            p.drawLine(0, static_cast<int>(y), r.width(), static_cast<int>(y));
+        }
+    }
+
+    // Main freq gridlines.
+    {
+        QPen pen(QColor("#203040"));
+        pen.setWidth(1);
+        p.setPen(pen);
+        for (float hz : kGridFreqs) {
+            const float x = freqToX(hz);
+            p.drawLine(static_cast<int>(x), 0, static_cast<int>(x), r.height());
+        }
+    }
+
+    // 0 dB reference line — slightly brighter.
+    {
+        QPen pen(QColor("#304050"));
+        pen.setWidth(1);
+        p.setPen(pen);
+        const float y = dbToY(0.0f);
+        p.drawLine(0, static_cast<int>(y), r.width(), static_cast<int>(y));
+    }
+
+    // Freq labels along the bottom, tiny.
+    {
+        QFont f = p.font();
+        f.setPointSizeF(7.0);
+        p.setFont(f);
+        p.setPen(QColor("#506070"));
+        const int fh = p.fontMetrics().height();
+        for (float hz : kGridFreqs) {
+            const QString lbl = freqLabel(hz);
+            const int w = p.fontMetrics().horizontalAdvance(lbl);
+            int x = static_cast<int>(freqToX(hz)) - w / 2;
+            x = std::clamp(x, 2, r.width() - w - 2);
+            p.drawText(x, r.height() - 2, lbl);
+            (void)fh;
+        }
+    }
+
+    // Placeholder "EQ curve" message — removed in Phase B.2 when we
+    // start drawing the actual summed response.
+    if (!m_eq) {
+        p.setPen(QColor("#405060"));
+        QFont f = p.font();
+        f.setPointSizeF(8.0);
+        p.setFont(f);
+        p.drawText(r, Qt::AlignCenter, "EQ curve — editor coming soon");
+    } else {
+        p.setPen(QColor("#405060"));
+        QFont f = p.font();
+        f.setPointSizeF(8.0);
+        p.setFont(f);
+        const QString msg = m_eq->isEnabled()
+            ? QString("%1 band%2 active").arg(m_eq->activeBandCount())
+                                          .arg(m_eq->activeBandCount() == 1 ? "" : "s")
+            : QString("(EQ disabled)");
+        p.drawText(r, Qt::AlignCenter, msg);
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientEqCurveWidget.h
+++ b/src/gui/ClientEqCurveWidget.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QWidget>
+
+namespace AetherSDR {
+
+class ClientEq;
+
+// Custom QPainter-rendered view of a ClientEq instance — log-freq grid,
+// dB grid, and (in later phases) the summed response curve, per-band
+// filled regions, FFT analyzer overlay, and draggable band handles.
+//
+// This widget is used in two places:
+//   - Compact mode inside the docked ClientEqApplet (analyzer + summed curve)
+//   - Full-size inside the floating ClientEqEditor (all above + interactions)
+//
+// Phase B.1: grid only.  Phases B.2+B.3 add the curve, filled regions,
+// analyzer, and drag interactions.
+class ClientEqCurveWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientEqCurveWidget(QWidget* parent = nullptr);
+
+    // Null is allowed — widget draws the grid with no response data.
+    void setEq(ClientEq* eq);
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+
+private:
+    // Map Hz <-> x in the drawing rect (log scale, 20 Hz to 20 kHz).
+    float freqToX(float hz) const;
+    float xToFreq(float x) const;
+    // Map dB <-> y in the drawing rect (±18 dB linear).
+    float dbToY(float db) const;
+    float yToDb(float y) const;
+
+    ClientEq* m_eq{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -24,6 +24,7 @@
 #include "PhoneCwApplet.h"
 #include "PhoneApplet.h"
 #include "EqApplet.h"
+#include "ClientEqApplet.h"
 #include "CatControlApplet.h"
 #include "DaxApplet.h"
 #include "TciApplet.h"
@@ -1987,6 +1988,17 @@ MainWindow::MainWindow(QWidget* parent)
 
     // ── EQ applet: graphic equalizer ─────────────────────────────────────────
     m_appletPanel->eqApplet()->setEqualizerModel(&m_radioModel.equalizerModel());
+
+    // ── Client EQ applet: client-side parametric EQ for RX/TX paths ──────────
+    m_appletPanel->clientEqApplet()->setAudioEngine(m_audio);
+    // Edit… requests land here — the floating editor window lands in the
+    // next PR in this series. For now we surface a concise toast so users
+    // understand the feature is arriving incrementally.
+    connect(m_appletPanel->clientEqApplet(), &ClientEqApplet::editRequested,
+            this, [this](ClientEqApplet::Path) {
+        statusBar()->showMessage("Client EQ editor lands in the next update.",
+                                 4000);
+    });
 
     // ── Antenna Genius applet: external 4O3A antenna switch ──────────────────
     m_appletPanel->agApplet()->setModel(&m_antennaGenius);


### PR DESCRIPTION
First visible slice of the client-side parametric EQ UI.  Registers a
new "CEQ" tile in the applet tray that exposes:

- RX / TX tab selector
- Enable toggle (per path, persisted via AudioEngine::saveClientEqSettings)
- Edit… button (stubbed — emits editRequested signal; a status bar
  message surfaces that the editor lands in the next update)
- Placeholder curve widget drawing the log-freq grid and a one-line
  status message ("N bands active" / "(EQ disabled)") bound to the
  currently selected path's ClientEq instance

The curve widget (ClientEqCurveWidget) is deliberately a standalone
class so the upcoming floating editor window can reuse its rendering
primitives — freq<->x log mapping, dB<->y linear mapping, shared grid
drawing. Phase B.2 will add the summed response curve and draggable
handles; Phase B.3 adds the Logic-Pro-style filter-type icon row,
bottom parameter-text row, filled per-band regions, and FFT analyzer.

No functional regression: CEQ defaults off, so users don't see any
change until they click the tile into view.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
