### PR TITLE
Factor meter smoothing out into a shared MeterSmoother helper

### DIFF
--- a/src/gui/ClientCompApplet.cpp
+++ b/src/gui/ClientCompApplet.cpp
@@ -1,5 +1,6 @@
 #include "ClientCompApplet.h"
 #include "ClientCompCurveWidget.h"
+#include "MeterSmoother.h"
 #include "core/AudioEngine.h"
 #include "core/ClientComp.h"
 
@@ -18,9 +19,9 @@ namespace AetherSDR {
 
 // Gain-reduction mini-strip used by the applet.  Named at file scope
 // (not in an anonymous namespace) so ClientCompApplet.h can forward-
-// declare it and keep a typed pointer.  Fill animates with the same
-// asymmetric attack/release ballistics as HGauge so the motion matches
-// every other metering surface in the app (Phone/CW Level, etc.).
+// declare it and keep a typed pointer.  Fill motion uses the shared
+// MeterSmoother ballistics so the strip reads identically to every
+// other metering surface in the app.
 class ClientCompGrBar : public QWidget {
 public:
     explicit ClientCompGrBar(QWidget* parent = nullptr) : QWidget(parent)
@@ -28,20 +29,10 @@ public:
         setFixedHeight(10);
 
         m_animTimer.setTimerType(Qt::PreciseTimer);
-        m_animTimer.setInterval(8);
+        m_animTimer.setInterval(kMeterSmootherIntervalMs);
         connect(&m_animTimer, &QTimer::timeout, this, [this]() {
-            const qint64 ms = m_animElapsed.restart();
-            if (ms <= 0) return;
-            const float delta = m_targetFrac - m_displayFrac;
-            if (std::fabs(delta) <= 0.001f) {
-                m_displayFrac = m_targetFrac;
+            if (!m_smooth.tick(m_animElapsed.restart()))
                 m_animTimer.stop();
-            } else {
-                const float tau = (delta >= 0.0f) ? 0.030f : 0.180f;
-                const float alpha = 1.0f - std::exp(
-                    -static_cast<float>(ms) / 1000.0f / tau);
-                m_displayFrac += delta * alpha;
-            }
             update();
         });
     }
@@ -51,9 +42,8 @@ public:
         if (std::fabs(grDb - m_grDb) < 0.05f) return;
         m_grDb = grDb;
         constexpr float kMaxGr = 20.0f;
-        m_targetFrac = std::clamp(-m_grDb, 0.0f, kMaxGr) / kMaxGr;
-        if (std::fabs(m_targetFrac - m_displayFrac) <= 0.001f) {
-            m_displayFrac = m_targetFrac;
+        m_smooth.setTarget(std::clamp(-m_grDb, 0.0f, kMaxGr) / kMaxGr);
+        if (!m_smooth.needsAnimation()) {
             if (m_animTimer.isActive()) m_animTimer.stop();
             update();
         } else if (!m_animTimer.isActive()) {
@@ -69,8 +59,9 @@ protected:
         const QRectF r = rect();
         p.fillRect(r, QColor("#0a1420"));
         constexpr float kMaxGr = 20.0f;
-        if (m_displayFrac > 0.0f) {
-            const float w = m_displayFrac * r.width();
+        const float frac = m_smooth.value();
+        if (frac > 0.0f) {
+            const float w = frac * r.width();
             QRectF fill(r.right() - w, r.top() + 1.0, w, r.height() - 2.0);
             p.fillRect(fill, QColor("#e8a540"));
         }
@@ -80,11 +71,10 @@ protected:
     }
 
 private:
-    float m_grDb{0.0f};
+    float         m_grDb{0.0f};
+    MeterSmoother m_smooth;
     QTimer        m_animTimer;
     QElapsedTimer m_animElapsed;
-    float         m_displayFrac{0.0f};
-    float         m_targetFrac{0.0f};
 };
 
 namespace {

--- a/src/gui/ClientCompMeter.cpp
+++ b/src/gui/ClientCompMeter.cpp
@@ -16,14 +16,6 @@ constexpr float kGrMaxMag   =  20.0f;    // GR range 0..-20 dB
 constexpr int   kPeakHoldMs =  700;
 constexpr float kPeakDecayDbPer100Ms = 1.0f;
 
-// Same ballistics as HGauge so every metering surface in the app
-// has matching motion.  Attack is fast enough to feel responsive on
-// speech peaks; release is slow enough that the fill doesn't flicker.
-constexpr int   kAnimIntervalMs = 8;
-constexpr float kAttackSeconds  = 0.030f;
-constexpr float kReleaseSeconds = 0.180f;
-constexpr float kSnapEpsilon    = 0.001f;
-
 const QColor kBarBg    ("#0a1420");
 const QColor kLevelLo  ("#56c48b");
 const QColor kLevelMid ("#e8d65a");
@@ -45,20 +37,10 @@ ClientCompMeter::ClientCompMeter(QWidget* parent) : QWidget(parent)
     m_peakHoldTimer.start();
 
     m_animTimer.setTimerType(Qt::PreciseTimer);
-    m_animTimer.setInterval(kAnimIntervalMs);
+    m_animTimer.setInterval(kMeterSmootherIntervalMs);
     connect(&m_animTimer, &QTimer::timeout, this, [this]() {
-        const qint64 ms = m_animElapsed.restart();
-        if (ms <= 0) return;
-        const float delta = m_targetFrac - m_displayFrac;
-        if (std::fabs(delta) <= kSnapEpsilon) {
-            m_displayFrac = m_targetFrac;
+        if (!m_smooth.tick(m_animElapsed.restart()))
             m_animTimer.stop();
-        } else {
-            const float tau = (delta >= 0.0f) ? kAttackSeconds : kReleaseSeconds;
-            const float alpha = 1.0f - std::exp(
-                -static_cast<float>(ms) / 1000.0f / tau);
-            m_displayFrac += delta * alpha;
-        }
         update();
     });
 }
@@ -69,8 +51,8 @@ void ClientCompMeter::setMode(Mode m)
     m_mode = m;
     m_currentDb = -120.0f;
     m_peakDb    = -120.0f;
-    m_displayFrac = 0.0f;
-    m_targetFrac  = 0.0f;
+    m_smooth.setTarget(0.0f);
+    m_smooth.snapToTarget();
     update();
 }
 
@@ -105,9 +87,8 @@ void ClientCompMeter::recomputeTarget()
         const float mag = std::clamp(-m_currentDb, 0.0f, kGrMaxMag);
         target = mag / kGrMaxMag;
     }
-    m_targetFrac = target;
-    if (std::fabs(m_targetFrac - m_displayFrac) <= kSnapEpsilon) {
-        m_displayFrac = m_targetFrac;
+    m_smooth.setTarget(target);
+    if (!m_smooth.needsAnimation()) {
         if (m_animTimer.isActive()) m_animTimer.stop();
     } else if (!m_animTimer.isActive()) {
         m_animElapsed.restart();
@@ -120,7 +101,7 @@ void ClientCompMeter::setValueDb(float db)
     // Peak-hold tracks the loudest recent reading (or largest GR) and
     // decays after a 700 ms hold.  Jumps instantly to any new extreme
     // so transients don't get hidden.  Bar fill is smoothed separately
-    // through m_targetFrac / m_displayFrac.
+    // via MeterSmoother.
     if (m_mode == Mode::Level) {
         m_currentDb = db;
         if (db > m_peakDb) {
@@ -165,7 +146,7 @@ void ClientCompMeter::paintEvent(QPaintEvent*)
     p.fillRect(bar, kBarBg);
 
     if (m_mode == Mode::Level) {
-        const float fillH = m_displayFrac * bar.height();
+        const float fillH = m_smooth.value() * bar.height();
         QRectF fill(bar.left(), bar.bottom() - fillH, bar.width(), fillH);
 
         QLinearGradient g(0, bar.bottom(), 0, bar.top());
@@ -222,7 +203,7 @@ void ClientCompMeter::paintEvent(QPaintEvent*)
             p.drawLine(QPointF(bar.left(), y), QPointF(bar.right(), y));
         }
     } else {
-        const float fillH = m_displayFrac * bar.height();
+        const float fillH = m_smooth.value() * bar.height();
         QRectF fill(bar.left(), bar.top(), bar.width(), fillH);
         p.fillRect(fill, kGrColor);
 

--- a/src/gui/ClientCompMeter.h
+++ b/src/gui/ClientCompMeter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "MeterSmoother.h"
+
 #include <QWidget>
 #include <QElapsedTimer>
 #include <QTimer>
@@ -59,11 +61,10 @@ private:
     float m_peakDb{-120.0f};
     QElapsedTimer m_peakHoldTimer;
 
-    // Smoothed fill animation (same ballistics as HGauge).
+    // Smoothed fill — shared MeterSmoother ballistics.
+    MeterSmoother m_smooth;
     QTimer        m_animTimer;
     QElapsedTimer m_animElapsed;
-    float         m_displayFrac{0.0f};
-    float         m_targetFrac{0.0f};
 
     // Optional limiter overlay state — Level mode only.
     float m_ceilingDb{1.0f};      // >0 means "no overlay"

--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "MeterSmoother.h"
+
 #include <QPainter>
 #include <QWidget>
 #include <QWheelEvent>
@@ -35,22 +37,15 @@ public:
         setFixedHeight(24);
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
-        m_displayFrac = qBound(0.0f, (0.0f - m_min) / (m_max - m_min), 1.0f);
-        m_targetFrac = m_displayFrac;
+        const float initial = qBound(
+            0.0f, (0.0f - m_min) / (m_max - m_min), 1.0f);
+        m_smooth.setTarget(initial);
+        m_smooth.snapToTarget();
         m_animTimer.setTimerType(Qt::PreciseTimer);
-        m_animTimer.setInterval(kAnimIntervalMs);
+        m_animTimer.setInterval(kMeterSmootherIntervalMs);
         connect(&m_animTimer, &QTimer::timeout, this, [this]() {
-            const qint64 ms = m_animElapsed.restart();
-            if (ms <= 0) return;
-            const float delta = m_targetFrac - m_displayFrac;
-            if (qAbs(delta) <= kSnapEpsilon) {
-                m_displayFrac = m_targetFrac;
+            if (!m_smooth.tick(m_animElapsed.restart()))
                 m_animTimer.stop();
-            } else {
-                const float tau = (delta >= 0.0f) ? kAttackSeconds : kReleaseSeconds;
-                const float alpha = 1.0f - std::exp(-static_cast<float>(ms) / 1000.0f / tau);
-                m_displayFrac += delta * alpha;
-            }
             update();
         });
     }
@@ -58,9 +53,9 @@ public:
     void setValue(float v) {
         if (qFuzzyCompare(m_value, v)) return;
         m_value = v;
-        m_targetFrac = qBound(0.0f, (v - m_min) / (m_max - m_min), 1.0f);
-        if (qAbs(m_targetFrac - m_displayFrac) <= kSnapEpsilon) {
-            m_displayFrac = m_targetFrac;
+        m_smooth.setTarget(
+            qBound(0.0f, (v - m_min) / (m_max - m_min), 1.0f));
+        if (!m_smooth.needsAnimation()) {
             if (m_animTimer.isActive()) m_animTimer.stop();
             update();
         } else if (!m_animTimer.isActive()) {
@@ -104,7 +99,7 @@ protected:
         p.drawRect(barX, barY, barW - 1, barH - 1);
 
         // Filled portion (animated)
-        int fillW = static_cast<int>(m_displayFrac * barW);
+        int fillW = static_cast<int>(m_smooth.value() * barW);
 
         if (m_reversed) {
             // Reversed: bar fills from right to left, single color.
@@ -195,15 +190,10 @@ private:
     QString m_label, m_unit;
     QVector<Tick> m_ticks;
 
-    // Smoothed bar animation (asymmetric attack/release)
+    // Shared meter ballistics — see MeterSmoother.h.
+    MeterSmoother m_smooth;
     QTimer        m_animTimer;
     QElapsedTimer m_animElapsed;
-    float         m_displayFrac{0.0f};
-    float         m_targetFrac{0.0f};
-    static constexpr int   kAnimIntervalMs = 8;
-    static constexpr float kAttackSeconds  = 0.030f;
-    static constexpr float kReleaseSeconds = 0.180f;
-    static constexpr float kSnapEpsilon    = 0.001f;
 };
 
 // ── RelayBar: horizontal bar for relay position (0–255) ───────────────────────

--- a/src/gui/MeterSmoother.h
+++ b/src/gui/MeterSmoother.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <QtGlobal>
+#include <cmath>
+
+namespace AetherSDR {
+
+// Shared asymmetric attack / release envelope follower for UI meter
+// bars.  Every metering surface in the app (HGauge, ClientCompMeter,
+// ClientCompApplet's GR strip, any future meter) runs the same
+// motion so the interface reads as one consistent instrument rather
+// than a grab-bag of different bar behaviours.
+//
+// "MeterSmoother ballistics" — 30 ms attack, 180 ms release, polled
+// at ~120 Hz.  Fast enough to feel responsive on speech peaks; slow
+// enough that the bar doesn't flicker on per-block noise.  Between a
+// classic VU (300 ms integration) and a fast PPM (a few ms) — suited
+// for ham-radio-style level / GR indication rather than broadcast
+// loudness compliance.
+//
+// Value domain is normalised [0, 1]; callers map physical units
+// (dBFS, dB of GR, etc.) to a fraction before calling setTarget().
+//
+// Usage (driven by a QTimer on the owning widget):
+//
+//     MeterSmoother m_smooth;
+//     QTimer        m_timer;
+//     QElapsedTimer m_clock;
+//
+//     // On new data:
+//     m_smooth.setTarget(fracFromDb(...));
+//     if (m_smooth.needsAnimation() && !m_timer.isActive()) {
+//         m_clock.restart();
+//         m_timer.start();
+//     }
+//
+//     // In the timer callback:
+//     if (!m_smooth.tick(m_clock.restart())) {
+//         m_timer.stop();   // settled
+//     }
+//     update();             // repaint, read m_smooth.value()
+class MeterSmoother {
+public:
+    // Ballistics are mutable per-instance so individual meters can
+    // opt into different behaviour (e.g. a GR bar with a slower
+    // release) while still reading off the same central name.
+    struct Ballistics {
+        float attackSeconds  = 0.030f;
+        float releaseSeconds = 0.180f;
+        float snapEpsilon    = 0.001f;
+    };
+
+    MeterSmoother() = default;
+    explicit MeterSmoother(Ballistics b) : m_b(b) {}
+
+    // Set the animation target.  Snaps immediately when already
+    // within snapEpsilon of the target, so small-delta moves don't
+    // trigger a pointless animation frame.
+    void setTarget(float target)
+    {
+        m_target = target;
+        if (std::fabs(m_target - m_display) <= m_b.snapEpsilon)
+            m_display = m_target;
+    }
+    float target() const { return m_target; }
+
+    // Current display value [0, 1].  Read on every paint.
+    float value() const { return m_display; }
+
+    // Snap to the current target with no animation (e.g. mode reset).
+    void snapToTarget() { m_display = m_target; }
+
+    // True when the bar is still catching up to the target.  Caller
+    // uses this to decide whether to keep its animation timer running.
+    bool needsAnimation() const
+    {
+        return std::fabs(m_target - m_display) > m_b.snapEpsilon;
+    }
+
+    // Advance the smoother by wall-clock milliseconds.  Returns true
+    // while still animating, false once the display has reached the
+    // target — caller can stop its driving timer when it returns false.
+    bool tick(qint64 elapsedMs)
+    {
+        if (elapsedMs <= 0) return needsAnimation();
+        const float delta = m_target - m_display;
+        if (std::fabs(delta) <= m_b.snapEpsilon) {
+            m_display = m_target;
+            return false;
+        }
+        const float tau = (delta >= 0.0f) ? m_b.attackSeconds
+                                          : m_b.releaseSeconds;
+        const float alpha = 1.0f - std::exp(
+            -static_cast<float>(elapsedMs) / 1000.0f / tau);
+        m_display += delta * alpha;
+        return true;
+    }
+
+    void setBallistics(const Ballistics& b) { m_b = b; }
+    const Ballistics& ballistics() const { return m_b; }
+
+private:
+    Ballistics m_b;
+    float      m_display{0.0f};
+    float      m_target{0.0f};
+};
+
+// Recommended driving-timer interval for a MeterSmoother.  8 ms ≈
+// 120 Hz — tight enough that the attack time constant resolves
+// smoothly, cheap enough to run on every active meter simultaneously.
+constexpr int kMeterSmootherIntervalMs = 8;
+
+} // namespace AetherSDR


### PR DESCRIPTION
The asymmetric attack / release envelope follower that drives every
metering surface in the app (HGauge, ClientCompMeter, the applet's
GR strip) had been copy-pasted with its own QTimer plumbing in each
consumer.  Now there are four+ places that want the same motion — the
pattern deserves a name.

Adds src/gui/MeterSmoother.h: header-only, holds the normalised
display / target state and the ballistics struct (30 ms attack,
180 ms release, 0.001 snap epsilon — the "HGauge ballistics" we
inherited from the first implementation).  Exposes setTarget(),
value(), snapToTarget(), needsAnimation(), and tick(elapsedMs)
which returns false when the bar has settled so the driving timer
can stop.  Also exports kMeterSmootherIntervalMs (~120 Hz) so
consumers don't each guess the polling rate.

Refactors:
- HGauge.h — drop local displayFrac / targetFrac / attack / release
  constants; delegate to MeterSmoother
- ClientCompMeter — same
- ClientCompApplet::ClientCompGrBar — same

Pure refactor — same motion, same constants, no behavioural change.
Future meters (Phase 2 expander, de-esser, tube, enhancer) pick up
the shared ballistics by including one header.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
