### PR TITLE
Client-side TX Compressor (Pro-XL-style, Phase 1) — DSP, applet, editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to AetherSDR are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [v0.8.17] — 2026-04-19
+
+### Client-side TX Compressor (Pro-XL-style, Phase 1)
+
+### Features
+
+**Client-side TX dynamics processor (#1661)**
+- Feed-forward compressor with soft-knee quadratic interpolation, linear-
+  domain peak envelope detection, stereo-linked gain application, and a
+  brickwall peak limiter on the output
+- Parameters: threshold (-60..0 dB), ratio (1:1..20:1), attack (0.1..300 ms),
+  release (5..2000 ms), knee (0..24 dB), makeup (-12..+24 dB), limiter
+  enable + ceiling (-24..0 dB)
+- Chain-order toggle in the editor: CMP→EQ (default, colour-then-shape)
+  or EQ→CMP (shape-then-tame) — the two client-side TX DSP stages now
+  run in a user-configurable order
+- Atomic parameter handoff from UI to audio thread, lock-free, no alloc
+  in process(), identical pattern to ClientEq
+
+**Docked Compressor applet + floating editor**
+- View-only CMP tile in the applet tray: live transfer curve with a
+  glowing ball that slides along the curve at the current envelope level,
+  horizontal GR strip beneath, Bypass toggle + Edit… button
+- Full floating editor (Ableton-inspired, extended for our limiter and
+  chain order): rotary knobs for Ratio / Attack / Release / Knee /
+  Makeup / Ceiling, interactive transfer curve with draggable threshold
+  handle + ratio handle, vertical Input / GR / Output meters, Limiter
+  enable toggle, chain-order selector, persistent window geometry
+- Meter ballistics match Phone/CW Level (30 ms attack, 180 ms release)
+
+**DSP test harness**
+- tests/client_comp_test.cpp — 11 standalone smoke tests: bypass,
+  below-threshold passthrough, static ratio (4:1 and 20:1), makeup,
+  limiter ceiling, stereo linking, attack timing, soft-knee monotonicity,
+  transient sanity, reset(). Built as `client_comp_test` CMake target.
+
+**Settings:** adds ClientCompTx* keys (Enabled, ThresholdDb, Ratio,
+AttackMs, ReleaseMs, KneeDb, MakeupDb, LimEnabled, LimCeilingDb) plus
+ClientCompTxChainOrder and ClientCompEditorGeometry.
+
+Phase 2+ (expander/gate, de-esser, tube, enhancer, low contour, IKA/IRC,
+lookahead limiter, preset system) tracked in #1661 for future releases.
+
 ## [v0.8.16] — 2026-04-18
 
 ### DIGI Applet Split, TCI Audio Reliability, PGXL-Aware S-Meter, Community Contributions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(AetherSDR VERSION 0.8.16 LANGUAGES C CXX)
+project(AetherSDR VERSION 0.8.17 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -402,6 +402,7 @@ set(CORE_SOURCES
     src/core/CommandParser.cpp
     src/core/AudioEngine.cpp
     src/core/ClientEq.cpp
+    src/core/ClientComp.cpp
     src/core/SpectralNR.cpp
     src/core/PanadapterStream.cpp
     src/core/RigctlProtocol.cpp
@@ -512,6 +513,12 @@ set(GUI_SOURCES
     src/gui/ClientEqIconRow.cpp
     src/gui/ClientEqOutputFader.cpp
     src/gui/ClientEqParamRow.cpp
+    src/gui/ClientCompApplet.cpp
+    src/gui/ClientCompCurveWidget.cpp
+    src/gui/ClientCompKnob.cpp
+    src/gui/ClientCompMeter.cpp
+    src/gui/ClientCompEditor.cpp
+    src/gui/ClientCompEditorCanvas.cpp
     src/gui/CatControlApplet.cpp
     src/gui/DaxApplet.cpp
     src/gui/TciApplet.cpp
@@ -1018,6 +1025,12 @@ add_executable(client_eq_test
     src/core/ClientEq.cpp
 )
 target_include_directories(client_eq_test PRIVATE src)
+
+add_executable(client_comp_test
+    tests/client_comp_test.cpp
+    src/core/ClientComp.cpp
+)
+target_include_directories(client_comp_test PRIVATE src)
 
 
 # ── Install rules ────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 AetherSDR brings FlexRadio operation to Linux without Wine or virtual machines. Built from the ground up with Qt6 and C++20, it speaks the SmartSDR protocol natively and aims to replicate the full SmartSDR experience.
 
-**Current version: 0.8.16** | [Download](https://github.com/ten9876/AetherSDR/releases/latest) | [Discussions](https://github.com/ten9876/AetherSDR/discussions) | [What's New](https://github.com/ten9876/AetherSDR/releases)
+**Current version: 0.8.17** | [Download](https://github.com/ten9876/AetherSDR/releases/latest) | [Discussions](https://github.com/ten9876/AetherSDR/discussions) | [What's New](https://github.com/ten9876/AetherSDR/releases)
 
 > **Cross-platform downloads available:** Linux AppImage, macOS universal DMG, Windows installer and portable ZIP.
 > Linux is the primary supported platform. macOS and Windows builds are provided as a courtesy.

--- a/docs/architecture-pipelines.md
+++ b/docs/architecture-pipelines.md
@@ -64,6 +64,13 @@ SpectrumWidget   SpectrumWidget  MeterModel     AudioEngine
 TX AUDIO PIPELINE:                          ◄── AUDIO THREAD
   QAudioSource (mic) ──→ AudioEngine.onTxAudioReady()
                               │
+                              ▼
+                 applyClientTxDsp{Int16,Float32}
+                 (ClientComp + ClientEq in user-configurable order;
+                  CMP→EQ default, EQ→CMP alt.  See src/core/ClientComp.h
+                  and src/core/ClientEq.h.  Lock-free atomics,
+                  meter snapshots published per block.)
+                              │
               ┌───────────────┼───────────────┐
               ▼               ▼               ▼
          Voice mode      DAX TX mode      RADE mode

--- a/docs/tx-audio-signal-path.md
+++ b/docs/tx-audio-signal-path.md
@@ -3,10 +3,40 @@
 Documented from FLEX-8600 firmware v4.1.5 meter definitions.
 All meters are source `TX-` unless noted. Units are dBFS unless noted.
 
-## Signal Flow
+## Client-side TX DSP (AetherSDR, before the radio)
+
+Since v0.8.15 AetherSDR applies its own client-side DSP to the TX
+stream between the mic/VirtualAudioBridge and the VITA-49 encoder.
+The radio receives the already-shaped signal and treats it identically
+to any other PC-mic input (enters at SC_MIC, meter 26).
 
 ```
-PC Mic Audio (Opus via remote_audio_tx)
+Mic capture (QAudioSource) / DAX TX audio
+  │
+  ▼
+┌─────────────────────────────┐
+│  Client EQ   (ClientEq)     │  ◄── 10-band parametric, #1660
+│  Client CMP  (ClientComp)   │  ◄── Pro-XL-style compressor + limiter, #1661
+│                             │     Chain order: CMP→EQ (default) or
+│                             │     EQ→CMP, user-selectable in the
+│                             │     floating editor
+└─────────┬───────────────────┘
+          │
+          ▼  (meters: ClientComp inputPeak/outputPeak/GR/limiterActive,
+          │         ClientEq FFT tap)
+          │
+          ▼
+     VITA-49 encode → UDP → radio
+```
+
+Post-encoding, the radio sees this stream as any other PC-mic source
+and runs it through the firmware TX chain below.
+
+## Firmware Signal Flow
+
+```
+PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
+                                          EQ + CMP already applied
   │
   ▼
 ┌─────────────────────────────┐

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1,6 +1,7 @@
 #include "AudioEngine.h"
 #include "AppSettings.h"
 #include "ClientEq.h"
+#include "ClientComp.h"
 #include "LogManager.h"
 #include "OpusCodec.h"
 #include "SpectralNR.h"
@@ -50,12 +51,15 @@ AudioEngine::AudioEngine(QObject* parent)
     : QObject(parent)
     , m_clientEqRx(std::make_unique<ClientEq>())
     , m_clientEqTx(std::make_unique<ClientEq>())
+    , m_clientCompTx(std::make_unique<ClientComp>())
 {
-    // Prepare client EQs at the native 24 kHz rate. Sink resampling is
+    // Prepare client DSP at the native 24 kHz rate. Sink resampling is
     // handled separately after EQ — EQ always runs at radio-native rate.
     m_clientEqRx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientEqTx->prepare(DEFAULT_SAMPLE_RATE);
-    loadClientEqSettings();  // restore persisted bands before first audio
+    m_clientCompTx->prepare(DEFAULT_SAMPLE_RATE);
+    loadClientEqSettings();    // restore persisted bands before first audio
+    loadClientCompSettings();  // restore persisted comp params + chain order
 
     // Restore saved audio device selections
     auto& s = AppSettings::instance();
@@ -802,6 +806,122 @@ void AudioEngine::applyClientEqTxFloat32(QByteArray& float32)
                           frames, channels);
     tapClientEqTxFloat32(reinterpret_cast<const float*>(float32.constData()),
                          samples, channels);
+}
+
+void AudioEngine::applyClientCompTxInt16(QByteArray& int16stereo)
+{
+    if (!m_clientCompTx || !m_clientCompTx->isEnabled()) return;
+    if (int16stereo.isEmpty()) return;
+
+    const int samples = int16stereo.size() / static_cast<int>(sizeof(int16_t));
+    if ((samples & 1) != 0) return;
+    const int frames = samples / 2;
+
+    m_clientCompTxScratch.resize(samples * static_cast<int>(sizeof(float)));
+    auto* f32 = reinterpret_cast<float*>(m_clientCompTxScratch.data());
+    const auto* i16 = reinterpret_cast<const int16_t*>(int16stereo.constData());
+    for (int i = 0; i < samples; ++i) f32[i] = i16[i] / 32768.0f;
+
+    m_clientCompTx->process(f32, frames, 2);
+
+    auto* out = reinterpret_cast<int16_t*>(int16stereo.data());
+    for (int i = 0; i < samples; ++i) {
+        out[i] = static_cast<int16_t>(
+            std::clamp(f32[i] * 32768.0f, -32768.0f, 32767.0f));
+    }
+}
+
+void AudioEngine::applyClientCompTxFloat32(QByteArray& float32)
+{
+    if (!m_clientCompTx || !m_clientCompTx->isEnabled()) return;
+    if (float32.isEmpty()) return;
+    const int samples  = float32.size() / static_cast<int>(sizeof(float));
+    const int channels = (samples % 2 == 0) ? 2 : 1;
+    const int frames   = samples / channels;
+    m_clientCompTx->process(reinterpret_cast<float*>(float32.data()),
+                            frames, channels);
+}
+
+void AudioEngine::applyClientTxDspInt16(QByteArray& int16stereo)
+{
+    // Order determines whether the compressor colours the raw mic signal
+    // before the EQ shapes it (default, Pro-XL "tone shaping after
+    // dynamics"), or the EQ shapes first and the compressor tames the
+    // resulting peaks.  EQ's tap is always fed post-EQ so the analyzer
+    // shows the final signal leaving the TX DSP chain.
+    if (m_txChainOrder.load() == TxChainOrder::CompThenEq) {
+        applyClientCompTxInt16(int16stereo);
+        applyClientEqTxInt16(int16stereo);
+    } else {
+        applyClientEqTxInt16(int16stereo);
+        applyClientCompTxInt16(int16stereo);
+    }
+}
+
+void AudioEngine::applyClientTxDspFloat32(QByteArray& float32)
+{
+    if (m_txChainOrder.load() == TxChainOrder::CompThenEq) {
+        applyClientCompTxFloat32(float32);
+        applyClientEqTxFloat32(float32);
+    } else {
+        applyClientEqTxFloat32(float32);
+        applyClientCompTxFloat32(float32);
+    }
+}
+
+void AudioEngine::setTxChainOrder(TxChainOrder order)
+{
+    m_txChainOrder.store(order);
+    AppSettings::instance().setValue(
+        "ClientCompTxChainOrder",
+        QString::number(static_cast<int>(order)));
+}
+
+void AudioEngine::loadClientCompSettings()
+{
+    if (!m_clientCompTx) return;
+    auto& s = AppSettings::instance();
+    m_clientCompTx->setEnabled(
+        s.value("ClientCompTxEnabled", "False").toString() == "True");
+    m_clientCompTx->setThresholdDb(
+        s.value("ClientCompTxThresholdDb", "-18.0").toFloat());
+    m_clientCompTx->setRatio(
+        s.value("ClientCompTxRatio", "3.0").toFloat());
+    m_clientCompTx->setAttackMs(
+        s.value("ClientCompTxAttackMs", "20.0").toFloat());
+    m_clientCompTx->setReleaseMs(
+        s.value("ClientCompTxReleaseMs", "200.0").toFloat());
+    m_clientCompTx->setKneeDb(
+        s.value("ClientCompTxKneeDb", "6.0").toFloat());
+    m_clientCompTx->setMakeupDb(
+        s.value("ClientCompTxMakeupDb", "0.0").toFloat());
+    m_clientCompTx->setLimiterEnabled(
+        s.value("ClientCompTxLimEnabled", "True").toString() == "True");
+    m_clientCompTx->setLimiterCeilingDb(
+        s.value("ClientCompTxLimCeilingDb", "-1.0").toFloat());
+
+    const int order = s.value("ClientCompTxChainOrder", "0").toInt();
+    m_txChainOrder.store(order == 1 ? TxChainOrder::EqThenComp
+                                     : TxChainOrder::CompThenEq);
+}
+
+void AudioEngine::saveClientCompSettings() const
+{
+    if (!m_clientCompTx) return;
+    auto& s = AppSettings::instance();
+    auto toBool = [](bool on) { return on ? QString("True") : QString("False"); };
+    s.setValue("ClientCompTxEnabled",     toBool(m_clientCompTx->isEnabled()));
+    s.setValue("ClientCompTxThresholdDb", QString::number(m_clientCompTx->thresholdDb()));
+    s.setValue("ClientCompTxRatio",       QString::number(m_clientCompTx->ratio()));
+    s.setValue("ClientCompTxAttackMs",    QString::number(m_clientCompTx->attackMs()));
+    s.setValue("ClientCompTxReleaseMs",   QString::number(m_clientCompTx->releaseMs()));
+    s.setValue("ClientCompTxKneeDb",      QString::number(m_clientCompTx->kneeDb()));
+    s.setValue("ClientCompTxMakeupDb",    QString::number(m_clientCompTx->makeupDb()));
+    s.setValue("ClientCompTxLimEnabled",  toBool(m_clientCompTx->limiterEnabled()));
+    s.setValue("ClientCompTxLimCeilingDb",
+               QString::number(m_clientCompTx->limiterCeilingDb()));
+    s.setValue("ClientCompTxChainOrder",
+               QString::number(static_cast<int>(m_txChainOrder.load())));
 }
 
 static QString wisdomDir()
@@ -1576,11 +1696,12 @@ void AudioEngine::onTxAudioReady()
     // Don't send mic audio — it would conflict with the DAX stream.
     if (m_daxTxMode) return;
 
-    // ── Client-side parametric TX EQ (int16 stereo 24 kHz) ──────────────
+    // ── Client-side TX DSP: compressor + parametric EQ ──────────────────
     // Runs after mic capture and resample, before PC mic gain / metering /
     // Opus / VITA-49, so the user hears the shaped signal exactly as the
-    // radio will receive it.
-    applyClientEqTxInt16(data);
+    // radio will receive it.  Chain order (CMP→EQ vs EQ→CMP) is user-
+    // selectable via setTxChainOrder().
+    applyClientTxDspInt16(data);
 
     // ── Apply client-side PC mic gain (int16) ───────────────────────────
     const float gain = m_pcMicGain.load();
@@ -1890,15 +2011,18 @@ void AudioEngine::feedDaxTxAudio(const QByteArray& inPcm)
 {
     if (m_txStreamId == 0 || inPcm.isEmpty()) return;
 
-    // Apply client-side TX EQ in place when enabled. Copy into a local
-    // because the caller owns `inPcm` — small cost only paid on this path
-    // when EQ is enabled. Downstream metering and encoding see the shaped
-    // signal, so the TX meter reflects what the radio is actually sending.
+    // Apply client-side TX DSP (compressor + EQ) in place when any stage
+    // is enabled. Copy into a local because the caller owns `inPcm`; the
+    // copy+process cost is only paid when something is active. Downstream
+    // metering and encoding see the shaped signal, so the TX meter
+    // reflects what the radio is actually sending.
+    const bool eqOn   = m_clientEqTx && m_clientEqTx->isEnabled();
+    const bool compOn = m_clientCompTx && m_clientCompTx->isEnabled();
     QByteArray working;
     const QByteArray* active = &inPcm;
-    if (m_clientEqTx && m_clientEqTx->isEnabled()) {
+    if (eqOn || compOn) {
         working = inPcm;
-        applyClientEqTxFloat32(working);
+        applyClientTxDspFloat32(working);
         active = &working;
     }
     const QByteArray& float32pcm = *active;

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -32,6 +32,7 @@ class NvidiaBnrFilter;
 class DeepFilterFilter;
 class Resampler;
 class ClientEq;
+class ClientComp;
 
 // AudioEngine handles audio playback (RX) and capture (TX).
 //
@@ -160,6 +161,20 @@ public:
     ClientEq* clientEqRx() { return m_clientEqRx.get(); }
     ClientEq* clientEqTx() { return m_clientEqTx.get(); }
 
+    // Client-side TX dynamics processor (Pro-XL-style compressor +
+    // brickwall limiter, #1661).  Runs on the TX audio path only;
+    // chain order (CMP→EQ vs EQ→CMP) is user-selectable.
+    ClientComp* clientCompTx() { return m_clientCompTx.get(); }
+
+    enum class TxChainOrder {
+        CompThenEq = 0,  // mic → CMP → EQ → radio (default, colour-then-shape)
+        EqThenComp = 1,  // mic → EQ → CMP → radio (shape-then-tame)
+    };
+    void setTxChainOrder(TxChainOrder order);
+    TxChainOrder txChainOrder() const { return m_txChainOrder.load(); }
+    void loadClientCompSettings();
+    void saveClientCompSettings() const;
+
     // Post-Client-EQ audio tap for the editor's FFT analyzer.  Exposes
     // a rolling mono buffer filled on the audio thread; UI thread copies
     // the most-recent N samples for FFT without allocating or blocking.
@@ -229,6 +244,12 @@ private:
     // Apply client-side TX EQ in-place. No-op if disabled. Caller owns data.
     void applyClientEqTxInt16(QByteArray& int16stereo);
     void applyClientEqTxFloat32(QByteArray& float32);
+    // Apply client-side TX compressor in-place.  No-op if disabled.
+    void applyClientCompTxInt16(QByteArray& int16stereo);
+    void applyClientCompTxFloat32(QByteArray& float32);
+    // Apply the whole TX DSP chain (CMP + EQ) in the configured order.
+    void applyClientTxDspInt16(QByteArray& int16stereo);
+    void applyClientTxDspFloat32(QByteArray& float32);
 
     // RX
     QAudioSink*   m_audioSink{nullptr};
@@ -323,9 +344,13 @@ private:
     // Client-side parametric EQ, independent instances for RX and TX.
     std::unique_ptr<ClientEq> m_clientEqRx;
     std::unique_ptr<ClientEq> m_clientEqTx;
+    // Client-side TX compressor (Pro-XL-style).
+    std::unique_ptr<ClientComp> m_clientCompTx;
+    std::atomic<TxChainOrder> m_txChainOrder{TxChainOrder::CompThenEq};
     // Scratch buffer for in-place EQ on the RX path (avoids per-call alloc).
     QByteArray m_clientEqRxScratch;
     QByteArray m_clientEqTxScratch;
+    QByteArray m_clientCompTxScratch;
     // Post-EQ analyzer tap. One ring per path, mono (L+R averaged).
     // Audio thread writes via tapClientEqRxStereo() / tapClientEqTxInt16()
     // / tapClientEqTxFloat32(); UI thread snapshots via the public

--- a/src/core/ClientComp.cpp
+++ b/src/core/ClientComp.cpp
@@ -1,0 +1,268 @@
+#include "ClientComp.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+float dbToLin(float db) noexcept
+{
+    return std::pow(10.0f, db * 0.05f);
+}
+
+float linToDb(float lin) noexcept
+{
+    return (lin > 1e-9f) ? 20.0f * std::log10(lin) : -180.0f;
+}
+
+// Classic time-constant coefficient: y += α·(target - y) with
+// α = 1 - exp(-1 / (fs · τ)).  Hits ≈63 % of the step in τ seconds.
+float coeffFromMs(float ms, double sampleRate) noexcept
+{
+    if (ms <= 0.0f) return 1.0f;
+    const float tau = ms * 0.001f;
+    return 1.0f - std::exp(-1.0f / static_cast<float>(sampleRate * tau));
+}
+
+} // namespace
+
+ClientComp::ClientComp() = default;
+
+void ClientComp::prepare(double sampleRate)
+{
+    m_sampleRate = sampleRate;
+    m_envLin     = 0.0f;
+    m_limEnvLin  = 0.0f;
+
+    // Bump version so recacheIfDirty rebuilds coefficients on first block.
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+    recacheIfDirty();
+}
+
+void ClientComp::setEnabled(bool on) noexcept
+{
+    m_atomics.enabled.store(on, std::memory_order_release);
+}
+
+bool ClientComp::isEnabled() const noexcept
+{
+    return m_atomics.enabled.load(std::memory_order_acquire);
+}
+
+void ClientComp::setThresholdDb(float db) noexcept
+{
+    m_atomics.thresholdDb.store(std::clamp(db, -60.0f, 0.0f),
+                                std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientComp::thresholdDb() const noexcept
+{ return m_atomics.thresholdDb.load(std::memory_order_relaxed); }
+
+void ClientComp::setRatio(float ratio) noexcept
+{
+    m_atomics.ratio.store(std::clamp(ratio, 1.0f, 20.0f),
+                          std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientComp::ratio() const noexcept
+{ return m_atomics.ratio.load(std::memory_order_relaxed); }
+
+void ClientComp::setAttackMs(float ms) noexcept
+{
+    m_atomics.attackMs.store(std::clamp(ms, 0.1f, 300.0f),
+                             std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientComp::attackMs() const noexcept
+{ return m_atomics.attackMs.load(std::memory_order_relaxed); }
+
+void ClientComp::setReleaseMs(float ms) noexcept
+{
+    m_atomics.releaseMs.store(std::clamp(ms, 5.0f, 2000.0f),
+                              std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientComp::releaseMs() const noexcept
+{ return m_atomics.releaseMs.load(std::memory_order_relaxed); }
+
+void ClientComp::setKneeDb(float db) noexcept
+{
+    m_atomics.kneeDb.store(std::clamp(db, 0.0f, 24.0f),
+                           std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientComp::kneeDb() const noexcept
+{ return m_atomics.kneeDb.load(std::memory_order_relaxed); }
+
+void ClientComp::setMakeupDb(float db) noexcept
+{
+    m_atomics.makeupDb.store(std::clamp(db, -12.0f, 24.0f),
+                             std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientComp::makeupDb() const noexcept
+{ return m_atomics.makeupDb.load(std::memory_order_relaxed); }
+
+void ClientComp::setLimiterEnabled(bool on) noexcept
+{
+    m_atomics.limEnabled.store(on, std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+bool ClientComp::limiterEnabled() const noexcept
+{ return m_atomics.limEnabled.load(std::memory_order_relaxed); }
+
+void ClientComp::setLimiterCeilingDb(float db) noexcept
+{
+    m_atomics.limCeilingDb.store(std::clamp(db, -24.0f, 0.0f),
+                                 std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientComp::limiterCeilingDb() const noexcept
+{ return m_atomics.limCeilingDb.load(std::memory_order_relaxed); }
+
+void ClientComp::reset() noexcept
+{
+    m_envLin = 0.0f;
+    m_limEnvLin = 0.0f;
+}
+
+float ClientComp::inputPeakDb() const noexcept
+{ return m_meters.inputPeakDb.load(std::memory_order_relaxed); }
+float ClientComp::outputPeakDb() const noexcept
+{ return m_meters.outputPeakDb.load(std::memory_order_relaxed); }
+float ClientComp::gainReductionDb() const noexcept
+{ return m_meters.gainReductionDb.load(std::memory_order_relaxed); }
+bool  ClientComp::limiterActive() const noexcept
+{ return m_meters.limiterActive.load(std::memory_order_relaxed); }
+
+void ClientComp::recacheIfDirty() noexcept
+{
+    const uint64_t v = m_atomics.version.load(std::memory_order_acquire);
+    if (v == m_lastVersion) return;
+    m_lastVersion = v;
+
+    m_cached.thresholdDb = m_atomics.thresholdDb.load(std::memory_order_relaxed);
+    const float r        = std::max(1.0f,
+                                    m_atomics.ratio.load(std::memory_order_relaxed));
+    m_cached.ratioInv    = 1.0f / r;
+    m_cached.attackCoeff = coeffFromMs(
+        m_atomics.attackMs.load(std::memory_order_relaxed), m_sampleRate);
+    m_cached.releaseCoeff = coeffFromMs(
+        m_atomics.releaseMs.load(std::memory_order_relaxed), m_sampleRate);
+    m_cached.kneeDb      = m_atomics.kneeDb.load(std::memory_order_relaxed);
+    m_cached.makeupLin   = dbToLin(
+        m_atomics.makeupDb.load(std::memory_order_relaxed));
+    m_cached.limEnabled  = m_atomics.limEnabled.load(std::memory_order_relaxed);
+    m_cached.limCeilingLin = dbToLin(
+        m_atomics.limCeilingDb.load(std::memory_order_relaxed));
+    // Limiter ballistics: very fast attack, moderately fast release.
+    m_cached.limAttackCoeff  = coeffFromMs(0.1f, m_sampleRate);
+    m_cached.limReleaseCoeff = coeffFromMs(50.0f, m_sampleRate);
+}
+
+float ClientComp::staticCurveGainDb(float envDb) const noexcept
+{
+    // Soft-knee downward compression in dB domain.  Returns the gain
+    // adjustment (≤ 0 dB) to apply to the signal at this envelope level.
+    const float T    = m_cached.thresholdDb;
+    const float W    = m_cached.kneeDb;
+    const float overshoot = envDb - T;
+    const float slope = 1.0f - m_cached.ratioInv;  // 0 = bypass, 1 = limit
+
+    if (W <= 0.0f) {
+        // Hard knee
+        return (overshoot > 0.0f) ? -overshoot * slope : 0.0f;
+    }
+
+    if (overshoot <= -0.5f * W) {
+        return 0.0f;  // below knee
+    }
+    if (overshoot >= 0.5f * W) {
+        return -overshoot * slope;  // above knee
+    }
+    // Soft-knee quadratic interpolation: smoothly blends from 0 to full
+    // reduction across [-W/2, +W/2].
+    const float x = overshoot + 0.5f * W;  // 0 .. W
+    return -slope * (x * x) / (2.0f * W);
+}
+
+void ClientComp::process(float* interleaved, int frames, int channels) noexcept
+{
+    if (frames <= 0) return;
+    if (channels != 1 && channels != 2) return;
+
+    recacheIfDirty();
+    const bool enabled = m_atomics.enabled.load(std::memory_order_acquire);
+
+    float inPeakLin  = 0.0f;
+    float outPeakLin = 0.0f;
+    float worstGrDb  = 0.0f;  // most negative (largest reduction)
+    bool  limFired   = false;
+
+    const float attackCoeff  = m_cached.attackCoeff;
+    const float releaseCoeff = m_cached.releaseCoeff;
+    const float makeup       = m_cached.makeupLin;
+    const float limCeiling   = m_cached.limCeilingLin;
+    const float limAttack    = m_cached.limAttackCoeff;
+    const float limRelease   = m_cached.limReleaseCoeff;
+
+    for (int f = 0; f < frames; ++f) {
+        float l = interleaved[f * channels];
+        float r = (channels == 2) ? interleaved[f * channels + 1] : l;
+
+        const float inAbs = std::max(std::fabs(l), std::fabs(r));
+        if (inAbs > inPeakLin) inPeakLin = inAbs;
+
+        // Compressor gain (only applied if enabled).  Linear-domain peak
+        // envelope: smoothed |x| with asymmetric attack/release, converted
+        // to dB once to feed the static curve.  This tracks the actual
+        // peak amplitude of the signal (unlike a dB-domain filter that
+        // would average log|x| and read ~4 dB below peak on a sine).
+        float gainLin = 1.0f;
+        if (enabled) {
+            const float alpha = (inAbs > m_envLin) ? attackCoeff : releaseCoeff;
+            m_envLin += alpha * (inAbs - m_envLin);
+            const float envDb = linToDb(std::max(m_envLin, 1e-6f));
+            const float gainDb = staticCurveGainDb(envDb);
+            if (gainDb < worstGrDb) worstGrDb = gainDb;
+            gainLin = dbToLin(gainDb) * makeup;
+        }
+        l *= gainLin;
+        r *= gainLin;
+
+        // Brickwall peak limiter — feed-forward, fast attack/release,
+        // so the envelope sits just above the instantaneous peak when
+        // signal exceeds the ceiling.
+        if (m_cached.limEnabled) {
+            const float maxAbs = std::max(std::fabs(l), std::fabs(r));
+            const float over   = maxAbs / std::max(limCeiling, 1e-6f);
+            const float target = std::max(1.0f, over);
+            const float lc = (target > m_limEnvLin) ? limAttack : limRelease;
+            m_limEnvLin += lc * (target - m_limEnvLin);
+            if (m_limEnvLin > 1.0f) {
+                const float reduce = 1.0f / m_limEnvLin;
+                l *= reduce;
+                r *= reduce;
+                limFired = true;
+            }
+        }
+
+        interleaved[f * channels] = l;
+        if (channels == 2) interleaved[f * channels + 1] = r;
+
+        const float outAbs = std::max(std::fabs(l), std::fabs(r));
+        if (outAbs > outPeakLin) outPeakLin = outAbs;
+    }
+
+    // Publish meter values — audio-thread side of the atomic handoff.
+    m_meters.inputPeakDb.store(linToDb(std::max(inPeakLin, 1e-6f)),
+                               std::memory_order_relaxed);
+    m_meters.outputPeakDb.store(linToDb(std::max(outPeakLin, 1e-6f)),
+                                std::memory_order_relaxed);
+    m_meters.gainReductionDb.store(worstGrDb, std::memory_order_relaxed);
+    m_meters.limiterActive.store(limFired, std::memory_order_relaxed);
+}
+
+} // namespace AetherSDR

--- a/src/core/ClientComp.h
+++ b/src/core/ClientComp.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace AetherSDR {
+
+// Client-side TX dynamics processor — the foundation of the Pro-XL-style
+// compression chain (#1661).  Phase 1 scope: core feed-forward compressor
+// with soft-knee static curve + attack/release envelope follower, plus a
+// brickwall peak limiter on the output.  Later phases will add expander/
+// gate, de-esser, tube, enhancer, low contour, and IKA/IRC auto modes.
+//
+// Thread model mirrors ClientEq: the UI thread writes parameters via
+// set*()  setters that update atomics and bump a version counter; the
+// audio thread reads the version once per block and recaches the values.
+// No locks, no allocations in process(), no exceptions.
+//
+// Stereo-linked detection: the envelope is driven by max(|L|, |R|) and
+// the computed gain multiplier is applied identically to both channels
+// so phase coherence is preserved.
+class ClientComp {
+public:
+    ClientComp();
+    ~ClientComp() = default;
+
+    ClientComp(const ClientComp&)            = delete;
+    ClientComp& operator=(const ClientComp&) = delete;
+
+    // Main thread — call before first process() and on sample-rate change.
+    void prepare(double sampleRate);
+
+    // Main thread — global enable / bypass. Lock-free.
+    void setEnabled(bool on) noexcept;
+    bool isEnabled() const noexcept;
+
+    // Core compressor parameters.
+    void  setThresholdDb(float db) noexcept;
+    float thresholdDb() const noexcept;
+    void  setRatio(float ratio) noexcept;        // 1.0 = bypass, 20.0 = limiter
+    float ratio() const noexcept;
+    void  setAttackMs(float ms) noexcept;
+    float attackMs() const noexcept;
+    void  setReleaseMs(float ms) noexcept;
+    float releaseMs() const noexcept;
+    void  setKneeDb(float db) noexcept;
+    float kneeDb() const noexcept;
+    void  setMakeupDb(float db) noexcept;
+    float makeupDb() const noexcept;
+
+    // Brickwall limiter on the output.  Ceiling in dBFS (negative).
+    void  setLimiterEnabled(bool on) noexcept;
+    bool  limiterEnabled() const noexcept;
+    void  setLimiterCeilingDb(float db) noexcept;
+    float limiterCeilingDb() const noexcept;
+
+    // Audio thread — process in place.  channels must be 1 or 2.
+    void process(float* interleaved, int frames, int channels) noexcept;
+
+    // Audio thread — flush envelope state (e.g. on TX start).
+    void reset() noexcept;
+
+    // UI thread — read-only snapshots of the latest detector state for
+    // meters. Updated once per block on the audio thread via atomics.
+    float inputPeakDb() const noexcept;       // pre-compression peak
+    float outputPeakDb() const noexcept;      // post-limiter peak
+    float gainReductionDb() const noexcept;   // latest GR in dB (≤ 0)
+    bool  limiterActive() const noexcept;     // true while limiter is clamping
+
+    // Sample rate this comp was prepared at.
+    double sampleRate() const noexcept { return m_sampleRate; }
+
+private:
+    struct Atomics {
+        std::atomic<bool>     enabled{false};
+        std::atomic<float>    thresholdDb{-18.0f};
+        std::atomic<float>    ratio{3.0f};
+        std::atomic<float>    attackMs{20.0f};
+        std::atomic<float>    releaseMs{200.0f};
+        std::atomic<float>    kneeDb{6.0f};
+        std::atomic<float>    makeupDb{0.0f};
+        std::atomic<bool>     limEnabled{true};
+        std::atomic<float>    limCeilingDb{-1.0f};
+        std::atomic<uint64_t> version{0};
+    };
+
+    struct Cached {
+        float thresholdDb{-18.0f};
+        float ratioInv{1.0f / 3.0f};       // 1/ratio, pre-computed
+        float attackCoeff{0.0f};           // 1 - exp(-1 / (fs · τ))
+        float releaseCoeff{0.0f};
+        float kneeDb{6.0f};
+        float makeupLin{1.0f};
+        bool  limEnabled{true};
+        float limCeilingLin{0.891f};       // 10^(-1/20)
+        float limAttackCoeff{0.0f};
+        float limReleaseCoeff{0.0f};
+    };
+
+    // Meter snapshots — atomic stores on the audio thread after each
+    // block, atomic loads on the UI thread for paint.
+    struct Meters {
+        std::atomic<float> inputPeakDb{-120.0f};
+        std::atomic<float> outputPeakDb{-120.0f};
+        std::atomic<float> gainReductionDb{0.0f};
+        std::atomic<bool>  limiterActive{false};
+    };
+
+    void recacheIfDirty() noexcept;
+    float staticCurveGainDb(float envDb) const noexcept;
+
+    double   m_sampleRate{24000.0};
+    Atomics  m_atomics;
+    Cached   m_cached;
+    Meters   m_meters;
+
+    // Audio-thread state — accessed only from process().
+    uint64_t m_lastVersion{0};
+    // Linear-domain peak envelope: tracks max(|L|,|R|) with attack/release
+    // ballistics. Converting to dB after smoothing gives proper peak
+    // tracking — log-domain smoothing of a sine would settle ~4 dB below
+    // the peak (average of log|sin|), which is wrong for a peak compressor.
+    float    m_envLin{0.0f};
+    float    m_limEnvLin{0.0f};       // limiter envelope (linear)
+};
+
+} // namespace AetherSDR

--- a/src/generated/WhatsNewData.cpp
+++ b/src/generated/WhatsNewData.cpp
@@ -6,6 +6,12 @@ namespace AetherSDR {
 
 const std::vector<ReleaseEntry>& whatsNewEntries() {
     static const std::vector<ReleaseEntry> entries = {
+        {QStringLiteral("0.8.17"), QStringLiteral("2026-04-19"), QStringLiteral("Client-side TX Compressor (Pro-XL-style, Phase 1)"), {
+            {ChangeCategory::Feature, QStringLiteral("Client-side TX dynamics processor"), QStringLiteral("Feed-forward compressor with soft-knee quadratic interpolation, linear- domain peak envelope detection, stereo-linked gain application, and a brickwall peak limiter on the output Parameters: thresh...")},
+            {ChangeCategory::Feature, QStringLiteral("Docked Compressor applet + floating editor"), QStringLiteral("View-only CMP tile in the applet tray: live transfer curve with a glowing ball that slides along the curve at the current envelope level, horizontal GR strip beneath, Bypass toggle + Edit… button F...")},
+            {ChangeCategory::Feature, QStringLiteral("DSP test harness"), QStringLiteral("tests/client_comp_test.cpp — 11 standalone smoke tests: bypass, below-threshold passthrough, static ratio (4:1 and 20:1), makeup, limiter ceiling, stereo linking, attack timing, soft-knee monotonic...")},
+            {ChangeCategory::Feature, QStringLiteral("Settings:"), QStringLiteral("")},
+        }},
         {QStringLiteral("0.8.16"), QStringLiteral("2026-04-18"), QStringLiteral("DIGI Applet Split, TCI Audio Reliability, PGXL-Aware S-Meter, Community Contributions"), {
             {ChangeCategory::Feature, QStringLiteral("DIGI applet split into CAT, DAX, TCI, IQ"), QStringLiteral("Four independent applets replace the monolithic DIGI tile Each has its own toggle button, drag-reorder slot, and float/dock affordance TCI gains per-channel RX gain (TciRxGain1-4) and a decoupled T...")},
             {ChangeCategory::Feature, QStringLiteral("PGXL standby-aware S-Meter"), QStringLiteral("VU / S-Meter switches between barefoot and PGXL 2kW scales automatically In STANDBY the meter shows exciter FWDPWR on the barefoot scale In OPERATE the meter shows amp output on the 2kW scale Scale...")},

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -11,6 +11,7 @@
 #include "PhoneApplet.h"
 #include "EqApplet.h"
 #include "ClientEqApplet.h"
+#include "ClientCompApplet.h"
 #include "CatControlApplet.h"
 #include "DaxApplet.h"
 #include "TciApplet.h"
@@ -662,6 +663,9 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
     m_clientEqApplet = new ClientEqApplet;
     m_appletOrder.append(makeEntry("CEQ", "Client EQ", m_clientEqApplet, false, btnRow2, btnLayout2));
+
+    m_clientCompApplet = new ClientCompApplet;
+    m_appletOrder.append(makeEntry("CMP", "Client Compressor", m_clientCompApplet, false, btnRow2, btnLayout2));
 
     m_catControlApplet = new CatControlApplet;
     m_appletOrder.append(makeEntry("CAT", "CAT Control", m_catControlApplet, false, btnRow2, btnLayout2));

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -24,6 +24,7 @@ class PhoneCwApplet;
 class PhoneApplet;
 class EqApplet;
 class ClientEqApplet;
+class ClientCompApplet;
 class CatControlApplet;
 class DaxApplet;
 class TciApplet;
@@ -56,6 +57,7 @@ public:
     PhoneApplet*    phoneApplet()    { return m_phoneApplet; }
     EqApplet*       eqApplet()       { return m_eqApplet; }
     ClientEqApplet* clientEqApplet() { return m_clientEqApplet; }
+    ClientCompApplet* clientCompApplet() { return m_clientCompApplet; }
     CatControlApplet* catControlApplet() { return m_catControlApplet; }
     DaxApplet*      daxApplet()      { return m_daxApplet; }
     TciApplet*      tciApplet()      { return m_tciApplet; }
@@ -123,6 +125,7 @@ private:
     PhoneApplet*   m_phoneApplet{nullptr};
     EqApplet*      m_eqApplet{nullptr};
     ClientEqApplet* m_clientEqApplet{nullptr};
+    ClientCompApplet* m_clientCompApplet{nullptr};
     CatControlApplet* m_catControlApplet{nullptr};
     DaxApplet*     m_daxApplet{nullptr};
     TciApplet*     m_tciApplet{nullptr};

--- a/src/gui/ClientCompApplet.cpp
+++ b/src/gui/ClientCompApplet.cpp
@@ -1,0 +1,210 @@
+#include "ClientCompApplet.h"
+#include "ClientCompCurveWidget.h"
+#include "core/AudioEngine.h"
+#include "core/ClientComp.h"
+
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QSignalBlocker>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QTimer>
+#include <QElapsedTimer>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+// Gain-reduction mini-strip used by the applet.  Named at file scope
+// (not in an anonymous namespace) so ClientCompApplet.h can forward-
+// declare it and keep a typed pointer.  Fill animates with the same
+// asymmetric attack/release ballistics as HGauge so the motion matches
+// every other metering surface in the app (Phone/CW Level, etc.).
+class ClientCompGrBar : public QWidget {
+public:
+    explicit ClientCompGrBar(QWidget* parent = nullptr) : QWidget(parent)
+    {
+        setFixedHeight(10);
+
+        m_animTimer.setTimerType(Qt::PreciseTimer);
+        m_animTimer.setInterval(8);
+        connect(&m_animTimer, &QTimer::timeout, this, [this]() {
+            const qint64 ms = m_animElapsed.restart();
+            if (ms <= 0) return;
+            const float delta = m_targetFrac - m_displayFrac;
+            if (std::fabs(delta) <= 0.001f) {
+                m_displayFrac = m_targetFrac;
+                m_animTimer.stop();
+            } else {
+                const float tau = (delta >= 0.0f) ? 0.030f : 0.180f;
+                const float alpha = 1.0f - std::exp(
+                    -static_cast<float>(ms) / 1000.0f / tau);
+                m_displayFrac += delta * alpha;
+            }
+            update();
+        });
+    }
+
+    void setGrDb(float grDb)
+    {
+        if (std::fabs(grDb - m_grDb) < 0.05f) return;
+        m_grDb = grDb;
+        constexpr float kMaxGr = 20.0f;
+        m_targetFrac = std::clamp(-m_grDb, 0.0f, kMaxGr) / kMaxGr;
+        if (std::fabs(m_targetFrac - m_displayFrac) <= 0.001f) {
+            m_displayFrac = m_targetFrac;
+            if (m_animTimer.isActive()) m_animTimer.stop();
+            update();
+        } else if (!m_animTimer.isActive()) {
+            m_animElapsed.restart();
+            m_animTimer.start();
+        }
+    }
+
+protected:
+    void paintEvent(QPaintEvent*) override
+    {
+        QPainter p(this);
+        const QRectF r = rect();
+        p.fillRect(r, QColor("#0a1420"));
+        constexpr float kMaxGr = 20.0f;
+        if (m_displayFrac > 0.0f) {
+            const float w = m_displayFrac * r.width();
+            QRectF fill(r.right() - w, r.top() + 1.0, w, r.height() - 2.0);
+            p.fillRect(fill, QColor("#e8a540"));
+        }
+        const float tickX = r.right() - (6.0f / kMaxGr) * r.width();
+        p.setPen(QPen(QColor("#2a4458"), 1.0));
+        p.drawLine(QPointF(tickX, r.top()), QPointF(tickX, r.bottom()));
+    }
+
+private:
+    float m_grDb{0.0f};
+    QTimer        m_animTimer;
+    QElapsedTimer m_animElapsed;
+    float         m_displayFrac{0.0f};
+    float         m_targetFrac{0.0f};
+};
+
+namespace {
+
+// Enable/Bypass toggle — matches ClientEqApplet's style so the two
+// applets sit visually side-by-side with identical button language.
+const QString kEnableStyle =
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 11px; font-weight: bold; padding: 2px 10px;"
+    "}"
+    "QPushButton:hover { background: #204060; }"
+    "QPushButton:checked {"
+    "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
+    "}";
+
+constexpr const char* kEditStyle =
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 11px; padding: 2px 10px;"
+    "}"
+    "QPushButton:hover { background: #204060; }";
+
+} // namespace
+
+ClientCompApplet::ClientCompApplet(QWidget* parent) : QWidget(parent)
+{
+    buildUI();
+    hide();  // hidden until toggled on from the button tray
+}
+
+void ClientCompApplet::buildUI()
+{
+    setStyleSheet("QWidget { background: transparent; }");
+
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(4, 4, 4, 4);
+    outer->setSpacing(4);
+
+    m_curve = new ClientCompCurveWidget;
+    m_curve->setCompactMode(true);
+    m_curve->setMinimumHeight(90);
+    outer->addWidget(m_curve, 1);
+
+    m_grBar = new ClientCompGrBar;
+    outer->addWidget(m_grBar);
+
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(4);
+
+        m_enable = new QPushButton("Enable");
+        m_enable->setCheckable(true);
+        m_enable->setStyleSheet(kEnableStyle);
+        m_enable->setFixedHeight(22);
+        row->addWidget(m_enable);
+
+        row->addStretch();
+
+        m_edit = new QPushButton("Edit…");
+        m_edit->setStyleSheet(kEditStyle);
+        m_edit->setFixedHeight(22);
+        m_edit->setToolTip("Open the client compressor editor");
+        row->addWidget(m_edit);
+
+        connect(m_enable, &QPushButton::toggled, this,
+                &ClientCompApplet::onEnableToggled);
+        connect(m_edit, &QPushButton::clicked, this, [this]() {
+            emit editRequested();
+        });
+
+        outer->addLayout(row);
+    }
+
+    m_meterTimer = new QTimer(this);
+    m_meterTimer->setInterval(33);
+    connect(m_meterTimer, &QTimer::timeout, this, &ClientCompApplet::tickMeter);
+}
+
+void ClientCompApplet::setAudioEngine(AudioEngine* engine)
+{
+    m_audio = engine;
+    if (!m_audio) return;
+    m_curve->setComp(m_audio->clientCompTx());
+    syncEnableFromEngine();
+    m_meterTimer->start();
+}
+
+void ClientCompApplet::syncEnableFromEngine()
+{
+    if (!m_audio || !m_enable) return;
+    ClientComp* c = m_audio->clientCompTx();
+    QSignalBlocker b(m_enable);
+    m_enable->setChecked(c && c->isEnabled());
+    if (m_curve) m_curve->update();
+}
+
+void ClientCompApplet::refreshEnableFromEngine()
+{
+    syncEnableFromEngine();
+}
+
+void ClientCompApplet::onEnableToggled(bool on)
+{
+    if (!m_audio) return;
+    ClientComp* c = m_audio->clientCompTx();
+    if (!c) return;
+    c->setEnabled(on);
+    m_audio->saveClientCompSettings();
+    if (m_curve) m_curve->update();
+}
+
+void ClientCompApplet::tickMeter()
+{
+    if (!m_audio || !m_grBar) return;
+    ClientComp* c = m_audio->clientCompTx();
+    if (!c) return;
+    const float gr = c->gainReductionDb();
+    m_grBar->setGrDb(gr);
+    m_grDb = gr;
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompApplet.h
+++ b/src/gui/ClientCompApplet.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompCurveWidget;
+class ClientCompGrBar;
+
+// Docked dashboard tile for the client-side TX compressor.  View-only —
+// shows the transfer curve with a live "ball" at the current envelope
+// level, plus a compact horizontal gain-reduction strip, plus Bypass /
+// Edit… buttons.  The full interactive editor lives in a separate
+// floating window (ClientCompEditor).
+//
+// Single-path design: unlike the EQ applet there's no RX / TX tab —
+// Phase 1 only exposes the TX-side compressor.  Phase 2+ can extend
+// this if we ever add an RX-side compressor; today that would just be
+// a CPU-waste feature.
+class ClientCompApplet : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientCompApplet(QWidget* parent = nullptr);
+
+    void setAudioEngine(AudioEngine* engine);
+
+    // Pull the Bypass toggle state from the bound ClientComp.  Called
+    // by MainWindow after the floating editor toggles its bypass
+    // button so both views stay in sync.
+    void refreshEnableFromEngine();
+
+signals:
+    // Fired when the user clicks Edit…. MainWindow owns the single
+    // editor window instance and shows / raises it in response.
+    void editRequested();
+
+private:
+    void buildUI();
+    void syncEnableFromEngine();
+    void onEnableToggled(bool on);
+    void tickMeter();
+
+    AudioEngine*          m_audio{nullptr};
+    QPushButton*          m_enable{nullptr};
+    QPushButton*          m_edit{nullptr};
+    ClientCompCurveWidget* m_curve{nullptr};
+    ClientCompGrBar*      m_grBar{nullptr};   // narrow horizontal GR strip
+    QTimer*               m_meterTimer{nullptr};
+
+    // Latest GR dB (0 = no reduction, negative = active).  Paint is
+    // driven by a QTimer polling ClientComp::gainReductionDb() at 30 Hz
+    // so the strip feels live.
+    float m_grDb{0.0f};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompCurveWidget.cpp
+++ b/src/gui/ClientCompCurveWidget.cpp
@@ -1,0 +1,239 @@
+#include "ClientCompCurveWidget.h"
+#include "core/ClientComp.h"
+
+#include <QPainter>
+#include <QPainterPath>
+#include <QPaintEvent>
+#include <QPen>
+#include <QLinearGradient>
+#include <QRadialGradient>
+#include <QTimer>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr float kBallSmoothAlpha = 0.30f;  // per-tick; ~8 ticks to settle
+
+const QColor kBgColor       ("#0a1420");
+const QColor kGridColor     ("#1e3040");
+const QColor kGridMajorColor("#2a4458");
+const QColor kAxisLabelColor("#607888");
+const QColor kIdentityColor ("#2a3a4a");
+const QColor kCurveColor    ("#4db8d4");
+const QColor kBallGlowColor ("#ffd070");
+const QColor kBallCoreColor ("#ffffff");
+
+// dBFS ticks for the grid (both axes).
+const float kMajorTicks[] = { 0.0f, -12.0f, -24.0f, -36.0f, -48.0f, -60.0f };
+const float kMinorTicks[] = { -6.0f, -18.0f, -30.0f, -42.0f, -54.0f };
+
+} // namespace
+
+ClientCompCurveWidget::ClientCompCurveWidget(QWidget* parent) : QWidget(parent)
+{
+    setMinimumHeight(80);
+    setAttribute(Qt::WA_OpaquePaintEvent, false);
+    m_pollTimer = new QTimer(this);
+    m_pollTimer->setInterval(33);  // ~30 Hz, plenty for a sliding ball
+    connect(m_pollTimer, &QTimer::timeout, this, [this]() {
+        if (!m_comp) return;
+        const float target = m_comp->inputPeakDb();
+        // One-pole smoother keeps the ball from twitching on silent frames
+        // where the peak meter reads -120 dBFS; on real signal it tracks
+        // within a few ticks.
+        m_lastInputDb += kBallSmoothAlpha * (target - m_lastInputDb);
+        update();
+    });
+}
+
+void ClientCompCurveWidget::setComp(ClientComp* comp)
+{
+    m_comp = comp;
+    if (m_comp) m_pollTimer->start();
+    else        m_pollTimer->stop();
+    update();
+}
+
+void ClientCompCurveWidget::setCompactMode(bool on)
+{
+    if (on == m_compact) return;
+    m_compact = on;
+    update();
+}
+
+float ClientCompCurveWidget::dbToX(float db) const
+{
+    const float t = (db - kMinDb) / (kMaxDb - kMinDb);
+    return static_cast<float>(rect().left()) + t * rect().width();
+}
+
+float ClientCompCurveWidget::dbToY(float db) const
+{
+    const float t = (db - kMinDb) / (kMaxDb - kMinDb);
+    return static_cast<float>(rect().bottom()) - t * rect().height();
+}
+
+float ClientCompCurveWidget::xToDb(float x) const
+{
+    const float t = (x - rect().left()) / std::max(1, rect().width());
+    return kMinDb + t * (kMaxDb - kMinDb);
+}
+
+float ClientCompCurveWidget::yToDb(float y) const
+{
+    const float t = (rect().bottom() - y) / std::max(1, rect().height());
+    return kMinDb + t * (kMaxDb - kMinDb);
+}
+
+float ClientCompCurveWidget::curveOutputDb(float inDb) const
+{
+    if (!m_comp) return inDb;
+    const float T     = m_comp->thresholdDb();
+    const float W     = m_comp->kneeDb();
+    const float ratio = std::max(1.0f, m_comp->ratio());
+    const float slope = 1.0f - 1.0f / ratio;   // 0 = unity, 1 = limit
+    const float over  = inDb - T;
+
+    float gain;
+    if (W <= 0.0f) {
+        gain = (over > 0.0f) ? -over * slope : 0.0f;
+    } else if (over <= -0.5f * W) {
+        gain = 0.0f;
+    } else if (over >= 0.5f * W) {
+        gain = -over * slope;
+    } else {
+        const float x = over + 0.5f * W;
+        gain = -slope * (x * x) / (2.0f * W);
+    }
+    return inDb + gain + m_comp->makeupDb();
+}
+
+void ClientCompCurveWidget::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    const QRectF r = rect();
+    p.fillRect(r, kBgColor);
+    drawGrid(p, r);
+    drawCurve(p, r);
+    if (m_comp) drawBall(p, r);
+}
+
+void ClientCompCurveWidget::drawGrid(QPainter& p, const QRectF& r) const
+{
+    p.save();
+
+    const QPen minorPen(kGridColor, 1.0);
+    const QPen majorPen(kGridMajorColor, 1.0);
+
+    // Minor ticks
+    p.setPen(minorPen);
+    for (float db : kMinorTicks) {
+        const float x = dbToX(db);
+        p.drawLine(QPointF(x, r.top()), QPointF(x, r.bottom()));
+        const float y = dbToY(db);
+        p.drawLine(QPointF(r.left(), y), QPointF(r.right(), y));
+    }
+
+    // Major ticks — heavier lines; labels too (unless compact).
+    p.setPen(majorPen);
+    QFont f = p.font();
+    f.setPixelSize(m_compact ? 7 : 9);
+    p.setFont(f);
+
+    for (float db : kMajorTicks) {
+        const float x = dbToX(db);
+        p.drawLine(QPointF(x, r.top()), QPointF(x, r.bottom()));
+        const float y = dbToY(db);
+        p.drawLine(QPointF(r.left(), y), QPointF(r.right(), y));
+
+        if (!m_compact && db != 0.0f && db != kMinDb) {
+            p.setPen(kAxisLabelColor);
+            p.drawText(QPointF(x + 2.0f, r.bottom() - 2.0f),
+                       QString::number(static_cast<int>(db)));
+            p.drawText(QPointF(r.left() + 2.0f, y - 2.0f),
+                       QString::number(static_cast<int>(db)));
+            p.setPen(majorPen);
+        }
+    }
+
+    // Unity diagonal (below-threshold passthrough) drawn as a dim
+    // reference so the user can see how far the curve bends away.
+    p.setPen(QPen(kIdentityColor, 1.0, Qt::DashLine));
+    p.drawLine(QPointF(dbToX(kMinDb), dbToY(kMinDb)),
+               QPointF(dbToX(kMaxDb), dbToY(kMaxDb)));
+
+    p.restore();
+}
+
+void ClientCompCurveWidget::drawCurve(QPainter& p, const QRectF& r) const
+{
+    if (!m_comp) return;
+
+    p.save();
+
+    // Walk across the input range in ~1 dB steps — the knee transition
+    // is smooth enough that this is plenty, and it keeps the path short.
+    QPainterPath path;
+    constexpr int steps = 121;                     // 60 dB range, 0.5 dB/step
+    for (int i = 0; i < steps; ++i) {
+        const float t    = static_cast<float>(i) / (steps - 1);
+        const float inDb = kMinDb + t * (kMaxDb - kMinDb);
+        const float outDb = std::clamp(curveOutputDb(inDb), kMinDb, kMaxDb);
+        const QPointF pt(dbToX(inDb), dbToY(outDb));
+        if (i == 0) path.moveTo(pt);
+        else        path.lineTo(pt);
+    }
+
+    QPen curvePen(kCurveColor, m_compact ? 1.5 : 2.0);
+    curvePen.setJoinStyle(Qt::RoundJoin);
+    curvePen.setCapStyle(Qt::RoundCap);
+    p.setPen(curvePen);
+    p.drawPath(path);
+
+    // Threshold tick on the curve — small filled dot at the knee centre
+    // so the user's eye finds the threshold point even at a glance.
+    if (!m_compact) {
+        const float T = m_comp->thresholdDb();
+        const QPointF t(dbToX(T), dbToY(curveOutputDb(T)));
+        p.setBrush(kCurveColor);
+        p.setPen(Qt::NoPen);
+        p.drawEllipse(t, 3.0, 3.0);
+    }
+
+    p.restore();
+}
+
+void ClientCompCurveWidget::drawBall(QPainter& p, const QRectF& r) const
+{
+    if (!m_comp) return;
+    const float inDb = std::clamp(m_lastInputDb, kMinDb, kMaxDb);
+    const float outDb = std::clamp(curveOutputDb(inDb), kMinDb, kMaxDb);
+    const QPointF pt(dbToX(inDb), dbToY(outDb));
+
+    p.save();
+    // Glow halo — radial gradient so the ball reads as a light source
+    // even at low GR.  Size scales slightly with input level so busy
+    // passages look livelier than quiet ones.
+    const float glow = m_compact ? 8.0f : 11.0f;
+    QRadialGradient g(pt, glow);
+    QColor glowColor = kBallGlowColor;
+    glowColor.setAlpha(200);
+    g.setColorAt(0.0, glowColor);
+    glowColor.setAlpha(0);
+    g.setColorAt(1.0, glowColor);
+    p.setBrush(g);
+    p.setPen(Qt::NoPen);
+    p.drawEllipse(pt, glow, glow);
+
+    // White core
+    p.setBrush(kBallCoreColor);
+    p.drawEllipse(pt, m_compact ? 2.5 : 3.5, m_compact ? 2.5 : 3.5);
+    p.restore();
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompCurveWidget.h
+++ b/src/gui/ClientCompCurveWidget.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <QWidget>
+
+class QTimer;
+
+namespace AetherSDR {
+
+class ClientComp;
+
+// Read-only transfer curve for the Pro-XL-style compressor.  Draws the
+// static gain curve (input dB on X, output dB on Y) from the live
+// ClientComp parameters, with a glowing "ball" sliding along the curve
+// at the current input envelope level so you can see the compressor
+// working in real time.
+//
+// Used in two places: inside the docked applet as a compact dashboard,
+// and inside the floating editor as the canvas backdrop.  Interactive
+// threshold-drag + ratio-handle behaviour lives in the subclass
+// ClientCompEditorCanvas, not here.
+//
+// Thread model: the bound ClientComp is read on the UI thread only.
+// Parameter reads and meter reads are already atomic internally, so
+// paintEvent + the meter-polling QTimer are both safe from the UI
+// thread without any additional locking.
+class ClientCompCurveWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientCompCurveWidget(QWidget* parent = nullptr);
+
+    // Null is allowed — widget draws the grid with no curve or ball.
+    void setComp(ClientComp* comp);
+    ClientComp* comp() const { return m_comp; }
+
+    // Compact mode: thinner gridlines, no axis labels.  On in the
+    // docked applet, off in the editor canvas.
+    void setCompactMode(bool on);
+
+    // X / Y extents of the displayed range.  Fixed — compressors are
+    // always drawn on an absolute dBFS grid.
+    static constexpr float kMinDb =  -60.0f;
+    static constexpr float kMaxDb =    0.0f;
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+
+    // Map dBFS <-> pixel inside the drawing rect.
+    float dbToX(float db) const;
+    float dbToY(float db) const;
+    float xToDb(float x) const;
+    float yToDb(float y) const;
+
+    // Shared static-curve math — returns the output level in dB for a
+    // given input level in dB, using the current threshold / ratio /
+    // knee from m_comp.  Mirrors ClientComp::staticCurveGainDb() but
+    // evaluated in the output-level domain so the curve can be traced
+    // straight onto the grid.
+    float curveOutputDb(float inDb) const;
+
+    // Draws the static transfer curve and the live ball on top.  Split
+    // out so the interactive subclass can call the same drawing pass
+    // then overlay its handles.
+    void drawGrid(QPainter& p, const QRectF& rect) const;
+    void drawCurve(QPainter& p, const QRectF& rect) const;
+    void drawBall(QPainter& p, const QRectF& rect) const;
+
+    // Polling timer that updates the ball position from the latest
+    // ClientComp::inputPeakDb() at ~30 Hz so the motion is smooth but
+    // cheap.  Started in setComp() when a non-null comp is bound.
+    QTimer*     m_pollTimer{nullptr};
+
+    ClientComp* m_comp{nullptr};
+    bool        m_compact{false};
+    float       m_lastInputDb{-120.0f};   // smoothed ball position
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompEditor.cpp
+++ b/src/gui/ClientCompEditor.cpp
@@ -1,0 +1,493 @@
+#include "ClientCompEditor.h"
+#include "ClientCompEditorCanvas.h"
+#include "ClientCompKnob.h"
+#include "ClientCompMeter.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ClientComp.h"
+
+#include <QCloseEvent>
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QHideEvent>
+#include <QLabel>
+#include <QMoveEvent>
+#include <QPushButton>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kDefaultWidth  = 860;
+constexpr int kDefaultHeight = 400;
+
+constexpr const char* kWindowStyle =
+    "QWidget { background: #08121d; color: #d7e7f2; }"
+    "QLabel  { background: transparent; color: #8aa8c0; font-size: 11px; }";
+
+const QString kBypassStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #0e1b28;"
+    "  color: #8aa8c0;"
+    "  border: 1px solid #243a4e;"
+    "  border-radius: 3px;"
+    "  font-size: 11px;"
+    "  font-weight: bold;"
+    "  padding: 3px 12px;"
+    "}"
+    "QPushButton:hover { background: #1a2a3a; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e;"
+    "  color: #f2c14e;"
+    "  border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #4a3a1e; }");
+
+const QString kLimBtnStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 10px; font-weight: bold; padding: 3px 6px;"
+    "}"
+    "QPushButton:hover { background: #204060; }"
+    "QPushButton:checked {"
+    "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
+    "}");
+
+} // namespace
+
+ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent, Qt::Window)
+    , m_audio(engine)
+{
+    setWindowTitle("Client Compressor");
+    setStyleSheet(kWindowStyle);
+    resize(kDefaultWidth, kDefaultHeight);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(8, 8, 8, 8);
+    root->setSpacing(6);
+
+    // ── Header strip: bypass + chain-order segmented picker ─────────
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(8);
+
+        m_bypass = new QPushButton("Bypass");
+        m_bypass->setCheckable(true);
+        m_bypass->setStyleSheet(kBypassStyle);
+        m_bypass->setFixedHeight(22);
+        m_bypass->setToolTip("Bypass the compressor (signal passes through unshaped)");
+        row->addWidget(m_bypass);
+
+        row->addStretch();
+
+        auto* lbl = new QLabel("Chain:");
+        row->addWidget(lbl);
+
+        m_chainOrder = new QComboBox;
+        m_chainOrder->addItem("CMP → EQ");
+        m_chainOrder->addItem("EQ → CMP");
+        m_chainOrder->setToolTip(
+            "Signal flow order from the mic to the radio. "
+            "CMP→EQ colours the raw mic first then shapes it. "
+            "EQ→CMP shapes first then tames peaks.");
+        row->addWidget(m_chainOrder);
+
+        root->addLayout(row);
+    }
+
+    // ── Main body: knobs column | canvas | meters | makeup/limiter ──
+    {
+        auto* body = new QHBoxLayout;
+        body->setSpacing(8);
+
+        // Knobs column (Ratio / Attack / Release / Knee).
+        {
+            auto* col = new QVBoxLayout;
+            col->setSpacing(4);
+
+            m_ratio = new ClientCompKnob;
+            m_ratio->setLabel("Ratio");
+            m_ratio->setRange(1.0f, 20.0f);
+            m_ratio->setDefault(3.0f);
+            m_ratio->setValueFromNorm([](float n) {
+                // Exponential — 1:1 at 0, 20:1 at 1, with a gentle curve
+                // so the middle of the knob lands near 4:1.
+                return 1.0f * std::pow(20.0f, n);
+            });
+            m_ratio->setNormFromValue([](float v) {
+                if (v <= 1.0f) return 0.0f;
+                return std::log(v) / std::log(20.0f);
+            });
+            m_ratio->setLabelFormat([](float v) {
+                return QString::number(v, 'f', 2) + " :1";
+            });
+            col->addWidget(m_ratio);
+
+            m_attack = new ClientCompKnob;
+            m_attack->setLabel("Attack");
+            m_attack->setRange(0.1f, 300.0f);
+            m_attack->setDefault(20.0f);
+            m_attack->setValueFromNorm([](float n) {
+                return 0.1f * std::pow(3000.0f, n);  // 0.1 .. 300 ms
+            });
+            m_attack->setNormFromValue([](float v) {
+                if (v <= 0.1f) return 0.0f;
+                return std::log(v / 0.1f) / std::log(3000.0f);
+            });
+            m_attack->setLabelFormat([](float v) {
+                return v < 10.0f ? QString::number(v, 'f', 1) + " ms"
+                                  : QString::number(v, 'f', 0) + " ms";
+            });
+            col->addWidget(m_attack);
+
+            m_release = new ClientCompKnob;
+            m_release->setLabel("Release");
+            m_release->setRange(5.0f, 2000.0f);
+            m_release->setDefault(200.0f);
+            m_release->setValueFromNorm([](float n) {
+                return 5.0f * std::pow(400.0f, n);    // 5 .. 2000 ms
+            });
+            m_release->setNormFromValue([](float v) {
+                if (v <= 5.0f) return 0.0f;
+                return std::log(v / 5.0f) / std::log(400.0f);
+            });
+            m_release->setLabelFormat([](float v) {
+                return QString::number(v, 'f', 0) + " ms";
+            });
+            col->addWidget(m_release);
+
+            m_knee = new ClientCompKnob;
+            m_knee->setLabel("Knee");
+            m_knee->setRange(0.0f, 24.0f);
+            m_knee->setDefault(6.0f);
+            m_knee->setLabelFormat([](float v) {
+                return QString::number(v, 'f', 1) + " dB";
+            });
+            col->addWidget(m_knee);
+
+            col->addStretch();
+            body->addLayout(col);
+        }
+
+        // Threshold mini-column: one tall slider view + numeric label.
+        // The interactive canvas owns the real threshold handle; this
+        // label just echoes the current value so the user can read the
+        // exact number at a glance.
+        {
+            auto* col = new QVBoxLayout;
+            col->setSpacing(2);
+            auto* hdr = new QLabel("Thresh");
+            hdr->setAlignment(Qt::AlignCenter);
+            col->addWidget(hdr);
+            m_thresholdLabel = new QLabel("-18.0 dB");
+            m_thresholdLabel->setAlignment(Qt::AlignCenter);
+            m_thresholdLabel->setStyleSheet(
+                "QLabel { color: #e8e8e8; font-size: 11px; font-weight: bold; }");
+            col->addWidget(m_thresholdLabel);
+
+            m_inputMeter = new ClientCompMeter;
+            m_inputMeter->setMode(ClientCompMeter::Mode::Level);
+            m_inputMeter->setLabel("In");
+            m_inputMeter->setMinimumWidth(20);
+            col->addWidget(m_inputMeter, 1);
+            body->addLayout(col);
+        }
+
+        // Canvas (center).
+        m_canvas = new ClientCompEditorCanvas;
+        body->addWidget(m_canvas, 1);
+
+        // GR + Output meters.
+        {
+            auto* col = new QVBoxLayout;
+            col->setSpacing(2);
+
+            m_grMeter = new ClientCompMeter;
+            m_grMeter->setMode(ClientCompMeter::Mode::GainReduction);
+            m_grMeter->setLabel("GR");
+            m_grMeter->setMinimumWidth(20);
+
+            m_outputMeter = new ClientCompMeter;
+            m_outputMeter->setMode(ClientCompMeter::Mode::Level);
+            m_outputMeter->setLabel("Out");
+            m_outputMeter->setMinimumWidth(20);
+
+            col->addWidget(m_grMeter, 1);
+            body->addLayout(col);
+
+            auto* col2 = new QVBoxLayout;
+            col2->setSpacing(2);
+            col2->addWidget(m_outputMeter, 1);
+            body->addLayout(col2);
+        }
+
+        // Limiter + Makeup column.
+        {
+            auto* col = new QVBoxLayout;
+            col->setSpacing(6);
+
+            m_limiterEnable = new QPushButton("LIMIT");
+            m_limiterEnable->setCheckable(true);
+            m_limiterEnable->setStyleSheet(kLimBtnStyle);
+            m_limiterEnable->setFixedHeight(22);
+            m_limiterEnable->setToolTip(
+                "Brickwall peak limiter on the compressor output");
+            col->addWidget(m_limiterEnable);
+
+            m_ceiling = new ClientCompKnob;
+            m_ceiling->setLabel("Ceiling");
+            m_ceiling->setRange(-24.0f, 0.0f);
+            m_ceiling->setDefault(-1.0f);
+            m_ceiling->setLabelFormat([](float v) {
+                return QString::number(v, 'f', 1) + " dB";
+            });
+            col->addWidget(m_ceiling);
+
+            m_makeup = new ClientCompKnob;
+            m_makeup->setLabel("Makeup");
+            m_makeup->setRange(-12.0f, 24.0f);
+            m_makeup->setDefault(0.0f);
+            m_makeup->setLabelFormat([](float v) {
+                return (v >= 0.0f ? "+" : "") + QString::number(v, 'f', 1) + " dB";
+            });
+            col->addWidget(m_makeup);
+            col->addStretch();
+            body->addLayout(col);
+        }
+
+        root->addLayout(body, 1);
+    }
+
+    // ── Signal wiring ───────────────────────────────────────────────
+    if (m_audio && m_audio->clientCompTx()) {
+        m_canvas->setComp(m_audio->clientCompTx());
+    }
+
+    connect(m_bypass, &QPushButton::toggled, this, [this](bool checked) {
+        if (!m_audio) return;
+        ClientComp* c = m_audio->clientCompTx();
+        if (!c) return;
+        // "Bypass checked" means the effect is bypassed → comp disabled.
+        c->setEnabled(!checked);
+        m_audio->saveClientCompSettings();
+        emit bypassToggled(checked);
+        if (m_canvas) m_canvas->update();
+    });
+
+    connect(m_chainOrder,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, [this](int idx) {
+        if (!m_audio) return;
+        m_audio->setTxChainOrder(
+            idx == 1 ? AudioEngine::TxChainOrder::EqThenComp
+                     : AudioEngine::TxChainOrder::CompThenEq);
+    });
+
+    connect(m_canvas, &ClientCompEditorCanvas::thresholdChanged,
+            this, &ClientCompEditor::applyThreshold);
+    connect(m_canvas, &ClientCompEditorCanvas::ratioChanged,
+            this, &ClientCompEditor::applyRatio);
+
+    connect(m_ratio,   &ClientCompKnob::valueChanged,
+            this, &ClientCompEditor::applyRatio);
+    connect(m_attack,  &ClientCompKnob::valueChanged,
+            this, &ClientCompEditor::applyAttack);
+    connect(m_release, &ClientCompKnob::valueChanged,
+            this, &ClientCompEditor::applyRelease);
+    connect(m_knee,    &ClientCompKnob::valueChanged,
+            this, &ClientCompEditor::applyKnee);
+    connect(m_makeup,  &ClientCompKnob::valueChanged,
+            this, &ClientCompEditor::applyMakeup);
+    connect(m_ceiling, &ClientCompKnob::valueChanged,
+            this, &ClientCompEditor::applyLimiterCeiling);
+    connect(m_limiterEnable, &QPushButton::toggled,
+            this, &ClientCompEditor::applyLimiterEnabled);
+
+    syncControlsFromEngine();
+
+    m_meterTimer = new QTimer(this);
+    m_meterTimer->setInterval(33);  // ~30 Hz
+    connect(m_meterTimer, &QTimer::timeout,
+            this, &ClientCompEditor::tickMeters);
+}
+
+ClientCompEditor::~ClientCompEditor() = default;
+
+void ClientCompEditor::showForTx()
+{
+    restoreGeometryFromSettings();
+    syncControlsFromEngine();
+    if (m_meterTimer) m_meterTimer->start();
+    show();
+    raise();
+    activateWindow();
+}
+
+void ClientCompEditor::syncControlsFromEngine()
+{
+    if (!m_audio) return;
+    ClientComp* c = m_audio->clientCompTx();
+    if (!c) return;
+    QSignalBlocker bb(m_bypass);
+    QSignalBlocker bco(m_chainOrder);
+    QSignalBlocker br(m_ratio);
+    QSignalBlocker ba(m_attack);
+    QSignalBlocker brl(m_release);
+    QSignalBlocker bk(m_knee);
+    QSignalBlocker bm(m_makeup);
+    QSignalBlocker bce(m_ceiling);
+    QSignalBlocker ble(m_limiterEnable);
+
+    m_bypass->setChecked(!c->isEnabled());
+    m_chainOrder->setCurrentIndex(
+        m_audio->txChainOrder() == AudioEngine::TxChainOrder::EqThenComp ? 1 : 0);
+    m_ratio->setValue(c->ratio());
+    m_attack->setValue(c->attackMs());
+    m_release->setValue(c->releaseMs());
+    m_knee->setValue(c->kneeDb());
+    m_makeup->setValue(c->makeupDb());
+    m_ceiling->setValue(c->limiterCeilingDb());
+    m_limiterEnable->setChecked(c->limiterEnabled());
+    m_thresholdLabel->setText(
+        QString::number(c->thresholdDb(), 'f', 1) + " dB");
+    if (m_canvas) m_canvas->update();
+}
+
+void ClientCompEditor::tickMeters()
+{
+    if (!m_audio) return;
+    ClientComp* c = m_audio->clientCompTx();
+    if (!c) return;
+    if (m_inputMeter)  m_inputMeter ->setValueDb(c->inputPeakDb());
+    if (m_grMeter)     m_grMeter    ->setValueDb(c->gainReductionDb());
+    if (m_outputMeter) m_outputMeter->setValueDb(c->outputPeakDb());
+}
+
+void ClientCompEditor::applyThreshold(float db)
+{
+    if (!m_audio) return;
+    ClientComp* c = m_audio->clientCompTx();
+    if (!c) return;
+    c->setThresholdDb(db);
+    m_audio->saveClientCompSettings();
+    if (m_thresholdLabel)
+        m_thresholdLabel->setText(QString::number(db, 'f', 1) + " dB");
+    if (m_canvas) m_canvas->update();
+}
+
+void ClientCompEditor::applyRatio(float ratio)
+{
+    if (!m_audio) return;
+    ClientComp* c = m_audio->clientCompTx();
+    if (!c) return;
+    c->setRatio(ratio);
+    m_audio->saveClientCompSettings();
+    // Mirror to the knob if the change came from the canvas.
+    if (m_ratio && std::fabs(m_ratio->value() - ratio) > 0.001f) {
+        QSignalBlocker b(m_ratio);
+        m_ratio->setValue(ratio);
+    }
+    if (m_canvas) m_canvas->update();
+}
+
+void ClientCompEditor::applyAttack(float ms)
+{
+    if (!m_audio) return;
+    if (auto* c = m_audio->clientCompTx()) c->setAttackMs(ms);
+    m_audio->saveClientCompSettings();
+}
+
+void ClientCompEditor::applyRelease(float ms)
+{
+    if (!m_audio) return;
+    if (auto* c = m_audio->clientCompTx()) c->setReleaseMs(ms);
+    m_audio->saveClientCompSettings();
+}
+
+void ClientCompEditor::applyKnee(float db)
+{
+    if (!m_audio) return;
+    if (auto* c = m_audio->clientCompTx()) c->setKneeDb(db);
+    m_audio->saveClientCompSettings();
+    if (m_canvas) m_canvas->update();
+}
+
+void ClientCompEditor::applyMakeup(float db)
+{
+    if (!m_audio) return;
+    if (auto* c = m_audio->clientCompTx()) c->setMakeupDb(db);
+    m_audio->saveClientCompSettings();
+    if (m_canvas) m_canvas->update();
+}
+
+void ClientCompEditor::applyLimiterEnabled(bool on)
+{
+    if (!m_audio) return;
+    if (auto* c = m_audio->clientCompTx()) c->setLimiterEnabled(on);
+    m_audio->saveClientCompSettings();
+}
+
+void ClientCompEditor::applyLimiterCeiling(float db)
+{
+    if (!m_audio) return;
+    if (auto* c = m_audio->clientCompTx()) c->setLimiterCeilingDb(db);
+    m_audio->saveClientCompSettings();
+}
+
+void ClientCompEditor::saveGeometryToSettings()
+{
+    auto& s = AppSettings::instance();
+    s.setValue("ClientCompEditorGeometry", saveGeometry().toBase64());
+}
+
+void ClientCompEditor::restoreGeometryFromSettings()
+{
+    auto& s = AppSettings::instance();
+    const QByteArray geom = QByteArray::fromBase64(
+        s.value("ClientCompEditorGeometry", "").toByteArray());
+    if (!geom.isEmpty()) {
+        m_restoring = true;
+        restoreGeometry(geom);
+        m_restoring = false;
+    }
+}
+
+void ClientCompEditor::closeEvent(QCloseEvent* ev)
+{
+    if (m_meterTimer) m_meterTimer->stop();
+    saveGeometryToSettings();
+    QWidget::closeEvent(ev);
+}
+
+void ClientCompEditor::moveEvent(QMoveEvent* ev)
+{
+    QWidget::moveEvent(ev);
+    if (!m_restoring) saveGeometryToSettings();
+}
+
+void ClientCompEditor::resizeEvent(QResizeEvent* ev)
+{
+    QWidget::resizeEvent(ev);
+    if (!m_restoring) saveGeometryToSettings();
+}
+
+void ClientCompEditor::showEvent(QShowEvent* ev)
+{
+    QWidget::showEvent(ev);
+    if (m_meterTimer) m_meterTimer->start();
+}
+
+void ClientCompEditor::hideEvent(QHideEvent* ev)
+{
+    QWidget::hideEvent(ev);
+    if (m_meterTimer) m_meterTimer->stop();
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompEditor.h
+++ b/src/gui/ClientCompEditor.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <QWidget>
+
+class QComboBox;
+class QLabel;
+class QPushButton;
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompEditorCanvas;
+class ClientCompKnob;
+class ClientCompMeter;
+
+// Floating editor for the Pro-XL-style TX compressor.  One instance
+// lives on MainWindow; calling showForTx() raises the window and
+// binds it to AudioEngine::clientCompTx().  Geometry persists via
+// AppSettings (`ClientCompEditorGeometry` key).
+//
+// Layout (Ableton-inspired, extended for limiter + chain order):
+//   ┌─ bypass │ CMP→EQ | EQ→CMP ──────────────────── × ┐
+//   │  ratio  │  [Thresh] [transfer curve]  │GR│Out│L│M│
+//   │  attack │                             │  │  │ │a│
+//   │  rlease │                             │  │  │ │k│
+//   │  knee   │                             │  │  │ │e│
+//   └─────────────────────────────────────────────────┘
+//
+// The canvas (center column) owns the threshold slider + curve + live
+// ball.  Meter strips and limiter controls are separate child widgets
+// wired to the same ClientComp via signals.
+class ClientCompEditor : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientCompEditor(AudioEngine* engine, QWidget* parent = nullptr);
+    ~ClientCompEditor() override;
+
+    void showForTx();
+
+signals:
+    // Fired when the bypass button is toggled inside the editor.  The
+    // docked applet subscribes so its Enable toggle stays in sync —
+    // both widgets read / write the same ClientComp::enabled flag.
+    void bypassToggled(bool bypassed);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+
+    // Pull the Bypass button / chain-order combo state from the engine
+    // so a programmatic change (e.g. loading settings) updates the UI.
+    void syncControlsFromEngine();
+
+    // Refresh meter widgets from the latest ClientComp snapshot.
+    void tickMeters();
+
+    // Commit a parameter change to the AudioEngine's ClientComp and
+    // persist via AppSettings.  All knob/canvas signals land here.
+    void applyThreshold(float db);
+    void applyRatio(float ratio);
+    void applyAttack(float ms);
+    void applyRelease(float ms);
+    void applyKnee(float db);
+    void applyMakeup(float db);
+    void applyLimiterEnabled(bool on);
+    void applyLimiterCeiling(float db);
+
+    AudioEngine*             m_audio{nullptr};
+    ClientCompEditorCanvas*  m_canvas{nullptr};
+    ClientCompKnob*          m_ratio{nullptr};
+    ClientCompKnob*          m_attack{nullptr};
+    ClientCompKnob*          m_release{nullptr};
+    ClientCompKnob*          m_knee{nullptr};
+    ClientCompKnob*          m_makeup{nullptr};
+    ClientCompKnob*          m_ceiling{nullptr};
+    ClientCompMeter*         m_inputMeter{nullptr};
+    ClientCompMeter*         m_grMeter{nullptr};
+    ClientCompMeter*         m_outputMeter{nullptr};
+    QLabel*                  m_thresholdLabel{nullptr};
+    QPushButton*             m_bypass{nullptr};
+    QPushButton*             m_limiterEnable{nullptr};
+    QComboBox*               m_chainOrder{nullptr};
+    QTimer*                  m_meterTimer{nullptr};
+    bool                     m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompEditorCanvas.cpp
+++ b/src/gui/ClientCompEditorCanvas.cpp
@@ -1,0 +1,151 @@
+#include "ClientCompEditorCanvas.h"
+#include "core/ClientComp.h"
+
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPaintEvent>
+#include <QPen>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr float kHandleHitRadius = 10.0f;
+
+const QColor kThresholdHandle("#e8a540");
+const QColor kRatioHandle    ("#4db8d4");
+const QColor kHandleOutline  ("#ffffff");
+
+} // namespace
+
+ClientCompEditorCanvas::ClientCompEditorCanvas(QWidget* parent)
+    : ClientCompCurveWidget(parent)
+{
+    setMinimumHeight(220);
+    setCursor(Qt::CrossCursor);
+    setMouseTracking(true);
+}
+
+bool ClientCompEditorCanvas::thresholdHandleHit(const QPointF& pos) const
+{
+    if (!m_comp) return false;
+    const float T = m_comp->thresholdDb();
+    // Threshold handle lives on the bottom edge at x=dbToX(T).
+    const QPointF h(dbToX(T), rect().bottom() - 6.0);
+    const float dx = static_cast<float>(pos.x() - h.x());
+    const float dy = static_cast<float>(pos.y() - h.y());
+    return (dx * dx + dy * dy) < kHandleHitRadius * kHandleHitRadius;
+}
+
+bool ClientCompEditorCanvas::ratioHandleHit(const QPointF& pos) const
+{
+    if (!m_comp) return false;
+    const float T = m_comp->thresholdDb();
+    const float outDb = curveOutputDb(T);
+    const QPointF h(dbToX(T), dbToY(outDb));
+    const float dx = static_cast<float>(pos.x() - h.x());
+    const float dy = static_cast<float>(pos.y() - h.y());
+    return (dx * dx + dy * dy) < kHandleHitRadius * kHandleHitRadius;
+}
+
+void ClientCompEditorCanvas::paintEvent(QPaintEvent* ev)
+{
+    ClientCompCurveWidget::paintEvent(ev);
+    if (!m_comp) return;
+
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    // Threshold handle — small filled triangle hanging off the bottom
+    // of the grid at the current threshold x.  Easy target for the
+    // mouse and doesn't compete visually with the curve dot.
+    const float T    = m_comp->thresholdDb();
+    const float tx   = dbToX(T);
+    const float by   = rect().bottom() - 4.0f;
+    QPainterPath tri;
+    tri.moveTo(tx,         by);
+    tri.lineTo(tx - 5.5f, by + 8.0f);
+    tri.lineTo(tx + 5.5f, by + 8.0f);
+    tri.closeSubpath();
+    p.setBrush(kThresholdHandle);
+    p.setPen(QPen(kHandleOutline, 1.0));
+    p.drawPath(tri);
+
+    // Ratio handle — larger filled dot at the knee centre so it reads
+    // as "drag me to change the slope."  White outline so it stays
+    // visible against the cyan curve even when GR is 0.
+    const float outDb = curveOutputDb(T);
+    const QPointF rh(tx, dbToY(outDb));
+    p.setBrush(kRatioHandle);
+    p.setPen(QPen(kHandleOutline, 1.2));
+    p.drawEllipse(rh, 6.5, 6.5);
+}
+
+void ClientCompEditorCanvas::mousePressEvent(QMouseEvent* ev)
+{
+    if (!m_comp || ev->button() != Qt::LeftButton) {
+        QWidget::mousePressEvent(ev);
+        return;
+    }
+    if (ratioHandleHit(ev->position())) {
+        m_drag = Drag::Ratio;
+        m_dragStart = ev->position();
+        m_dragStartValue = m_comp->ratio();
+        setCursor(Qt::SizeVerCursor);
+        ev->accept();
+        return;
+    }
+    if (thresholdHandleHit(ev->position())) {
+        m_drag = Drag::Threshold;
+        m_dragStart = ev->position();
+        m_dragStartValue = m_comp->thresholdDb();
+        setCursor(Qt::SizeHorCursor);
+        ev->accept();
+        return;
+    }
+    QWidget::mousePressEvent(ev);
+}
+
+void ClientCompEditorCanvas::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (m_drag == Drag::None || !m_comp) {
+        QWidget::mouseMoveEvent(ev);
+        return;
+    }
+
+    if (m_drag == Drag::Threshold) {
+        const float t = std::clamp(xToDb(static_cast<float>(ev->position().x())),
+                                   kMinDb, kMaxDb);
+        emit thresholdChanged(t);
+        update();
+    } else if (m_drag == Drag::Ratio) {
+        // Vertical pixels → ratio.  Dragging up increases ratio
+        // (steeper compression / limiter behaviour), dragging down
+        // decreases it toward 1:1.  Exponential feels best — a small
+        // motion near 1:1 stays subtle and a big motion near the top
+        // pushes into limiter territory.
+        const float dy = static_cast<float>(m_dragStart.y() - ev->position().y());
+        const float scale = (ev->modifiers() & Qt::ShiftModifier) ? 0.25f : 1.0f;
+        const float factor = std::pow(4.0f, scale * dy / 200.0f);
+        const float next = std::clamp(m_dragStartValue * factor, 1.0f, 20.0f);
+        emit ratioChanged(next);
+        update();
+    }
+    ev->accept();
+}
+
+void ClientCompEditorCanvas::mouseReleaseEvent(QMouseEvent* ev)
+{
+    if (m_drag == Drag::None) {
+        QWidget::mouseReleaseEvent(ev);
+        return;
+    }
+    m_drag = Drag::None;
+    setCursor(Qt::CrossCursor);
+    ev->accept();
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompEditorCanvas.h
+++ b/src/gui/ClientCompEditorCanvas.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "ClientCompCurveWidget.h"
+
+namespace AetherSDR {
+
+// Interactive transfer curve for the floating editor.  Extends the
+// read-only ClientCompCurveWidget with two draggable handles:
+//
+//   - Threshold handle: a triangle pointing right, sitting on the
+//     input-axis bottom strip.  Dragging it left / right changes the
+//     threshold.  Clamped to the displayed [-60, 0] dBFS range.
+//
+//   - Ratio handle: the filled dot at the knee centre.  Dragging it
+//     vertically changes the ratio (upward = gentler, downward =
+//     steeper).  Horizontal drag is ignored so the user can't change
+//     threshold from the curve dot (that's the threshold handle's
+//     job, keeping the gestures orthogonal).
+//
+// Emits atomic signals on every mouse-move so callers can live-update
+// the DSP and settings.  Visual feedback comes from the parent's
+// paintEvent, re-run after each mutation.
+class ClientCompEditorCanvas : public ClientCompCurveWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientCompEditorCanvas(QWidget* parent = nullptr);
+
+signals:
+    void thresholdChanged(float db);
+    void ratioChanged(float ratio);
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseMoveEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
+
+private:
+    enum class Drag { None, Threshold, Ratio };
+
+    Drag   m_drag{Drag::None};
+    QPointF m_dragStart;
+    float   m_dragStartValue{0.0f};
+
+    bool thresholdHandleHit(const QPointF& pos) const;
+    bool ratioHandleHit(const QPointF& pos) const;
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompKnob.cpp
+++ b/src/gui/ClientCompKnob.cpp
@@ -1,0 +1,209 @@
+#include "ClientCompKnob.h"
+
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPaintEvent>
+#include <QPen>
+#include <QWheelEvent>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr float kDragPxPerFullRange = 200.0f;  // 200 px vertical = 0..1
+constexpr float kWheelNormStep      = 0.01f;   // 1% per wheel notch
+constexpr float kFineMultiplier     = 0.25f;   // Shift-drag scales ×0.25
+constexpr float kArcStartDeg        = 225.0f;  // 7:30 clockwise to
+constexpr float kArcSpanDeg         = -270.0f; // 4:30  = 270° sweep
+
+const QColor kRingBg     ("#1a2a3a");
+const QColor kRingArc    ("#4db8d4");
+const QColor kPointer    ("#e8e8e8");
+const QColor kLabelColor ("#b0c4d6");
+const QColor kValueColor ("#e8e8e8");
+
+} // namespace
+
+ClientCompKnob::ClientCompKnob(QWidget* parent) : QWidget(parent)
+{
+    setMinimumSize(58, 64);
+    setFocusPolicy(Qt::StrongFocus);
+    setAttribute(Qt::WA_OpaquePaintEvent, false);
+}
+
+void ClientCompKnob::setLabel(const QString& text)
+{
+    m_label = text;
+    update();
+}
+
+void ClientCompKnob::setRange(float minPhysical, float maxPhysical)
+{
+    m_minPhys = minPhysical;
+    m_maxPhys = maxPhysical;
+    setValue(m_physical);
+}
+
+void ClientCompKnob::setDefault(float physical)
+{
+    m_defaultPhys = physical;
+}
+
+void ClientCompKnob::setValueFromNorm(ValueMap fromNorm)
+{
+    m_fromNorm = std::move(fromNorm);
+    setValue(m_physical);  // re-evaluate with new mapping
+}
+
+void ClientCompKnob::setNormFromValue(ValueMap toNorm)
+{
+    m_toNorm = std::move(toNorm);
+    setValue(m_physical);
+}
+
+void ClientCompKnob::setLabelFormat(LabelFormat fmt)
+{
+    m_fmt = std::move(fmt);
+    update();
+}
+
+void ClientCompKnob::setValue(float physical)
+{
+    m_physical = std::clamp(physical, m_minPhys, m_maxPhys);
+    if (m_toNorm) {
+        m_norm = std::clamp(m_toNorm(m_physical), 0.0f, 1.0f);
+    } else {
+        const float span = std::max(1e-9f, m_maxPhys - m_minPhys);
+        m_norm = std::clamp((m_physical - m_minPhys) / span, 0.0f, 1.0f);
+    }
+    update();
+}
+
+void ClientCompKnob::applyNorm(float norm)
+{
+    m_norm = std::clamp(norm, 0.0f, 1.0f);
+    if (m_fromNorm) {
+        m_physical = std::clamp(m_fromNorm(m_norm), m_minPhys, m_maxPhys);
+    } else {
+        m_physical = m_minPhys + m_norm * (m_maxPhys - m_minPhys);
+    }
+    emit valueChanged(m_physical);
+    update();
+}
+
+QString ClientCompKnob::formatValue() const
+{
+    if (m_fmt) return m_fmt(m_physical);
+    return QString::number(m_physical, 'f', 2);
+}
+
+void ClientCompKnob::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    const int w = width();
+    const int h = height();
+    const int diameter = std::min(w - 4, h - 24);  // leave room for text rows
+    const QRectF ring((w - diameter) * 0.5f, 12.0f, diameter, diameter);
+
+    // Label (above the ring).
+    QFont labelFont = p.font();
+    labelFont.setPixelSize(9);
+    labelFont.setBold(true);
+    p.setFont(labelFont);
+    p.setPen(kLabelColor);
+    p.drawText(QRectF(0, 0, w, 12), Qt::AlignCenter, m_label);
+
+    // Background ring.
+    const qreal thick = std::max(2.0, diameter * 0.10);
+    QPen bgPen(kRingBg, thick);
+    bgPen.setCapStyle(Qt::FlatCap);
+    p.setPen(bgPen);
+    p.drawArc(ring.adjusted(thick * 0.5, thick * 0.5,
+                            -thick * 0.5, -thick * 0.5),
+              static_cast<int>(kArcStartDeg * 16.0f),
+              static_cast<int>(kArcSpanDeg * 16.0f));
+
+    // Value arc.
+    QPen arcPen(kRingArc, thick);
+    arcPen.setCapStyle(Qt::FlatCap);
+    p.setPen(arcPen);
+    p.drawArc(ring.adjusted(thick * 0.5, thick * 0.5,
+                            -thick * 0.5, -thick * 0.5),
+              static_cast<int>(kArcStartDeg * 16.0f),
+              static_cast<int>((kArcSpanDeg * m_norm) * 16.0f));
+
+    // Pointer tick line from the inner edge of the arc to the inner
+    // tick radius — visible indicator of exact knob position.
+    const float angle = (kArcStartDeg + kArcSpanDeg * m_norm) * (M_PI / 180.0);
+    const QPointF c = ring.center();
+    const float rOut = diameter * 0.5f - thick * 0.5f;
+    const float rIn  = diameter * 0.5f - thick * 1.6f;
+    const QPointF pOut(c.x() + rOut * std::cos(angle),
+                       c.y() - rOut * std::sin(angle));
+    const QPointF pIn (c.x() + rIn  * std::cos(angle),
+                       c.y() - rIn  * std::sin(angle));
+    QPen pointerPen(kPointer, thick * 0.6);
+    pointerPen.setCapStyle(Qt::RoundCap);
+    p.setPen(pointerPen);
+    p.drawLine(pIn, pOut);
+
+    // Value text beneath the ring.
+    QFont valFont = p.font();
+    valFont.setPixelSize(9);
+    valFont.setBold(false);
+    p.setFont(valFont);
+    p.setPen(kValueColor);
+    p.drawText(QRectF(0, h - 12, w, 12), Qt::AlignCenter, formatValue());
+}
+
+void ClientCompKnob::mousePressEvent(QMouseEvent* ev)
+{
+    if (ev->button() != Qt::LeftButton) return;
+    m_dragging = true;
+    m_dragStartY = ev->position().y();
+    m_dragStartNorm = m_norm;
+    setCursor(Qt::SizeVerCursor);
+    ev->accept();
+}
+
+void ClientCompKnob::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (!m_dragging) return;
+    const float dy = static_cast<float>(m_dragStartY - ev->position().y());
+    const float scale = (ev->modifiers() & Qt::ShiftModifier)
+                          ? kFineMultiplier : 1.0f;
+    applyNorm(m_dragStartNorm + scale * dy / kDragPxPerFullRange);
+    ev->accept();
+}
+
+void ClientCompKnob::mouseReleaseEvent(QMouseEvent* ev)
+{
+    if (!m_dragging) return;
+    m_dragging = false;
+    setCursor(Qt::ArrowCursor);
+    ev->accept();
+}
+
+void ClientCompKnob::mouseDoubleClickEvent(QMouseEvent* ev)
+{
+    if (ev->button() != Qt::LeftButton) return;
+    setValue(m_defaultPhys);
+    emit valueChanged(m_physical);
+    ev->accept();
+}
+
+void ClientCompKnob::wheelEvent(QWheelEvent* ev)
+{
+    const int ticks = ev->angleDelta().y() / 120;
+    const float scale = (ev->modifiers() & Qt::ShiftModifier)
+                          ? kFineMultiplier : 1.0f;
+    applyNorm(m_norm + ticks * kWheelNormStep * scale);
+    ev->accept();
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompKnob.h
+++ b/src/gui/ClientCompKnob.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <QWidget>
+#include <QString>
+#include <functional>
+
+namespace AetherSDR {
+
+// Shared rotary knob for the compressor editor.  Click-drag vertical to
+// change the value, wheel for fine adjustment, double-click to reset to
+// the configured default.  Value mapping is user-supplied so the knob
+// can be linear (Makeup), exponential (Ratio/Attack/Release), or
+// anything else a caller needs.
+//
+// Value semantics:
+//   - Internal state is "normalized" in [0, 1].
+//   - setValueFunc/toValueFunc convert between the normalized 0..1 and
+//     the caller-facing physical unit.
+//   - valueLabelFunc formats the caller-facing value for display.
+//   - valueChanged(float) emits the physical value whenever the user
+//     moves the knob.
+class ClientCompKnob : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientCompKnob(QWidget* parent = nullptr);
+
+    // Caller-facing label drawn above the knob (e.g. "Ratio", "Attack").
+    void setLabel(const QString& text);
+
+    // Physical value range (inclusive).  Only used to clamp external
+    // setValue() calls; the actual normalised range is always 0..1.
+    void setRange(float minPhysical, float maxPhysical);
+
+    // Default used by double-click reset.
+    void setDefault(float physical);
+
+    // Conversion between the 0..1 knob position and the physical value
+    // the caller cares about.  Callers install these once after
+    // construction; omit them and the knob is linear over [0, 1].
+    using ValueMap = std::function<float(float)>;
+    void setValueFromNorm(ValueMap fromNorm);
+    void setNormFromValue(ValueMap toNorm);
+
+    // Text format for the value label.  Receives the physical value.
+    using LabelFormat = std::function<QString(float)>;
+    void setLabelFormat(LabelFormat fmt);
+
+    // Programmatic setter — e.g. loadClientCompSettings on startup.
+    void setValue(float physical);
+    float value() const { return m_physical; }
+
+signals:
+    void valueChanged(float physical);
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseMoveEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
+    void mouseDoubleClickEvent(QMouseEvent* ev) override;
+    void wheelEvent(QWheelEvent* ev) override;
+
+private:
+    void applyNorm(float norm);
+    QString formatValue() const;
+
+    QString     m_label;
+    float       m_minPhys{0.0f};
+    float       m_maxPhys{1.0f};
+    float       m_defaultPhys{0.0f};
+    float       m_norm{0.0f};
+    float       m_physical{0.0f};
+    ValueMap    m_fromNorm;
+    ValueMap    m_toNorm;
+    LabelFormat m_fmt;
+
+    bool        m_dragging{false};
+    int         m_dragStartY{0};
+    float       m_dragStartNorm{0.0f};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompMeter.cpp
+++ b/src/gui/ClientCompMeter.cpp
@@ -1,0 +1,182 @@
+#include "ClientCompMeter.h"
+
+#include <QPainter>
+#include <QPaintEvent>
+#include <QLinearGradient>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr float kLevelMinDb = -60.0f;
+constexpr float kLevelMaxDb =   0.0f;
+constexpr float kGrMaxMag   =  20.0f;    // GR range 0..-20 dB
+constexpr int   kPeakHoldMs =  700;
+constexpr float kPeakDecayDbPer100Ms = 1.0f;
+
+// Same ballistics as HGauge so every metering surface in the app
+// has matching motion.  Attack is fast enough to feel responsive on
+// speech peaks; release is slow enough that the fill doesn't flicker.
+constexpr int   kAnimIntervalMs = 8;
+constexpr float kAttackSeconds  = 0.030f;
+constexpr float kReleaseSeconds = 0.180f;
+constexpr float kSnapEpsilon    = 0.001f;
+
+const QColor kBarBg    ("#0a1420");
+const QColor kLevelLo  ("#56c48b");
+const QColor kLevelMid ("#e8d65a");
+const QColor kLevelHi  ("#e85a5a");
+const QColor kGrColor  ("#e8a540");
+const QColor kLabelColor("#b0c4d6");
+const QColor kPeakLine ("#ffffff");
+
+} // namespace
+
+ClientCompMeter::ClientCompMeter(QWidget* parent) : QWidget(parent)
+{
+    setMinimumWidth(18);
+    setMinimumHeight(80);
+    setAttribute(Qt::WA_OpaquePaintEvent, false);
+    m_peakHoldTimer.start();
+
+    m_animTimer.setTimerType(Qt::PreciseTimer);
+    m_animTimer.setInterval(kAnimIntervalMs);
+    connect(&m_animTimer, &QTimer::timeout, this, [this]() {
+        const qint64 ms = m_animElapsed.restart();
+        if (ms <= 0) return;
+        const float delta = m_targetFrac - m_displayFrac;
+        if (std::fabs(delta) <= kSnapEpsilon) {
+            m_displayFrac = m_targetFrac;
+            m_animTimer.stop();
+        } else {
+            const float tau = (delta >= 0.0f) ? kAttackSeconds : kReleaseSeconds;
+            const float alpha = 1.0f - std::exp(
+                -static_cast<float>(ms) / 1000.0f / tau);
+            m_displayFrac += delta * alpha;
+        }
+        update();
+    });
+}
+
+void ClientCompMeter::setMode(Mode m)
+{
+    if (m == m_mode) return;
+    m_mode = m;
+    m_currentDb = -120.0f;
+    m_peakDb    = -120.0f;
+    m_displayFrac = 0.0f;
+    m_targetFrac  = 0.0f;
+    update();
+}
+
+void ClientCompMeter::setLabel(const QString& label)
+{
+    m_label = label;
+    update();
+}
+
+void ClientCompMeter::recomputeTarget()
+{
+    float target = 0.0f;
+    if (m_mode == Mode::Level) {
+        target = std::clamp(
+            (m_currentDb - kLevelMinDb) / (kLevelMaxDb - kLevelMinDb),
+            0.0f, 1.0f);
+    } else {
+        const float mag = std::clamp(-m_currentDb, 0.0f, kGrMaxMag);
+        target = mag / kGrMaxMag;
+    }
+    m_targetFrac = target;
+    if (std::fabs(m_targetFrac - m_displayFrac) <= kSnapEpsilon) {
+        m_displayFrac = m_targetFrac;
+        if (m_animTimer.isActive()) m_animTimer.stop();
+    } else if (!m_animTimer.isActive()) {
+        m_animElapsed.restart();
+        m_animTimer.start();
+    }
+}
+
+void ClientCompMeter::setValueDb(float db)
+{
+    // Peak-hold tracks the loudest recent reading (or largest GR) and
+    // decays after a 700 ms hold.  Jumps instantly to any new extreme
+    // so transients don't get hidden.  Bar fill is smoothed separately
+    // through m_targetFrac / m_displayFrac.
+    if (m_mode == Mode::Level) {
+        m_currentDb = db;
+        if (db > m_peakDb) {
+            m_peakDb = db;
+            m_peakHoldTimer.restart();
+        } else if (m_peakHoldTimer.elapsed() > kPeakHoldMs) {
+            m_peakDb -= kPeakDecayDbPer100Ms / 10.0f;
+            m_peakDb = std::max(m_peakDb, m_currentDb);
+        }
+    } else {
+        m_currentDb = db;
+        if (db < m_peakDb) {
+            m_peakDb = db;
+            m_peakHoldTimer.restart();
+        } else if (m_peakHoldTimer.elapsed() > kPeakHoldMs) {
+            m_peakDb += kPeakDecayDbPer100Ms / 10.0f;
+            m_peakDb = std::min(m_peakDb, m_currentDb);
+        }
+    }
+    recomputeTarget();
+}
+
+void ClientCompMeter::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    const int w = width();
+    const int h = height();
+    const int labelH = m_label.isEmpty() ? 0 : 12;
+    const QRectF bar(2.0, labelH + 2.0, w - 4.0, h - labelH - 4.0);
+
+    if (!m_label.isEmpty()) {
+        QFont f = p.font();
+        f.setPixelSize(9);
+        f.setBold(true);
+        p.setFont(f);
+        p.setPen(kLabelColor);
+        p.drawText(QRectF(0, 0, w, labelH), Qt::AlignCenter, m_label);
+    }
+
+    p.fillRect(bar, kBarBg);
+
+    if (m_mode == Mode::Level) {
+        const float fillH = m_displayFrac * bar.height();
+        QRectF fill(bar.left(), bar.bottom() - fillH, bar.width(), fillH);
+
+        QLinearGradient g(0, bar.bottom(), 0, bar.top());
+        g.setColorAt(0.0, kLevelLo);
+        g.setColorAt(0.7, kLevelMid);
+        g.setColorAt(1.0, kLevelHi);
+        p.fillRect(fill, g);
+
+        if (m_peakDb > kLevelMinDb) {
+            const float tp = std::clamp(
+                (m_peakDb - kLevelMinDb) / (kLevelMaxDb - kLevelMinDb),
+                0.0f, 1.0f);
+            const float y = bar.bottom() - tp * bar.height();
+            p.setPen(QPen(kPeakLine, 1.0));
+            p.drawLine(QPointF(bar.left(), y), QPointF(bar.right(), y));
+        }
+    } else {
+        const float fillH = m_displayFrac * bar.height();
+        QRectF fill(bar.left(), bar.top(), bar.width(), fillH);
+        p.fillRect(fill, kGrColor);
+
+        const float peakMag = std::clamp(-m_peakDb, 0.0f, kGrMaxMag);
+        if (peakMag > 0.0f) {
+            const float y = bar.top() + (peakMag / kGrMaxMag) * bar.height();
+            p.setPen(QPen(kPeakLine, 1.0));
+            p.drawLine(QPointF(bar.left(), y), QPointF(bar.right(), y));
+        }
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompMeter.h
+++ b/src/gui/ClientCompMeter.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <QWidget>
+#include <QElapsedTimer>
+#include <QTimer>
+
+namespace AetherSDR {
+
+// Vertical peak + peak-hold meter for the compressor editor.  Two
+// visual modes are supported via setMode():
+//   - Level: fills from the bottom upwards (input / output).  Colour
+//     grades green→amber→red as the level approaches 0 dBFS.
+//   - GainReduction: fills from the TOP downwards (amber).  A larger
+//     negative gainReductionDb pulls the fill further down.
+//
+// Range is fixed to dBFS [-60, 0] for Level and [-20, 0] for GR.  Bar
+// fill is smoothed with the same asymmetric attack/release ballistics
+// as HGauge (30ms attack, 180ms release, polled at 120 Hz) so the
+// motion reads smoothly instead of twitching on every audio block.
+class ClientCompMeter : public QWidget {
+    Q_OBJECT
+
+public:
+    enum class Mode { Level, GainReduction };
+
+    explicit ClientCompMeter(QWidget* parent = nullptr);
+
+    void setMode(Mode m);
+    Mode mode() const { return m_mode; }
+
+    // Feed the latest dB value.  Bar fill smoothly animates toward
+    // the new value; peak-hold line still jumps instantly to any
+    // higher reading, then decays after 700 ms.
+    void setValueDb(float db);
+
+    // Optional label shown above the bar (e.g. "GR", "Out").
+    void setLabel(const QString& label);
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+
+private:
+    // Update m_targetFrac from the current mode + currentDb and start
+    // the animation timer if the bar needs to move.
+    void recomputeTarget();
+
+    Mode m_mode{Mode::Level};
+    QString m_label;
+
+    float m_currentDb{-120.0f};
+    float m_peakDb{-120.0f};
+    QElapsedTimer m_peakHoldTimer;
+
+    // Smoothed fill animation (same ballistics as HGauge).
+    QTimer        m_animTimer;
+    QElapsedTimer m_animElapsed;
+    float         m_displayFrac{0.0f};
+    float         m_targetFrac{0.0f};
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -26,6 +26,8 @@
 #include "EqApplet.h"
 #include "ClientEqApplet.h"
 #include "ClientEqEditor.h"
+#include "ClientCompApplet.h"
+#include "ClientCompEditor.h"
 #include "CatControlApplet.h"
 #include "DaxApplet.h"
 #include "TciApplet.h"
@@ -2009,6 +2011,22 @@ MainWindow::MainWindow(QWidget* parent)
             });
         }
         m_clientEqEditor->showForPath(path);
+    });
+
+    // ── Client Compressor applet: client-side TX dynamics processor ──────────
+    m_appletPanel->clientCompApplet()->setAudioEngine(m_audio);
+    connect(m_appletPanel->clientCompApplet(), &ClientCompApplet::editRequested,
+            this, [this]() {
+        if (!m_clientCompEditor) {
+            m_clientCompEditor = new ClientCompEditor(m_audio, this);
+            connect(m_clientCompEditor, &ClientCompEditor::bypassToggled,
+                    this, [this](bool) {
+                if (m_appletPanel && m_appletPanel->clientCompApplet()) {
+                    m_appletPanel->clientCompApplet()->refreshEnableFromEngine();
+                }
+            });
+        }
+        m_clientCompEditor->showForTx();
     });
 
     // ── Antenna Genius applet: external 4O3A antenna switch ──────────────────

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -305,6 +305,7 @@ private:
     bool m_userDisconnected{false};  // true after explicit disconnect, blocks auto-connect
     QDialog* m_reconnectDlg{nullptr}; // shown on unexpected disconnect, dismissed on reconnect
     class ClientEqEditor* m_clientEqEditor{nullptr}; // lazy — created on first Edit… click
+    class ClientCompEditor* m_clientCompEditor{nullptr}; // lazy — created on first Edit… click
     bool m_displaySettingsPushed{false};  // one-shot: push saved display settings after pan created
     bool m_applyingLayout{false};        // true during layout tear-down/recreate — suppresses panadapterAdded handler
     QTimer* m_layoutRestoreTimer{nullptr}; // debounced layout rearrange after pans added on connect

--- a/tests/client_comp_test.cpp
+++ b/tests/client_comp_test.cpp
@@ -1,0 +1,506 @@
+// Standalone test harness for ClientComp DSP.
+// Build: produced by CMake as `client_comp_test` target.
+// Run:   ./build/client_comp_test
+// Exit code 0 on all pass, 1 on any failure.
+
+#include "core/ClientComp.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using AetherSDR::ClientComp;
+
+namespace {
+
+constexpr double kSampleRate = 24000.0;
+constexpr int    kBlockSize  = 128;
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-52s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+std::vector<float> makeTone(double freq, int frames, float amplitude)
+{
+    std::vector<float> buf(frames * 2);
+    const double twoPi = 6.283185307179586476;
+    for (int i = 0; i < frames; ++i) {
+        const float s = amplitude * static_cast<float>(
+            std::sin(twoPi * freq * i / kSampleRate));
+        buf[i * 2]     = s;
+        buf[i * 2 + 1] = s;
+    }
+    return buf;
+}
+
+float rmsStereo(const float* data, int frames)
+{
+    double sumSq = 0.0;
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) {
+        sumSq += static_cast<double>(data[i]) * data[i];
+    }
+    return static_cast<float>(std::sqrt(sumSq / samples));
+}
+
+float peakAbsStereo(const float* data, int frames)
+{
+    float peak = 0.0f;
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) {
+        peak = std::max(peak, std::fabs(data[i]));
+    }
+    return peak;
+}
+
+void processBlocks(ClientComp& comp, float* buf, int frames)
+{
+    int remaining = frames;
+    float* p = buf;
+    while (remaining > 0) {
+        const int n = std::min(kBlockSize, remaining);
+        comp.process(p, n, 2);
+        p += n * 2;
+        remaining -= n;
+    }
+}
+
+bool anyNaNorInf(const float* data, int frames)
+{
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) {
+        if (!std::isfinite(data[i])) return true;
+    }
+    return false;
+}
+
+float linToDb(float lin)
+{
+    return (lin > 1e-9f) ? 20.0f * std::log10(lin) : -180.0f;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+void testBypassDisabled()
+{
+    ClientComp comp;
+    comp.prepare(kSampleRate);
+    comp.setEnabled(false);
+    comp.setLimiterEnabled(false);
+
+    const int frames = static_cast<int>(kSampleRate);
+    auto buf = makeTone(1000.0, frames, 0.5f);
+    const float rmsBefore = rmsStereo(buf.data(), frames);
+    processBlocks(comp, buf.data(), frames);
+    const float rmsAfter  = rmsStereo(buf.data(), frames);
+
+    const float drift = std::fabs(rmsAfter - rmsBefore);
+    report("disabled comp + disabled limiter = pass-through",
+           drift < 1e-6f,
+           "drift=" + std::to_string(drift));
+}
+
+// With input well below threshold, comp+limiter should leave signal alone.
+void testBelowThreshold()
+{
+    ClientComp comp;
+    comp.prepare(kSampleRate);
+    comp.setEnabled(true);
+    comp.setThresholdDb(-20.0f);
+    comp.setRatio(4.0f);
+    comp.setKneeDb(0.0f);  // hard knee so below-threshold is pure passthrough
+    comp.setMakeupDb(0.0f);
+    comp.setLimiterEnabled(true);
+    comp.setLimiterCeilingDb(-1.0f);
+
+    // -40 dBFS input (amplitude 0.01), well below -20 dBFS threshold.
+    const int frames = static_cast<int>(kSampleRate);
+    auto buf = makeTone(1000.0, frames, 0.01f);
+
+    // Warmup — the envelope starts at -120 dBFS and has to climb, but
+    // with the signal already below threshold we don't get compression.
+    const int warm = static_cast<int>(kSampleRate) * 2;
+    auto warmBuf = makeTone(1000.0, warm, 0.01f);
+    processBlocks(comp, warmBuf.data(), warm);
+
+    const float rmsBefore = rmsStereo(buf.data(), frames);
+    processBlocks(comp, buf.data(), frames);
+    const float rmsAfter  = rmsStereo(buf.data(), frames);
+
+    const float drift = std::fabs(rmsAfter - rmsBefore) / rmsBefore;
+    report("below-threshold signal is pass-through",
+           drift < 0.01f,
+           "relative drift=" + std::to_string(drift));
+}
+
+// 4:1 ratio, hard knee, threshold -20. Drive at -10 dBFS peak. Expected
+// output peak: -20 + (10/4) = -17.5 dBFS steady-state.
+// Uses long attack/release so the log-domain envelope settles to the
+// peak instead of riding the 1kHz sine waveform.
+void testStaticRatio()
+{
+    ClientComp comp;
+    comp.prepare(kSampleRate);
+    comp.setEnabled(true);
+    comp.setThresholdDb(-20.0f);
+    comp.setRatio(4.0f);
+    comp.setKneeDb(0.0f);
+    comp.setMakeupDb(0.0f);
+    comp.setAttackMs(50.0f);
+    comp.setReleaseMs(500.0f);
+    comp.setLimiterEnabled(false);
+
+    const float amp = std::pow(10.0f, -10.0f / 20.0f);  // -10 dBFS peak
+
+    // Warmup: envelope τ = 500ms, settle over 3s.
+    const int warm = static_cast<int>(kSampleRate) * 3;
+    auto warmBuf = makeTone(1000.0, warm, amp);
+    processBlocks(comp, warmBuf.data(), warm);
+
+    const int frames = static_cast<int>(kSampleRate);
+    auto buf = makeTone(1000.0, frames, amp);
+    processBlocks(comp, buf.data(), frames);
+
+    const float measPeak  = peakAbsStereo(buf.data(), frames);
+    const float measDbfs  = linToDb(measPeak);
+    const float errDb     = measDbfs - (-17.5f);
+    report("4:1 ratio above threshold: -10 dBFS in -> -17.5 dBFS out",
+           std::fabs(errDb) < 1.0f,
+           "measured=" + std::to_string(measDbfs) + " dBFS, err="
+               + std::to_string(errDb) + " dB");
+}
+
+// High ratio (20:1) clamps near threshold.
+void testLimitRatio()
+{
+    ClientComp comp;
+    comp.prepare(kSampleRate);
+    comp.setEnabled(true);
+    comp.setThresholdDb(-12.0f);
+    comp.setRatio(20.0f);
+    comp.setKneeDb(0.0f);
+    comp.setMakeupDb(0.0f);
+    comp.setAttackMs(50.0f);
+    comp.setReleaseMs(500.0f);
+    comp.setLimiterEnabled(false);
+
+    const float amp = std::pow(10.0f, -3.0f / 20.0f);  // -3 dBFS peak
+    const int warm = static_cast<int>(kSampleRate) * 3;
+    auto warmBuf = makeTone(1000.0, warm, amp);
+    processBlocks(comp, warmBuf.data(), warm);
+
+    const int frames = static_cast<int>(kSampleRate);
+    auto buf = makeTone(1000.0, frames, amp);
+    processBlocks(comp, buf.data(), frames);
+
+    const float measPeak = peakAbsStereo(buf.data(), frames);
+    const float measDbfs = linToDb(measPeak);
+    const float expected = -12.0f + 9.0f / 20.0f;
+    const float errDb    = measDbfs - expected;
+    report("20:1 ratio: -3 dBFS in -> near threshold out",
+           std::fabs(errDb) < 1.5f,
+           "measured=" + std::to_string(measDbfs) + " dBFS, expected="
+               + std::to_string(expected));
+}
+
+// Makeup gain applied to below-threshold signal = clean linear boost.
+void testMakeupGain()
+{
+    ClientComp comp;
+    comp.prepare(kSampleRate);
+    comp.setEnabled(true);
+    comp.setThresholdDb(-6.0f);   // high threshold: signal stays below it
+    comp.setRatio(4.0f);
+    comp.setKneeDb(0.0f);
+    comp.setMakeupDb(6.0f);        // +6 dB makeup
+    comp.setLimiterEnabled(false);
+
+    const float amp = 0.1f;  // low signal
+    const int warm = static_cast<int>(kSampleRate) * 1;
+    auto warmBuf = makeTone(1000.0, warm, amp);
+    processBlocks(comp, warmBuf.data(), warm);
+
+    const int frames = static_cast<int>(kSampleRate);
+    auto buf = makeTone(1000.0, frames, amp);
+    const float rmsBefore = rmsStereo(buf.data(), frames);
+    processBlocks(comp, buf.data(), frames);
+    const float rmsAfter  = rmsStereo(buf.data(), frames);
+
+    const float gainDb = 20.0f * std::log10(rmsAfter / rmsBefore);
+    report("+6 dB makeup on below-threshold signal",
+           std::fabs(gainDb - 6.0f) < 0.5f,
+           "gain=" + std::to_string(gainDb) + " dB");
+}
+
+// Brickwall limiter must clamp peaks to ceiling even with comp off.
+void testLimiterCeiling()
+{
+    ClientComp comp;
+    comp.prepare(kSampleRate);
+    comp.setEnabled(false);  // comp off, only limiter active
+    comp.setLimiterEnabled(true);
+    comp.setLimiterCeilingDb(-6.0f);  // ceiling at 0.5012 linear
+
+    const float ceilingLin = std::pow(10.0f, -6.0f / 20.0f);
+    const int frames = static_cast<int>(kSampleRate);
+    auto buf = makeTone(1000.0, frames, 0.9f);  // well above ceiling
+
+    // Warmup pass so limiter envelope is primed
+    auto warm = makeTone(1000.0, frames, 0.9f);
+    processBlocks(comp, warm.data(), frames);
+
+    processBlocks(comp, buf.data(), frames);
+    const float peak = peakAbsStereo(buf.data(), frames);
+
+    // Allow a tiny overshoot (≤ +0.5 dB) for limiter settling between sine peaks.
+    const float peakDb    = 20.0f * std::log10(peak);
+    const float ceilingDb = 20.0f * std::log10(ceilingLin);
+    report("limiter clamps 0.9 peak to -6 dBFS ceiling",
+           peakDb - ceilingDb < 0.5f,
+           "peak=" + std::to_string(peakDb) + " dBFS (ceiling="
+               + std::to_string(ceilingDb) + ")");
+}
+
+// Stereo linking: max(|L|,|R|) drives envelope, and the same gain is
+// applied to both. Feed L-only signal and check R remains silent (no
+// cross-channel leakage) but the L channel is still compressed.
+void testStereoLinked()
+{
+    ClientComp comp;
+    comp.prepare(kSampleRate);
+    comp.setEnabled(true);
+    comp.setThresholdDb(-20.0f);
+    comp.setRatio(4.0f);
+    comp.setKneeDb(0.0f);
+    comp.setMakeupDb(0.0f);
+    comp.setLimiterEnabled(false);
+
+    const int frames = static_cast<int>(kSampleRate);
+    std::vector<float> buf(frames * 2, 0.0f);
+    const float amp = 0.5f;
+    const double twoPi = 6.283185307179586476;
+    for (int i = 0; i < frames; ++i) {
+        buf[i * 2]     = amp * static_cast<float>(
+            std::sin(twoPi * 1000.0 * i / kSampleRate));
+        buf[i * 2 + 1] = 0.0f;  // R silent
+    }
+
+    // Warmup
+    std::vector<float> warm(frames * 2, 0.0f);
+    for (int i = 0; i < frames; ++i) {
+        warm[i * 2] = amp * static_cast<float>(
+            std::sin(twoPi * 1000.0 * i / kSampleRate));
+    }
+    processBlocks(comp, warm.data(), frames);
+
+    processBlocks(comp, buf.data(), frames);
+
+    // R channel should stay exactly zero (no cross-talk).
+    float rPeak = 0.0f;
+    for (int i = 0; i < frames; ++i) {
+        rPeak = std::max(rPeak, std::fabs(buf[i * 2 + 1]));
+    }
+    // L channel should show compression (< input amplitude).
+    float lPeak = 0.0f;
+    for (int i = 0; i < frames; ++i) {
+        lPeak = std::max(lPeak, std::fabs(buf[i * 2]));
+    }
+
+    report("stereo-linked: R stays silent when only L is active",
+           rPeak < 1e-6f,
+           "R peak=" + std::to_string(rPeak));
+    report("stereo-linked: L channel still compressed",
+           lPeak < amp * 0.95f,
+           "L peak=" + std::to_string(lPeak)
+               + " (input=" + std::to_string(amp) + ")");
+}
+
+// Attack timing: envelope should reach ~63 % of step in τ ms.
+// Drive silence → 0.5 amp step, sample GR shortly after the step.
+void testAttackTiming()
+{
+    ClientComp comp;
+    comp.prepare(kSampleRate);
+    comp.setEnabled(true);
+    comp.setThresholdDb(-20.0f);
+    comp.setRatio(10.0f);
+    comp.setKneeDb(0.0f);
+    comp.setMakeupDb(0.0f);
+    comp.setAttackMs(20.0f);
+    comp.setReleaseMs(500.0f);
+    comp.setLimiterEnabled(false);
+    comp.reset();
+
+    // 20ms of silence, then loud tone burst.
+    const int preFrames = static_cast<int>(kSampleRate * 0.020);
+    const int burstFrames = static_cast<int>(kSampleRate * 0.200);
+
+    std::vector<float> pre(preFrames * 2, 0.0f);
+    processBlocks(comp, pre.data(), preFrames);
+
+    auto burst = makeTone(1000.0, burstFrames, 0.5f);
+    processBlocks(comp, burst.data(), burstFrames);
+
+    // After 200ms (10× attack time constant) gain reduction should be
+    // close to the steady-state value. For 0.5 amp = -6 dBFS with
+    // threshold -20, ratio 10: overshoot 14 dB / ratio 10 = 1.4 dB
+    // above threshold, so GR = 14 - 1.4 = 12.6 dB.
+    const float gr = comp.gainReductionDb();
+    report("attack reaches steady-state after 10τ",
+           gr < -10.0f && gr > -14.0f,
+           "GR=" + std::to_string(gr) + " dB");
+}
+
+// Soft-knee continuity: sweep the static curve and verify no discontinuity.
+void testSoftKneeMonotonic()
+{
+    ClientComp comp;
+    comp.prepare(kSampleRate);
+    comp.setEnabled(true);
+    comp.setThresholdDb(-18.0f);
+    comp.setRatio(4.0f);
+    comp.setKneeDb(12.0f);  // wide knee
+    comp.setMakeupDb(0.0f);
+    comp.setAttackMs(0.1f);
+    comp.setReleaseMs(5.0f);
+    comp.setLimiterEnabled(false);
+
+    // Sweep amplitude from -40 dBFS to 0 dBFS in fine steps, measure RMS
+    // gain at each. Must be monotonically decreasing (compression grows).
+    float lastGainDb = 999.0f;
+    bool monotonic = true;
+    float worstJump = 0.0f;
+
+    for (int dbfs = -40; dbfs <= 0; dbfs += 2) {
+        comp.reset();
+        const float amp = std::pow(10.0f, dbfs / 20.0f);
+        const int warm = static_cast<int>(kSampleRate * 0.5);
+        auto warmBuf = makeTone(1000.0, warm, amp);
+        processBlocks(comp, warmBuf.data(), warm);
+
+        const int frames = static_cast<int>(kSampleRate * 0.1);
+        auto buf = makeTone(1000.0, frames, amp);
+        const float rmsBefore = rmsStereo(buf.data(), frames);
+        processBlocks(comp, buf.data(), frames);
+        const float rmsAfter  = rmsStereo(buf.data(), frames);
+
+        const float gainDb = 20.0f * std::log10(rmsAfter / rmsBefore);
+        if (gainDb > lastGainDb + 0.1f) {
+            monotonic = false;
+            const float jump = gainDb - lastGainDb;
+            if (jump > worstJump) worstJump = jump;
+        }
+        lastGainDb = gainDb;
+    }
+    report("soft-knee: gain curve is monotonically decreasing",
+           monotonic,
+           "worst jump=" + std::to_string(worstJump) + " dB");
+}
+
+// Sanity: no NaN/inf under a nasty transient sequence.
+void testTransientSanity()
+{
+    ClientComp comp;
+    comp.prepare(kSampleRate);
+    comp.setEnabled(true);
+    comp.setThresholdDb(-24.0f);
+    comp.setRatio(10.0f);
+    comp.setKneeDb(6.0f);
+    comp.setMakeupDb(12.0f);
+    comp.setAttackMs(5.0f);
+    comp.setReleaseMs(100.0f);
+    comp.setLimiterEnabled(true);
+    comp.setLimiterCeilingDb(-1.0f);
+
+    const int frames = static_cast<int>(kSampleRate) * 2;
+    std::vector<float> buf(frames * 2);
+    const double twoPi = 6.283185307179586476;
+    for (int i = 0; i < frames; ++i) {
+        // Amplitude-modulated tone + spikes: stress envelope+limiter.
+        const float env = 0.1f + 0.8f
+            * static_cast<float>(std::fabs(std::sin(twoPi * 3.0 * i / kSampleRate)));
+        const float s = env * static_cast<float>(
+            std::sin(twoPi * 1000.0 * i / kSampleRate));
+        buf[i * 2]     = s;
+        buf[i * 2 + 1] = s;
+    }
+
+    processBlocks(comp, buf.data(), frames);
+
+    const bool finite = !anyNaNorInf(buf.data(), frames);
+    const float peak = peakAbsStereo(buf.data(), frames);
+    report("stress: AM tone output is finite",
+           finite,
+           "");
+    report("stress: output peak respects limiter ceiling (+1 dB headroom)",
+           peak < 1.0f,
+           "peak=" + std::to_string(peak));
+}
+
+// reset() must clear envelope so a new burst starts from silence.
+void testResetClearsEnvelope()
+{
+    ClientComp comp;
+    comp.prepare(kSampleRate);
+    comp.setEnabled(true);
+    comp.setThresholdDb(-20.0f);
+    comp.setRatio(4.0f);
+    comp.setKneeDb(0.0f);
+    comp.setMakeupDb(0.0f);
+    comp.setAttackMs(50.0f);
+    comp.setReleaseMs(500.0f);
+    comp.setLimiterEnabled(false);
+
+    // Drive envelope up
+    auto loud = makeTone(1000.0, static_cast<int>(kSampleRate), 0.5f);
+    processBlocks(comp, loud.data(), static_cast<int>(kSampleRate));
+    const float grBefore = comp.gainReductionDb();
+
+    comp.reset();
+
+    // After reset, the first block of silence should leave GR at ~0.
+    std::vector<float> silence(kBlockSize * 2, 0.0f);
+    comp.process(silence.data(), kBlockSize, 2);
+    const float grAfter = comp.gainReductionDb();
+
+    report("reset() pulls envelope down",
+           grBefore < -2.0f && grAfter > -1.0f,
+           "before=" + std::to_string(grBefore) + ", after="
+               + std::to_string(grAfter));
+}
+
+} // namespace
+
+int main()
+{
+    std::printf("ClientComp DSP test harness (fs=%.0f Hz, block=%d)\n\n",
+                kSampleRate, kBlockSize);
+
+    testBypassDisabled();
+    testBelowThreshold();
+    testStaticRatio();
+    testLimitRatio();
+    testMakeupGain();
+    testLimiterCeiling();
+    testStereoLinked();
+    testAttackTiming();
+    testSoftKneeMonotonic();
+    testTransientSanity();
+    testResetClearsEnvelope();
+
+    std::printf("\n%s\n",
+                g_failed == 0
+                    ? "All tests passed."
+                    : (std::to_string(g_failed) + " test(s) failed.").c_str());
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Adds the first phase of the Pro-XL-style TX dynamics processor tracked
in #1661.  Ships the full end-to-end stack: DSP engine, AudioEngine
integration, docked dashboard tile, and full floating editor.

DSP (src/core/ClientComp.{h,cpp}):
- Feed-forward compressor with soft-knee quadratic interpolation in dB
  domain, linear-domain peak envelope detection, stereo-linked gain
  application, and a brickwall peak limiter on the output
- Params: threshold, ratio (1..20), attack (0.1..300 ms), release
  (5..2000 ms), knee, makeup, limiter enable + ceiling
- Atomic parameter handoff UI→audio, lock-free, no alloc in process()
- Meter atomics exposed for input peak, output peak, GR, limiterActive

AudioEngine wiring (src/core/AudioEngine.{h,cpp}):
- Adds clientCompTx(), load/saveClientCompSettings(), TxChainOrder enum
- TX path now runs applyClientTxDspInt16 / applyClientTxDspFloat32,
  which execute the compressor and EQ in the chain-order configured by
  setTxChainOrder() — CMP→EQ (default) or EQ→CMP

DSP tests (tests/client_comp_test.cpp):
- 11 standalone smoke tests covering bypass, below-threshold passthrough,
  static ratio (4:1 and 20:1), makeup gain, limiter ceiling, stereo
  linking, attack timing, soft-knee monotonicity, transient sanity,
  reset().  Built as `client_comp_test` CMake target, all green.

Docked applet (src/gui/ClientCompApplet, ClientCompCurveWidget):
- View-only CMP tile in the applet tray — transfer curve with glowing
  ball that slides at the current envelope level, horizontal GR strip
  beneath, Bypass toggle + Edit… button.  Mirror of ClientEqApplet.

Floating editor (ClientCompEditor, ClientCompEditorCanvas,
ClientCompKnob, ClientCompMeter):
- Ableton-inspired layout extended for the limiter and chain order:
  Ratio / Attack / Release / Knee knobs on the left, threshold handle
  + interactive curve in the center, live Input / GR / Output meters,
  Limiter enable + Ceiling + Makeup on the right
- Dragging the curve-dot changes ratio exponentially; dragging the
  bottom triangle changes threshold; rotary knobs for every other param
- Bar meters use the same ballistics as Phone/CW Level (30 ms attack,
  180 ms release, polled at 120 Hz) so motion matches the rest of the
  app

MainWindow + AppletPanel wiring:
- New CMP tile in the applet tray, lazy-instantiated editor, bypass
  state mirrored between the applet and the editor via bypassToggled
- AppletPanel default order now includes "CMP" between "CEQ" and "CAT"

Persistence (AppSettings):
  ClientCompTxEnabled / ThresholdDb / Ratio / AttackMs / ReleaseMs /
  KneeDb / MakeupDb / LimEnabled / LimCeilingDb / ChainOrder, plus
  ClientCompEditorGeometry for the floating window.

Bumps version to 0.8.17.

Phase 2+ (expander/gate, de-esser, tube, enhancer, low contour,
IKA/IRC auto modes, lookahead limiter, preset system) tracked in
#1661 for follow-up releases.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
