### PR TITLE
Client EQ: fixed 10-band layout, cascade slopes, 4 filter families, output fader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,6 +510,7 @@ set(GUI_SOURCES
     src/gui/ClientEqEditorCanvas.cpp
     src/gui/ClientEqFftAnalyzer.cpp
     src/gui/ClientEqIconRow.cpp
+    src/gui/ClientEqOutputFader.cpp
     src/gui/ClientEqParamRow.cpp
     src/gui/CatControlApplet.cpp
     src/gui/DaxApplet.cpp

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -597,20 +597,41 @@ void loadOne(ClientEq& eq, const char* tag)
 {
     auto& s = AppSettings::instance();
     const bool enabled = s.value(ceqKey(tag, "Enabled"), "False").toString() == "True";
-    const int count = std::clamp(
+    const int savedCount = std::clamp(
         s.value(ceqKey(tag, "BandCount"), "0").toString().toInt(),
         0, ClientEq::kMaxBands);
+    const float masterGain = std::clamp(
+        s.value(ceqKey(tag, "MasterGain"), "1.0").toString().toFloat(),
+        0.0f, 4.0f);
+    const int familyIdx = std::clamp(
+        s.value(ceqKey(tag, "FilterFamily"), "0").toString().toInt(), 0, 3);
     eq.setEnabled(enabled);
-    eq.setActiveBandCount(count);
+    eq.setMasterGain(masterGain);
+    eq.setFilterFamily(static_cast<ClientEq::FilterFamily>(familyIdx));
 
-    for (int i = 0; i < count; ++i) {
+    // Fixed 8-slot layout.  If the user's saved state has fewer bands,
+    // we keep their saved ones in slots [0, savedCount) and pad the
+    // remaining slots with the default Logic-Pro-style templates, all
+    // disabled.  Existing users migrate in place — their configured
+    // bands survive, they just gain a few untouched defaults next to them.
+    const int activeCount = ClientEq::kDefaultBandCount;
+    eq.setActiveBandCount(activeCount);
+
+    for (int i = 0; i < activeCount; ++i) {
         ClientEq::BandParams p;
-        p.freqHz  = s.value(ceqBandKey(tag, i, "Freq"), "1000").toString().toFloat();
-        p.gainDb  = s.value(ceqBandKey(tag, i, "Gain"), "0").toString().toFloat();
-        p.q       = s.value(ceqBandKey(tag, i, "Q"),    "0.707").toString().toFloat();
-        p.type    = static_cast<ClientEq::FilterType>(
-            s.value(ceqBandKey(tag, i, "Type"), "0").toString().toInt());
-        p.enabled = s.value(ceqBandKey(tag, i, "BandEn"), "True").toString() == "True";
+        if (i < savedCount) {
+            p.freqHz  = s.value(ceqBandKey(tag, i, "Freq"), "1000").toString().toFloat();
+            p.gainDb  = s.value(ceqBandKey(tag, i, "Gain"), "0").toString().toFloat();
+            p.q       = s.value(ceqBandKey(tag, i, "Q"),    "0.707").toString().toFloat();
+            p.type    = static_cast<ClientEq::FilterType>(
+                s.value(ceqBandKey(tag, i, "Type"), "0").toString().toInt());
+            p.enabled = s.value(ceqBandKey(tag, i, "BandEn"), "True").toString() == "True";
+            p.slopeDbPerOct = std::clamp(
+                s.value(ceqBandKey(tag, i, "Slope"), "12").toString().toInt(),
+                12, 48);
+        } else {
+            p = ClientEq::defaultBand(i);  // disabled by default
+        }
         eq.setBand(i, p);
     }
 }
@@ -620,6 +641,10 @@ void saveOne(const ClientEq& eq, const char* tag)
     auto& s = AppSettings::instance();
     s.setValue(ceqKey(tag, "Enabled"),
                eq.isEnabled() ? "True" : "False");
+    s.setValue(ceqKey(tag, "MasterGain"),
+               QString::number(eq.masterGain(), 'f', 3));
+    s.setValue(ceqKey(tag, "FilterFamily"),
+               QString::number(static_cast<int>(eq.filterFamily())));
     const int count = eq.activeBandCount();
     s.setValue(ceqKey(tag, "BandCount"), QString::number(count));
     for (int i = 0; i < count; ++i) {
@@ -634,6 +659,8 @@ void saveOne(const ClientEq& eq, const char* tag)
                    QString::number(static_cast<int>(p.type)));
         s.setValue(ceqBandKey(tag, i, "BandEn"),
                    p.enabled ? "True" : "False");
+        s.setValue(ceqBandKey(tag, i, "Slope"),
+                   QString::number(p.slopeDbPerOct));
     }
 }
 

--- a/src/core/ClientEq.cpp
+++ b/src/core/ClientEq.cpp
@@ -7,6 +7,7 @@ namespace AetherSDR {
 
 namespace {
 
+constexpr float kPi    = 3.14159265358979323846f;
 constexpr float kTwoPi = 6.28318530717958647692f;
 
 // Minimum difference in smoothed params before we bother recomputing the
@@ -47,7 +48,7 @@ struct SectionDesign {
 SectionDesign butterworthSection(int k, int numSections)
 {
     const int N = 2 * numSections;
-    const float angle = static_cast<float>((2 * k + 1) * M_PI) /
+    const float angle = static_cast<float>((2 * k + 1) * kPi) /
                         static_cast<float>(2 * N);
     return { 1.0f / (2.0f * std::sin(angle)), 1.0f };
     // Note: sin form of 1/(2·cos(θ)): we want angle from jω axis;
@@ -68,7 +69,7 @@ SectionDesign chebyshevSection(int k, int numSections, float rippleDb)
     const int N = 2 * numSections;
     const float eps = std::sqrt(std::pow(10.0f, rippleDb / 10.0f) - 1.0f);
     const float nu  = std::asinh(1.0f / eps) / static_cast<float>(N);
-    const float theta = static_cast<float>((2 * k + 1) * M_PI) /
+    const float theta = static_cast<float>((2 * k + 1) * kPi) /
                         static_cast<float>(2 * N);
     const float re = -std::sinh(nu) * std::sin(theta);
     const float im =  std::cosh(nu) * std::cos(theta);

--- a/src/core/ClientEq.cpp
+++ b/src/core/ClientEq.cpp
@@ -20,10 +20,136 @@ constexpr float kQEps      = 0.0005f;
 // 15ms at 24 kHz is ~360 samples, computed in prepare().
 constexpr float kSmoothTimeConstantSec = 0.015f;
 
+// Chebyshev I passband ripple (dB) — classic 1 dB Chebyshev default.
+constexpr float kChebyshevRippleDb = 1.0f;
+// Elliptic passband ripple and stopband attenuation.
+constexpr float kEllipticRippleDb  = 1.0f;
+constexpr float kEllipticStopDb    = 60.0f;
+
 float dbToAmp(float db) noexcept
 {
     // A = 10^(dB / 40) — the sqrt() form used in RBJ peaking/shelf
     return std::pow(10.0f, db * 0.025f);
+}
+
+// Per-family Q values for each biquad section of an even-order cascade.
+// numSections is the order / 2 (so order 4 → 2 sections, order 8 → 4).
+// Section index 0 is the "broadest" (lowest Q); the highest index is the
+// most resonant.  For Chebyshev/Elliptic we also return an (optional)
+// per-section frequency scale relative to the nominal cutoff.
+struct SectionDesign {
+    float q;
+    float freqScale;  // multiply nominal cutoff by this
+};
+
+// Butterworth: flat-maximal, Q_k = 1 / (2·cos((2k-1)·π / (2N)))
+// All sections share the nominal cutoff (freqScale = 1).
+SectionDesign butterworthSection(int k, int numSections)
+{
+    const int N = 2 * numSections;
+    const float angle = static_cast<float>((2 * k + 1) * M_PI) /
+                        static_cast<float>(2 * N);
+    return { 1.0f / (2.0f * std::sin(angle)), 1.0f };
+    // Note: sin form of 1/(2·cos(θ)): we want angle from jω axis;
+    // standard Butterworth pole angle measured from the negative real
+    // axis is (2k-1)π/(2N) for k=1..N/2 — but using sin here rotates
+    // into the correct quadrant.  Q = 1/(2·sin(θ_k)) with θ measured
+    // from jω axis works out algebraically the same.
+}
+
+// Chebyshev Type I: poles on an ellipse.  Ripple in passband, flat
+// stopband, steeper transition than Butterworth.
+// Pole: p_k = -sinh(ν)·sin((2k-1)π/2N) + j·cosh(ν)·cos((2k-1)π/2N)
+// where ν = asinh(1/ε)/N, ε = sqrt(10^(rippleDb/10) - 1)
+// Natural frequency of section k:  ω_k = |p_k|
+// Q_k = ω_k / (2·|Re(p_k)|)
+SectionDesign chebyshevSection(int k, int numSections, float rippleDb)
+{
+    const int N = 2 * numSections;
+    const float eps = std::sqrt(std::pow(10.0f, rippleDb / 10.0f) - 1.0f);
+    const float nu  = std::asinh(1.0f / eps) / static_cast<float>(N);
+    const float theta = static_cast<float>((2 * k + 1) * M_PI) /
+                        static_cast<float>(2 * N);
+    const float re = -std::sinh(nu) * std::sin(theta);
+    const float im =  std::cosh(nu) * std::cos(theta);
+    const float mag = std::sqrt(re * re + im * im);
+    const float q   = mag / (2.0f * std::fabs(re));
+    return { q, mag };
+}
+
+// Bessel: maximally flat group delay.  Pole locations come from reverse
+// Bessel polynomials — we use tabulated normalised values for orders up
+// to 8 (which covers 48 dB/oct cap).  Frequencies are normalised so the
+// -3 dB point sits at ω=1, so freqScale equals pole radius as-is.
+SectionDesign besselSection(int k, int numSections)
+{
+    // Pole magnitudes and Qs for Bessel filters normalized to -3 dB.
+    // Values from "Filter Design for Signal Processing" (Shpak) /
+    // Analog Devices MT-224 app note, verified against scipy.signal.
+    struct Table { float mag; float q; };
+    // Indexed by [numSections-1][section_idx]
+    static constexpr Table kBessel2[1] = { { 1.2736f, 0.5773f } };
+    static constexpr Table kBessel4[2] = {
+        { 1.4192f, 0.5219f },
+        { 1.5912f, 0.8055f },
+    };
+    static constexpr Table kBessel6[3] = {
+        { 1.6060f, 0.5103f },
+        { 1.6913f, 0.6112f },
+        { 1.9071f, 1.0234f },
+    };
+    static constexpr Table kBessel8[4] = {
+        { 1.7837f, 0.5060f },
+        { 1.8376f, 0.5596f },
+        { 1.9591f, 0.6608f },
+        { 2.1953f, 1.2257f },
+    };
+    const Table* t = nullptr;
+    if      (numSections == 1) t = kBessel2;
+    else if (numSections == 2) t = kBessel4;
+    else if (numSections == 3) t = kBessel6;
+    else                       t = kBessel8;
+    const int idx = std::clamp(k, 0, numSections - 1);
+    return { t[idx].q, t[idx].mag };
+}
+
+// Elliptic (Cauer): steepest rolloff for a given order, with both
+// passband ripple and stopband ripple.  Real implementation requires
+// Jacobi elliptic functions and is a project on its own.  For this
+// pass we approximate with a Chebyshev-II pole geometry — sharp knee
+// without full stopband zero placement — which gives a visibly steeper
+// cutoff than Butterworth while keeping the audio path numerically
+// stable.  Full elliptic (with zeros) can replace this in a follow-up.
+SectionDesign ellipticSection(int k, int numSections)
+{
+    // Treat as a tighter Chebyshev for visual/audible distinction.
+    SectionDesign c = chebyshevSection(k, numSections, 0.5f);
+    c.q *= 1.15f;  // modest Q boost to mimic elliptic's steeper transition
+    return c;
+}
+
+SectionDesign designSection(ClientEq::FilterFamily family,
+                            int k, int numSections)
+{
+    using F = ClientEq::FilterFamily;
+    switch (family) {
+    case F::Butterworth: return butterworthSection(k, numSections);
+    case F::Chebyshev:   return chebyshevSection(k, numSections,
+                                                 kChebyshevRippleDb);
+    case F::Bessel:      return besselSection(k, numSections);
+    case F::Elliptic:    return ellipticSection(k, numSections);
+    }
+    return butterworthSection(k, numSections);
+}
+
+int slopeToSections(int slopeDbPerOct)
+{
+    // Quantise to supported steps: 12 / 24 / 36 / 48 dB/oct → 1 / 2 / 3 / 4
+    // cascade sections.  Anything lower clamps to 1 section (12 dB/oct).
+    if (slopeDbPerOct >= 48) return 4;
+    if (slopeDbPerOct >= 36) return 3;
+    if (slopeDbPerOct >= 24) return 2;
+    return 1;
 }
 
 } // namespace
@@ -40,7 +166,25 @@ ClientEq::ClientEq()
         m_runtime[i].cachedType     = static_cast<FilterType>(
             m_bands[i].type.load(std::memory_order_relaxed));
         m_runtime[i].cachedEnabled  = m_bands[i].enabled.load(std::memory_order_relaxed);
+        m_runtime[i].cachedSlopeDbPerOct = m_bands[i].slopeDbPerOct.load(std::memory_order_relaxed);
+        m_runtime[i].activeSections = 1;
     }
+}
+
+void ClientEq::setFilterFamily(FilterFamily f) noexcept
+{
+    m_filterFamily.store(static_cast<int>(f), std::memory_order_relaxed);
+    // Bump every band's version so the audio thread recomputes cascade
+    // coefficients on the next block.  Family change invalidates them all.
+    for (int i = 0; i < kMaxBands; ++i) {
+        m_bands[i].version.fetch_add(1, std::memory_order_release);
+    }
+}
+
+ClientEq::FilterFamily ClientEq::filterFamily() const noexcept
+{
+    return static_cast<FilterFamily>(
+        m_filterFamily.load(std::memory_order_relaxed));
 }
 
 void ClientEq::prepare(double sampleRate)
@@ -53,8 +197,10 @@ void ClientEq::prepare(double sampleRate)
     // Force coefficient recompute on first process() call
     for (int i = 0; i < kMaxBands; ++i) {
         computeCoefficients(m_runtime[i]);
-        m_runtime[i].z1L = m_runtime[i].z2L = 0.0f;
-        m_runtime[i].z1R = m_runtime[i].z2R = 0.0f;
+        for (auto& s : m_runtime[i].sections) {
+            s.z1L = s.z2L = 0.0f;
+            s.z1R = s.z2R = 0.0f;
+        }
     }
 }
 
@@ -68,6 +214,16 @@ bool ClientEq::isEnabled() const noexcept
     return m_enabled.load(std::memory_order_acquire);
 }
 
+void ClientEq::setMasterGain(float linear) noexcept
+{
+    m_masterGain.store(std::clamp(linear, 0.0f, 4.0f), std::memory_order_relaxed);
+}
+
+float ClientEq::masterGain() const noexcept
+{
+    return m_masterGain.load(std::memory_order_relaxed);
+}
+
 void ClientEq::setBand(int idx, const BandParams& p) noexcept
 {
     if (idx < 0 || idx >= kMaxBands) return;
@@ -77,6 +233,8 @@ void ClientEq::setBand(int idx, const BandParams& p) noexcept
     b.q     .store(std::clamp(p.q,      0.1f,  18.0f),    std::memory_order_relaxed);
     b.type  .store(static_cast<int>(p.type),              std::memory_order_relaxed);
     b.enabled.store(p.enabled,                            std::memory_order_relaxed);
+    b.slopeDbPerOct.store(std::clamp(p.slopeDbPerOct, 12, 48),
+                          std::memory_order_relaxed);
     // Bump version last so audio thread sees a consistent snapshot
     b.version.fetch_add(1, std::memory_order_release);
 }
@@ -91,6 +249,7 @@ ClientEq::BandParams ClientEq::band(int idx) const noexcept
     p.q       = b.q.load(std::memory_order_relaxed);
     p.type    = static_cast<FilterType>(b.type.load(std::memory_order_relaxed));
     p.enabled = b.enabled.load(std::memory_order_relaxed);
+    p.slopeDbPerOct = b.slopeDbPerOct.load(std::memory_order_relaxed);
     return p;
 }
 
@@ -107,112 +266,124 @@ int ClientEq::activeBandCount() const noexcept
 void ClientEq::reset() noexcept
 {
     for (int i = 0; i < kMaxBands; ++i) {
-        m_runtime[i].z1L = m_runtime[i].z2L = 0.0f;
-        m_runtime[i].z1R = m_runtime[i].z2R = 0.0f;
+        for (auto& s : m_runtime[i].sections) {
+            s.z1L = s.z2L = 0.0f;
+            s.z1R = s.z2R = 0.0f;
+        }
     }
 }
+
+namespace {
+
+// Helper: analog-prototype magnitude² ratio (num²/den²) for a single
+// biquad section of a given type at probe frequency.  The caller passes
+// the section's own freq and Q — for peak/shelf these come straight from
+// the user params, for HP/LP they come from the family's pole layout.
+void sectionMagSq(ClientEq::FilterType type,
+                  double w0sq, double wsq, double w0w,
+                  double q, double A,
+                  double& num2, double& den2)
+{
+    using FT = ClientEq::FilterType;
+    switch (type) {
+    case FT::Peak: {
+        const double diff = w0sq - wsq;
+        const double tN   = A * w0w / q;
+        const double tD   = w0w / (A * q);
+        num2 = diff * diff + tN * tN;
+        den2 = diff * diff + tD * tD;
+        break;
+    }
+    case FT::LowShelf: {
+        const double dN = A * w0sq - wsq;
+        const double dD = w0sq - A * wsq;
+        const double cross = w0w / q;
+        const double crossA = A * cross * cross;
+        num2 = A * A * (dN * dN + crossA);
+        den2 = dD * dD + crossA;
+        break;
+    }
+    case FT::HighShelf: {
+        const double dN = w0sq - A * wsq;
+        const double dD = A * w0sq - wsq;
+        const double cross = w0w / q;
+        const double crossA = A * cross * cross;
+        num2 = A * A * (dN * dN + crossA);
+        den2 = dD * dD + crossA;
+        break;
+    }
+    case FT::LowPass: {
+        const double diff = w0sq - wsq;
+        const double cross = w0w / q;
+        num2 = w0sq * w0sq;
+        den2 = diff * diff + cross * cross;
+        break;
+    }
+    case FT::HighPass: {
+        const double diff = w0sq - wsq;
+        const double cross = w0w / q;
+        num2 = wsq * wsq;
+        den2 = diff * diff + cross * cross;
+        break;
+    }
+    }
+}
+
+} // namespace
 
 float ClientEq::bandMagnitudeDb(const BandParams& p,
                                 float probeFreqHz,
                                 double sampleRate) noexcept
 {
-    if (!p.enabled || probeFreqHz <= 0.0f || sampleRate <= 0.0) return 0.0f;
+    return bandMagnitudeDb(p, probeFreqHz, sampleRate,
+                           FilterFamily::Butterworth);
+}
 
-    // Clamp the probe frequency to just below Nyquist. Above fs/2 the
-    // magnitude response folds (|H(ω)| is periodic with period 2π in the
-    // digital domain), so a band centered at, say, 9 kHz with fs=24 kHz
-    // would produce a phantom peak mirrored at fs - 9 = 15 kHz when the
-    // canvas draws out to 20 kHz. Holding the value at ~Nyquist gives an
-    // honest flat line above fs/2 — the audio path can't carry anything
-    // there anyway.
-    const float nyquist = static_cast<float>(sampleRate * 0.49f);
-    probeFreqHz = std::min(probeFreqHz, nyquist);
+float ClientEq::bandMagnitudeDb(const BandParams& p,
+                                float probeFreqHz,
+                                double sampleRate,
+                                FilterFamily family) noexcept
+{
+    if (!p.enabled || probeFreqHz <= 0.0f) return 0.0f;
+    (void)sampleRate;
 
-    // Derive RBJ coefficients from params — same math as computeCoefficients()
-    // but pure / stateless and using the *target* params rather than the
-    // smoothed current values. The duplication is deliberate: the audio
-    // path's copy is hot and stays inlined; this one is a display helper.
-    const float freq = std::clamp(p.freqHz, 10.0f, nyquist);
-    const float q    = std::max(0.1f, p.q);
-    const float A    = dbToAmp(p.gainDb);
-    const float omega = kTwoPi * freq / static_cast<float>(sampleRate);
-    const float cosW  = std::cos(omega);
-    const float sinW  = std::sin(omega);
-    const float alpha = sinW / (2.0f * q);
+    // For peak/shelf: single-section math with user Q and gain.
+    // For HP/LP: cascade of (slope / 12) sections, each with its own Q
+    // and freq scale from the active family's pole layout.
+    const double f0 = std::max(1.0, static_cast<double>(p.freqHz));
+    const double userQ = std::max(0.1, static_cast<double>(p.q));
+    const double A     = std::pow(10.0,
+                                  static_cast<double>(p.gainDb) / 40.0);
+    const double w  = static_cast<double>(kTwoPi) *
+                      static_cast<double>(probeFreqHz);
+    const double wsq = w * w;
 
-    float b0 = 1.0f, b1 = 0.0f, b2 = 0.0f;
-    float a0 = 1.0f, a1 = 0.0f, a2 = 0.0f;
-    switch (p.type) {
-    case FilterType::Peak:
-        b0 = 1.0f + alpha * A;
-        b1 = -2.0f * cosW;
-        b2 = 1.0f - alpha * A;
-        a0 = 1.0f + alpha / A;
-        a1 = -2.0f * cosW;
-        a2 = 1.0f - alpha / A;
-        break;
-    case FilterType::LowShelf: {
-        const float sqrtA  = std::sqrt(A);
-        const float twoSqrtAalpha = 2.0f * sqrtA * alpha;
-        b0 =        A * ((A + 1.0f) - (A - 1.0f) * cosW + twoSqrtAalpha);
-        b1 =  2.0f * A * ((A - 1.0f) - (A + 1.0f) * cosW);
-        b2 =        A * ((A + 1.0f) - (A - 1.0f) * cosW - twoSqrtAalpha);
-        a0 =             (A + 1.0f) + (A - 1.0f) * cosW + twoSqrtAalpha;
-        a1 =     -2.0f * ((A - 1.0f) + (A + 1.0f) * cosW);
-        a2 =             (A + 1.0f) + (A - 1.0f) * cosW - twoSqrtAalpha;
-        break;
+    const bool isSlope = (p.type == FilterType::LowPass
+                       || p.type == FilterType::HighPass);
+
+    double totalDb = 0.0;
+    const int numSections = isSlope ? slopeToSections(p.slopeDbPerOct) : 1;
+
+    for (int k = 0; k < numSections; ++k) {
+        double sectionFreq = f0;
+        double sectionQ    = userQ;
+        if (isSlope) {
+            const SectionDesign d = designSection(family, k, numSections);
+            sectionFreq = f0 * static_cast<double>(d.freqScale);
+            sectionQ    = static_cast<double>(d.q);
+        }
+        const double w0   = static_cast<double>(kTwoPi) * sectionFreq;
+        const double w0sq = w0 * w0;
+        const double w0w  = w0 * w;
+
+        double num2 = 0.0, den2 = 1.0;
+        sectionMagSq(p.type, w0sq, wsq, w0w, sectionQ, A, num2, den2);
+        if (den2 < 1e-40) continue;
+        const double magSq = num2 / den2;
+        if (magSq < 1e-24) return -240.0f;
+        totalDb += 10.0 * std::log10(magSq);
     }
-    case FilterType::HighShelf: {
-        const float sqrtA  = std::sqrt(A);
-        const float twoSqrtAalpha = 2.0f * sqrtA * alpha;
-        b0 =        A * ((A + 1.0f) + (A - 1.0f) * cosW + twoSqrtAalpha);
-        b1 = -2.0f * A * ((A - 1.0f) + (A + 1.0f) * cosW);
-        b2 =        A * ((A + 1.0f) + (A - 1.0f) * cosW - twoSqrtAalpha);
-        a0 =             (A + 1.0f) - (A - 1.0f) * cosW + twoSqrtAalpha;
-        a1 =      2.0f * ((A - 1.0f) - (A + 1.0f) * cosW);
-        a2 =             (A + 1.0f) - (A - 1.0f) * cosW - twoSqrtAalpha;
-        break;
-    }
-    case FilterType::LowPass:
-        b0 = (1.0f - cosW) * 0.5f;
-        b1 =  1.0f - cosW;
-        b2 = (1.0f - cosW) * 0.5f;
-        a0 =  1.0f + alpha;
-        a1 = -2.0f * cosW;
-        a2 =  1.0f - alpha;
-        break;
-    case FilterType::HighPass:
-        b0 =  (1.0f + cosW) * 0.5f;
-        b1 = -(1.0f + cosW);
-        b2 =  (1.0f + cosW) * 0.5f;
-        a0 =  1.0f + alpha;
-        a1 = -2.0f * cosW;
-        a2 =  1.0f - alpha;
-        break;
-    }
-    const float invA0 = 1.0f / a0;
-    b0 *= invA0; b1 *= invA0; b2 *= invA0;
-    a1 *= invA0; a2 *= invA0;
-
-    // Evaluate |H(e^jΩ)| at Ω = 2π * probeFreq / fs
-    const float W = kTwoPi * probeFreqHz / static_cast<float>(sampleRate);
-    const float cw1 = std::cos(W);
-    const float sw1 = std::sin(W);
-    const float cw2 = std::cos(2.0f * W);
-    const float sw2 = std::sin(2.0f * W);
-
-    const float numRe = b0 + b1 * cw1 + b2 * cw2;
-    const float numIm =       -b1 * sw1 - b2 * sw2;
-    const float denRe = 1.0f + a1 * cw1 + a2 * cw2;
-    const float denIm =       -a1 * sw1 - a2 * sw2;
-
-    const float numMag = std::sqrt(numRe * numRe + numIm * numIm);
-    const float denMag = std::sqrt(denRe * denRe + denIm * denIm);
-    if (denMag < 1e-20f) return 0.0f;
-
-    const float mag = numMag / denMag;
-    if (mag < 1e-12f) return -240.0f;
-    return 20.0f * std::log10(mag);
+    return static_cast<float>(totalDb);
 }
 
 bool ClientEq::smoothTowardTarget(int idx, Runtime& runtime,
@@ -240,78 +411,106 @@ bool ClientEq::smoothTowardTarget(int idx, Runtime& runtime,
 
 void ClientEq::computeCoefficients(Runtime& runtime) noexcept
 {
-    // RBJ Audio EQ Cookbook. Each branch produces b0/b1/b2/a0/a1/a2,
-    // we normalise by a0 at the end so process() can skip the division.
-    const float freq = std::clamp(runtime.current.freqHz,
-                                  10.0f, static_cast<float>(m_sampleRate * 0.49f));
-    const float q    = std::max(0.1f, runtime.current.q);
-    const float A    = dbToAmp(runtime.current.gainDb);
-    const float omega = kTwoPi * freq / static_cast<float>(m_sampleRate);
-    const float cosW  = std::cos(omega);
-    const float sinW  = std::sin(omega);
-    const float alpha = sinW / (2.0f * q);
+    // Build up to kMaxSections biquad coefficients for this band.  For
+    // peak / shelf the cascade is always 1 section (native 2nd-order
+    // topology). For HP / LP the cascade count = slope / 12, with each
+    // section's Q taken from the active FilterFamily's pole layout.
+    const bool isSlope = (runtime.cachedType == FilterType::LowPass
+                       || runtime.cachedType == FilterType::HighPass);
+    const int numSections = isSlope
+        ? slopeToSections(runtime.cachedSlopeDbPerOct)
+        : 1;
+    runtime.activeSections = std::clamp(numSections, 1, kMaxSections);
 
-    float b0 = 1.0f, b1 = 0.0f, b2 = 0.0f;
-    float a0 = 1.0f, a1 = 0.0f, a2 = 0.0f;
+    const float baseFreq = std::clamp(runtime.current.freqHz,
+                                      10.0f,
+                                      static_cast<float>(m_sampleRate * 0.49f));
+    const float userQ = std::max(0.1f, runtime.current.q);
+    const float A     = dbToAmp(runtime.current.gainDb);
 
-    switch (runtime.cachedType) {
-    case FilterType::Peak: {
-        b0 = 1.0f + alpha * A;
-        b1 = -2.0f * cosW;
-        b2 = 1.0f - alpha * A;
-        a0 = 1.0f + alpha / A;
-        a1 = -2.0f * cosW;
-        a2 = 1.0f - alpha / A;
-        break;
-    }
-    case FilterType::LowShelf: {
-        const float sqrtA  = std::sqrt(A);
-        const float twoSqrtAalpha = 2.0f * sqrtA * alpha;
-        b0 =        A * ((A + 1.0f) - (A - 1.0f) * cosW + twoSqrtAalpha);
-        b1 =  2.0f * A * ((A - 1.0f) - (A + 1.0f) * cosW);
-        b2 =        A * ((A + 1.0f) - (A - 1.0f) * cosW - twoSqrtAalpha);
-        a0 =             (A + 1.0f) + (A - 1.0f) * cosW + twoSqrtAalpha;
-        a1 =     -2.0f * ((A - 1.0f) + (A + 1.0f) * cosW);
-        a2 =             (A + 1.0f) + (A - 1.0f) * cosW - twoSqrtAalpha;
-        break;
-    }
-    case FilterType::HighShelf: {
-        const float sqrtA  = std::sqrt(A);
-        const float twoSqrtAalpha = 2.0f * sqrtA * alpha;
-        b0 =        A * ((A + 1.0f) + (A - 1.0f) * cosW + twoSqrtAalpha);
-        b1 = -2.0f * A * ((A - 1.0f) + (A + 1.0f) * cosW);
-        b2 =        A * ((A + 1.0f) + (A - 1.0f) * cosW - twoSqrtAalpha);
-        a0 =             (A + 1.0f) - (A - 1.0f) * cosW + twoSqrtAalpha;
-        a1 =      2.0f * ((A - 1.0f) - (A + 1.0f) * cosW);
-        a2 =             (A + 1.0f) - (A - 1.0f) * cosW - twoSqrtAalpha;
-        break;
-    }
-    case FilterType::LowPass: {
-        b0 = (1.0f - cosW) * 0.5f;
-        b1 =  1.0f - cosW;
-        b2 = (1.0f - cosW) * 0.5f;
-        a0 =  1.0f + alpha;
-        a1 = -2.0f * cosW;
-        a2 =  1.0f - alpha;
-        break;
-    }
-    case FilterType::HighPass: {
-        b0 =  (1.0f + cosW) * 0.5f;
-        b1 = -(1.0f + cosW);
-        b2 =  (1.0f + cosW) * 0.5f;
-        a0 =  1.0f + alpha;
-        a1 = -2.0f * cosW;
-        a2 =  1.0f - alpha;
-        break;
-    }
-    }
+    auto fillOneSection = [&](int sectionIdx, float sectionFreq, float sectionQ) {
+        const float freq = std::clamp(sectionFreq, 10.0f,
+                                      static_cast<float>(m_sampleRate * 0.49f));
+        const float q    = std::max(0.1f, sectionQ);
+        const float omega = kTwoPi * freq / static_cast<float>(m_sampleRate);
+        const float cosW  = std::cos(omega);
+        const float sinW  = std::sin(omega);
+        const float alpha = sinW / (2.0f * q);
 
-    const float invA0 = 1.0f / a0;
-    runtime.coeff.b0 = b0 * invA0;
-    runtime.coeff.b1 = b1 * invA0;
-    runtime.coeff.b2 = b2 * invA0;
-    runtime.coeff.a1 = a1 * invA0;
-    runtime.coeff.a2 = a2 * invA0;
+        float b0 = 1.0f, b1 = 0.0f, b2 = 0.0f;
+        float a0 = 1.0f, a1 = 0.0f, a2 = 0.0f;
+
+        switch (runtime.cachedType) {
+        case FilterType::Peak:
+            b0 = 1.0f + alpha * A;
+            b1 = -2.0f * cosW;
+            b2 = 1.0f - alpha * A;
+            a0 = 1.0f + alpha / A;
+            a1 = -2.0f * cosW;
+            a2 = 1.0f - alpha / A;
+            break;
+        case FilterType::LowShelf: {
+            const float sqrtA  = std::sqrt(A);
+            const float twoSqrtAalpha = 2.0f * sqrtA * alpha;
+            b0 =        A * ((A + 1.0f) - (A - 1.0f) * cosW + twoSqrtAalpha);
+            b1 =  2.0f * A * ((A - 1.0f) - (A + 1.0f) * cosW);
+            b2 =        A * ((A + 1.0f) - (A - 1.0f) * cosW - twoSqrtAalpha);
+            a0 =             (A + 1.0f) + (A - 1.0f) * cosW + twoSqrtAalpha;
+            a1 =     -2.0f * ((A - 1.0f) + (A + 1.0f) * cosW);
+            a2 =             (A + 1.0f) + (A - 1.0f) * cosW - twoSqrtAalpha;
+            break;
+        }
+        case FilterType::HighShelf: {
+            const float sqrtA  = std::sqrt(A);
+            const float twoSqrtAalpha = 2.0f * sqrtA * alpha;
+            b0 =        A * ((A + 1.0f) + (A - 1.0f) * cosW + twoSqrtAalpha);
+            b1 = -2.0f * A * ((A - 1.0f) + (A + 1.0f) * cosW);
+            b2 =        A * ((A + 1.0f) + (A - 1.0f) * cosW - twoSqrtAalpha);
+            a0 =             (A + 1.0f) - (A - 1.0f) * cosW + twoSqrtAalpha;
+            a1 =      2.0f * ((A - 1.0f) - (A + 1.0f) * cosW);
+            a2 =             (A + 1.0f) - (A - 1.0f) * cosW - twoSqrtAalpha;
+            break;
+        }
+        case FilterType::LowPass:
+            b0 = (1.0f - cosW) * 0.5f;
+            b1 =  1.0f - cosW;
+            b2 = (1.0f - cosW) * 0.5f;
+            a0 =  1.0f + alpha;
+            a1 = -2.0f * cosW;
+            a2 =  1.0f - alpha;
+            break;
+        case FilterType::HighPass:
+            b0 =  (1.0f + cosW) * 0.5f;
+            b1 = -(1.0f + cosW);
+            b2 =  (1.0f + cosW) * 0.5f;
+            a0 =  1.0f + alpha;
+            a1 = -2.0f * cosW;
+            a2 =  1.0f - alpha;
+            break;
+        }
+
+        const float invA0 = 1.0f / a0;
+        Coeff& c = runtime.sections[sectionIdx].coeff;
+        c.b0 = b0 * invA0;
+        c.b1 = b1 * invA0;
+        c.b2 = b2 * invA0;
+        c.a1 = a1 * invA0;
+        c.a2 = a2 * invA0;
+    };
+
+    if (isSlope) {
+        // Cascade of N sections — per-section Q comes from the active
+        // filter family's pole layout.  Section freq is nominal cutoff
+        // scaled by the family's per-section multiplier.
+        for (int k = 0; k < runtime.activeSections; ++k) {
+            const SectionDesign d = designSection(runtime.cachedFamily,
+                                                  k, runtime.activeSections);
+            fillOneSection(k, baseFreq * d.freqScale, d.q);
+        }
+    } else {
+        // Peak and shelf: single native 2nd-order section using user Q.
+        fillOneSection(0, baseFreq, userQ);
+    }
 }
 
 void ClientEq::process(float* interleaved, int frames, int channels) noexcept
@@ -334,6 +533,8 @@ void ClientEq::process(float* interleaved, int frames, int channels) noexcept
     // when anything changes. We force a recompute on version change too,
     // because a filter-type swap won't move the smoothed params at all
     // and would otherwise keep running the old coefficients.
+    const FilterFamily currentFamily = static_cast<FilterFamily>(
+        m_filterFamily.load(std::memory_order_relaxed));
     for (int i = 0; i < activeCount; ++i) {
         Runtime& rt = m_runtime[i];
         AtomicBand& ab = m_bands[i];
@@ -344,6 +545,8 @@ void ClientEq::process(float* interleaved, int frames, int channels) noexcept
             rt.cachedType = static_cast<FilterType>(
                 ab.type.load(std::memory_order_relaxed));
             rt.cachedEnabled = ab.enabled.load(std::memory_order_relaxed);
+            rt.cachedSlopeDbPerOct = ab.slopeDbPerOct.load(std::memory_order_relaxed);
+            rt.cachedFamily = currentFamily;
             rt.lastVersion = version;
             needRecompute = true;
         }
@@ -356,8 +559,8 @@ void ClientEq::process(float* interleaved, int frames, int channels) noexcept
         }
     }
 
-    // Process — per-sample, cascade all active enabled bands.
-    // Direct Form II Transposed biquad:
+    // Process — per-sample, cascade all active enabled bands and all of
+    // their cascade sections.  Direct Form II Transposed biquad per section:
     //   y[n] = b0*x[n] + z1
     //   z1   = b1*x[n] - a1*y[n] + z2
     //   z2   = b2*x[n] - a2*y[n]
@@ -368,17 +571,20 @@ void ClientEq::process(float* interleaved, int frames, int channels) noexcept
             for (int i = 0; i < activeCount; ++i) {
                 Runtime& rt = m_runtime[i];
                 if (!rt.cachedEnabled) continue;
-                const Coeff& c = rt.coeff;
+                for (int s = 0; s < rt.activeSections; ++s) {
+                    Section& sec = rt.sections[s];
+                    const Coeff& c = sec.coeff;
 
-                const float yl = c.b0 * l + rt.z1L;
-                rt.z1L = c.b1 * l - c.a1 * yl + rt.z2L;
-                rt.z2L = c.b2 * l - c.a2 * yl;
-                l = yl;
+                    const float yl = c.b0 * l + sec.z1L;
+                    sec.z1L = c.b1 * l - c.a1 * yl + sec.z2L;
+                    sec.z2L = c.b2 * l - c.a2 * yl;
+                    l = yl;
 
-                const float yr = c.b0 * r + rt.z1R;
-                rt.z1R = c.b1 * r - c.a1 * yr + rt.z2R;
-                rt.z2R = c.b2 * r - c.a2 * yr;
-                r = yr;
+                    const float yr = c.b0 * r + sec.z1R;
+                    sec.z1R = c.b1 * r - c.a1 * yr + sec.z2R;
+                    sec.z2R = c.b2 * r - c.a2 * yr;
+                    r = yr;
+                }
             }
             interleaved[f * 2]     = l;
             interleaved[f * 2 + 1] = r;
@@ -389,15 +595,65 @@ void ClientEq::process(float* interleaved, int frames, int channels) noexcept
             for (int i = 0; i < activeCount; ++i) {
                 Runtime& rt = m_runtime[i];
                 if (!rt.cachedEnabled) continue;
-                const Coeff& c = rt.coeff;
-                const float y = c.b0 * x + rt.z1L;
-                rt.z1L = c.b1 * x - c.a1 * y + rt.z2L;
-                rt.z2L = c.b2 * x - c.a2 * y;
-                x = y;
+                for (int s = 0; s < rt.activeSections; ++s) {
+                    Section& sec = rt.sections[s];
+                    const Coeff& c = sec.coeff;
+                    const float y = c.b0 * x + sec.z1L;
+                    sec.z1L = c.b1 * x - c.a1 * y + sec.z2L;
+                    sec.z2L = c.b2 * x - c.a2 * y;
+                    x = y;
+                }
             }
             interleaved[f] = x;
         }
     }
+
+    // Master output gain — applied after every band contribution.
+    // Skip the multiply when unity to avoid burning cycles on the common
+    // fader-at-0-dB path.
+    const float gain = m_masterGain.load(std::memory_order_relaxed);
+    if (gain != 1.0f) {
+        const int totalSamples = frames * channels;
+        for (int i = 0; i < totalSamples; ++i) {
+            interleaved[i] *= gain;
+        }
+    }
+}
+
+ClientEq::BandParams ClientEq::defaultBand(int idx)
+{
+    // 10-band Logic-style layout.  Frequencies log-spaced across the
+    // voice range so the handles read as an evenly spread row at 0 dB.
+    // Butterworth (Q = 0.707, = 1/√2) everywhere — the industry-standard
+    // neutral default. Matches Logic Pro's Channel EQ; users can tighten
+    // any band post-hoc with Shift+drag or HP/LP vertical drag.
+    struct Preset { FilterType type; float freqHz; float q; };
+    static constexpr Preset kPresets[kDefaultBandCount] = {
+        { FilterType::HighPass,  40.0f,    0.707f },
+        { FilterType::LowShelf,  100.0f,   0.707f },
+        { FilterType::Peak,      200.0f,   0.707f },
+        { FilterType::Peak,      400.0f,   0.707f },
+        { FilterType::Peak,      800.0f,   0.707f },
+        { FilterType::Peak,      1500.0f,  0.707f },
+        { FilterType::Peak,      3000.0f,  0.707f },
+        { FilterType::Peak,      5000.0f,  0.707f },
+        { FilterType::HighShelf, 8000.0f,  0.707f },
+        { FilterType::LowPass,   12000.0f, 0.707f },
+    };
+    BandParams p;
+    if (idx < 0 || idx >= kDefaultBandCount) {
+        p.type    = FilterType::Peak;
+        p.freqHz  = 1000.0f;
+        p.q       = 0.707f;
+    } else {
+        const auto& preset = kPresets[idx];
+        p.type    = preset.type;
+        p.freqHz  = preset.freqHz;
+        p.q       = preset.q;
+    }
+    p.gainDb  = 0.0f;
+    p.enabled = false;
+    return p;
 }
 
 } // namespace AetherSDR

--- a/src/core/ClientEq.h
+++ b/src/core/ClientEq.h
@@ -30,7 +30,17 @@ public:
         HighPass   = 4,
     };
 
-    static constexpr int kMaxBands = 16;
+    // Global filter family — applies to the cascade math for HP/LP bands
+    // (shelves and peaks always use their native 2nd-order topology).
+    enum class FilterFamily : int {
+        Butterworth = 0,   // maximally flat passband
+        Chebyshev   = 1,   // steeper rolloff with 1 dB passband ripple
+        Bessel      = 2,   // flat group delay (gentler rolloff)
+        Elliptic    = 3,   // steepest rolloff, ripple in both bands
+    };
+
+    static constexpr int kMaxBands    = 16;
+    static constexpr int kMaxSections = 4;  // up to 48 dB/oct HP/LP
 
     struct BandParams {
         float      freqHz{1000.0f};
@@ -38,6 +48,10 @@ public:
         float      q{0.707f};
         FilterType type{FilterType::Peak};
         bool       enabled{true};
+        // Slope in dB/octave for HP / LP — 12 / 24 / 36 / 48.  Ignored
+        // for peak and shelf bands (they always use their native 2nd-
+        // order topology).
+        int        slopeDbPerOct{12};
     };
 
     ClientEq();
@@ -52,6 +66,15 @@ public:
     // Main thread — global enable (bypass when false). Lock-free.
     void setEnabled(bool on) noexcept;
     bool isEnabled() const noexcept;
+
+    // Main thread — master output gain applied after all bands.  Linear
+    // scale (1.0 = 0 dB).  Clamped to [0.0, 4.0] = [-inf, +12 dB].
+    void setMasterGain(float linear) noexcept;
+    float masterGain() const noexcept;
+
+    // Global filter family for HP/LP cascade math.  Lock-free.
+    void setFilterFamily(FilterFamily f) noexcept;
+    FilterFamily filterFamily() const noexcept;
 
     // Main thread — set a single band's parameters. Triggers a recompute
     // on the audio thread at its next block. Lock-free.
@@ -81,9 +104,23 @@ public:
     // to call from any thread. Used by the editor and applet to draw
     // the response curve without having to read the audio thread's
     // coefficients. A disabled band returns 0.0 (transparent).
+    // The family-less overload assumes Butterworth for HP/LP cascades.
     static float bandMagnitudeDb(const BandParams& p,
                                  float probeFreqHz,
                                  double sampleRate) noexcept;
+    static float bandMagnitudeDb(const BandParams& p,
+                                 float probeFreqHz,
+                                 double sampleRate,
+                                 FilterFamily family) noexcept;
+
+    // Default 10-band Logic-Pro-style layout: HP / LS / Peak×6 / HS / LP,
+    // evenly log-spaced across 40 Hz .. 12 kHz.  All bands return with
+    // enabled=false — the editor UI auto-enables a band the first time
+    // the user interacts with it (drag handle, click icon, right-click).
+    // Handles sit on the 0 dB line so the dots appear as a horizontal
+    // row until the user shapes them.
+    static constexpr int kDefaultBandCount = 10;
+    static BandParams defaultBand(int idx);
 
 private:
     struct Coeff {
@@ -97,14 +134,21 @@ private:
         float q{0.707f};
     };
 
+    struct Section {
+        Coeff coeff;
+        float z1L{0.0f}, z2L{0.0f};
+        float z1R{0.0f}, z2R{0.0f};
+    };
+
     struct Runtime {
-        Coeff      coeff;
+        std::array<Section, kMaxSections> sections;
+        int        activeSections{1};
         Smoothed   current;      // post-smoothing values used for coeff
-        float      z1L{0.0f}, z2L{0.0f};
-        float      z1R{0.0f}, z2R{0.0f};
         uint64_t   lastVersion{0};
         FilterType cachedType{FilterType::Peak};
         bool       cachedEnabled{true};
+        int        cachedSlopeDbPerOct{12};
+        FilterFamily cachedFamily{FilterFamily::Butterworth};
     };
 
     struct AtomicBand {
@@ -113,6 +157,7 @@ private:
         std::atomic<float>    q{0.707f};
         std::atomic<int>      type{static_cast<int>(FilterType::Peak)};
         std::atomic<bool>     enabled{true};
+        std::atomic<int>      slopeDbPerOct{12};
         std::atomic<uint64_t> version{0};
     };
 
@@ -131,6 +176,8 @@ private:
     float              m_smoothCoeff{0.0f};   // recomputed in prepare()
     std::atomic<bool>  m_enabled{false};
     std::atomic<int>   m_activeBandCount{0};
+    std::atomic<float> m_masterGain{1.0f};    // post-band master output
+    std::atomic<int>   m_filterFamily{static_cast<int>(FilterFamily::Butterworth)};
 
     std::array<AtomicBand, kMaxBands> m_bands;
     std::array<Runtime,    kMaxBands> m_runtime;

--- a/src/gui/ClientEqCurveWidget.cpp
+++ b/src/gui/ClientEqCurveWidget.cpp
@@ -198,7 +198,8 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
 
         QPainterPath fftPath;
         fftPath.moveTo(0, h);
-        bool started = false;
+        bool  started = false;
+        float lastX   = 0.0f;
         for (int i = 1; i < bins; ++i) {
             // bins.size() == fftSize/2 + 1; bin i maps to i * fs / fftSize.
             const float f = static_cast<float>(i) *
@@ -209,8 +210,15 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
             const float y = dbfsToY(m_fftBinsDb[i]);
             if (!started) { fftPath.lineTo(x, h); started = true; }
             fftPath.lineTo(x, y);
+            lastX = x;
         }
-        fftPath.lineTo(r.width(), h);
+        // Close the filled region at the last valid bin's x, not at the
+        // canvas right edge.  Above Nyquist the FFT has no bins; drawing
+        // out to r.width() produced a misleading near-horizontal "shelf"
+        // connecting the last bin's level to the bottom-right corner.
+        if (started) {
+            fftPath.lineTo(lastX, h);
+        }
         fftPath.closeSubpath();
 
         QLinearGradient grad(0, 0, 0, h);
@@ -238,10 +246,14 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
     const int   W         = r.width();
     const bool  eqOn      = m_eq->isEnabled();
 
-    // Sample each pixel column — cheap (~W * bandCount coeff evaluations).
-    // Build the summed response path plus per-band sub-paths. Per-band
-    // paths are drawn behind the summed curve so the summed line reads
-    // as the master response on top.
+    // bandMagnitudeDb evaluates analog-prototype transfer functions in
+    // double precision, so the drawn response is ideal across the full
+    // 20 Hz - 20 kHz canvas — no aliasing, no Nyquist artefacts, no low-
+    // end precision loss. The audio path still uses the real-rate digital
+    // biquads; this is the analog reference the biquad approximates.
+    // HP/LP bands cascade internally based on slopeDbPerOct and the
+    // globally-selected FilterFamily on the bound ClientEq.
+    const ClientEq::FilterFamily family = m_eq->filterFamily();
     QVector<float> summed(W, 0.0f);
     QVector<QVector<float>> perBand(bandCount, QVector<float>(W, 0.0f));
     for (int x = 0; x < W; ++x) {
@@ -249,7 +261,7 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
         float acc = 0.0f;
         for (int i = 0; i < bandCount; ++i) {
             const auto bp = m_eq->band(i);
-            const float dB = ClientEq::bandMagnitudeDb(bp, probe, fs);
+            const float dB = ClientEq::bandMagnitudeDb(bp, probe, fs, family);
             perBand[i][x] = dB;
             acc += dB;
         }

--- a/src/gui/ClientEqEditor.cpp
+++ b/src/gui/ClientEqEditor.cpp
@@ -2,12 +2,14 @@
 #include "ClientEqEditorCanvas.h"
 #include "ClientEqFftAnalyzer.h"
 #include "ClientEqIconRow.h"
+#include "ClientEqOutputFader.h"
 #include "ClientEqParamRow.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/ClientEq.h"
 
 #include <QCloseEvent>
+#include <QComboBox>
 #include <QHBoxLayout>
 #include <QHideEvent>
 #include <QLabel>
@@ -81,6 +83,48 @@ ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
         hint->setStyleSheet("QLabel { color: #506070; font-size: 10px; }");
         row->addWidget(hint, 1);
 
+        // Global filter-family selector — applies to HP/LP cascade math.
+        // Shelves and peaks keep their native 2nd-order topology.
+        m_familyCombo = new QComboBox;
+        m_familyCombo->addItem("Butterworth",
+            static_cast<int>(ClientEq::FilterFamily::Butterworth));
+        m_familyCombo->addItem("Chebyshev",
+            static_cast<int>(ClientEq::FilterFamily::Chebyshev));
+        m_familyCombo->addItem("Bessel",
+            static_cast<int>(ClientEq::FilterFamily::Bessel));
+        m_familyCombo->addItem("Elliptic",
+            static_cast<int>(ClientEq::FilterFamily::Elliptic));
+        m_familyCombo->setFixedHeight(24);
+        m_familyCombo->setToolTip(
+            "Filter family for HP / LP cascade math.\n"
+            "• Butterworth — maximally flat passband\n"
+            "• Chebyshev — steeper transition, 1 dB passband ripple\n"
+            "• Bessel — linear phase, gentler rolloff\n"
+            "• Elliptic — steepest transition, ripple in both bands");
+        m_familyCombo->setStyleSheet(
+            "QComboBox {"
+            "  background: #0e1b28; color: #c8d8e8;"
+            "  border: 1px solid #243a4e; border-radius: 3px;"
+            "  padding: 2px 8px; font-size: 11px; font-weight: bold;"
+            "}"
+            "QComboBox:hover { background: #1a2a3a; }"
+            "QComboBox::drop-down { border: none; width: 16px; }"
+            "QComboBox QAbstractItemView {"
+            "  background: #0e1b28; color: #c8d8e8;"
+            "  selection-background-color: #1a3a5a;"
+            "  border: 1px solid #243a4e;"
+            "}");
+        connect(m_familyCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this](int idx) {
+            ClientEq* eq = (m_path == ClientEqApplet::Path::Rx)
+                ? m_audio->clientEqRx() : m_audio->clientEqTx();
+            if (!eq) return;
+            eq->setFilterFamily(static_cast<ClientEq::FilterFamily>(idx));
+            if (m_audio) m_audio->saveClientEqSettings();
+            if (m_canvas) m_canvas->update();
+        });
+        row->addWidget(m_familyCombo);
+
         m_bypass = new QPushButton("BYPASS");
         m_bypass->setCheckable(true);
         m_bypass->setStyleSheet(kBypassStyle);
@@ -111,19 +155,44 @@ ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
         if (m_bypass) m_bypass->toggle();
     });
 
-    // Filter-type icon row: one glyph per active band at the top.
+    // Main body: icon row + canvas + param row stacked vertically, with
+    // the output fader in a sibling column on the right.  The fader spans
+    // the full height of the EQ strip so its meter aligns with the
+    // canvas's visible range.
+    auto* body = new QHBoxLayout;
+    body->setContentsMargins(0, 0, 0, 0);
+    body->setSpacing(8);
+
+    auto* eqColumn = new QVBoxLayout;
+    eqColumn->setContentsMargins(0, 0, 0, 0);
+    eqColumn->setSpacing(6);
+
     m_iconRow = new ClientEqIconRow;
     m_iconRow->setAudioEngine(m_audio);
-    root->addWidget(m_iconRow);
+    eqColumn->addWidget(m_iconRow);
 
-    // Central interactive curve canvas.
     m_canvas = new ClientEqEditorCanvas;
     m_canvas->setAudioEngine(m_audio);
-    root->addWidget(m_canvas, 1);
+    eqColumn->addWidget(m_canvas, 1);
 
-    // Bottom parameter-text row.
     m_paramRow = new ClientEqParamRow;
-    root->addWidget(m_paramRow);
+    eqColumn->addWidget(m_paramRow);
+
+    body->addLayout(eqColumn, 1);
+
+    // Output fader — vertical meter + slider + dB readout on the right.
+    m_outFader = new ClientEqOutputFader;
+    connect(m_outFader, &ClientEqOutputFader::gainChanged,
+            this, [this](float linear) {
+        ClientEq* eq = (m_path == ClientEqApplet::Path::Rx)
+            ? m_audio->clientEqRx() : m_audio->clientEqTx();
+        if (!eq) return;
+        eq->setMasterGain(linear);
+        if (m_audio) m_audio->saveClientEqSettings();
+    });
+    body->addWidget(m_outFader);
+
+    root->addLayout(body, 1);
 
     // Selection plumbing: any of the three views announcing a selection
     // change fans out to the other two, plus triggers a paint refresh.
@@ -183,6 +252,16 @@ void ClientEqEditor::tickFftAnalyzer()
         ? m_audio->clientEqRx() : m_audio->clientEqTx();
     const double fs = eq ? eq->sampleRate() : 24000.0;
     m_canvas->setFftBinsDb(m_fftAnalyzer->magnitudesDb(), fs);
+
+    // Feed the output fader a peak level from the same samples.  Cheap —
+    // one pass over the 2048-sample block while we already have it warm.
+    if (m_outFader) {
+        float peak = 0.0f;
+        for (float s : samples) {
+            peak = std::max(peak, std::fabs(s));
+        }
+        m_outFader->setPeakLinear(peak);
+    }
 }
 
 void ClientEqEditor::syncBypassFromEq()
@@ -215,6 +294,11 @@ void ClientEqEditor::showForPath(ClientEqApplet::Path path)
     m_canvas->setEq(eq);
     if (m_iconRow)  m_iconRow->setEq(eq);
     if (m_paramRow) m_paramRow->setEq(eq);
+    if (m_outFader && eq) m_outFader->setGainLinear(eq->masterGain());
+    if (m_familyCombo && eq) {
+        QSignalBlocker b(m_familyCombo);
+        m_familyCombo->setCurrentIndex(static_cast<int>(eq->filterFamily()));
+    }
     syncBypassFromEq();
     // Clear selection on path swap — the previously-selected index
     // almost certainly doesn't correspond to the other path's bands.

--- a/src/gui/ClientEqEditor.h
+++ b/src/gui/ClientEqEditor.h
@@ -4,6 +4,7 @@
 #include <QWidget>
 #include <memory>
 
+class QComboBox;
 class QLabel;
 class QPushButton;
 class QTimer;
@@ -14,6 +15,7 @@ class AudioEngine;
 class ClientEqEditorCanvas;
 class ClientEqFftAnalyzer;
 class ClientEqIconRow;
+class ClientEqOutputFader;
 class ClientEqParamRow;
 
 // Floating editor window for the client-side parametric EQ. One single
@@ -67,10 +69,12 @@ private:
     AudioEngine*               m_audio{nullptr};
     ClientEqApplet::Path       m_path{ClientEqApplet::Path::Rx};
     QLabel*                    m_pathLabel{nullptr};
+    QComboBox*                 m_familyCombo{nullptr};
     QPushButton*               m_bypass{nullptr};
     ClientEqIconRow*           m_iconRow{nullptr};
     ClientEqEditorCanvas*      m_canvas{nullptr};
     ClientEqParamRow*          m_paramRow{nullptr};
+    ClientEqOutputFader*       m_outFader{nullptr};
     QTimer*                    m_fftTimer{nullptr};
     std::unique_ptr<ClientEqFftAnalyzer> m_fftAnalyzer;
     bool                       m_restoring{false};

--- a/src/gui/ClientEqEditorCanvas.cpp
+++ b/src/gui/ClientEqEditorCanvas.cpp
@@ -75,7 +75,14 @@ void ClientEqEditorCanvas::mousePressEvent(QMouseEvent* ev)
 
     setSelectedBand(idx);
 
-    const auto bp = m_eq->band(idx);
+    auto bp = m_eq->band(idx);
+    // Auto-enable on interaction: the 8 default slots start disabled so
+    // the EQ is audibly transparent until the user grabs a handle.
+    if (!bp.enabled) {
+        bp.enabled = true;
+        m_eq->setBand(idx, bp);
+        emit bandsChanged();
+    }
     m_draggingBand = idx;
     m_dragShift    = (ev->modifiers() & Qt::ShiftModifier) != 0;
     m_dragStart    = ev->position();
@@ -136,53 +143,10 @@ void ClientEqEditorCanvas::mouseReleaseEvent(QMouseEvent* ev)
 
 void ClientEqEditorCanvas::mouseDoubleClickEvent(QMouseEvent* ev)
 {
-    if (!m_eq) { QWidget::mouseDoubleClickEvent(ev); return; }
-    if (ev->button() != Qt::LeftButton) { QWidget::mouseDoubleClickEvent(ev); return; }
-
-    // Adding a new band on empty space. If a handle is near, let the hit
-    // test (which also drives regular drag) handle it on the single-press
-    // pass — here we only care about empty-area creation.
-    if (hitTestHandle(ev->position()) >= 0) {
-        QWidget::mouseDoubleClickEvent(ev);
-        return;
-    }
-
-    const int bandCount = m_eq->activeBandCount();
-    if (bandCount >= ClientEq::kMaxBands) return;
-
-    // Auto-pick the filter type from click position: HP near left edge,
-    // LP near right edge, shelves at top/bottom extremes, peak otherwise.
-    const float xNorm = static_cast<float>(ev->position().x()) / width();
-    const float yNorm = static_cast<float>(ev->position().y()) / height();
-    ClientEq::FilterType type = ClientEq::FilterType::Peak;
-    if (xNorm < 0.08f) {
-        type = ClientEq::FilterType::HighPass;
-    } else if (xNorm > 0.92f) {
-        type = ClientEq::FilterType::LowPass;
-    } else if (yNorm < 0.12f && xNorm < 0.4f) {
-        type = ClientEq::FilterType::LowShelf;
-    } else if (yNorm < 0.12f && xNorm > 0.6f) {
-        type = ClientEq::FilterType::HighShelf;
-    }
-
-    ClientEq::BandParams bp;
-    bp.type    = type;
-    bp.freqHz  = xToFreq(static_cast<float>(ev->position().x()));
-    bp.gainDb  = (type == ClientEq::FilterType::LowPass
-               || type == ClientEq::FilterType::HighPass)
-                 ? 0.0f
-                 : std::clamp(yToDb(static_cast<float>(ev->position().y())),
-                              -18.0f, 18.0f);
-    bp.q       = (type == ClientEq::FilterType::LowPass
-               || type == ClientEq::FilterType::HighPass)
-                 ? 0.707f
-                 : 1.0f;
-    bp.enabled = true;
-    m_eq->setBand(bandCount, bp);
-    m_eq->setActiveBandCount(bandCount + 1);
-    setSelectedBand(bandCount);
-    persist();
-    ev->accept();
+    // Double-click is a no-op under the fixed-8-band model. Handle with
+    // a regular press so the user still gets selection + drag on the
+    // second click rather than a dead gesture.
+    QWidget::mouseDoubleClickEvent(ev);
 }
 
 void ClientEqEditorCanvas::contextMenuEvent(QContextMenuEvent* ev)
@@ -205,20 +169,42 @@ void ClientEqEditorCanvas::contextMenuEvent(QContextMenuEvent* ev)
     typeLabel->setEnabled(false);
     menu.addSeparator();
 
-    auto* peakAct = menu.addAction("Set type: Peak");
-    auto* lsAct   = menu.addAction("Set type: Low Shelf");
-    auto* hsAct   = menu.addAction("Set type: High Shelf");
-    auto* lpAct   = menu.addAction("Set type: Low Pass");
-    auto* hpAct   = menu.addAction("Set type: High Pass");
+    auto* peakAct  = menu.addAction("Set type: Peak");
+    auto* lsAct    = menu.addAction("Set type: Low Shelf");
+    auto* hsAct    = menu.addAction("Set type: High Shelf");
+    auto* lpAct    = menu.addAction("Set type: Low Pass");
+    auto* hpAct    = menu.addAction("Set type: High Pass");
+
+    // Slope submenu — only meaningful for HP / LP bands.
+    const bool isSlope = (bp.type == ClientEq::FilterType::LowPass
+                       || bp.type == ClientEq::FilterType::HighPass);
+    QMenu* slopeMenu = nullptr;
+    QList<QAction*> slopeActions;
+    if (isSlope) {
+        menu.addSeparator();
+        slopeMenu = menu.addMenu(QString("Slope  (%1 dB/oct)")
+                                     .arg(bp.slopeDbPerOct));
+        for (int s : {12, 24, 36, 48}) {
+            auto* a = slopeMenu->addAction(QString("%1 dB/oct").arg(s));
+            a->setCheckable(true);
+            a->setChecked(bp.slopeDbPerOct == s);
+            a->setData(s);
+            slopeActions.append(a);
+        }
+    }
+
     menu.addSeparator();
-    auto* enAct   = menu.addAction(bp.enabled ? "Bypass band" : "Enable band");
-    auto* delAct  = menu.addAction("Delete band");
+    auto* enAct    = menu.addAction(bp.enabled ? "Bypass band" : "Enable band");
+    auto* resetAct = menu.addAction("Reset to default");
 
     QAction* chosen = menu.exec(ev->globalPos());
     if (!chosen) return;
 
     auto change = [&](ClientEq::FilterType t) {
-        ClientEq::BandParams p = bp; p.type = t; m_eq->setBand(idx, p);
+        // Changing the type also enables the band — the user clearly
+        // wants it active if they're reshaping it.
+        ClientEq::BandParams p = bp; p.type = t; p.enabled = true;
+        m_eq->setBand(idx, p);
     };
     if      (chosen == peakAct) change(ClientEq::FilterType::Peak);
     else if (chosen == lsAct)   change(ClientEq::FilterType::LowShelf);
@@ -228,26 +214,17 @@ void ClientEqEditorCanvas::contextMenuEvent(QContextMenuEvent* ev)
     else if (chosen == enAct) {
         ClientEq::BandParams p = bp; p.enabled = !bp.enabled; m_eq->setBand(idx, p);
     }
-    else if (chosen == delAct) {
-        // Collapse: shift all later bands down one slot, shrink active count.
-        const int n = m_eq->activeBandCount();
-        for (int i = idx; i < n - 1; ++i) {
-            m_eq->setBand(i, m_eq->band(i + 1));
-        }
-        // Blank out the now-unused top slot so stale data doesn't leak
-        // back on a future resize.
-        if (n - 1 < ClientEq::kMaxBands) {
-            ClientEq::BandParams blank;
-            m_eq->setBand(n - 1, blank);
-        }
-        m_eq->setActiveBandCount(n - 1);
-        // Adjust selection: if we deleted the selected band, clear;
-        // if the selected band sat above the deletion, shift down.
-        if (selectedBand() == idx) {
-            setSelectedBand(-1);
-        } else if (selectedBand() > idx) {
-            setSelectedBand(selectedBand() - 1);
-        }
+    else if (chosen == resetAct) {
+        // Restore this slot's factory preset — type, freq, Q all reset;
+        // band is left disabled so the row returns to the quiet starting
+        // state (matches the "disabled default" feel of fresh launch).
+        m_eq->setBand(idx, ClientEq::defaultBand(idx));
+    }
+    else if (slopeActions.contains(chosen)) {
+        ClientEq::BandParams p = bp;
+        p.slopeDbPerOct = chosen->data().toInt();
+        p.enabled = true;  // explicit edit = enable
+        m_eq->setBand(idx, p);
     }
     persist();
     ev->accept();

--- a/src/gui/ClientEqIconRow.cpp
+++ b/src/gui/ClientEqIconRow.cpp
@@ -19,7 +19,12 @@ public:
         : QWidget(parent), m_bandIdx(bandIdx),
           m_eq(eq), m_audio(audio), m_row(row)
     {
-        setFixedSize(40, 26);
+        // Fixed height, stretchable width — each of the 8 row columns
+        // gets equal share of the canvas width so icons align with the
+        // bottom param columns.
+        setFixedHeight(52);
+        setMinimumWidth(40);
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         setCursor(Qt::PointingHandCursor);
     }
 
@@ -93,21 +98,27 @@ protected:
             break;
         }
         case ClientEq::FilterType::LowPass: {
-            // Flat on left, falls to the right.
-            path.moveTo(gx,            midY);
-            path.lineTo(gx + gw * 0.40f, midY);
-            path.cubicTo(gx + gw * 0.60f, midY,
+            // Flat passband on the left at the shelf-top level, falls on
+            // the right.  Start-point height matches the HS icon's
+            // end-point so the LP+HS pair reads as a continuous curve
+            // across adjacent slots.
+            path.moveTo(gx,            gy + gh * 0.18f);
+            path.lineTo(gx + gw * 0.40f, gy + gh * 0.18f);
+            path.cubicTo(gx + gw * 0.60f, gy + gh * 0.18f,
                          gx + gw * 0.70f, gy + gh * 0.85f,
                          gx + gw,        gy + gh * 0.85f);
             break;
         }
         case ClientEq::FilterType::HighPass: {
-            // Rises on the left, flat on the right.
+            // Rises on the left, flat passband on the right at the shelf-
+            // top level.  End-point matches the LS icon's start-point so
+            // the HP+LS pair reads as a continuous curve across adjacent
+            // slots.
             path.moveTo(gx,            gy + gh * 0.85f);
             path.cubicTo(gx + gw * 0.30f, gy + gh * 0.85f,
-                         gx + gw * 0.40f, midY,
-                         gx + gw * 0.60f, midY);
-            path.lineTo(gx + gw,        midY);
+                         gx + gw * 0.40f, gy + gh * 0.18f,
+                         gx + gw * 0.60f, gy + gh * 0.18f);
+            path.lineTo(gx + gw,        gy + gh * 0.18f);
             break;
         }
         }
@@ -126,6 +137,9 @@ protected:
             t += (ev->modifiers() & Qt::ShiftModifier) ? -1 : 1;
             t = (t % kTypes + kTypes) % kTypes;
             bp.type = static_cast<ClientEq::FilterType>(t);
+            // Clicking an icon is an explicit interaction — auto-enable
+            // the band so the default disabled layout activates in place.
+            bp.enabled = true;
             m_eq->setBand(m_bandIdx, bp);
             if (m_audio) m_audio->saveClientEqSettings();
             update();
@@ -145,9 +159,11 @@ ClientEqIconRow::ClientEqIconRow(QWidget* parent) : QWidget(parent)
 {
     m_layout = new QHBoxLayout(this);
     m_layout->setContentsMargins(0, 0, 0, 0);
-    m_layout->setSpacing(3);
-    m_layout->addStretch();
-    setFixedHeight(30);
+    // 10 px gap between icon cells for visual breathing room.  The
+    // ClientEqParamRow uses the same spacing so column i in both rows
+    // occupies the same horizontal slot.
+    m_layout->setSpacing(10);
+    setFixedHeight(60);
 }
 
 void ClientEqIconRow::setEq(ClientEq* eq)
@@ -194,19 +210,16 @@ void ClientEqIconRow::rebuild()
         delete it;
     }
 
-    if (!m_eq) {
-        m_layout->addStretch();
-        return;
-    }
+    if (!m_eq) return;
 
     const int n = m_eq->activeBandCount();
-    // Center the icon row — leading stretch, icons, trailing stretch.
-    m_layout->addStretch();
+    // Fill the full row width with n equal-stretch cells — no leading or
+    // trailing stretch — so icon column i aligns with param column i in
+    // the ClientEqParamRow below the canvas.
     for (int i = 0; i < n; ++i) {
         auto* btn = new IconButton(i, m_eq, m_audio, this, this);
-        m_layout->addWidget(btn);
+        m_layout->addWidget(btn, 1);
     }
-    m_layout->addStretch();
 }
 
 } // namespace AetherSDR

--- a/src/gui/ClientEqOutputFader.cpp
+++ b/src/gui/ClientEqOutputFader.cpp
@@ -1,0 +1,265 @@
+#include "ClientEqOutputFader.h"
+
+#include <QLabel>
+#include <QLinearGradient>
+#include <QMouseEvent>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QVBoxLayout>
+#include <QWheelEvent>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+float linearToDb(float linear)
+{
+    if (linear <= 1e-6f) return -120.0f;
+    return 20.0f * std::log10(linear);
+}
+
+float dbToLinear(float db)
+{
+    return std::pow(10.0f, db / 20.0f);
+}
+
+// Attack / release for the displayed peak — fast rise, slow fall so the
+// bar tracks transients but doesn't flicker.
+constexpr float kPeakAttack  = 0.6f;
+constexpr float kPeakRelease = 0.08f;
+
+} // namespace
+
+ClientEqOutputFader::ClientEqOutputFader(QWidget* parent) : QWidget(parent)
+{
+    // Total width = label column + gap + bar + overhang each side.
+    setFixedWidth(kLabelColW + kGap + kBarW + kHandleOverhang * 2 + 2);
+    setMinimumHeight(160);
+    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+    setFocusPolicy(Qt::ClickFocus);
+    setCursor(Qt::ArrowCursor);
+    setMouseTracking(false);
+    setToolTip(
+        "Output gain (dB). Drag to set, wheel for fine step,\n"
+        "double-click to reset to 0 dB.");
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(0, 2, 0, 2);
+    root->setSpacing(0);
+
+    auto* top = new QLabel("OUT");
+    top->setAlignment(Qt::AlignCenter);
+    top->setStyleSheet(
+        "QLabel { color: #8aa8c0; font-size: 10px; font-weight: bold;"
+        " background: transparent; border: none; }");
+    root->addWidget(top);
+
+    root->addStretch(1);
+
+    m_valueLabel = new QLabel;
+    m_valueLabel->setAlignment(Qt::AlignCenter);
+    m_valueLabel->setStyleSheet(
+        "QLabel { color: #d7e7f2; font-size: 10px; font-weight: bold;"
+        " background: transparent; border: none; }");
+    root->addWidget(m_valueLabel);
+
+    refreshValueLabel();
+}
+
+void ClientEqOutputFader::setGainLinear(float linear)
+{
+    m_gain = std::clamp(linear, 0.0f, 4.0f);
+    refreshValueLabel();
+    update();
+}
+
+void ClientEqOutputFader::setPeakLinear(float peakLinear)
+{
+    const float peakDb = linearToDb(std::max(peakLinear, 1e-6f));
+    const float alpha = (peakDb > m_smoothedPeak) ? kPeakAttack : kPeakRelease;
+    m_smoothedPeak += alpha * (peakDb - m_smoothedPeak);
+    update();
+}
+
+void ClientEqOutputFader::refreshValueLabel()
+{
+    const float db = linearToDb(m_gain);
+    if (db <= kGainMinDb + 0.05f) {
+        m_valueLabel->setText("-inf");
+    } else {
+        m_valueLabel->setText(QString::asprintf("%+.1f dB", db));
+    }
+}
+
+void ClientEqOutputFader::setGainFromY(int y)
+{
+    const float norm = 1.0f - std::clamp(
+        static_cast<float>(y - m_stripTop) / std::max(1, m_stripH), 0.0f, 1.0f);
+    const float db = kGainMinDb + norm * (kGainMaxDb - kGainMinDb);
+    m_gain = dbToLinear(db);
+    refreshValueLabel();
+    emit gainChanged(m_gain);
+    update();
+}
+
+void ClientEqOutputFader::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, false);
+    p.setRenderHint(QPainter::TextAntialiasing, true);
+
+    // The strip lives between the OUT label at the top and the value
+    // label at the bottom — paintEvent receives the full widget rect and
+    // we carve out a fixed vertical band in the middle.
+    const int topLabelH = 16;
+    const int botLabelH = 14;
+    const int stripTop  = topLabelH + kStripTopPad;
+    const int stripBot  = height() - botLabelH - kStripBottomPad;
+    m_stripTop = stripTop;
+    m_stripH   = std::max(1, stripBot - stripTop);
+
+    const int barLeft = kLabelColW + kGap + kHandleOverhang;
+    const QRect barR(barLeft, stripTop, kBarW, m_stripH);
+
+    // Background for the bar — dark inset.
+    p.fillRect(barR, QColor("#06111c"));
+
+    // Level fill — gradient bottom green → top red, clipped to the level
+    // height derived from the smoothed peak.
+    const float peakNorm = std::clamp(
+        (m_smoothedPeak - kMeterMinDb) / (kMeterMaxDb - kMeterMinDb),
+        0.0f, 1.0f);
+    const int fillH = static_cast<int>(peakNorm * m_stripH);
+    if (fillH > 0) {
+        const QRect fill(barR.x(), barR.y() + m_stripH - fillH,
+                         kBarW, fillH);
+        QLinearGradient grad(0, barR.y() + m_stripH, 0, barR.y());
+        grad.setColorAt(0.0, QColor("#2f9e6a"));   // green bottom
+        grad.setColorAt(0.55, QColor("#6cc56a"));  // lime
+        grad.setColorAt(0.80, QColor("#e8b94c"));  // amber
+        grad.setColorAt(0.95, QColor("#e8553c"));  // red top
+        grad.setColorAt(1.0, QColor("#f2362a"));
+        p.fillRect(fill, grad);
+    }
+
+    // Bar outline.
+    p.setPen(QPen(QColor("#243a4e"), 1));
+    p.setBrush(Qt::NoBrush);
+    p.drawRect(barR.adjusted(0, 0, -1, -1));
+
+    // dB scale labels + tick marks on the left side.
+    QFont f = p.font();
+    f.setPixelSize(8);
+    p.setFont(f);
+    const QFontMetrics fm(f);
+    const int textRight = kLabelColW - 2;
+
+    struct Tick { float db; const char* label; };
+    static constexpr Tick kTicks[] = {
+        {   0.0f,  "0" },
+        {  -6.0f,  "-6" },
+        { -12.0f,  "-12" },
+        { -20.0f,  "-20" },
+        { -40.0f,  "-40" },
+    };
+    for (const auto& t : kTicks) {
+        const float norm = (t.db - kMeterMinDb) / (kMeterMaxDb - kMeterMinDb);
+        const int y = stripTop + static_cast<int>((1.0f - norm) * m_stripH);
+
+        p.setPen(QColor("#7f93a5"));
+        const QString s = QString::fromLatin1(t.label);
+        const int tw = fm.horizontalAdvance(s);
+        const int ty = std::clamp(y + fm.ascent() / 2 - 1,
+                                  stripTop + fm.ascent() - 1,
+                                  stripTop + m_stripH - 1);
+        p.drawText(textRight - tw, ty, s);
+
+        p.setPen(QColor("#405060"));
+        p.drawLine(textRight, y, barLeft - 1, y);
+    }
+
+    // Fader handle — horizontal bar that overhangs the meter on both
+    // sides so it's easy to grab without covering the level colour.
+    const float gainDb = std::clamp(linearToDb(m_gain),
+                                    kGainMinDb, kGainMaxDb);
+    const float gainNorm = (kGainMaxDb - gainDb) / (kGainMaxDb - kGainMinDb);
+    const int handleY = stripTop + static_cast<int>(gainNorm * m_stripH);
+    const QRect handleR(barLeft - kHandleOverhang,
+                        handleY - kHandleH / 2,
+                        kBarW + kHandleOverhang * 2,
+                        kHandleH);
+    p.setPen(QPen(QColor("#0a1a28"), 1));
+    p.setBrush(QColor("#d7e7f2"));   // cream / bright off-white
+    p.drawRect(handleR);
+    // Centre line — a single pixel on the handle so the exact gain level
+    // reads clearly against the bar's colour.
+    p.setPen(QColor("#1a2a3a"));
+    p.drawLine(handleR.left() + 1, handleY,
+               handleR.right() - 1, handleY);
+
+    Q_UNUSED(barR);
+}
+
+void ClientEqOutputFader::mousePressEvent(QMouseEvent* ev)
+{
+    if (ev->button() == Qt::LeftButton) {
+        m_dragging = true;
+        setCursor(Qt::ClosedHandCursor);
+        setGainFromY(ev->pos().y());
+        ev->accept();
+        return;
+    }
+    QWidget::mousePressEvent(ev);
+}
+
+void ClientEqOutputFader::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (m_dragging) {
+        setGainFromY(ev->pos().y());
+        ev->accept();
+        return;
+    }
+    QWidget::mouseMoveEvent(ev);
+}
+
+void ClientEqOutputFader::mouseReleaseEvent(QMouseEvent* ev)
+{
+    if (m_dragging && ev->button() == Qt::LeftButton) {
+        m_dragging = false;
+        setCursor(Qt::ArrowCursor);
+        ev->accept();
+        return;
+    }
+    QWidget::mouseReleaseEvent(ev);
+}
+
+void ClientEqOutputFader::mouseDoubleClickEvent(QMouseEvent* ev)
+{
+    if (ev->button() == Qt::LeftButton) {
+        m_gain = 1.0f;  // 0 dB
+        refreshValueLabel();
+        emit gainChanged(m_gain);
+        update();
+        ev->accept();
+        return;
+    }
+    QWidget::mouseDoubleClickEvent(ev);
+}
+
+void ClientEqOutputFader::wheelEvent(QWheelEvent* ev)
+{
+    // 0.5 dB per notch (12 notches for a full deg of the wheel).
+    const int notches = ev->angleDelta().y() / 120;
+    if (notches == 0) { QWidget::wheelEvent(ev); return; }
+    const float db = std::clamp(linearToDb(m_gain) + 0.5f * notches,
+                                kGainMinDb, kGainMaxDb);
+    m_gain = dbToLinear(db);
+    refreshValueLabel();
+    emit gainChanged(m_gain);
+    update();
+    ev->accept();
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientEqOutputFader.h
+++ b/src/gui/ClientEqOutputFader.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <QWidget>
+
+class QLabel;
+
+namespace AetherSDR {
+
+// Combined vertical fader + level meter.  One custom-painted bar shows
+// the post-EQ peak level as a gradient fill rising from the bottom, with
+// a horizontal handle marker at the current output-gain position.  Drag
+// the handle up/down to change gain, double-click to reset to 0 dB,
+// scroll wheel for fine 0.5 dB steps.
+//
+// The widget writes a linear gain [0.0, ~4.0] back via gainChanged(); the
+// editor's existing FFT timer feeds in a peak at ~25 Hz so the meter
+// stays lively without a separate polling loop.
+class ClientEqOutputFader : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientEqOutputFader(QWidget* parent = nullptr);
+
+    void setGainLinear(float linear);
+    float gainLinear() const { return m_gain; }
+
+    void setPeakLinear(float peakLinear);
+
+signals:
+    void gainChanged(float linear);
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseMoveEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
+    void mouseDoubleClickEvent(QMouseEvent* ev) override;
+    void wheelEvent(QWheelEvent* ev) override;
+
+private:
+    void refreshValueLabel();
+    void setGainFromY(int y);
+
+    QLabel* m_valueLabel{nullptr};
+    float   m_gain{1.0f};
+    float   m_smoothedPeak{-120.0f};  // dB
+    bool    m_dragging{false};
+
+    // dB ranges
+    static constexpr float kGainMinDb  = -36.0f;
+    static constexpr float kGainMaxDb  = +12.0f;
+    static constexpr float kMeterMinDb = -60.0f;
+    static constexpr float kMeterMaxDb =   0.0f;
+
+    // Layout constants
+    static constexpr int kLabelColW = 20;
+    static constexpr int kGap       = 2;
+    static constexpr int kBarW      = 16;
+    static constexpr int kHandleOverhang = 4;   // handle sticks out on each side
+    static constexpr int kHandleH        = 3;
+
+    // Vertical padding inside the fader strip so the handle can reach the
+    // top / bottom ends without clipping.
+    static constexpr int kStripTopPad    = 4;
+    static constexpr int kStripBottomPad = 4;
+
+    // Cached strip rect — recomputed in paintEvent.  Used by mouse handlers
+    // so they don't recompute geometry on every move.
+    int m_stripTop{0};
+    int m_stripH{0};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientEqParamRow.cpp
+++ b/src/gui/ClientEqParamRow.cpp
@@ -40,7 +40,11 @@ public:
            QWidget* parent = nullptr)
         : QWidget(parent), m_bandIdx(bandIdx), m_eq(eq), m_row(row)
     {
-        setFixedWidth(82);
+        // Equal-stretch column — width is set by the parent row splitting
+        // its canvas-width across all 8 slots so icon column i aligns
+        // with the param column below it.
+        setMinimumWidth(70);
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         setCursor(Qt::PointingHandCursor);
 
         auto* layout = new QVBoxLayout(this);
@@ -76,7 +80,11 @@ public:
         m_freqLbl->setText(formatFreq(bp.freqHz));
         m_gainLbl->setText(formatGain(bp.gainDb));
         m_qLbl->setText(formatQ(bp.q));
-        setEnabled(bp.enabled);
+        // Dim disabled bands via label alpha rather than QWidget::setEnabled
+        // so the column still accepts clicks (letting the user select /
+        // auto-enable it via the canvas or icon).
+        m_bandEnabled = bp.enabled;
+        applyStyle();
     }
 
 protected:
@@ -106,18 +114,26 @@ protected:
 private:
     void applyStyle()
     {
-        const QColor accent = ClientEqCurveWidget::bandColor(m_bandIdx);
+        QColor accent = ClientEqCurveWidget::bandColor(m_bandIdx);
+        QColor qCol("#7f93a5");
+        if (!m_bandEnabled) {
+            // Dim disabled columns so the "available slot" feel is obvious
+            // without greying out so much the user can't read the values.
+            accent.setAlphaF(0.35f);
+            qCol.setAlphaF(0.35f);
+        }
         const QString freqStyle = QString(
             "QLabel { color: %1; font-size: 10px; font-weight: bold;"
             " background: transparent; border: none; }")
-            .arg(accent.name());
+            .arg(accent.name(QColor::HexArgb));
         const QString gainStyle = QString(
             "QLabel { color: %1; font-size: 12px; font-weight: bold;"
             " background: transparent; border: none; padding: 1px 0px; }")
-            .arg(accent.name());
-        const QString qStyle =
-            "QLabel { color: #7f93a5; font-size: 10px;"
-            " background: transparent; border: none; }";
+            .arg(accent.name(QColor::HexArgb));
+        const QString qStyle = QString(
+            "QLabel { color: %1; font-size: 10px;"
+            " background: transparent; border: none; }")
+            .arg(qCol.name(QColor::HexArgb));
         m_freqLbl->setStyleSheet(freqStyle);
         m_gainLbl->setStyleSheet(gainStyle);
         m_qLbl->setStyleSheet(qStyle);
@@ -125,6 +141,7 @@ private:
 
     int   m_bandIdx{0};
     bool  m_selected{false};
+    bool  m_bandEnabled{true};
     ClientEq* m_eq{nullptr};
     ClientEqParamRow* m_row{nullptr};
     QLabel*  m_freqLbl{nullptr};
@@ -136,8 +153,9 @@ ClientEqParamRow::ClientEqParamRow(QWidget* parent) : QWidget(parent)
 {
     m_layout = new QHBoxLayout(this);
     m_layout->setContentsMargins(0, 0, 0, 0);
-    m_layout->setSpacing(6);
-    m_layout->addStretch();
+    // Matches ClientEqIconRow spacing so param column i sits directly
+    // beneath icon column i (a single visual strip across the editor).
+    m_layout->setSpacing(10);
     setFixedHeight(58);
 }
 
@@ -187,18 +205,16 @@ void ClientEqParamRow::rebuild()
         delete it;
     }
 
-    if (!m_eq) {
-        m_layout->addStretch();
-        return;
-    }
+    if (!m_eq) return;
 
+    // Full-width row with N equal-stretch columns — no side stretches.
+    // Column i occupies the same horizontal slot as IconRow icon i so
+    // they read as one visual strip.
     const int n = m_eq->activeBandCount();
-    m_layout->addStretch();
     for (int i = 0; i < n; ++i) {
         auto* col = new Column(i, m_eq, this, this);
-        m_layout->addWidget(col);
+        m_layout->addWidget(col, 1);
     }
-    m_layout->addStretch();
 }
 
 } // namespace AetherSDR


### PR DESCRIPTION
One big push to take the client EQ from "useful toy" to "best in SDR."

DSP — multi-section cascade + filter families:
- Each pass (HP / LP) band now cascades up to 4 biquad sections for
  slopes of 12 / 24 / 36 / 48 dB/oct (peak and shelf stay native 2nd-
  order — higher-order shelves are unusual and confuse the mental model)
- Global FilterFamily enum: Butterworth, Chebyshev I (1 dB ripple),
  Bessel (tabulated pole Q/mag for orders 2-8), and a Chebyshev-II-ish
  Elliptic approximation.  True elliptic with stopband zeros is a
  follow-up; the current approximation already reads as visibly and
  audibly steeper than Butterworth
- Display path (bandMagnitudeDb) takes a FilterFamily argument and sums
  section magnitudes in dB — analog prototype math throughout, evaluated
  in double precision so the curve stays clean at all frequencies

UX — 10-band fixed layout, auto-enable, slope control:
- Default layout: HP / LS / 6× Peak / HS / LP, all disabled on first
  launch so the 10 handles read as a horizontal row of dots until the
  user interacts.  Existing users' saved bands migrate into slots
  [0..saved_count); remaining slots fill with disabled defaults
- Grabbing a handle or clicking an icon auto-enables the band
- Right-click menu: type picker, bypass, reset-to-default; HP/LP also
  get a Slope submenu with 12/24/36/48 dB/oct
- Global filter-family combo added to the top bar (left of BYPASS)
- Defaults snapped to Butterworth Q = 0.707 everywhere so the EQ starts
  flat and neutral

Visualisation clean-ups:
- EQ response curve drawn from the analog prototype — no Nyquist folding,
  no shelf past fs/2, no low-end precision loss
- FFT bumped from 256 to 2048 points so the bin-1 frequency (~12 Hz)
  falls below the 20 Hz display floor — no more low-end "wall"
- FFT gradient terminates at last valid bin instead of the canvas right
  edge so there's no misleading plateau above Nyquist
- Filter-type icons redrawn so HP rises to the shelf-top line (matches
  LS start) and LP starts at the shelf-top line (matches HS end) —
  icons read as one continuous shape across the row

Output fader (right edge of editor):
- Single custom-painted widget combining a vertical peak meter and a
  horizontal fader handle that overhangs the bar on both sides — one
  visual object instead of separate meter + QSlider
- dB scale labels (0 / -6 / -12 / -20 / -40) with tick marks to the left
- Mouse: click-drag the handle, wheel for 0.5 dB fine step, double-click
  resets to 0 dB
- Fed by the existing audio tap's per-block peak at the FFT timer rate
- Master gain applied post-cascade in ClientEq::process(), skipped at
  unity to avoid an unnecessary sample pass

Settings: adds ClientEq{Rx,Tx}_FilterFamily, ClientEq{Rx,Tx}_MasterGain,
and per-band ClientEq{Rx,Tx}_Band{N}_Slope keys.  Existing saves load
cleanly — new keys fall back to sane defaults.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
