### PR TITLE
Client Comp editor polish: threshold fader + visible chevron + limiter activity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,7 +516,9 @@ set(GUI_SOURCES
     src/gui/ClientCompApplet.cpp
     src/gui/ClientCompCurveWidget.cpp
     src/gui/ClientCompKnob.cpp
+    src/gui/ClientCompLimiterButton.cpp
     src/gui/ClientCompMeter.cpp
+    src/gui/ClientCompThresholdFader.cpp
     src/gui/ClientCompEditor.cpp
     src/gui/ClientCompEditorCanvas.cpp
     src/gui/CatControlApplet.cpp

--- a/src/core/ClientComp.cpp
+++ b/src/core/ClientComp.cpp
@@ -134,6 +134,8 @@ float ClientComp::outputPeakDb() const noexcept
 { return m_meters.outputPeakDb.load(std::memory_order_relaxed); }
 float ClientComp::gainReductionDb() const noexcept
 { return m_meters.gainReductionDb.load(std::memory_order_relaxed); }
+float ClientComp::limiterGrDb() const noexcept
+{ return m_meters.limiterGrDb.load(std::memory_order_relaxed); }
 bool  ClientComp::limiterActive() const noexcept
 { return m_meters.limiterActive.load(std::memory_order_relaxed); }
 
@@ -199,6 +201,7 @@ void ClientComp::process(float* interleaved, int frames, int channels) noexcept
     float inPeakLin  = 0.0f;
     float outPeakLin = 0.0f;
     float worstGrDb  = 0.0f;  // most negative (largest reduction)
+    float worstLimGrDb = 0.0f;  // limiter-only GR, most negative
     bool  limFired   = false;
 
     const float attackCoeff  = m_cached.attackCoeff;
@@ -241,11 +244,20 @@ void ClientComp::process(float* interleaved, int frames, int channels) noexcept
             const float target = std::max(1.0f, over);
             const float lc = (target > m_limEnvLin) ? limAttack : limRelease;
             m_limEnvLin += lc * (target - m_limEnvLin);
-            if (m_limEnvLin > 1.0f) {
+            // Threshold slightly above 1.0 — the envelope decays
+            // asymptotically toward 1.0 in float and never quite
+            // reaches it, so a strict `> 1.0f` check would latch the
+            // active indicator forever after any trigger.  Anything
+            // under 0.005 dB of reduction is inaudible anyway.
+            if (m_limEnvLin > 1.0006f) {
                 const float reduce = 1.0f / m_limEnvLin;
                 l *= reduce;
                 r *= reduce;
                 limFired = true;
+                // Track the worst (most negative) limiter GR this block
+                // so the UI can draw a distinct lim-GR indicator.
+                const float limGrDb = linToDb(reduce);
+                if (limGrDb < worstLimGrDb) worstLimGrDb = limGrDb;
             }
         }
 
@@ -262,6 +274,7 @@ void ClientComp::process(float* interleaved, int frames, int channels) noexcept
     m_meters.outputPeakDb.store(linToDb(std::max(outPeakLin, 1e-6f)),
                                 std::memory_order_relaxed);
     m_meters.gainReductionDb.store(worstGrDb, std::memory_order_relaxed);
+    m_meters.limiterGrDb.store(worstLimGrDb, std::memory_order_relaxed);
     m_meters.limiterActive.store(limFired, std::memory_order_relaxed);
 }
 

--- a/src/core/ClientComp.h
+++ b/src/core/ClientComp.h
@@ -64,7 +64,8 @@ public:
     // meters. Updated once per block on the audio thread via atomics.
     float inputPeakDb() const noexcept;       // pre-compression peak
     float outputPeakDb() const noexcept;      // post-limiter peak
-    float gainReductionDb() const noexcept;   // latest GR in dB (≤ 0)
+    float gainReductionDb() const noexcept;   // comp GR in dB (≤ 0)
+    float limiterGrDb() const noexcept;       // limiter-only GR in dB (≤ 0)
     bool  limiterActive() const noexcept;     // true while limiter is clamping
 
     // Sample rate this comp was prepared at.
@@ -103,6 +104,7 @@ private:
         std::atomic<float> inputPeakDb{-120.0f};
         std::atomic<float> outputPeakDb{-120.0f};
         std::atomic<float> gainReductionDb{0.0f};
+        std::atomic<float> limiterGrDb{0.0f};
         std::atomic<bool>  limiterActive{false};
     };
 

--- a/src/gui/ClientCompEditor.cpp
+++ b/src/gui/ClientCompEditor.cpp
@@ -1,7 +1,9 @@
 #include "ClientCompEditor.h"
 #include "ClientCompEditorCanvas.h"
 #include "ClientCompKnob.h"
+#include "ClientCompLimiterButton.h"
 #include "ClientCompMeter.h"
+#include "ClientCompThresholdFader.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/ClientComp.h"
@@ -176,29 +178,12 @@ ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
             body->addLayout(col);
         }
 
-        // Threshold mini-column: one tall slider view + numeric label.
-        // The interactive canvas owns the real threshold handle; this
-        // label just echoes the current value so the user can read the
-        // exact number at a glance.
-        {
-            auto* col = new QVBoxLayout;
-            col->setSpacing(2);
-            auto* hdr = new QLabel("Thresh");
-            hdr->setAlignment(Qt::AlignCenter);
-            col->addWidget(hdr);
-            m_thresholdLabel = new QLabel("-18.0 dB");
-            m_thresholdLabel->setAlignment(Qt::AlignCenter);
-            m_thresholdLabel->setStyleSheet(
-                "QLabel { color: #e8e8e8; font-size: 11px; font-weight: bold; }");
-            col->addWidget(m_thresholdLabel);
-
-            m_inputMeter = new ClientCompMeter;
-            m_inputMeter->setMode(ClientCompMeter::Mode::Level);
-            m_inputMeter->setLabel("In");
-            m_inputMeter->setMinimumWidth(20);
-            col->addWidget(m_inputMeter, 1);
-            body->addLayout(col);
-        }
+        // Threshold fader — combined input-level meter + threshold
+        // slider, matching the Client EQ output-fader visual language.
+        // Drag the amber handle to set threshold; the chevron on the
+        // curve canvas stays linked via the shared ClientComp state.
+        m_threshFader = new ClientCompThresholdFader;
+        body->addWidget(m_threshFader);
 
         // Canvas (center).
         m_canvas = new ClientCompEditorCanvas;
@@ -233,12 +218,10 @@ ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
             auto* col = new QVBoxLayout;
             col->setSpacing(6);
 
-            m_limiterEnable = new QPushButton("LIMIT");
-            m_limiterEnable->setCheckable(true);
-            m_limiterEnable->setStyleSheet(kLimBtnStyle);
-            m_limiterEnable->setFixedHeight(22);
+            m_limiterEnable = new ClientCompLimiterButton;
             m_limiterEnable->setToolTip(
-                "Brickwall peak limiter on the compressor output");
+                "Brickwall peak limiter on the compressor output.\n"
+                "Button glows red when the limiter is actively clamping.");
             col->addWidget(m_limiterEnable);
 
             m_ceiling = new ClientCompKnob;
@@ -291,6 +274,8 @@ ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
     });
 
     connect(m_canvas, &ClientCompEditorCanvas::thresholdChanged,
+            this, &ClientCompEditor::applyThreshold);
+    connect(m_threshFader, &ClientCompThresholdFader::thresholdChanged,
             this, &ClientCompEditor::applyThreshold);
     connect(m_canvas, &ClientCompEditorCanvas::ratioChanged,
             this, &ClientCompEditor::applyRatio);
@@ -355,8 +340,7 @@ void ClientCompEditor::syncControlsFromEngine()
     m_makeup->setValue(c->makeupDb());
     m_ceiling->setValue(c->limiterCeilingDb());
     m_limiterEnable->setChecked(c->limiterEnabled());
-    m_thresholdLabel->setText(
-        QString::number(c->thresholdDb(), 'f', 1) + " dB");
+    if (m_threshFader) m_threshFader->setThresholdDb(c->thresholdDb());
     if (m_canvas) m_canvas->update();
 }
 
@@ -365,9 +349,21 @@ void ClientCompEditor::tickMeters()
     if (!m_audio) return;
     ClientComp* c = m_audio->clientCompTx();
     if (!c) return;
-    if (m_inputMeter)  m_inputMeter ->setValueDb(c->inputPeakDb());
+    if (m_threshFader) m_threshFader->setInputPeakDb(c->inputPeakDb());
     if (m_grMeter)     m_grMeter    ->setValueDb(c->gainReductionDb());
-    if (m_outputMeter) m_outputMeter->setValueDb(c->outputPeakDb());
+    if (m_outputMeter) {
+        m_outputMeter->setValueDb(c->outputPeakDb());
+        if (c->limiterEnabled()) {
+            m_outputMeter->setLimiterCeilingDb(c->limiterCeilingDb());
+            m_outputMeter->setLimiterGrDb(c->limiterGrDb());
+        } else {
+            m_outputMeter->setLimiterCeilingDb(1.0f);  // disable overlay
+            m_outputMeter->setLimiterGrDb(0.0f);
+        }
+    }
+    if (m_limiterEnable) {
+        m_limiterEnable->setActive(c->limiterActive() && c->limiterEnabled());
+    }
 }
 
 void ClientCompEditor::applyThreshold(float db)
@@ -377,8 +373,13 @@ void ClientCompEditor::applyThreshold(float db)
     if (!c) return;
     c->setThresholdDb(db);
     m_audio->saveClientCompSettings();
-    if (m_thresholdLabel)
-        m_thresholdLabel->setText(QString::number(db, 'f', 1) + " dB");
+    // Mirror the value onto whichever control didn't originate the
+    // change.  Canvas chevron drags land here too, so this keeps the
+    // fader handle in sync.  Signal blocking avoids a feedback loop.
+    if (m_threshFader && std::fabs(m_threshFader->thresholdDb() - db) > 0.01f) {
+        QSignalBlocker b(m_threshFader);
+        m_threshFader->setThresholdDb(db);
+    }
     if (m_canvas) m_canvas->update();
 }
 

--- a/src/gui/ClientCompEditor.h
+++ b/src/gui/ClientCompEditor.h
@@ -12,7 +12,9 @@ namespace AetherSDR {
 class AudioEngine;
 class ClientCompEditorCanvas;
 class ClientCompKnob;
+class ClientCompLimiterButton;
 class ClientCompMeter;
+class ClientCompThresholdFader;
 
 // Floating editor for the Pro-XL-style TX compressor.  One instance
 // lives on MainWindow; calling showForTx() raises the window and
@@ -82,12 +84,11 @@ private:
     ClientCompKnob*          m_knee{nullptr};
     ClientCompKnob*          m_makeup{nullptr};
     ClientCompKnob*          m_ceiling{nullptr};
-    ClientCompMeter*         m_inputMeter{nullptr};
+    ClientCompThresholdFader* m_threshFader{nullptr};
     ClientCompMeter*         m_grMeter{nullptr};
     ClientCompMeter*         m_outputMeter{nullptr};
-    QLabel*                  m_thresholdLabel{nullptr};
     QPushButton*             m_bypass{nullptr};
-    QPushButton*             m_limiterEnable{nullptr};
+    ClientCompLimiterButton* m_limiterEnable{nullptr};
     QComboBox*               m_chainOrder{nullptr};
     QTimer*                  m_meterTimer{nullptr};
     bool                     m_restoring{false};

--- a/src/gui/ClientCompEditorCanvas.cpp
+++ b/src/gui/ClientCompEditorCanvas.cpp
@@ -1,11 +1,14 @@
 #include "ClientCompEditorCanvas.h"
 #include "core/ClientComp.h"
 
+#include <QEvent>
+#include <QHelpEvent>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPaintEvent>
 #include <QPen>
+#include <QToolTip>
 #include <algorithm>
 #include <cmath>
 
@@ -33,11 +36,13 @@ bool ClientCompEditorCanvas::thresholdHandleHit(const QPointF& pos) const
 {
     if (!m_comp) return false;
     const float T = m_comp->thresholdDb();
-    // Threshold handle lives on the bottom edge at x=dbToX(T).
-    const QPointF h(dbToX(T), rect().bottom() - 6.0);
-    const float dx = static_cast<float>(pos.x() - h.x());
-    const float dy = static_cast<float>(pos.y() - h.y());
-    return (dx * dx + dy * dy) < kHandleHitRadius * kHandleHitRadius;
+    // Threshold is grabbable along the entire vertical guide line, not
+    // just on the chevron at the bottom — making the whole column a
+    // drag target means the user can grab the threshold from anywhere
+    // on its guide, which is where their eye is already looking.
+    const float tx = dbToX(T);
+    const float dx = std::fabs(static_cast<float>(pos.x() - tx));
+    return dx < kHandleHitRadius;
 }
 
 bool ClientCompEditorCanvas::ratioHandleHit(const QPointF& pos) const
@@ -59,19 +64,30 @@ void ClientCompEditorCanvas::paintEvent(QPaintEvent* ev)
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing, true);
 
-    // Threshold handle — small filled triangle hanging off the bottom
-    // of the grid at the current threshold x.  Easy target for the
-    // mouse and doesn't compete visually with the curve dot.
-    const float T    = m_comp->thresholdDb();
-    const float tx   = dbToX(T);
-    const float by   = rect().bottom() - 4.0f;
+    // Threshold visual — full-height dashed amber guide line + a
+    // chevron at the bottom.  Previously the handle was a tiny
+    // triangle that was easy to miss; the guide line now reads as
+    // "the threshold lives at this x" from a glance, and its whole
+    // column is draggable (see thresholdHandleHit).
+    const float T  = m_comp->thresholdDb();
+    const float tx = dbToX(T);
+
+    const float curveY = dbToY(std::clamp(curveOutputDb(T), kMinDb, kMaxDb));
+    QColor guideColor = kThresholdHandle;
+    guideColor.setAlpha(160);
+    QPen guidePen(guideColor, 1.5, Qt::DashLine);
+    guidePen.setDashPattern({4.0, 3.0});
+    p.setPen(guidePen);
+    p.drawLine(QPointF(tx, curveY), QPointF(tx, rect().bottom() - 8.0f));
+
+    const float by = rect().bottom() - 2.0f;
     QPainterPath tri;
-    tri.moveTo(tx,         by);
-    tri.lineTo(tx - 5.5f, by + 8.0f);
-    tri.lineTo(tx + 5.5f, by + 8.0f);
+    tri.moveTo(tx,          by - 14.0f);
+    tri.lineTo(tx - 9.0f,   by);
+    tri.lineTo(tx + 9.0f,   by);
     tri.closeSubpath();
     p.setBrush(kThresholdHandle);
-    p.setPen(QPen(kHandleOutline, 1.0));
+    p.setPen(QPen(kHandleOutline, 1.5));
     p.drawPath(tri);
 
     // Ratio handle — larger filled dot at the knee centre so it reads
@@ -146,6 +162,40 @@ void ClientCompEditorCanvas::mouseReleaseEvent(QMouseEvent* ev)
     m_drag = Drag::None;
     setCursor(Qt::CrossCursor);
     ev->accept();
+}
+
+bool ClientCompEditorCanvas::event(QEvent* ev)
+{
+    if (ev->type() == QEvent::ToolTip && m_comp) {
+        auto* help = static_cast<QHelpEvent*>(ev);
+        if (ratioHandleHit(help->pos())) {
+            const float ratio = m_comp->ratio();
+            QToolTip::showText(help->globalPos(),
+                QString("<b>Ratio — %1 :1</b><br>"
+                        "Amount of compression above the threshold. "
+                        "Higher = harder squeeze.<br>"
+                        "<i>Drag up/down to change. Hold Shift for fine adjust.</i>")
+                    .arg(ratio, 0, 'f', 2),
+                this);
+            return true;
+        }
+        if (thresholdHandleHit(help->pos())) {
+            const float T = m_comp->thresholdDb();
+            QToolTip::showText(help->globalPos(),
+                QString("<b>Threshold — %1 dBFS</b><br>"
+                        "Audio level where compression begins. "
+                        "Anything louder gets reduced.<br>"
+                        "<i>Drag the chevron left/right, or grab anywhere along "
+                        "the dashed guide line.</i>")
+                    .arg(T, 0, 'f', 1),
+                this);
+            return true;
+        }
+        QToolTip::hideText();
+        ev->ignore();
+        return true;
+    }
+    return ClientCompCurveWidget::event(ev);
 }
 
 } // namespace AetherSDR

--- a/src/gui/ClientCompEditorCanvas.h
+++ b/src/gui/ClientCompEditorCanvas.h
@@ -35,6 +35,10 @@ protected:
     void mousePressEvent(QMouseEvent* ev) override;
     void mouseMoveEvent(QMouseEvent* ev) override;
     void mouseReleaseEvent(QMouseEvent* ev) override;
+    // Per-region tooltips — QWidget::setToolTip is whole-widget; this
+    // widget has two distinct draggable regions so we intercept the
+    // tooltip event and dispatch based on the hover point.
+    bool event(QEvent* ev) override;
 
 private:
     enum class Drag { None, Threshold, Ratio };

--- a/src/gui/ClientCompLimiterButton.cpp
+++ b/src/gui/ClientCompLimiterButton.cpp
@@ -1,0 +1,108 @@
+#include "ClientCompLimiterButton.h"
+
+#include <QPainter>
+#include <QPaintEvent>
+#include <QRadialGradient>
+
+namespace AetherSDR {
+
+namespace {
+
+// Three-state colour palette:
+//   - Disarmed (limiter disabled) — dim, grey, clearly "off"
+//   - Armed (limiter enabled, not firing) — dark green body, bright green text
+//   - Active (firing, held 500 ms) — red body + halo, white text
+const QColor kBgArmed    ("#006040");
+const QColor kBgDisarmed ("#0e1b28");
+const QColor kBgActive   ("#d03030");
+const QColor kBorderArm  ("#00a060");
+const QColor kBorderOff  ("#2a3a4a");
+const QColor kBorderHit  ("#ff8080");
+const QColor kTextArmed  ("#00ff88");
+const QColor kTextOff    ("#607888");
+const QColor kTextActive ("#ffffff");
+
+} // namespace
+
+ClientCompLimiterButton::ClientCompLimiterButton(QWidget* parent)
+    : QPushButton(parent)
+{
+    setCheckable(true);
+    setFlat(false);
+    setText("LIMIT");
+    setFixedHeight(22);
+    m_activeHold.start();
+}
+
+void ClientCompLimiterButton::setActive(bool active)
+{
+    if (active) {
+        m_activeHold.restart();
+        if (!m_active) { m_active = true; update(); }
+        return;
+    }
+    if (m_active && m_activeHold.elapsed() > kHoldMs) {
+        m_active = false;
+        update();
+    }
+}
+
+void ClientCompLimiterButton::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+    p.setRenderHint(QPainter::TextAntialiasing, true);
+
+    const QRectF r = rect().adjusted(0.5, 0.5, -0.5, -0.5);
+    const qreal radius = 3.0;
+
+    // Colour the body by state precedence: active > checked > idle.
+    QColor bg;
+    QColor border;
+    QColor textColor;
+    if (m_active) {
+        bg = kBgActive;
+        border = kBorderHit;
+        textColor = kTextActive;
+    } else if (isChecked()) {
+        bg = kBgArmed;
+        border = kBorderArm;
+        textColor = kTextArmed;
+    } else {
+        bg = kBgDisarmed;
+        border = kBorderOff;
+        textColor = kTextOff;
+    }
+
+    if (underMouse() && !m_active) {
+        bg = bg.lighter(120);
+    }
+
+    p.setBrush(bg);
+    p.setPen(QPen(border, 1.0));
+    p.drawRoundedRect(r, radius, radius);
+
+    // Active halo — soft red glow around the button when firing.  Small
+    // but unmistakable; the strobe + colour change reads like a clipping
+    // indicator on hardware gear.
+    if (m_active) {
+        QRadialGradient g(r.center(), r.width() * 0.6);
+        QColor glow = kBgActive;
+        glow.setAlpha(90);
+        g.setColorAt(0.0, glow);
+        glow.setAlpha(0);
+        g.setColorAt(1.0, glow);
+        p.setBrush(g);
+        p.setPen(Qt::NoPen);
+        p.drawRoundedRect(r.adjusted(-3, -3, 3, 3), radius + 3, radius + 3);
+    }
+
+    QFont f = p.font();
+    f.setPixelSize(10);
+    f.setBold(true);
+    p.setFont(f);
+    p.setPen(textColor);
+    p.drawText(r, Qt::AlignCenter, text());
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompLimiterButton.h
+++ b/src/gui/ClientCompLimiterButton.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QPushButton>
+#include <QElapsedTimer>
+
+namespace AetherSDR {
+
+// LIMIT toggle with a built-in activity indicator.  When the user
+// enables the limiter (checkable), the button reads as "armed".
+// Whenever ClientComp::limiterActive() returns true, the caller
+// strobes the button via setActive(true) — the button then glows
+// red for ~120 ms before decaying back to "armed" so brief firings
+// still register visually.
+//
+// Kept as a subclass so the paint logic stays self-contained and
+// the editor can treat it as a drop-in for QPushButton.
+class ClientCompLimiterButton : public QPushButton {
+    Q_OBJECT
+
+public:
+    explicit ClientCompLimiterButton(QWidget* parent = nullptr);
+
+    // Called from the editor's meter-poll tick with the latest
+    // limiterActive state.  Transitions from false→true restart the
+    // hold timer; the button redraws accordingly.
+    void setActive(bool active);
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+
+private:
+    bool m_active{false};
+    QElapsedTimer m_activeHold;
+    // 500 ms hold after the last active tick — long enough that a brief
+    // limiter firing still leaves a visible red flash, short enough that
+    // sustained program material doesn't leave the button constantly
+    // red after the signal goes quiet.
+    static constexpr int kHoldMs = 500;
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompMeter.cpp
+++ b/src/gui/ClientCompMeter.cpp
@@ -31,6 +31,9 @@ const QColor kLevelHi  ("#e85a5a");
 const QColor kGrColor  ("#e8a540");
 const QColor kLabelColor("#b0c4d6");
 const QColor kPeakLine ("#ffffff");
+const QColor kCeilingLine("#f2c14e");     // bright amber — matches LIMIT button
+const QColor kCeilingZone("#3a1810");     // dim red tint for the "no-go" zone
+const QColor kLimGrTick ("#4db8d4");      // cyan, distinct from the white peak line
 
 } // namespace
 
@@ -74,6 +77,20 @@ void ClientCompMeter::setMode(Mode m)
 void ClientCompMeter::setLabel(const QString& label)
 {
     m_label = label;
+    update();
+}
+
+void ClientCompMeter::setLimiterCeilingDb(float db)
+{
+    if (std::fabs(db - m_ceilingDb) < 0.01f) return;
+    m_ceilingDb = db;
+    update();
+}
+
+void ClientCompMeter::setLimiterGrDb(float db)
+{
+    if (std::fabs(db - m_limGrDb) < 0.01f) return;
+    m_limGrDb = db;
     update();
 }
 
@@ -156,6 +173,45 @@ void ClientCompMeter::paintEvent(QPaintEvent*)
         g.setColorAt(0.7, kLevelMid);
         g.setColorAt(1.0, kLevelHi);
         p.fillRect(fill, g);
+
+        // Limiter overlay — draw ceiling zone + line if a ceiling has
+        // been set.  m_ceilingDb > 0 is our sentinel for "no overlay"
+        // (ceilings are always ≤ 0 dBFS in practice).
+        if (m_ceilingDb <= kLevelMaxDb + 0.0001f) {
+            const float tc = std::clamp(
+                (m_ceilingDb - kLevelMinDb) / (kLevelMaxDb - kLevelMinDb),
+                0.0f, 1.0f);
+            const float cy = bar.bottom() - tc * bar.height();
+
+            // Red-zone shading above the ceiling — "do not enter."
+            const QRectF zone(bar.left(), bar.top(),
+                              bar.width(), cy - bar.top());
+            if (zone.height() > 0) {
+                QColor zoneColor = kCeilingZone;
+                zoneColor.setAlpha(140);
+                p.fillRect(zone, zoneColor);
+            }
+
+            // Ceiling line — bright amber, slightly thicker than the
+            // peak line so it reads as a structural limit, not a meter
+            // value.
+            p.setPen(QPen(kCeilingLine, 1.5));
+            p.drawLine(QPointF(bar.left() - 2.0, cy),
+                       QPointF(bar.right() + 2.0, cy));
+
+            // Limiter GR tick — cyan stub hanging from the ceiling
+            // line into the bar whenever the limiter is clamping.
+            // Length ∝ |m_limGrDb|, capped at 12 dB so big spikes
+            // don't blow past the bar.
+            if (m_limGrDb < -0.05f) {
+                const float grSpanDb = std::min(-m_limGrDb, 12.0f);
+                const float tickH =
+                    (grSpanDb / (kLevelMaxDb - kLevelMinDb)) * bar.height();
+                p.setPen(QPen(kLimGrTick, 2.0));
+                p.drawLine(QPointF(bar.center().x(), cy),
+                           QPointF(bar.center().x(), cy + tickH));
+            }
+        }
 
         if (m_peakDb > kLevelMinDb) {
             const float tp = std::clamp(

--- a/src/gui/ClientCompMeter.h
+++ b/src/gui/ClientCompMeter.h
@@ -36,6 +36,14 @@ public:
     // Optional label shown above the bar (e.g. "GR", "Out").
     void setLabel(const QString& label);
 
+    // Limiter overlay (Level mode only).  When a ceiling <= 0 dBFS is
+    // supplied, the meter draws a dim red "no-go zone" above the
+    // ceiling, a bright amber horizontal line at the ceiling dB, and a
+    // cyan tick hanging from the line whenever limiterGrDb < 0.  Pass
+    // any value > 0 to disable the overlay.
+    void setLimiterCeilingDb(float db);
+    void setLimiterGrDb(float db);
+
 protected:
     void paintEvent(QPaintEvent* ev) override;
 
@@ -56,6 +64,10 @@ private:
     QElapsedTimer m_animElapsed;
     float         m_displayFrac{0.0f};
     float         m_targetFrac{0.0f};
+
+    // Optional limiter overlay state — Level mode only.
+    float m_ceilingDb{1.0f};      // >0 means "no overlay"
+    float m_limGrDb{0.0f};        // 0 means "no limiting this frame"
 };
 
 } // namespace AetherSDR

--- a/src/gui/ClientCompThresholdFader.cpp
+++ b/src/gui/ClientCompThresholdFader.cpp
@@ -1,0 +1,259 @@
+#include "ClientCompThresholdFader.h"
+
+#include <QLabel>
+#include <QLinearGradient>
+#include <QMouseEvent>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QVBoxLayout>
+#include <QWheelEvent>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+// Same ballistics as ClientEqOutputFader — fast rise, slow fall.
+constexpr float kPeakAttack  = 0.6f;
+constexpr float kPeakRelease = 0.08f;
+
+const QColor kHandleFill   ("#e8a540");   // amber — same as threshold chevron
+const QColor kHandleStroke ("#0a1a28");
+const QColor kHandleCenter ("#3a2a10");
+
+} // namespace
+
+ClientCompThresholdFader::ClientCompThresholdFader(QWidget* parent)
+    : QWidget(parent)
+{
+    setFixedWidth(kLabelColW + kGap + kBarW + kHandleOverhang * 2 + 2);
+    setMinimumHeight(160);
+    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+    setFocusPolicy(Qt::ClickFocus);
+    setCursor(Qt::ArrowCursor);
+    setToolTip(
+        "Threshold (dBFS). Drag to set, wheel for 0.5 dB step,\n"
+        "double-click to reset to -18 dB.\n"
+        "Linked to the threshold chevron on the curve.");
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(0, 2, 0, 2);
+    root->setSpacing(0);
+
+    auto* top = new QLabel("THRESH");
+    top->setAlignment(Qt::AlignCenter);
+    top->setStyleSheet(
+        "QLabel { color: #e8a540; font-size: 9px; font-weight: bold;"
+        " background: transparent; border: none; }");
+    root->addWidget(top);
+
+    root->addStretch(1);
+
+    m_valueLabel = new QLabel;
+    m_valueLabel->setAlignment(Qt::AlignCenter);
+    m_valueLabel->setStyleSheet(
+        "QLabel { color: #e8e8e8; font-size: 10px; font-weight: bold;"
+        " background: transparent; border: none; }");
+    root->addWidget(m_valueLabel);
+
+    refreshValueLabel();
+}
+
+void ClientCompThresholdFader::setThresholdDb(float db)
+{
+    const float clamped = std::clamp(db, kThreshMinDb, kThreshMaxDb);
+    if (std::fabs(clamped - m_thresholdDb) < 0.01f) return;
+    m_thresholdDb = clamped;
+    refreshValueLabel();
+    update();
+}
+
+void ClientCompThresholdFader::setInputPeakDb(float db)
+{
+    const float alpha = (db > m_smoothedPeakDb) ? kPeakAttack : kPeakRelease;
+    m_smoothedPeakDb += alpha * (db - m_smoothedPeakDb);
+    update();
+}
+
+void ClientCompThresholdFader::refreshValueLabel()
+{
+    m_valueLabel->setText(QString::asprintf("%+.1f dB", m_thresholdDb));
+}
+
+void ClientCompThresholdFader::setThresholdFromY(int y)
+{
+    // Map y to dBFS: top of strip = kThreshMaxDb (0), bottom = kThreshMinDb (-60).
+    const float norm = 1.0f - std::clamp(
+        static_cast<float>(y - m_stripTop) / std::max(1, m_stripH),
+        0.0f, 1.0f);
+    const float db = kThreshMinDb + norm * (kThreshMaxDb - kThreshMinDb);
+    m_thresholdDb = std::clamp(db, kThreshMinDb, kThreshMaxDb);
+    refreshValueLabel();
+    emit thresholdChanged(m_thresholdDb);
+    update();
+}
+
+void ClientCompThresholdFader::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, false);
+    p.setRenderHint(QPainter::TextAntialiasing, true);
+
+    // Strip vertical bounds — carve between the THRESH label and the
+    // numeric value label.
+    const int topLabelH = 16;
+    const int botLabelH = 14;
+    const int stripTop  = topLabelH + kStripTopPad;
+    const int stripBot  = height() - botLabelH - kStripBottomPad;
+    m_stripTop = stripTop;
+    m_stripH   = std::max(1, stripBot - stripTop);
+
+    const int barLeft = kLabelColW + kGap + kHandleOverhang;
+    const QRect barR(barLeft, stripTop, kBarW, m_stripH);
+
+    p.fillRect(barR, QColor("#06111c"));
+
+    // Level fill — same green→amber→red gradient as the output fader so
+    // the metering vocabulary is consistent across the app.
+    const float peakNorm = std::clamp(
+        (m_smoothedPeakDb - kMeterMinDb) / (kMeterMaxDb - kMeterMinDb),
+        0.0f, 1.0f);
+    const int fillH = static_cast<int>(peakNorm * m_stripH);
+    if (fillH > 0) {
+        const QRect fill(barR.x(), barR.y() + m_stripH - fillH,
+                         kBarW, fillH);
+        QLinearGradient grad(0, barR.y() + m_stripH, 0, barR.y());
+        grad.setColorAt(0.0, QColor("#2f9e6a"));
+        grad.setColorAt(0.55, QColor("#6cc56a"));
+        grad.setColorAt(0.80, QColor("#e8b94c"));
+        grad.setColorAt(0.95, QColor("#e8553c"));
+        grad.setColorAt(1.0, QColor("#f2362a"));
+        p.fillRect(fill, grad);
+    }
+
+    p.setPen(QPen(QColor("#243a4e"), 1));
+    p.setBrush(Qt::NoBrush);
+    p.drawRect(barR.adjusted(0, 0, -1, -1));
+
+    // dB scale on the left.
+    QFont f = p.font();
+    f.setPixelSize(8);
+    p.setFont(f);
+    const QFontMetrics fm(f);
+    const int textRight = kLabelColW - 2;
+
+    struct Tick { float db; const char* label; };
+    static constexpr Tick kTicks[] = {
+        {   0.0f,  "0" },
+        { -12.0f,  "-12" },
+        { -24.0f,  "-24" },
+        { -36.0f,  "-36" },
+        { -48.0f,  "-48" },
+    };
+    for (const auto& t : kTicks) {
+        const float norm = (t.db - kMeterMinDb) / (kMeterMaxDb - kMeterMinDb);
+        const int y = stripTop + static_cast<int>((1.0f - norm) * m_stripH);
+
+        p.setPen(QColor("#7f93a5"));
+        const QString s = QString::fromLatin1(t.label);
+        const int tw = fm.horizontalAdvance(s);
+        const int ty = std::clamp(y + fm.ascent() / 2 - 1,
+                                  stripTop + fm.ascent() - 1,
+                                  stripTop + m_stripH - 1);
+        p.drawText(textRight - tw, ty, s);
+
+        p.setPen(QColor("#405060"));
+        p.drawLine(textRight, y, barLeft - 1, y);
+    }
+
+    // Threshold handle — amber bar overhanging both sides of the meter,
+    // matching the chevron's colour.  The value label already shows the
+    // numeric value, so the handle just marks the position visually.
+    const float threshNorm =
+        (kThreshMaxDb - m_thresholdDb) / (kThreshMaxDb - kThreshMinDb);
+    const int handleY = stripTop + static_cast<int>(threshNorm * m_stripH);
+    const QRect handleR(barLeft - kHandleOverhang,
+                        handleY - kHandleH / 2,
+                        kBarW + kHandleOverhang * 2,
+                        kHandleH);
+    p.setPen(QPen(kHandleStroke, 1));
+    p.setBrush(kHandleFill);
+    p.drawRect(handleR);
+    p.setPen(kHandleCenter);
+    p.drawLine(handleR.left() + 1, handleY,
+               handleR.right() - 1, handleY);
+
+    // Tiny caret on the left edge of the handle so the control reads
+    // as "grabbable" even when stationary.
+    QPainterPath caret;
+    const int cy = handleY;
+    caret.moveTo(barLeft - kHandleOverhang - 4, cy);
+    caret.lineTo(barLeft - kHandleOverhang,     cy - 3);
+    caret.lineTo(barLeft - kHandleOverhang,     cy + 3);
+    caret.closeSubpath();
+    p.setBrush(kHandleFill);
+    p.setPen(Qt::NoPen);
+    p.drawPath(caret);
+}
+
+void ClientCompThresholdFader::mousePressEvent(QMouseEvent* ev)
+{
+    if (ev->button() == Qt::LeftButton) {
+        m_dragging = true;
+        setCursor(Qt::ClosedHandCursor);
+        setThresholdFromY(ev->pos().y());
+        ev->accept();
+        return;
+    }
+    QWidget::mousePressEvent(ev);
+}
+
+void ClientCompThresholdFader::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (m_dragging) {
+        setThresholdFromY(ev->pos().y());
+        ev->accept();
+        return;
+    }
+    QWidget::mouseMoveEvent(ev);
+}
+
+void ClientCompThresholdFader::mouseReleaseEvent(QMouseEvent* ev)
+{
+    if (m_dragging && ev->button() == Qt::LeftButton) {
+        m_dragging = false;
+        setCursor(Qt::ArrowCursor);
+        ev->accept();
+        return;
+    }
+    QWidget::mouseReleaseEvent(ev);
+}
+
+void ClientCompThresholdFader::mouseDoubleClickEvent(QMouseEvent* ev)
+{
+    if (ev->button() == Qt::LeftButton) {
+        m_thresholdDb = kThreshDefaultDb;
+        refreshValueLabel();
+        emit thresholdChanged(m_thresholdDb);
+        update();
+        ev->accept();
+        return;
+    }
+    QWidget::mouseDoubleClickEvent(ev);
+}
+
+void ClientCompThresholdFader::wheelEvent(QWheelEvent* ev)
+{
+    const int notches = ev->angleDelta().y() / 120;
+    if (notches == 0) { QWidget::wheelEvent(ev); return; }
+    m_thresholdDb = std::clamp(m_thresholdDb + 0.5f * notches,
+                               kThreshMinDb, kThreshMaxDb);
+    refreshValueLabel();
+    emit thresholdChanged(m_thresholdDb);
+    update();
+    ev->accept();
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompThresholdFader.h
+++ b/src/gui/ClientCompThresholdFader.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <QWidget>
+
+class QLabel;
+
+namespace AetherSDR {
+
+// Combined input-level meter + threshold fader for the compressor
+// editor.  Visual + interaction pattern mirrors ClientEqOutputFader —
+// one custom-painted strip with a peak-level gradient fill plus a
+// horizontal handle overhanging both sides of the bar.  Dragging the
+// handle emits thresholdChanged(db); that same value is what the
+// threshold chevron on the curve canvas represents, so the two
+// controls stay in lockstep via the shared ClientComp state.
+//
+// Level scale is absolute dBFS [-60, 0], matching ClientCompMeter's
+// Level mode.  Handle range is the same: you can pull the threshold
+// anywhere the input meter can display.
+class ClientCompThresholdFader : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientCompThresholdFader(QWidget* parent = nullptr);
+
+    void setThresholdDb(float db);
+    float thresholdDb() const { return m_thresholdDb; }
+
+    // Feed the latest input peak (dBFS).  Peak-follower smoothing is
+    // applied internally so the bar doesn't flicker on silent frames.
+    void setInputPeakDb(float db);
+
+signals:
+    void thresholdChanged(float db);
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseMoveEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
+    void mouseDoubleClickEvent(QMouseEvent* ev) override;
+    void wheelEvent(QWheelEvent* ev) override;
+
+private:
+    void refreshValueLabel();
+    void setThresholdFromY(int y);
+
+    QLabel* m_valueLabel{nullptr};
+    float   m_thresholdDb{-18.0f};
+    float   m_smoothedPeakDb{-120.0f};
+    bool    m_dragging{false};
+
+    static constexpr float kMeterMinDb = -60.0f;
+    static constexpr float kMeterMaxDb =   0.0f;
+    static constexpr float kThreshMinDb = -60.0f;
+    static constexpr float kThreshMaxDb =   0.0f;
+    static constexpr float kThreshDefaultDb = -18.0f;
+
+    static constexpr int kLabelColW      = 22;
+    static constexpr int kGap            = 2;
+    static constexpr int kBarW           = 16;
+    static constexpr int kHandleOverhang = 4;
+    static constexpr int kHandleH        = 3;
+    static constexpr int kStripTopPad    = 4;
+    static constexpr int kStripBottomPad = 4;
+
+    int m_stripTop{0};
+    int m_stripH{0};
+};
+
+} // namespace AetherSDR


### PR DESCRIPTION
Several UX upgrades to the compressor editor, driven by user feedback:

Threshold — more visible, more grabbable:
- Replace the barely-visible 8-px chevron on the curve with a full-
  height dashed amber guide line + a larger 18×14 chevron at the
  bottom.  Grabbing anywhere along the vertical guide now drags the
  threshold — no more hunting for the tiny triangle.
- Per-region tooltips via QEvent::ToolTip — hovering the chevron or
  the ratio handle shows the current value + what the control does.

New ClientCompThresholdFader widget:
- Combined input-level peak meter + draggable threshold slider,
  mirroring the ClientEq output-fader visual (vertical bar with an
  amber handle that overhangs both sides, dB scale, caret pointer,
  value label).  Drag/wheel/double-click match the EQ fader.
- Linked to the chevron on the curve via the shared ClientComp
  state — moving either control mirrors the other instantly through
  applyThreshold() with QSignalBlocker guarding the feedback loop.
- Replaces the old "Thresh" column (static label + separate input
  meter) so the editor is one widget narrower and one concept clearer.

Four-part limiter visualization on the Output meter:
- Bright amber horizontal line at the current ceiling dB, follows the
  Ceiling knob live, extends slightly past the bar edges so it reads
  as a structural limit and not a peak value.
- Dim red "no-go zone" shading above the ceiling line.
- Cyan gain-reduction tick hanging from the ceiling into the bar,
  length proportional to |limiterGrDb|, distinct colour from the
  compressor GR meter so the two don't get confused.
- Overlay auto-disappears when the limiter is bypassed.

Three-state LIMIT button (new ClientCompLimiterButton):
- Disarmed (limiter disabled): dim grey-blue body, muted text.
- Armed (enabled, not firing): dark green body, bright green text.
- Active (firing): red body + soft radial red halo + white text,
  held for 500 ms after the last trigger so brief spikes still
  leave a visible flash.  Precedence active > armed > disarmed.

DSP:
- Add limiterGrDb() atomic accessor on ClientComp — tracks the
  worst-per-block limiter-specific gain reduction, separate from
  the compressor GR.
- Fix latched-active bug: the limiter envelope decays asymptotically
  toward 1.0 in float math and never quite reaches it, so a strict
  `> 1.0f` check kept limiterActive true forever.  Gate at 1.0006
  (<0.005 dB reduction is inaudible).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
