### PR TITLE
Fix TCI DAX duplicate stream causing 2× audio speed / WSJT-X FT8 no-decode

### DIFF
--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -860,8 +860,31 @@ int PanadapterStream::packetTotalCount() const
 void PanadapterStream::registerDaxStream(quint32 streamId, int channel)
 {
     QMutexLocker lock(&m_streamMutex);
+    // Enforce one active stream per channel. A stale stream from a previous
+    // session or a duplicate subscription created by another code path would
+    // cause daxAudioReady to fire twice per audio period — doubling perceived
+    // speed. Remove any prior mapping for this channel before inserting.
+    for (auto it = m_daxStreamIds.begin(); it != m_daxStreamIds.end(); ) {
+        if (it.value() == channel && it.key() != streamId) {
+            qCDebug(lcVita49) << "PanadapterStream: evicting stale DAX stream"
+                              << Qt::hex << it.key() << "from channel" << channel;
+            it = m_daxStreamIds.erase(it);
+        } else {
+            ++it;
+        }
+    }
     m_daxStreamIds[streamId] = channel;
     qCDebug(lcVita49) << "PanadapterStream: registered DAX stream" << Qt::hex << streamId << "-> channel" << channel;
+}
+
+quint32 PanadapterStream::daxStreamIdForChannel(int channel) const
+{
+    QMutexLocker lock(&m_streamMutex);
+    for (auto it = m_daxStreamIds.constBegin(); it != m_daxStreamIds.constEnd(); ++it) {
+        if (it.value() == channel)
+            return it.key();
+    }
+    return 0;
 }
 
 void PanadapterStream::unregisterDaxStream(quint32 streamId)

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -82,6 +82,7 @@ public:
     void registerDaxStream(quint32 streamId, int channel);
     void unregisterDaxStream(quint32 streamId);
     QList<quint32> daxStreamIds() const;
+    quint32 daxStreamIdForChannel(int channel) const;
 
     // DAX IQ stream routing
     void registerIqStream(quint32 streamId, int channel);

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1319,13 +1319,26 @@ void TciServer::ensureDaxForTci()
         }
     }
 
-    // Create DAX RX streams for channels that need them.  Insert placeholder
-    // (streamId=0) so the statusReceived handler knows to register the response.
+    // Create DAX RX streams for channels that need them.  If an existing stream
+    // is already registered in PanadapterStream (e.g. created by DaxBridge or
+    // left over from a previous session), reuse it rather than stacking a
+    // second subscription — duplicate streams cause daxAudioReady to fire
+    // twice per period, doubling the apparent audio speed at the TCI client.
     for (int ch : channelsNeeded) {
         if (m_tciDaxStreamIds.contains(ch)) continue; // already have/pending
-        m_tciDaxStreamIds[ch] = 0;
-        m_model->sendCommand(QString("stream create type=dax_rx dax_channel=%1").arg(ch));
-        qCInfo(lcCat) << "TCI: creating DAX RX stream for channel" << ch << "(#1331)";
+        quint32 existingId = m_model->panStream()
+                           ? m_model->panStream()->daxStreamIdForChannel(ch)
+                           : 0;
+        if (existingId != 0) {
+            m_tciDaxStreamIds[ch] = existingId;
+            m_tciDaxBorrowedChannels.insert(ch);
+            qCInfo(lcCat) << "TCI: reusing existing DAX RX stream" << Qt::hex << existingId
+                          << "for channel" << ch << "(#1331)";
+        } else {
+            m_tciDaxStreamIds[ch] = 0;
+            m_model->sendCommand(QString("stream create type=dax_rx dax_channel=%1").arg(ch));
+            qCInfo(lcCat) << "TCI: creating DAX RX stream for channel" << ch << "(#1331)";
+        }
     }
 
     // Re-assert slice → DAX channel mapping so the radio registers our
@@ -1346,9 +1359,12 @@ void TciServer::releaseDaxForTci()
 {
     if (!m_model) return;
 
-    // Remove DAX RX streams we created
+    // Remove DAX RX streams we created (skip borrowed streams — owned by DaxBridge
+    // or pre-existing; removing them would break other audio consumers).
     for (auto it = m_tciDaxStreamIds.begin(); it != m_tciDaxStreamIds.end(); ++it) {
+        int ch = it.key();
         quint32 streamId = it.value();
+        if (m_tciDaxBorrowedChannels.contains(ch)) continue;
         if (streamId != 0) {
             if (m_model->panStream()) {
                 m_model->panStream()->unregisterDaxStream(streamId);
@@ -1358,10 +1374,11 @@ void TciServer::releaseDaxForTci()
                     .arg(streamId, 8, 16, QChar('0')));
             }
             qCInfo(lcCat) << "TCI: removed DAX RX stream" << Qt::hex << streamId
-                          << "channel" << it.key() << "(#1331)";
+                          << "channel" << ch << "(#1331)";
         }
     }
     m_tciDaxStreamIds.clear();
+    m_tciDaxBorrowedChannels.clear();
 
     // Release DAX channel assignments we made
     for (int sliceId : m_tciDaxSlices) {

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -124,7 +124,8 @@ private:
     QWebSocketServer* m_server{nullptr};
     QList<ClientState> m_clients;
     QSet<int>         m_tciDaxSlices;   // slice IDs where we auto-assigned DAX (#1331)
-    QMap<int, quint32> m_tciDaxStreamIds; // DAX channel → stream ID created by TCI
+    QMap<int, quint32> m_tciDaxStreamIds;      // DAX channel → stream ID created or borrowed by TCI
+    QSet<int>          m_tciDaxBorrowedChannels; // channels where TCI reused an existing stream
     QTimer*           m_meterTimer{nullptr};  // 200ms status broadcast
     QTimer*           m_txChronoTimer{nullptr}; // TX_CHRONO frame cadence
     QWebSocket*       m_txChronoClient{nullptr};


### PR DESCRIPTION
## Root Cause

Two independent code paths both subscribed to `dax_rx` for the same DAX channel:

1. **DaxBridge** (`MainWindow`/`DaxAudioBridge`) — creates a DAX RX stream when TCI clients connect and DAX is running
2. **`TciServer::ensureDaxForTci`** — independently creates its own DAX RX stream for the same channel

The radio delivered identical VITA-49 audio packets to both stream IDs. `PanadapterStream` accepted both registrations and emitted `daxAudioReady` twice per audio period. The TCI accumulation buffer filled at 2× the expected rate, producing audio at 2× speed at WSJT-X — causing FT8 decoding to fail entirely.

## Fix

- **`PanadapterStream::registerDaxStream`** now evicts any existing stream registered to the same channel before inserting, enforcing at-most-one-stream-per-channel semantics
- **`TciServer::ensureDaxForTci`** uses a new `daxStreamIdForChannel()` query to detect and reuse an existing DaxBridge-owned stream (marking it "borrowed") rather than creating a duplicate
- **`TciServer::releaseDaxForTci`** skips stream removal for borrowed channels so DaxBridge-owned streams are not torn down when TCI clients disconnect

## Files Changed

- `src/core/PanadapterStream.cpp` — `registerDaxStream` evicts stale same-channel entries; new `daxStreamIdForChannel()` method
- `src/core/PanadapterStream.h` — declaration for `daxStreamIdForChannel()`
- `src/core/TciServer.cpp` — borrow-existing-stream logic in `ensureDaxForTci`/`releaseDaxForTci`
- `src/core/TciServer.h` — `QSet<int> m_tciDaxBorrowedChannels`

## Test Plan

- [x] Connect WSJT-X via TCI with DAX running — FT8 decodes correctly at normal speed
- [x] TCI RX audio plays back at correct pitch/speed in WSJT-X waterfall
- [x] Disconnecting TCI client does not tear down DaxBridge RX stream (DAX audio continues in the app)
- [x] Reconnecting TCI client reuses the existing stream without creating a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)