### PR TITLE
Fix TCI TX no RF output: always send dax=1 on PTT regardless of low-latency route

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1071,9 +1071,9 @@ void TciServer::startTxChrono(QWebSocket* client, int trx)
     m_txAudioPeak = 0.0f;
     m_txSawDuplicatedStereo = false;
 
-    // Respect the same DAX TX routing preference used by the bridge path.
-    // Default remains radio-native dax=1; low-latency mode switches to the
-    // float32 dax_tx route with dax=0.
+    // DaxTxLowLatency selects VITA-49 packet format only (PCC 0x03E3 float32
+    // stereo vs PCC 0x0123 int16 mono in feedDaxTxAudio). Both formats require
+    // dax=1 on the radio side — see the sendCmdPublic call below.
     if (m_audio) {
         m_audio->setDaxTxUseRadioRoute(m_txUseRadioRoute);
         m_audio->setDaxTxMode(true);

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1082,9 +1082,12 @@ void TciServer::startTxChrono(QWebSocket* client, int trx)
     // Create TX resampler: 48kHz (TCI client) → 24kHz (radio DAX/native rate)
     m_txResampler = std::make_unique<Resampler>(48000.0, 24000.0, 4096);
     if (m_model) {
-        m_model->sendCmdPublic(
-            QStringLiteral("transmit set dax=%1").arg(m_txUseRadioRoute ? 1 : 0),
-            nullptr);
+        // Always dax=1 for TCI TX. The DaxTxLowLatency flag only controls
+        // VITA-49 packet format (PCC 0x03E3 vs 0x0123 in feedDaxTxAudio);
+        // both formats require dax=1 so the radio routes the dax_tx stream
+        // to the modulator. Sending dax=0 keeps the radio on the physical
+        // mic and silently discards every dax_tx packet. — fw v1.4.0.0
+        m_model->sendCmdPublic("transmit set dax=1", nullptr);
     }
 
     m_txChronoClock.start();


### PR DESCRIPTION
## Root Cause

`TciServer::startTxChrono` sent `transmit set dax=0` when `DaxTxLowLatency=True` was set in AppSettings. With `dax=0` the radio routes the physical microphone to the TX modulator and **silently discards every `dax_tx` VITA-49 packet**. The result: relay clicks, TCI TX level meter shows audio, but zero RF output.

The `DaxTxLowLatency` flag controls **VITA-49 packet format only** (`PCC 0x03E3` float32 stereo vs `PCC 0x0123` int16 mono in `feedDaxTxAudio`). Both formats still require `dax=1` to route the `dax_tx` stream to the modulator. The conditional `dax=0/1` was a conceptual error — packet format and radio audio routing are independent knobs.

## Fix

Hardcode `transmit set dax=1` in `startTxChrono`. The `DaxTxLowLatency` packet format selection in `feedDaxTxAudio` is unchanged and continues to work for its intended use case (external FreeDV via virtual audio cable on macOS/Windows).

Also updated a stale comment at line 1074 that still described the old `dax=0` behavior, per review feedback.

## Files Changed

- `src/core/TciServer.cpp` — `startTxChrono` always sends `transmit set dax=1`; stale comment updated

## Test Plan

- [ ] With `DaxTxLowLatency=True` (or False): WSJT-X FT8 TX produces RF output
- [ ] All TX meters respond normally during TCI TX (SC_MIC, FWDPWR, SWR)
- [ ] DAX TX via DaxBridge is unaffected (still auto-toggles `dax=1`/`0` on mode changes)
- [ ] After unkeying, voice TX on hardware mic works normally (radio restores its own routing on TX release — `stopTxChrono` does not send `dax=0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)