### PR TITLE
TX DSP chain: Gate, DeEss, Tube, PUDU + monitor + EQ/UI polish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,11 @@ set(CORE_SOURCES
     src/core/AudioEngine.cpp
     src/core/ClientEq.cpp
     src/core/ClientComp.cpp
+    src/core/ClientGate.cpp
+    src/core/ClientDeEss.cpp
+    src/core/ClientTube.cpp
+    src/core/ClientPudu.cpp
+    src/core/ClientPuduMonitor.cpp
     src/core/SpectralNR.cpp
     src/core/PanadapterStream.cpp
     src/core/RigctlProtocol.cpp
@@ -522,6 +527,19 @@ set(GUI_SOURCES
     src/gui/ClientCompApplet.cpp
     src/gui/ClientCompCurveWidget.cpp
     src/gui/ClientCompKnob.cpp
+    src/gui/ClientGateApplet.cpp
+    src/gui/ClientGateCurveWidget.cpp
+    src/gui/ClientGateEditor.cpp
+    src/gui/ClientGateLevelView.cpp
+    src/gui/ClientDeEssApplet.cpp
+    src/gui/ClientDeEssCurveWidget.cpp
+    src/gui/ClientDeEssEditor.cpp
+    src/gui/ClientTubeApplet.cpp
+    src/gui/ClientTubeCurveWidget.cpp
+    src/gui/ClientTubeEditor.cpp
+    src/gui/ClientPuduApplet.cpp
+    src/gui/ClientPuduEditor.cpp
+    src/gui/PooDooLogo.cpp
     src/gui/ClientCompLimiterButton.cpp
     src/gui/ClientCompMeter.cpp
     src/gui/ClientCompThresholdFader.cpp
@@ -1039,6 +1057,30 @@ add_executable(client_comp_test
     src/core/ClientComp.cpp
 )
 target_include_directories(client_comp_test PRIVATE src)
+
+add_executable(client_gate_test
+    tests/client_gate_test.cpp
+    src/core/ClientGate.cpp
+)
+target_include_directories(client_gate_test PRIVATE src)
+
+add_executable(client_deess_test
+    tests/client_deess_test.cpp
+    src/core/ClientDeEss.cpp
+)
+target_include_directories(client_deess_test PRIVATE src)
+
+add_executable(client_tube_test
+    tests/client_tube_test.cpp
+    src/core/ClientTube.cpp
+)
+target_include_directories(client_tube_test PRIVATE src)
+
+add_executable(client_pudu_test
+    tests/client_pudu_test.cpp
+    src/core/ClientPudu.cpp
+)
+target_include_directories(client_pudu_test PRIVATE src)
 
 # Container system Phase 1 tests — needs QApplication + Widgets.
 add_executable(container_widget_test

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -2,6 +2,11 @@
 #include "AppSettings.h"
 #include "ClientEq.h"
 #include "ClientComp.h"
+#include "ClientGate.h"
+#include "ClientDeEss.h"
+#include "ClientTube.h"
+#include "ClientPudu.h"
+#include "ClientPuduMonitor.h"
 #include "LogManager.h"
 #include "OpusCodec.h"
 #include "SpectralNR.h"
@@ -52,14 +57,26 @@ AudioEngine::AudioEngine(QObject* parent)
     , m_clientEqRx(std::make_unique<ClientEq>())
     , m_clientEqTx(std::make_unique<ClientEq>())
     , m_clientCompTx(std::make_unique<ClientComp>())
+    , m_clientGateTx(std::make_unique<ClientGate>())
+    , m_clientDeEssTx(std::make_unique<ClientDeEss>())
+    , m_clientTubeTx(std::make_unique<ClientTube>())
+    , m_clientPuduTx(std::make_unique<ClientPudu>())
 {
     // Prepare client DSP at the native 24 kHz rate. Sink resampling is
     // handled separately after EQ — EQ always runs at radio-native rate.
     m_clientEqRx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientEqTx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientCompTx->prepare(DEFAULT_SAMPLE_RATE);
+    m_clientGateTx->prepare(DEFAULT_SAMPLE_RATE);
+    m_clientDeEssTx->prepare(DEFAULT_SAMPLE_RATE);
+    m_clientTubeTx->prepare(DEFAULT_SAMPLE_RATE);
+    m_clientPuduTx->prepare(DEFAULT_SAMPLE_RATE);
     loadClientEqSettings();    // restore persisted bands before first audio
     loadClientCompSettings();  // restore persisted comp params + chain order
+    loadClientGateSettings();  // restore persisted gate params
+    loadClientDeEssSettings(); // restore persisted de-esser params
+    loadClientTubeSettings();  // restore persisted tube params
+    loadClientPuduSettings();  // restore persisted PUDU params
 
     // Restore saved audio device selections
     auto& s = AppSettings::instance();
@@ -842,6 +859,142 @@ void AudioEngine::applyClientCompTxFloat32(QByteArray& float32)
                             frames, channels);
 }
 
+void AudioEngine::applyClientGateTxInt16(QByteArray& int16stereo)
+{
+    if (!m_clientGateTx || !m_clientGateTx->isEnabled()) return;
+    if (int16stereo.isEmpty()) return;
+
+    const int samples = int16stereo.size() / static_cast<int>(sizeof(int16_t));
+    if ((samples & 1) != 0) return;
+    const int frames = samples / 2;
+
+    m_clientGateTxScratch.resize(samples * static_cast<int>(sizeof(float)));
+    auto* f32 = reinterpret_cast<float*>(m_clientGateTxScratch.data());
+    const auto* i16 = reinterpret_cast<const int16_t*>(int16stereo.constData());
+    for (int i = 0; i < samples; ++i) f32[i] = i16[i] / 32768.0f;
+
+    m_clientGateTx->process(f32, frames, 2);
+
+    auto* out = reinterpret_cast<int16_t*>(int16stereo.data());
+    for (int i = 0; i < samples; ++i) {
+        out[i] = static_cast<int16_t>(
+            std::clamp(f32[i] * 32768.0f, -32768.0f, 32767.0f));
+    }
+}
+
+void AudioEngine::applyClientGateTxFloat32(QByteArray& float32)
+{
+    if (!m_clientGateTx || !m_clientGateTx->isEnabled()) return;
+    if (float32.isEmpty()) return;
+    const int samples  = float32.size() / static_cast<int>(sizeof(float));
+    const int channels = (samples % 2 == 0) ? 2 : 1;
+    const int frames   = samples / channels;
+    m_clientGateTx->process(reinterpret_cast<float*>(float32.data()),
+                            frames, channels);
+}
+
+void AudioEngine::applyClientDeEssTxInt16(QByteArray& int16stereo)
+{
+    if (!m_clientDeEssTx || !m_clientDeEssTx->isEnabled()) return;
+    if (int16stereo.isEmpty()) return;
+
+    const int samples = int16stereo.size() / static_cast<int>(sizeof(int16_t));
+    if ((samples & 1) != 0) return;
+    const int frames = samples / 2;
+
+    m_clientDeEssTxScratch.resize(samples * static_cast<int>(sizeof(float)));
+    auto* f32 = reinterpret_cast<float*>(m_clientDeEssTxScratch.data());
+    const auto* i16 = reinterpret_cast<const int16_t*>(int16stereo.constData());
+    for (int i = 0; i < samples; ++i) f32[i] = i16[i] / 32768.0f;
+
+    m_clientDeEssTx->process(f32, frames, 2);
+
+    auto* out = reinterpret_cast<int16_t*>(int16stereo.data());
+    for (int i = 0; i < samples; ++i) {
+        out[i] = static_cast<int16_t>(
+            std::clamp(f32[i] * 32768.0f, -32768.0f, 32767.0f));
+    }
+}
+
+void AudioEngine::applyClientDeEssTxFloat32(QByteArray& float32)
+{
+    if (!m_clientDeEssTx || !m_clientDeEssTx->isEnabled()) return;
+    if (float32.isEmpty()) return;
+    const int samples  = float32.size() / static_cast<int>(sizeof(float));
+    const int channels = (samples % 2 == 0) ? 2 : 1;
+    const int frames   = samples / channels;
+    m_clientDeEssTx->process(reinterpret_cast<float*>(float32.data()),
+                             frames, channels);
+}
+
+void AudioEngine::applyClientTubeTxInt16(QByteArray& int16stereo)
+{
+    if (!m_clientTubeTx || !m_clientTubeTx->isEnabled()) return;
+    if (int16stereo.isEmpty()) return;
+
+    const int samples = int16stereo.size() / static_cast<int>(sizeof(int16_t));
+    if ((samples & 1) != 0) return;
+    const int frames = samples / 2;
+
+    m_clientTubeTxScratch.resize(samples * static_cast<int>(sizeof(float)));
+    auto* f32 = reinterpret_cast<float*>(m_clientTubeTxScratch.data());
+    const auto* i16 = reinterpret_cast<const int16_t*>(int16stereo.constData());
+    for (int i = 0; i < samples; ++i) f32[i] = i16[i] / 32768.0f;
+
+    m_clientTubeTx->process(f32, frames, 2);
+
+    auto* out = reinterpret_cast<int16_t*>(int16stereo.data());
+    for (int i = 0; i < samples; ++i) {
+        out[i] = static_cast<int16_t>(
+            std::clamp(f32[i] * 32768.0f, -32768.0f, 32767.0f));
+    }
+}
+
+void AudioEngine::applyClientTubeTxFloat32(QByteArray& float32)
+{
+    if (!m_clientTubeTx || !m_clientTubeTx->isEnabled()) return;
+    if (float32.isEmpty()) return;
+    const int samples  = float32.size() / static_cast<int>(sizeof(float));
+    const int channels = (samples % 2 == 0) ? 2 : 1;
+    const int frames   = samples / channels;
+    m_clientTubeTx->process(reinterpret_cast<float*>(float32.data()),
+                            frames, channels);
+}
+
+void AudioEngine::applyClientPuduTxInt16(QByteArray& int16stereo)
+{
+    if (!m_clientPuduTx || !m_clientPuduTx->isEnabled()) return;
+    if (int16stereo.isEmpty()) return;
+
+    const int samples = int16stereo.size() / static_cast<int>(sizeof(int16_t));
+    if ((samples & 1) != 0) return;
+    const int frames = samples / 2;
+
+    m_clientPuduTxScratch.resize(samples * static_cast<int>(sizeof(float)));
+    auto* f32 = reinterpret_cast<float*>(m_clientPuduTxScratch.data());
+    const auto* i16 = reinterpret_cast<const int16_t*>(int16stereo.constData());
+    for (int i = 0; i < samples; ++i) f32[i] = i16[i] / 32768.0f;
+
+    m_clientPuduTx->process(f32, frames, 2);
+
+    auto* out = reinterpret_cast<int16_t*>(int16stereo.data());
+    for (int i = 0; i < samples; ++i) {
+        out[i] = static_cast<int16_t>(
+            std::clamp(f32[i] * 32768.0f, -32768.0f, 32767.0f));
+    }
+}
+
+void AudioEngine::applyClientPuduTxFloat32(QByteArray& float32)
+{
+    if (!m_clientPuduTx || !m_clientPuduTx->isEnabled()) return;
+    if (float32.isEmpty()) return;
+    const int samples  = float32.size() / static_cast<int>(sizeof(float));
+    const int channels = (samples % 2 == 0) ? 2 : 1;
+    const int frames   = samples / channels;
+    m_clientPuduTx->process(reinterpret_cast<float*>(float32.data()),
+                            frames, channels);
+}
+
 void AudioEngine::applyClientTxDspInt16(QByteArray& int16stereo)
 {
     // Order determines whether the compressor colours the raw mic signal
@@ -857,15 +1010,14 @@ void AudioEngine::applyClientTxDspInt16(QByteArray& int16stereo)
         const auto stage = static_cast<TxChainStage>((packed >> (i * 8)) & 0xFF);
         switch (stage) {
             case TxChainStage::None:   return;     // end-of-list marker
-            case TxChainStage::Eq:     applyClientEqTxInt16(int16stereo);   break;
-            case TxChainStage::Comp:   applyClientCompTxInt16(int16stereo); break;
-            // Gate / DeEss / Tube / Enh — placeholders for Phase 2+
-            // (#1661).  No DSP yet, pass-through.
-            case TxChainStage::Gate:
-            case TxChainStage::DeEss:
-            case TxChainStage::Tube:
-            case TxChainStage::Enh:
-                break;
+            case TxChainStage::Eq:     applyClientEqTxInt16(int16stereo);    break;
+            case TxChainStage::Comp:   applyClientCompTxInt16(int16stereo);  break;
+            case TxChainStage::Gate:   applyClientGateTxInt16(int16stereo);  break;
+            case TxChainStage::DeEss:  applyClientDeEssTxInt16(int16stereo); break;
+            case TxChainStage::Tube:   applyClientTubeTxInt16(int16stereo);  break;
+            // "Enh" is the legacy enum name; the user-facing label is
+            // PUDU (Phase 5 exciter, Aphex/Behringer-modelled).
+            case TxChainStage::Enh:    applyClientPuduTxInt16(int16stereo);  break;
         }
     }
 }
@@ -877,13 +1029,12 @@ void AudioEngine::applyClientTxDspFloat32(QByteArray& float32)
         const auto stage = static_cast<TxChainStage>((packed >> (i * 8)) & 0xFF);
         switch (stage) {
             case TxChainStage::None:   return;
-            case TxChainStage::Eq:     applyClientEqTxFloat32(float32);   break;
-            case TxChainStage::Comp:   applyClientCompTxFloat32(float32); break;
-            case TxChainStage::Gate:
-            case TxChainStage::DeEss:
-            case TxChainStage::Tube:
-            case TxChainStage::Enh:
-                break;
+            case TxChainStage::Eq:     applyClientEqTxFloat32(float32);    break;
+            case TxChainStage::Comp:   applyClientCompTxFloat32(float32);  break;
+            case TxChainStage::Gate:   applyClientGateTxFloat32(float32);  break;
+            case TxChainStage::DeEss:  applyClientDeEssTxFloat32(float32); break;
+            case TxChainStage::Tube:   applyClientTubeTxFloat32(float32);  break;
+            case TxChainStage::Enh:    applyClientPuduTxFloat32(float32);  break;
         }
     }
 }
@@ -1093,6 +1244,211 @@ void AudioEngine::saveClientCompSettings() const
         if (!n.isEmpty()) names.append(n);
     }
     s.setValue("ClientCompTxChainStages", names.join(","));
+}
+
+void AudioEngine::loadClientGateSettings()
+{
+    if (!m_clientGateTx) return;
+    auto& s = AppSettings::instance();
+    m_clientGateTx->setEnabled(
+        s.value("ClientGateTxEnabled", "False").toString() == "True");
+    // Mode first — it snaps ratio + floor to presets, so apply before
+    // those two so a persisted mode doesn't overwrite a custom ratio.
+    const int modeInt = s.value("ClientGateTxMode", "0").toInt();
+    m_clientGateTx->setMode(modeInt == 1
+        ? ClientGate::Mode::Gate
+        : ClientGate::Mode::Expander);
+    m_clientGateTx->setThresholdDb(
+        s.value("ClientGateTxThresholdDb", "-40.0").toFloat());
+    m_clientGateTx->setReturnDb(
+        s.value("ClientGateTxReturnDb", "2.0").toFloat());
+    m_clientGateTx->setRatio(
+        s.value("ClientGateTxRatio", "2.0").toFloat());
+    m_clientGateTx->setAttackMs(
+        s.value("ClientGateTxAttackMs", "0.5").toFloat());
+    m_clientGateTx->setHoldMs(
+        s.value("ClientGateTxHoldMs", "20.0").toFloat());
+    m_clientGateTx->setReleaseMs(
+        s.value("ClientGateTxReleaseMs", "100.0").toFloat());
+    m_clientGateTx->setFloorDb(
+        s.value("ClientGateTxFloorDb", "-15.0").toFloat());
+    m_clientGateTx->setLookaheadMs(
+        s.value("ClientGateTxLookaheadMs", "0.0").toFloat());
+}
+
+void AudioEngine::saveClientGateSettings() const
+{
+    if (!m_clientGateTx) return;
+    auto& s = AppSettings::instance();
+    auto toBool = [](bool on) { return on ? QString("True") : QString("False"); };
+    s.setValue("ClientGateTxEnabled", toBool(m_clientGateTx->isEnabled()));
+    s.setValue("ClientGateTxMode",
+        QString::number(static_cast<int>(m_clientGateTx->mode())));
+    s.setValue("ClientGateTxThresholdDb",
+        QString::number(m_clientGateTx->thresholdDb()));
+    s.setValue("ClientGateTxReturnDb",
+        QString::number(m_clientGateTx->returnDb()));
+    s.setValue("ClientGateTxRatio",
+        QString::number(m_clientGateTx->ratio()));
+    s.setValue("ClientGateTxAttackMs",
+        QString::number(m_clientGateTx->attackMs()));
+    s.setValue("ClientGateTxHoldMs",
+        QString::number(m_clientGateTx->holdMs()));
+    s.setValue("ClientGateTxReleaseMs",
+        QString::number(m_clientGateTx->releaseMs()));
+    s.setValue("ClientGateTxFloorDb",
+        QString::number(m_clientGateTx->floorDb()));
+    s.setValue("ClientGateTxLookaheadMs",
+        QString::number(m_clientGateTx->lookaheadMs()));
+}
+
+void AudioEngine::loadClientDeEssSettings()
+{
+    if (!m_clientDeEssTx) return;
+    auto& s = AppSettings::instance();
+    m_clientDeEssTx->setEnabled(
+        s.value("ClientDeEssTxEnabled", "False").toString() == "True");
+    m_clientDeEssTx->setFrequencyHz(
+        s.value("ClientDeEssTxFrequencyHz", "6000.0").toFloat());
+    m_clientDeEssTx->setQ(
+        s.value("ClientDeEssTxQ", "2.0").toFloat());
+    m_clientDeEssTx->setThresholdDb(
+        s.value("ClientDeEssTxThresholdDb", "-30.0").toFloat());
+    m_clientDeEssTx->setAmountDb(
+        s.value("ClientDeEssTxAmountDb", "-6.0").toFloat());
+    m_clientDeEssTx->setAttackMs(
+        s.value("ClientDeEssTxAttackMs", "1.0").toFloat());
+    m_clientDeEssTx->setReleaseMs(
+        s.value("ClientDeEssTxReleaseMs", "100.0").toFloat());
+}
+
+void AudioEngine::saveClientDeEssSettings() const
+{
+    if (!m_clientDeEssTx) return;
+    auto& s = AppSettings::instance();
+    auto toBool = [](bool on) { return on ? QString("True") : QString("False"); };
+    s.setValue("ClientDeEssTxEnabled",
+        toBool(m_clientDeEssTx->isEnabled()));
+    s.setValue("ClientDeEssTxFrequencyHz",
+        QString::number(m_clientDeEssTx->frequencyHz()));
+    s.setValue("ClientDeEssTxQ",
+        QString::number(m_clientDeEssTx->q()));
+    s.setValue("ClientDeEssTxThresholdDb",
+        QString::number(m_clientDeEssTx->thresholdDb()));
+    s.setValue("ClientDeEssTxAmountDb",
+        QString::number(m_clientDeEssTx->amountDb()));
+    s.setValue("ClientDeEssTxAttackMs",
+        QString::number(m_clientDeEssTx->attackMs()));
+    s.setValue("ClientDeEssTxReleaseMs",
+        QString::number(m_clientDeEssTx->releaseMs()));
+}
+
+void AudioEngine::loadClientTubeSettings()
+{
+    if (!m_clientTubeTx) return;
+    auto& s = AppSettings::instance();
+    m_clientTubeTx->setEnabled(
+        s.value("ClientTubeTxEnabled", "False").toString() == "True");
+    const int modelInt = s.value("ClientTubeTxModel", "0").toInt();
+    m_clientTubeTx->setModel(
+        modelInt == 1 ? ClientTube::Model::B :
+        modelInt == 2 ? ClientTube::Model::C :
+                        ClientTube::Model::A);
+    m_clientTubeTx->setDriveDb(
+        s.value("ClientTubeTxDriveDb", "0.0").toFloat());
+    m_clientTubeTx->setBiasAmount(
+        s.value("ClientTubeTxBias", "0.0").toFloat());
+    m_clientTubeTx->setTone(
+        s.value("ClientTubeTxTone", "0.0").toFloat());
+    m_clientTubeTx->setOutputGainDb(
+        s.value("ClientTubeTxOutputDb", "0.0").toFloat());
+    m_clientTubeTx->setDryWet(
+        s.value("ClientTubeTxDryWet", "1.0").toFloat());
+    m_clientTubeTx->setEnvelopeAmount(
+        s.value("ClientTubeTxEnvelope", "0.0").toFloat());
+    m_clientTubeTx->setAttackMs(
+        s.value("ClientTubeTxAttackMs", "5.0").toFloat());
+    m_clientTubeTx->setReleaseMs(
+        s.value("ClientTubeTxReleaseMs", "35.0").toFloat());
+}
+
+void AudioEngine::saveClientTubeSettings() const
+{
+    if (!m_clientTubeTx) return;
+    auto& s = AppSettings::instance();
+    auto toBool = [](bool on) { return on ? QString("True") : QString("False"); };
+    s.setValue("ClientTubeTxEnabled",  toBool(m_clientTubeTx->isEnabled()));
+    s.setValue("ClientTubeTxModel",
+        QString::number(static_cast<int>(m_clientTubeTx->model())));
+    s.setValue("ClientTubeTxDriveDb",
+        QString::number(m_clientTubeTx->driveDb()));
+    s.setValue("ClientTubeTxBias",
+        QString::number(m_clientTubeTx->biasAmount()));
+    s.setValue("ClientTubeTxTone",
+        QString::number(m_clientTubeTx->tone()));
+    s.setValue("ClientTubeTxOutputDb",
+        QString::number(m_clientTubeTx->outputGainDb()));
+    s.setValue("ClientTubeTxDryWet",
+        QString::number(m_clientTubeTx->dryWet()));
+    s.setValue("ClientTubeTxEnvelope",
+        QString::number(m_clientTubeTx->envelopeAmount()));
+    s.setValue("ClientTubeTxAttackMs",
+        QString::number(m_clientTubeTx->attackMs()));
+    s.setValue("ClientTubeTxReleaseMs",
+        QString::number(m_clientTubeTx->releaseMs()));
+}
+
+void AudioEngine::loadClientPuduSettings()
+{
+    if (!m_clientPuduTx) return;
+    auto& s = AppSettings::instance();
+    m_clientPuduTx->setEnabled(
+        s.value("ClientPuduTxEnabled", "False").toString() == "True");
+    const int modeInt = s.value("ClientPuduTxMode", "0").toInt();
+    m_clientPuduTx->setMode(modeInt == 1
+        ? ClientPudu::Mode::Behringer
+        : ClientPudu::Mode::Aphex);
+    m_clientPuduTx->setPooDriveDb(
+        s.value("ClientPuduTxPooDriveDb", "6.0").toFloat());
+    m_clientPuduTx->setPooTuneHz(
+        s.value("ClientPuduTxPooTuneHz", "100.0").toFloat());
+    m_clientPuduTx->setPooMix(
+        s.value("ClientPuduTxPooMix", "0.3").toFloat());
+    m_clientPuduTx->setDooTuneHz(
+        s.value("ClientPuduTxDooTuneHz", "5000.0").toFloat());
+    m_clientPuduTx->setDooHarmonicsDb(
+        s.value("ClientPuduTxDooHarmonicsDb", "6.0").toFloat());
+    m_clientPuduTx->setDooMix(
+        s.value("ClientPuduTxDooMix", "0.3").toFloat());
+}
+
+void AudioEngine::setTxPostDspMonitor(ClientPuduMonitor* m) noexcept
+{
+    // Release-store so the audio thread sees the new pointer on its
+    // next block via matching acquire-load at the tap site.
+    m_txPostDspMonitor.store(m, std::memory_order_release);
+}
+
+void AudioEngine::saveClientPuduSettings() const
+{
+    if (!m_clientPuduTx) return;
+    auto& s = AppSettings::instance();
+    auto toBool = [](bool on) { return on ? QString("True") : QString("False"); };
+    s.setValue("ClientPuduTxEnabled", toBool(m_clientPuduTx->isEnabled()));
+    s.setValue("ClientPuduTxMode",
+        QString::number(static_cast<int>(m_clientPuduTx->mode())));
+    s.setValue("ClientPuduTxPooDriveDb",
+        QString::number(m_clientPuduTx->pooDriveDb()));
+    s.setValue("ClientPuduTxPooTuneHz",
+        QString::number(m_clientPuduTx->pooTuneHz()));
+    s.setValue("ClientPuduTxPooMix",
+        QString::number(m_clientPuduTx->pooMix()));
+    s.setValue("ClientPuduTxDooTuneHz",
+        QString::number(m_clientPuduTx->dooTuneHz()));
+    s.setValue("ClientPuduTxDooHarmonicsDb",
+        QString::number(m_clientPuduTx->dooHarmonicsDb()));
+    s.setValue("ClientPuduTxDooMix",
+        QString::number(m_clientPuduTx->dooMix()));
 }
 
 static QString wisdomDir()
@@ -1873,6 +2229,14 @@ void AudioEngine::onTxAudioReady()
     // radio will receive it.  Chain order (CMP→EQ vs EQ→CMP) is user-
     // selectable via setTxChainOrder().
     applyClientTxDspInt16(data);
+
+    // ── PUDU monitor tap ─────────────────────────────────────────
+    // Feeds the post-DSP int16 bytes into the TX monitor if one is
+    // registered.  Lock-free atomic pointer load; the monitor's
+    // feedTxPostDsp() itself handles the not-recording fast-path.
+    if (auto* mon = m_txPostDspMonitor.load(std::memory_order_acquire)) {
+        mon->feedTxPostDsp(data);
+    }
 
     // ── Apply client-side PC mic gain (int16) ───────────────────────────
     const float gain = m_pcMicGain.load();

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -33,6 +33,11 @@ class DeepFilterFilter;
 class Resampler;
 class ClientEq;
 class ClientComp;
+class ClientGate;
+class ClientDeEss;
+class ClientTube;
+class ClientPudu;
+class ClientPuduMonitor;
 
 // AudioEngine handles audio playback (RX) and capture (TX).
 //
@@ -166,6 +171,32 @@ public:
     // Execution order is controlled by the TX chain order below.
     ClientComp* clientCompTx() { return m_clientCompTx.get(); }
 
+    // Client-side TX downward expander / noise gate (#1661 Phase 2).
+    // Single DSP module with an Expander ↔ Gate mode toggle that
+    // snaps ratio + floor to known-good presets.
+    ClientGate* clientGateTx() { return m_clientGateTx.get(); }
+
+    // Client-side TX de-esser (#1661 Phase 3).  Sidechain-filtered
+    // dynamics: a user-tunable bandpass feeds the envelope detector,
+    // broadband attenuation (capped at amountDb) is applied when
+    // sibilant energy crosses threshold.
+    ClientDeEss* clientDeEssTx() { return m_clientDeEssTx.get(); }
+
+    // Client-side TX dynamic tube saturator (#1661 Phase 4).  Three
+    // selectable curves, bipolar envelope-driven drive, tilt tone
+    // pre-filter, parallel dry/wet mix.
+    ClientTube* clientTubeTx() { return m_clientTubeTx.get(); }
+
+    // Client-side TX exciter — PUDU (#1661 Phase 5).  Aphex-lineage
+    // vs. Behringer-lineage two-band exciter, the centrepiece of the
+    // PooDoo Audio™ chain.
+    ClientPudu* clientPuduTx() { return m_clientPuduTx.get(); }
+
+    // Register/unregister a monitor that taps the post-DSP TX int16
+    // stream on the audio thread.  Passed pointer must outlive the
+    // registration — clear to nullptr before destroying the monitor.
+    void setTxPostDspMonitor(ClientPuduMonitor* m) noexcept;
+
     // Generalised TX DSP chain — each stage is a separate processing
     // block run in order on the TX audio path.  Only Eq and Comp are
     // implemented today; the remaining stages are placeholders for
@@ -203,6 +234,22 @@ public:
 
     void loadClientCompSettings();
     void saveClientCompSettings() const;
+
+    // Client-side TX gate — persistence mirrors the compressor.
+    void loadClientGateSettings();
+    void saveClientGateSettings() const;
+
+    // Client-side TX de-esser — persistence.
+    void loadClientDeEssSettings();
+    void saveClientDeEssSettings() const;
+
+    // Client-side TX dynamic tube — persistence.
+    void loadClientTubeSettings();
+    void saveClientTubeSettings() const;
+
+    // Client-side TX PUDU exciter — persistence.
+    void loadClientPuduSettings();
+    void saveClientPuduSettings() const;
 
     // Post-Client-EQ audio tap for the editor's FFT analyzer.  Exposes
     // a rolling mono buffer filled on the audio thread; UI thread copies
@@ -276,6 +323,18 @@ private:
     // Apply client-side TX compressor in-place.  No-op if disabled.
     void applyClientCompTxInt16(QByteArray& int16stereo);
     void applyClientCompTxFloat32(QByteArray& float32);
+    // Apply client-side TX gate in-place.  No-op if disabled.
+    void applyClientGateTxInt16(QByteArray& int16stereo);
+    void applyClientGateTxFloat32(QByteArray& float32);
+    // Apply client-side TX de-esser in-place.  No-op if disabled.
+    void applyClientDeEssTxInt16(QByteArray& int16stereo);
+    void applyClientDeEssTxFloat32(QByteArray& float32);
+    // Apply client-side TX tube saturator in-place.  No-op if disabled.
+    void applyClientTubeTxInt16(QByteArray& int16stereo);
+    void applyClientTubeTxFloat32(QByteArray& float32);
+    // Apply client-side TX PUDU exciter in-place.  No-op if disabled.
+    void applyClientPuduTxInt16(QByteArray& int16stereo);
+    void applyClientPuduTxFloat32(QByteArray& float32);
     // Apply the whole TX DSP chain (CMP + EQ) in the configured order.
     void applyClientTxDspInt16(QByteArray& int16stereo);
     void applyClientTxDspFloat32(QByteArray& float32);
@@ -375,6 +434,17 @@ private:
     std::unique_ptr<ClientEq> m_clientEqTx;
     // Client-side TX compressor (Pro-XL-style).
     std::unique_ptr<ClientComp> m_clientCompTx;
+    // Client-side TX downward expander / noise gate.
+    std::unique_ptr<ClientGate> m_clientGateTx;
+    // Client-side TX de-esser.
+    std::unique_ptr<ClientDeEss> m_clientDeEssTx;
+    // Client-side TX tube saturator.
+    std::unique_ptr<ClientTube> m_clientTubeTx;
+    // Client-side TX PUDU exciter.
+    std::unique_ptr<ClientPudu> m_clientPuduTx;
+    // Post-DSP TX monitor — owned by MainWindow; we just hold a
+    // pointer the audio thread can load lock-free per block.
+    std::atomic<ClientPuduMonitor*> m_txPostDspMonitor{nullptr};
     // Generalised TX DSP chain — stages packed one-byte-per-slot into
     // a uint64_t so the audio thread can load the full order in a
     // single atomic read per block.  TxChainStage::None terminates the
@@ -386,6 +456,10 @@ private:
     QByteArray m_clientEqRxScratch;
     QByteArray m_clientEqTxScratch;
     QByteArray m_clientCompTxScratch;
+    QByteArray m_clientGateTxScratch;
+    QByteArray m_clientDeEssTxScratch;
+    QByteArray m_clientTubeTxScratch;
+    QByteArray m_clientPuduTxScratch;
     // Post-EQ analyzer tap. One ring per path, mono (L+R averaged).
     // Audio thread writes via tapClientEqRxStereo() / tapClientEqTxInt16()
     // / tapClientEqTxFloat32(); UI thread snapshots via the public

--- a/src/core/ClientDeEss.cpp
+++ b/src/core/ClientDeEss.cpp
@@ -1,0 +1,239 @@
+#include "ClientDeEss.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr float kTwoPi = 6.283185307179586476f;
+
+float dbToLin(float db) noexcept
+{
+    return std::pow(10.0f, db * 0.05f);
+}
+
+float linToDb(float lin) noexcept
+{
+    return (lin > 1e-9f) ? 20.0f * std::log10(lin) : -180.0f;
+}
+
+float coeffFromMs(float ms, double sampleRate) noexcept
+{
+    if (ms <= 0.0f) return 1.0f;
+    const float tau = ms * 0.001f;
+    return 1.0f - std::exp(-1.0f / static_cast<float>(sampleRate * tau));
+}
+
+// RBJ bandpass (constant 0 dB peak gain).  Centre f, quality q.
+void computeBandpass(float f, float q, double sr,
+                     ClientDeEss* /*unused*/,
+                     float& b0, float& b1, float& b2,
+                     float& a1, float& a2)
+{
+    const float omega = kTwoPi * f / static_cast<float>(sr);
+    const float sinw  = std::sin(omega);
+    const float cosw  = std::cos(omega);
+    const float alpha = sinw / (2.0f * std::max(0.1f, q));
+
+    const float a0 = 1.0f + alpha;
+    b0 =  alpha         / a0;
+    b1 =  0.0f;
+    b2 = -alpha         / a0;
+    a1 = (-2.0f * cosw) / a0;
+    a2 = (1.0f - alpha) / a0;
+}
+
+inline float processBiquad(float x,
+                           const ClientDeEss::BiquadCoef& c,
+                           ClientDeEss::BiquadState& s) noexcept
+{
+    // Direct Form II Transposed — low noise at single precision.
+    const float y = c.b0 * x + s.z1;
+    s.z1 = c.b1 * x - c.a1 * y + s.z2;
+    s.z2 = c.b2 * x - c.a2 * y;
+    return y;
+}
+
+} // namespace
+
+ClientDeEss::ClientDeEss() = default;
+
+void ClientDeEss::prepare(double sampleRate)
+{
+    m_sampleRate = sampleRate;
+    reset();
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+    recacheIfDirty();
+}
+
+void ClientDeEss::setEnabled(bool on) noexcept
+{
+    m_atomics.enabled.store(on, std::memory_order_release);
+}
+bool ClientDeEss::isEnabled() const noexcept
+{
+    return m_atomics.enabled.load(std::memory_order_acquire);
+}
+
+void ClientDeEss::setFrequencyHz(float hz) noexcept
+{
+    m_atomics.frequencyHz.store(std::clamp(hz, 1000.0f, 12000.0f),
+                                std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientDeEss::frequencyHz() const noexcept
+{ return m_atomics.frequencyHz.load(std::memory_order_relaxed); }
+
+void ClientDeEss::setQ(float q) noexcept
+{
+    m_atomics.q.store(std::clamp(q, 0.5f, 5.0f),
+                      std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientDeEss::q() const noexcept
+{ return m_atomics.q.load(std::memory_order_relaxed); }
+
+void ClientDeEss::setThresholdDb(float db) noexcept
+{
+    m_atomics.thresholdDb.store(std::clamp(db, -60.0f, 0.0f),
+                                std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientDeEss::thresholdDb() const noexcept
+{ return m_atomics.thresholdDb.load(std::memory_order_relaxed); }
+
+void ClientDeEss::setAmountDb(float db) noexcept
+{
+    m_atomics.amountDb.store(std::clamp(db, -24.0f, 0.0f),
+                             std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientDeEss::amountDb() const noexcept
+{ return m_atomics.amountDb.load(std::memory_order_relaxed); }
+
+void ClientDeEss::setAttackMs(float ms) noexcept
+{
+    m_atomics.attackMs.store(std::clamp(ms, 0.1f, 30.0f),
+                             std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientDeEss::attackMs() const noexcept
+{ return m_atomics.attackMs.load(std::memory_order_relaxed); }
+
+void ClientDeEss::setReleaseMs(float ms) noexcept
+{
+    m_atomics.releaseMs.store(std::clamp(ms, 10.0f, 500.0f),
+                              std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientDeEss::releaseMs() const noexcept
+{ return m_atomics.releaseMs.load(std::memory_order_relaxed); }
+
+void ClientDeEss::reset() noexcept
+{
+    m_envLin = 0.0f;
+    m_bpL = {};
+    m_bpR = {};
+}
+
+float ClientDeEss::inputPeakDb() const noexcept
+{ return m_meters.inputPeakDb.load(std::memory_order_relaxed); }
+float ClientDeEss::sidechainPeakDb() const noexcept
+{ return m_meters.sidechainPeakDb.load(std::memory_order_relaxed); }
+float ClientDeEss::gainReductionDb() const noexcept
+{ return m_meters.gainReductionDb.load(std::memory_order_relaxed); }
+
+void ClientDeEss::recacheIfDirty() noexcept
+{
+    const uint64_t v = m_atomics.version.load(std::memory_order_acquire);
+    if (v == m_lastVersion) return;
+    m_lastVersion = v;
+
+    computeBandpass(
+        m_atomics.frequencyHz.load(std::memory_order_relaxed),
+        m_atomics.q.load(std::memory_order_relaxed),
+        m_sampleRate, this,
+        m_cached.bp.b0, m_cached.bp.b1, m_cached.bp.b2,
+        m_cached.bp.a1, m_cached.bp.a2);
+
+    m_cached.thresholdDb = m_atomics.thresholdDb.load(std::memory_order_relaxed);
+    m_cached.amountDb    = m_atomics.amountDb.load(std::memory_order_relaxed);
+    m_cached.attackCoeff = coeffFromMs(
+        m_atomics.attackMs.load(std::memory_order_relaxed), m_sampleRate);
+    m_cached.releaseCoeff = coeffFromMs(
+        m_atomics.releaseMs.load(std::memory_order_relaxed), m_sampleRate);
+}
+
+float ClientDeEss::staticCurveGainDb(float envDb) const noexcept
+{
+    // Soft compressor on the sidechain band, clamped to amountDb so
+    // total broadband attenuation never exceeds the user's max.
+    // Hard-knee is fine here — sibilants are transient and the knee
+    // doesn't contribute much to perceived smoothness.
+    const float over = envDb - m_cached.thresholdDb;
+    if (over <= 0.0f) return 0.0f;
+    // 4:1 reduction slope above threshold, clamped to amountDb.
+    constexpr float kSlope = 0.75f;   // (1 - 1/4) — feels natural for dessing
+    const float gainDb = -over * kSlope;
+    return std::max(gainDb, m_cached.amountDb);
+}
+
+void ClientDeEss::process(float* interleaved, int frames, int channels) noexcept
+{
+    if (frames <= 0) return;
+    if (channels != 1 && channels != 2) return;
+
+    recacheIfDirty();
+    const bool enabled = m_atomics.enabled.load(std::memory_order_acquire);
+
+    float inPeakLin = 0.0f;
+    float scPeakLin = 0.0f;
+    float worstGrDb = 0.0f;
+
+    const float attackCoeff  = m_cached.attackCoeff;
+    const float releaseCoeff = m_cached.releaseCoeff;
+    const BiquadCoef& bp     = m_cached.bp;
+
+    for (int f = 0; f < frames; ++f) {
+        float l = interleaved[f * channels];
+        float r = (channels == 2) ? interleaved[f * channels + 1] : l;
+
+        const float inAbs = std::max(std::fabs(l), std::fabs(r));
+        if (inAbs > inPeakLin) inPeakLin = inAbs;
+
+        // Sidechain: run the full signal through the bandpass filter
+        // per channel.  The filters stay live even when disabled so
+        // their state is warm if the user toggles enable.
+        const float scL = processBiquad(l, bp, m_bpL);
+        const float scR = (channels == 2) ? processBiquad(r, bp, m_bpR) : scL;
+        const float scAbs = std::max(std::fabs(scL), std::fabs(scR));
+        if (scAbs > scPeakLin) scPeakLin = scAbs;
+
+        float gainLin = 1.0f;
+        if (enabled) {
+            // Peak envelope on the sidechain band.
+            const float alpha = (scAbs > m_envLin) ? attackCoeff : releaseCoeff;
+            m_envLin += alpha * (scAbs - m_envLin);
+            const float envDb = linToDb(std::max(m_envLin, 1e-6f));
+
+            const float gainDb = staticCurveGainDb(envDb);
+            if (gainDb < worstGrDb) worstGrDb = gainDb;
+            gainLin = dbToLin(gainDb);
+        }
+
+        l *= gainLin;
+        r *= gainLin;
+        interleaved[f * channels] = l;
+        if (channels == 2) interleaved[f * channels + 1] = r;
+    }
+
+    m_meters.inputPeakDb.store(linToDb(std::max(inPeakLin, 1e-6f)),
+                               std::memory_order_relaxed);
+    m_meters.sidechainPeakDb.store(linToDb(std::max(scPeakLin, 1e-6f)),
+                                   std::memory_order_relaxed);
+    m_meters.gainReductionDb.store(worstGrDb, std::memory_order_relaxed);
+}
+
+} // namespace AetherSDR

--- a/src/core/ClientDeEss.h
+++ b/src/core/ClientDeEss.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace AetherSDR {
+
+// Client-side de-esser — TX DSP chain Phase 3 (#1661).  Sibilant
+// suppression via sidechain-filtered dynamics: the input is split
+// through a bandpass filter (2–10 kHz) whose output drives an
+// envelope detector; when the detector crosses threshold we apply
+// broadband attenuation (capped at `amount` dB) to the full signal.
+//
+// Single-band design.  Classic approach, tracks modern plugins like
+// Ableton's DeEsser and FabFilter's Pro-DS in structure.  Future
+// phases could add split-band (only attenuate HF), stereo-linked
+// vs. dual-mono detection, or listen-to-sidechain monitoring.
+//
+// Thread model mirrors ClientComp / ClientGate: UI thread writes
+// atomics + bumps a version counter; the audio thread reads the
+// version once per block and recaches coefficients.  No locks,
+// no allocations in process(), no exceptions.
+class ClientDeEss {
+public:
+    ClientDeEss();
+    ~ClientDeEss() = default;
+
+    ClientDeEss(const ClientDeEss&)            = delete;
+    ClientDeEss& operator=(const ClientDeEss&) = delete;
+
+    void prepare(double sampleRate);
+
+    void setEnabled(bool on) noexcept;
+    bool isEnabled() const noexcept;
+
+    // Sidechain band: bandpass centre frequency (Hz) and Q.  Centre
+    // usually 4–7 kHz for voice sibilants; Q around 1.5–3 keeps the
+    // band tight enough to miss low-end speech content.
+    void  setFrequencyHz(float hz) noexcept;         // 1000..12000 Hz
+    float frequencyHz() const noexcept;
+    void  setQ(float q) noexcept;                    // 0.5..5.0
+    float q() const noexcept;
+
+    // Gate-like dynamics on the sidechain envelope.  Threshold is
+    // specified in dBFS; amount is the MAX attenuation in dB (a
+    // negative value, e.g. -6 dB).  Attack/release default tight
+    // since sibilants are fast events.
+    void  setThresholdDb(float db) noexcept;         // -60..0 dB
+    float thresholdDb() const noexcept;
+    void  setAmountDb(float db) noexcept;            // -24..0 dB (max reduction)
+    float amountDb() const noexcept;
+    void  setAttackMs(float ms) noexcept;            // 0.1..30 ms
+    float attackMs() const noexcept;
+    void  setReleaseMs(float ms) noexcept;           // 10..500 ms
+    float releaseMs() const noexcept;
+
+    // Audio thread — process in place.  channels must be 1 or 2.
+    void process(float* interleaved, int frames, int channels) noexcept;
+
+    // Audio thread — flush all state (envelope + biquad memory).
+    void reset() noexcept;
+
+    // UI thread — read-only snapshots of the latest detector state.
+    float inputPeakDb() const noexcept;             // full-band input peak
+    float sidechainPeakDb() const noexcept;         // HF-band sidechain peak
+    float gainReductionDb() const noexcept;         // ≤ 0 dB
+
+    double sampleRate() const noexcept { return m_sampleRate; }
+
+    // Public because the cpp-local biquad helper takes references to
+    // these.  Not part of the user-facing API.
+    struct BiquadCoef {
+        float b0{1.0f}, b1{0.0f}, b2{0.0f};
+        float a1{0.0f}, a2{0.0f};
+    };
+    struct BiquadState {
+        float z1{0.0f}, z2{0.0f};
+    };
+
+private:
+    struct Atomics {
+        std::atomic<bool>     enabled{false};
+        std::atomic<float>    frequencyHz{6000.0f};
+        std::atomic<float>    q{2.0f};
+        std::atomic<float>    thresholdDb{-30.0f};
+        std::atomic<float>    amountDb{-6.0f};
+        std::atomic<float>    attackMs{1.0f};
+        std::atomic<float>    releaseMs{100.0f};
+        std::atomic<uint64_t> version{0};
+    };
+
+    struct Cached {
+        BiquadCoef bp{};
+        float thresholdDb{-30.0f};
+        float amountDb{-6.0f};       // negative — max attenuation
+        float attackCoeff{0.0f};
+        float releaseCoeff{0.0f};
+    };
+
+    struct Meters {
+        std::atomic<float> inputPeakDb{-120.0f};
+        std::atomic<float> sidechainPeakDb{-120.0f};
+        std::atomic<float> gainReductionDb{0.0f};
+    };
+
+    void recacheIfDirty() noexcept;
+    float staticCurveGainDb(float envDb) const noexcept;
+
+    double m_sampleRate{24000.0};
+    Atomics m_atomics;
+    Cached  m_cached;
+    Meters  m_meters;
+
+    // Audio-thread state — accessed only from process().
+    uint64_t m_lastVersion{0};
+    BiquadState m_bpL{};
+    BiquadState m_bpR{};
+    float m_envLin{0.0f};
+};
+
+} // namespace AetherSDR

--- a/src/core/ClientEq.cpp
+++ b/src/core/ClientEq.cpp
@@ -365,13 +365,21 @@ float ClientEq::bandMagnitudeDb(const BandParams& p,
     double totalDb = 0.0;
     const int numSections = isSlope ? slopeToSections(p.slopeDbPerOct) : 1;
 
+    // Match computeCoefficients()'s HP/LP behaviour: user Q scales
+    // the family's designed section Q as a resonance multiplier
+    // relative to the 0.707 default.  Without this the curve drawer
+    // would show a static response while the DSP was already
+    // resonating from the user's drag.
+    constexpr double kDefaultQ = 0.707;
+    const double resonanceScale = isSlope ? (userQ / kDefaultQ) : 1.0;
+
     for (int k = 0; k < numSections; ++k) {
         double sectionFreq = f0;
         double sectionQ    = userQ;
         if (isSlope) {
             const SectionDesign d = designSection(family, k, numSections);
             sectionFreq = f0 * static_cast<double>(d.freqScale);
-            sectionQ    = static_cast<double>(d.q);
+            sectionQ    = static_cast<double>(d.q) * resonanceScale;
         }
         const double w0   = static_cast<double>(kTwoPi) * sectionFreq;
         const double w0sq = w0 * w0;
@@ -500,13 +508,19 @@ void ClientEq::computeCoefficients(Runtime& runtime) noexcept
     };
 
     if (isSlope) {
-        // Cascade of N sections — per-section Q comes from the active
-        // filter family's pole layout.  Section freq is nominal cutoff
-        // scaled by the family's per-section multiplier.
+        // Cascade of N sections.  Per-section Q comes from the active
+        // filter family's pole layout (Butterworth/LR/Bessel).  We
+        // still want the user's Q control to have an audible effect
+        // — use it as a RESONANCE MULTIPLIER relative to the 0.707
+        // default so the family's character is preserved when the
+        // user leaves Q at the default, while higher Q adds
+        // resonance at the corner and lower Q over-damps.
+        constexpr float kDefaultQ = 0.707f;
+        const float resonanceScale = userQ / kDefaultQ;
         for (int k = 0; k < runtime.activeSections; ++k) {
             const SectionDesign d = designSection(runtime.cachedFamily,
                                                   k, runtime.activeSections);
-            fillOneSection(k, baseFreq * d.freqScale, d.q);
+            fillOneSection(k, baseFreq * d.freqScale, d.q * resonanceScale);
         }
     } else {
         // Peak and shelf: single native 2nd-order section using user Q.

--- a/src/core/ClientGate.cpp
+++ b/src/core/ClientGate.cpp
@@ -1,0 +1,335 @@
+#include "ClientGate.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+float dbToLin(float db) noexcept
+{
+    return std::pow(10.0f, db * 0.05f);
+}
+
+float linToDb(float lin) noexcept
+{
+    return (lin > 1e-9f) ? 20.0f * std::log10(lin) : -180.0f;
+}
+
+float coeffFromMs(float ms, double sampleRate) noexcept
+{
+    if (ms <= 0.0f) return 1.0f;
+    const float tau = ms * 0.001f;
+    return 1.0f - std::exp(-1.0f / static_cast<float>(sampleRate * tau));
+}
+
+} // namespace
+
+ClientGate::ClientGate() = default;
+
+void ClientGate::prepare(double sampleRate)
+{
+    m_sampleRate    = sampleRate;
+    m_envLin        = 0.0f;
+    m_currentGainDb = 0.0f;
+    m_holdCountdown = 0;
+    m_isOpen        = false;
+
+    // Allocate the lookahead delay line once at prepare() so process()
+    // never allocates.  Size it for kMaxLookaheadMs + 1 frame of slack.
+    m_delayCap = static_cast<int>(kMaxLookaheadMs * 0.001f
+                                  * static_cast<float>(sampleRate) + 0.5f) + 1;
+    m_delay.assign(m_delayCap * 2, 0.0f);   // stereo interleaved
+    m_delayWrite = 0;
+
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+    recacheIfDirty();
+}
+
+void ClientGate::setEnabled(bool on) noexcept
+{
+    m_atomics.enabled.store(on, std::memory_order_release);
+}
+bool ClientGate::isEnabled() const noexcept
+{
+    return m_atomics.enabled.load(std::memory_order_acquire);
+}
+
+void ClientGate::setMode(Mode m) noexcept
+{
+    m_atomics.mode.store(static_cast<uint8_t>(m), std::memory_order_relaxed);
+    // Preset pairs — only ratio + floor change; threshold / attack /
+    // release / hold / return / lookahead are left alone so user
+    // fine-tuning survives a mode toggle.
+    if (m == Mode::Expander) {
+        m_atomics.ratio.store(2.0f,    std::memory_order_relaxed);
+        m_atomics.floorDb.store(-15.0f, std::memory_order_relaxed);
+    } else {
+        m_atomics.ratio.store(10.0f,   std::memory_order_relaxed);
+        m_atomics.floorDb.store(-40.0f, std::memory_order_relaxed);
+    }
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+ClientGate::Mode ClientGate::mode() const noexcept
+{
+    return static_cast<Mode>(
+        m_atomics.mode.load(std::memory_order_relaxed));
+}
+
+void ClientGate::setThresholdDb(float db) noexcept
+{
+    m_atomics.thresholdDb.store(std::clamp(db, -80.0f, 0.0f),
+                                std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientGate::thresholdDb() const noexcept
+{ return m_atomics.thresholdDb.load(std::memory_order_relaxed); }
+
+void ClientGate::setRatio(float ratio) noexcept
+{
+    m_atomics.ratio.store(std::clamp(ratio, 1.0f, 10.0f),
+                          std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientGate::ratio() const noexcept
+{ return m_atomics.ratio.load(std::memory_order_relaxed); }
+
+void ClientGate::setAttackMs(float ms) noexcept
+{
+    m_atomics.attackMs.store(std::clamp(ms, 0.1f, 100.0f),
+                             std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientGate::attackMs() const noexcept
+{ return m_atomics.attackMs.load(std::memory_order_relaxed); }
+
+void ClientGate::setReleaseMs(float ms) noexcept
+{
+    m_atomics.releaseMs.store(std::clamp(ms, 5.0f, 2000.0f),
+                              std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientGate::releaseMs() const noexcept
+{ return m_atomics.releaseMs.load(std::memory_order_relaxed); }
+
+void ClientGate::setHoldMs(float ms) noexcept
+{
+    m_atomics.holdMs.store(std::clamp(ms, 0.0f, 500.0f),
+                           std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientGate::holdMs() const noexcept
+{ return m_atomics.holdMs.load(std::memory_order_relaxed); }
+
+void ClientGate::setFloorDb(float db) noexcept
+{
+    m_atomics.floorDb.store(std::clamp(db, -80.0f, 0.0f),
+                            std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientGate::floorDb() const noexcept
+{ return m_atomics.floorDb.load(std::memory_order_relaxed); }
+
+void ClientGate::setReturnDb(float db) noexcept
+{
+    m_atomics.returnDb.store(std::clamp(db, 0.0f, 20.0f),
+                             std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientGate::returnDb() const noexcept
+{ return m_atomics.returnDb.load(std::memory_order_relaxed); }
+
+void ClientGate::setLookaheadMs(float ms) noexcept
+{
+    m_atomics.lookaheadMs.store(
+        std::clamp(ms, 0.0f, static_cast<float>(kMaxLookaheadMs)),
+        std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientGate::lookaheadMs() const noexcept
+{ return m_atomics.lookaheadMs.load(std::memory_order_relaxed); }
+
+void ClientGate::reset() noexcept
+{
+    m_envLin        = 0.0f;
+    m_currentGainDb = 0.0f;
+    m_holdCountdown = 0;
+    m_isOpen        = false;
+    std::fill(m_delay.begin(), m_delay.end(), 0.0f);
+    m_delayWrite    = 0;
+}
+
+float ClientGate::inputPeakDb() const noexcept
+{ return m_meters.inputPeakDb.load(std::memory_order_relaxed); }
+float ClientGate::outputPeakDb() const noexcept
+{ return m_meters.outputPeakDb.load(std::memory_order_relaxed); }
+float ClientGate::gainReductionDb() const noexcept
+{ return m_meters.gainReductionDb.load(std::memory_order_relaxed); }
+bool  ClientGate::gateOpen() const noexcept
+{ return m_meters.gateOpen.load(std::memory_order_relaxed); }
+
+void ClientGate::recacheIfDirty() noexcept
+{
+    const uint64_t v = m_atomics.version.load(std::memory_order_acquire);
+    if (v == m_lastVersion) return;
+    m_lastVersion = v;
+
+    m_cached.thresholdDb = m_atomics.thresholdDb.load(std::memory_order_relaxed);
+    const float r        = std::max(1.0f,
+                                    m_atomics.ratio.load(std::memory_order_relaxed));
+    m_cached.slope       = r - 1.0f;
+    m_cached.attackCoeff = coeffFromMs(
+        m_atomics.attackMs.load(std::memory_order_relaxed), m_sampleRate);
+    m_cached.releaseCoeff = coeffFromMs(
+        m_atomics.releaseMs.load(std::memory_order_relaxed), m_sampleRate);
+    // Fixed fast envelope-detector release — decouples threshold
+    // detection from the user's gain-smoother release.  Without this
+    // a long release_ms would also stretch how long the envelope
+    // stays "above threshold" after a loud burst, pushing the hold
+    // window far past where the user expects it.
+    m_cached.envReleaseCoeff = coeffFromMs(10.0f, m_sampleRate);
+    m_cached.holdSamples = static_cast<int>(
+        m_atomics.holdMs.load(std::memory_order_relaxed) * 0.001f
+        * static_cast<float>(m_sampleRate) + 0.5f);
+    m_cached.floorDb     = m_atomics.floorDb.load(std::memory_order_relaxed);
+    m_cached.closeThresholdDb = m_cached.thresholdDb
+        - m_atomics.returnDb.load(std::memory_order_relaxed);
+    // Clamp lookahead to the delay-line capacity minus one (so write
+    // and read indices can never alias on the same frame).
+    const int laSamples = static_cast<int>(
+        m_atomics.lookaheadMs.load(std::memory_order_relaxed) * 0.001f
+        * static_cast<float>(m_sampleRate) + 0.5f);
+    m_cached.lookaheadSamples =
+        std::clamp(laSamples, 0, std::max(0, m_delayCap - 1));
+}
+
+float ClientGate::staticCurveGainDb(float envDb) const noexcept
+{
+    // Downward expander curve — attenuates below threshold, unity above.
+    //   gain_dB = clamp(-(T - env) * (ratio - 1), floor, 0)
+    // At env = T, gain = 0 (unity).  For env < T the attenuation grows
+    // linearly with shortfall.  floor is the attenuation limit (e.g.
+    // -40 dB for a hard gate), clamping the curve so the gate does not
+    // invert into infinite attenuation at very quiet envelope levels.
+    const float T         = m_cached.thresholdDb;
+    const float shortfall = T - envDb;
+    if (shortfall <= 0.0f) return 0.0f;          // above threshold: unity
+    const float gainDb = -shortfall * m_cached.slope;
+    return std::max(gainDb, m_cached.floorDb);   // clamp to floor
+}
+
+void ClientGate::process(float* interleaved, int frames, int channels) noexcept
+{
+    if (frames <= 0) return;
+    if (channels != 1 && channels != 2) return;
+
+    recacheIfDirty();
+    const bool enabled = m_atomics.enabled.load(std::memory_order_acquire);
+
+    float inPeakLin  = 0.0f;
+    float outPeakLin = 0.0f;
+    float worstGrDb  = 0.0f;   // most negative (largest attenuation)
+    bool  openAny    = false;  // true if gate was above threshold any sample
+
+    const float openT           = m_cached.thresholdDb;
+    const float closeT          = m_cached.closeThresholdDb;
+    const float attackCoeff     = m_cached.attackCoeff;
+    const float releaseCoeff    = m_cached.releaseCoeff;
+    const float envReleaseCoeff = m_cached.envReleaseCoeff;
+    const int   holdSamples     = m_cached.holdSamples;
+    const int   laSamples       = m_cached.lookaheadSamples;
+
+    for (int f = 0; f < frames; ++f) {
+        // Read the new input (applied to the detector) and write it
+        // to the delay line.  The delayed sample that we multiply by
+        // gain is read BEFORE the write — so with lookahead = N the
+        // gain we compute from input[n] is applied to input[n-N].
+        const float inL = interleaved[f * channels];
+        const float inR = (channels == 2) ? interleaved[f * channels + 1] : inL;
+
+        const float inAbs = std::max(std::fabs(inL), std::fabs(inR));
+        if (inAbs > inPeakLin) inPeakLin = inAbs;
+
+        // Delayed sample pair — what we'll actually multiply by gain.
+        float outL = inL, outR = inR;
+        if (laSamples > 0 && m_delayCap > 0) {
+            int readIdx = m_delayWrite - laSamples;
+            if (readIdx < 0) readIdx += m_delayCap;
+            outL = m_delay[readIdx * 2];
+            outR = m_delay[readIdx * 2 + 1];
+            m_delay[m_delayWrite * 2]     = inL;
+            m_delay[m_delayWrite * 2 + 1] = inR;
+            m_delayWrite = (m_delayWrite + 1) % m_delayCap;
+        }
+
+        float gainLin = 1.0f;
+        if (enabled) {
+            // Fast peak-detector envelope — used purely for
+            // threshold detection.  User ballistics apply to the
+            // gain smoother below.  Instant attack, fixed 10 ms
+            // release so the detector tracks peaks accurately.
+            const float envAlpha = (inAbs > m_envLin)
+                ? 1.0f
+                : envReleaseCoeff;
+            m_envLin += envAlpha * (inAbs - m_envLin);
+            const float envDb = linToDb(std::max(m_envLin, 1e-6f));
+
+            // Schmitt-trigger threshold detection:
+            //   - closed → open when envDb ≥ thresholdDb
+            //   - open → closed when envDb < thresholdDb - returnDb
+            // Curve target tracks m_isOpen so the gain smoother
+            // sees a clean step (no flicker when envelope hovers
+            // near the threshold).
+            if (m_isOpen) {
+                if (envDb < closeT) m_isOpen = false;
+            } else {
+                if (envDb >= openT) m_isOpen = true;
+            }
+            if (m_isOpen) openAny = true;
+
+            const float targetGainDb = m_isOpen ? 0.0f
+                                                : staticCurveGainDb(envDb);
+
+            // Gain state machine:
+            //   - opening (less attenuation wanted): slide toward
+            //     target using attack coefficient
+            //   - closing (more attenuation wanted): freeze gain
+            //     for holdSamples, then slide toward target using
+            //     release coefficient
+            if (targetGainDb >= m_currentGainDb) {
+                m_currentGainDb += attackCoeff
+                    * (targetGainDb - m_currentGainDb);
+                m_holdCountdown = holdSamples;
+            } else {
+                if (m_holdCountdown > 0) {
+                    --m_holdCountdown;
+                } else {
+                    m_currentGainDb += releaseCoeff
+                        * (targetGainDb - m_currentGainDb);
+                }
+            }
+
+            if (m_currentGainDb < worstGrDb) worstGrDb = m_currentGainDb;
+            gainLin = dbToLin(m_currentGainDb);
+        }
+
+        outL *= gainLin;
+        outR *= gainLin;
+
+        interleaved[f * channels] = outL;
+        if (channels == 2) interleaved[f * channels + 1] = outR;
+
+        const float outAbs = std::max(std::fabs(outL), std::fabs(outR));
+        if (outAbs > outPeakLin) outPeakLin = outAbs;
+    }
+
+    m_meters.inputPeakDb.store(linToDb(std::max(inPeakLin, 1e-6f)),
+                               std::memory_order_relaxed);
+    m_meters.outputPeakDb.store(linToDb(std::max(outPeakLin, 1e-6f)),
+                                std::memory_order_relaxed);
+    m_meters.gainReductionDb.store(worstGrDb, std::memory_order_relaxed);
+    m_meters.gateOpen.store(openAny, std::memory_order_relaxed);
+}
+
+} // namespace AetherSDR

--- a/src/core/ClientGate.h
+++ b/src/core/ClientGate.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+
+namespace AetherSDR {
+
+// Downward expander / noise gate — TX DSP chain Phase 2 (#1661).  The
+// same DSP core covers both behaviours: a low ratio with a shallow range
+// gives gentle expansion that preserves natural decay, while a high ratio
+// with a deep range gives a hard gate that slams shut below threshold.
+// The Mode setter snaps ratio + range to preset pairs so the UI can
+// offer a one-click Expander ↔ Gate toggle without hiding the underlying
+// knobs from power users.
+//
+// Thread model mirrors ClientComp: UI thread writes via set*() which
+// update atomics + bump a version counter; the audio thread reads the
+// version once per block and recaches values.  No locks, no allocations
+// in process(), no exceptions.
+class ClientGate {
+public:
+    enum class Mode : uint8_t {
+        Expander = 0,   // soft — ratio 2:1, range -15 dB
+        Gate     = 1,   // hard — ratio 10:1, range -40 dB
+    };
+
+    ClientGate();
+    ~ClientGate() = default;
+
+    ClientGate(const ClientGate&)            = delete;
+    ClientGate& operator=(const ClientGate&) = delete;
+
+    // Main thread — call before first process() and on sample-rate change.
+    void prepare(double sampleRate);
+
+    // Main thread — global enable / bypass. Lock-free.
+    void setEnabled(bool on) noexcept;
+    bool isEnabled() const noexcept;
+
+    // Snap ratio + range to canonical presets.  Does not affect other
+    // parameters (attack/release/hold/threshold); user can fine-tune
+    // from either preset.
+    void setMode(Mode m) noexcept;
+    Mode mode() const noexcept;
+
+    void  setThresholdDb(float db) noexcept;       // -80 .. 0 dB
+    float thresholdDb() const noexcept;
+    void  setRatio(float ratio) noexcept;          // 1.0 (off) .. 10.0 (hard gate)
+    float ratio() const noexcept;
+    void  setAttackMs(float ms) noexcept;          // 0.1 .. 100 ms
+    float attackMs() const noexcept;
+    void  setReleaseMs(float ms) noexcept;         // 5 .. 2000 ms
+    float releaseMs() const noexcept;
+    void  setHoldMs(float ms) noexcept;            // 0 .. 500 ms — gain freeze before release
+    float holdMs() const noexcept;
+    void  setFloorDb(float db) noexcept;           // -80 .. 0 dB, max attenuation floor
+    float floorDb() const noexcept;
+    void  setReturnDb(float db) noexcept;          // 0 .. 20 dB hysteresis — gate stays open
+                                                    // until envelope drops to threshold - return
+    float returnDb() const noexcept;
+    void  setLookaheadMs(float ms) noexcept;       // 0 .. 5 ms — delays signal so detector
+                                                    // sees transients before the gain stage
+    float lookaheadMs() const noexcept;
+
+    // Audio thread — process in place.  channels must be 1 or 2.
+    void process(float* interleaved, int frames, int channels) noexcept;
+
+    // Audio thread — flush envelope/hold state (e.g. on TX start).
+    void reset() noexcept;
+
+    // UI thread — read-only snapshots of the latest detector state.
+    float inputPeakDb() const noexcept;
+    float outputPeakDb() const noexcept;
+    float gainReductionDb() const noexcept;   // ≤ 0 dB (attenuation)
+    bool  gateOpen() const noexcept;          // true when signal is above threshold
+
+    double sampleRate() const noexcept { return m_sampleRate; }
+
+private:
+    struct Atomics {
+        std::atomic<bool>     enabled{false};
+        std::atomic<uint8_t>  mode{static_cast<uint8_t>(Mode::Expander)};
+        std::atomic<float>    thresholdDb{-40.0f};
+        std::atomic<float>    ratio{2.0f};
+        std::atomic<float>    attackMs{0.5f};
+        std::atomic<float>    releaseMs{100.0f};
+        std::atomic<float>    holdMs{20.0f};
+        std::atomic<float>    floorDb{-15.0f};
+        std::atomic<float>    returnDb{2.0f};
+        std::atomic<float>    lookaheadMs{0.0f};
+        std::atomic<uint64_t> version{0};
+    };
+
+    struct Cached {
+        float thresholdDb{-40.0f};
+        float closeThresholdDb{-42.0f}; // thresholdDb - returnDb (hysteresis)
+        float slope{1.0f};              // ratio - 1, pre-computed
+        float attackCoeff{0.0f};        // gain-smoother attack (1 - exp(-1/(fs·τ)))
+        float releaseCoeff{0.0f};       // gain-smoother release
+        float envReleaseCoeff{0.0f};    // fast envelope-detector release (fixed 10 ms)
+        int   holdSamples{0};           // hold_ms converted to sample count
+        float floorDb{-15.0f};          // max attenuation floor (negative dB)
+        int   lookaheadSamples{0};      // sample-count delay for look-ahead path
+    };
+
+    struct Meters {
+        std::atomic<float> inputPeakDb{-120.0f};
+        std::atomic<float> outputPeakDb{-120.0f};
+        std::atomic<float> gainReductionDb{0.0f};
+        std::atomic<bool>  gateOpen{true};
+    };
+
+    void recacheIfDirty() noexcept;
+    float staticCurveGainDb(float envDb) const noexcept;
+
+    double   m_sampleRate{24000.0};
+    Atomics  m_atomics;
+    Cached   m_cached;
+    Meters   m_meters;
+
+    // Audio-thread state — accessed only from process().
+    uint64_t m_lastVersion{0};
+    float    m_envLin{0.0f};          // peak envelope (linear)
+    float    m_currentGainDb{0.0f};   // the gain currently being applied (≤ 0)
+    int      m_holdCountdown{0};      // samples remaining in hold phase
+    bool     m_isOpen{false};         // Schmitt-trigger state — above-threshold latch
+
+    // Look-ahead delay line — allocated in prepare() with enough headroom
+    // for the max lookahead_ms setting.  Stereo interleaved like the
+    // external buffer so process() can do one read per frame.
+    static constexpr int kMaxLookaheadMs = 5;
+    std::vector<float> m_delay;        // stereo-interleaved delay line
+    int m_delayCap{0};                 // capacity in frames
+    int m_delayWrite{0};               // write index (frame-space)
+};
+
+} // namespace AetherSDR

--- a/src/core/ClientPudu.cpp
+++ b/src/core/ClientPudu.cpp
@@ -1,0 +1,380 @@
+#include "ClientPudu.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr float kTwoPi = 6.283185307179586476f;
+
+float dbToLin(float db) noexcept
+{
+    return std::pow(10.0f, db * 0.05f);
+}
+
+float linToDb(float lin) noexcept
+{
+    return (lin > 1e-9f) ? 20.0f * std::log10(lin) : -180.0f;
+}
+
+float coeffFromMs(float ms, double sampleRate) noexcept
+{
+    if (ms <= 0.0f) return 1.0f;
+    const float tau = ms * 0.001f;
+    return 1.0f - std::exp(-1.0f / static_cast<float>(sampleRate * tau));
+}
+
+// RBJ highpass biquad (Q = 0.707 — 2-pole Butterworth).
+void computeHighpass(float fc, double sr,
+                     ClientPudu::BiquadCoef& c) noexcept
+{
+    const float Q     = 0.70710678f;
+    const float omega = kTwoPi * fc / static_cast<float>(sr);
+    const float sinw  = std::sin(omega);
+    const float cosw  = std::cos(omega);
+    const float alpha = sinw / (2.0f * Q);
+
+    const float a0    = 1.0f + alpha;
+    c.b0 =  (1.0f + cosw) / 2.0f / a0;
+    c.b1 = -(1.0f + cosw)        / a0;
+    c.b2 =  (1.0f + cosw) / 2.0f / a0;
+    c.a1 = -2.0f * cosw          / a0;
+    c.a2 =  (1.0f - alpha)       / a0;
+}
+
+// RBJ lowpass biquad (Q = 0.707).
+void computeLowpass(float fc, double sr,
+                    ClientPudu::BiquadCoef& c) noexcept
+{
+    const float Q     = 0.70710678f;
+    const float omega = kTwoPi * fc / static_cast<float>(sr);
+    const float sinw  = std::sin(omega);
+    const float cosw  = std::cos(omega);
+    const float alpha = sinw / (2.0f * Q);
+
+    const float a0    = 1.0f + alpha;
+    c.b0 =  (1.0f - cosw) / 2.0f / a0;
+    c.b1 =  (1.0f - cosw)        / a0;
+    c.b2 =  (1.0f - cosw) / 2.0f / a0;
+    c.a1 = -2.0f * cosw          / a0;
+    c.a2 =  (1.0f - alpha)       / a0;
+}
+
+// 2nd-order all-pass biquad centred at fc — preserves magnitude but
+// rotates phase by up to 360° across the corner.  Used in Behringer
+// mode LF path for phase-aligned re-injection.
+void computeAllpass(float fc, double sr,
+                    ClientPudu::BiquadCoef& c) noexcept
+{
+    const float Q     = 0.70710678f;
+    const float omega = kTwoPi * fc / static_cast<float>(sr);
+    const float sinw  = std::sin(omega);
+    const float cosw  = std::cos(omega);
+    const float alpha = sinw / (2.0f * Q);
+
+    const float a0 =  1.0f + alpha;
+    c.b0 = (1.0f - alpha) / a0;
+    c.b1 = -2.0f * cosw   / a0;
+    c.b2 = (1.0f + alpha) / a0;
+    c.a1 = -2.0f * cosw   / a0;
+    c.a2 = (1.0f - alpha) / a0;
+}
+
+inline float processBiquad(float x,
+                           const ClientPudu::BiquadCoef& c,
+                           ClientPudu::BiquadState& s) noexcept
+{
+    const float y = c.b0 * x + s.z1;
+    s.z1 = c.b1 * x - c.a1 * y + s.z2;
+    s.z2 = c.b2 * x - c.a2 * y;
+    return y;
+}
+
+} // namespace
+
+ClientPudu::ClientPudu() = default;
+
+void ClientPudu::prepare(double sampleRate)
+{
+    m_sampleRate = sampleRate;
+    reset();
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+    recacheIfDirty();
+}
+
+void ClientPudu::setEnabled(bool on) noexcept
+{ m_atomics.enabled.store(on, std::memory_order_release); }
+bool ClientPudu::isEnabled() const noexcept
+{ return m_atomics.enabled.load(std::memory_order_acquire); }
+
+void ClientPudu::setMode(Mode m) noexcept
+{
+    m_atomics.mode.store(static_cast<uint8_t>(m), std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+ClientPudu::Mode ClientPudu::mode() const noexcept
+{ return static_cast<Mode>(m_atomics.mode.load(std::memory_order_relaxed)); }
+
+void ClientPudu::setPooDriveDb(float db) noexcept
+{
+    m_atomics.pooDriveDb.store(std::clamp(db, 0.0f, 24.0f),
+                               std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientPudu::pooDriveDb() const noexcept
+{ return m_atomics.pooDriveDb.load(std::memory_order_relaxed); }
+
+void ClientPudu::setPooTuneHz(float hz) noexcept
+{
+    m_atomics.pooTuneHz.store(std::clamp(hz, 50.0f, 160.0f),
+                              std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientPudu::pooTuneHz() const noexcept
+{ return m_atomics.pooTuneHz.load(std::memory_order_relaxed); }
+
+void ClientPudu::setPooMix(float v) noexcept
+{
+    m_atomics.pooMix.store(std::clamp(v, 0.0f, 1.0f),
+                           std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientPudu::pooMix() const noexcept
+{ return m_atomics.pooMix.load(std::memory_order_relaxed); }
+
+void ClientPudu::setDooTuneHz(float hz) noexcept
+{
+    m_atomics.dooTuneHz.store(std::clamp(hz, 1000.0f, 10000.0f),
+                              std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientPudu::dooTuneHz() const noexcept
+{ return m_atomics.dooTuneHz.load(std::memory_order_relaxed); }
+
+void ClientPudu::setDooHarmonicsDb(float db) noexcept
+{
+    m_atomics.dooHarmonicsDb.store(std::clamp(db, 0.0f, 24.0f),
+                                   std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientPudu::dooHarmonicsDb() const noexcept
+{ return m_atomics.dooHarmonicsDb.load(std::memory_order_relaxed); }
+
+void ClientPudu::setDooMix(float v) noexcept
+{
+    m_atomics.dooMix.store(std::clamp(v, 0.0f, 1.0f),
+                           std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientPudu::dooMix() const noexcept
+{ return m_atomics.dooMix.load(std::memory_order_relaxed); }
+
+void ClientPudu::reset() noexcept
+{
+    m_chL = {};
+    m_chR = {};
+    m_lfEnvLin = 0.0f;
+}
+
+float ClientPudu::inputPeakDb() const noexcept
+{ return m_meters.inputPeakDb.load(std::memory_order_relaxed); }
+float ClientPudu::outputPeakDb() const noexcept
+{ return m_meters.outputPeakDb.load(std::memory_order_relaxed); }
+float ClientPudu::wetRmsDb() const noexcept
+{ return m_meters.wetRmsDb.load(std::memory_order_relaxed); }
+
+void ClientPudu::recacheIfDirty() noexcept
+{
+    const uint64_t v = m_atomics.version.load(std::memory_order_acquire);
+    if (v == m_lastVersion) return;
+    m_lastVersion = v;
+
+    m_cached.mode = m_atomics.mode.load(std::memory_order_relaxed);
+
+    // HF path.
+    const float dooFc = m_atomics.dooTuneHz.load(std::memory_order_relaxed);
+    computeHighpass(dooFc, m_sampleRate, m_cached.hpf);
+    m_cached.dooDriveLin = dbToLin(
+        m_atomics.dooHarmonicsDb.load(std::memory_order_relaxed));
+    m_cached.dooMix = m_atomics.dooMix.load(std::memory_order_relaxed);
+
+    // LF path.
+    const float pooFc = m_atomics.pooTuneHz.load(std::memory_order_relaxed);
+    computeLowpass(pooFc, m_sampleRate, m_cached.lpf);
+    computeAllpass(pooFc, m_sampleRate, m_cached.allpass);
+    m_cached.pooDriveLin = dbToLin(
+        m_atomics.pooDriveDb.load(std::memory_order_relaxed));
+    m_cached.pooMix = m_atomics.pooMix.load(std::memory_order_relaxed);
+
+    // LF envelope ballistics.  Aphex dynamic EQ wants slightly
+    // slower envelope (~15 ms attack, ~150 ms release) for musical
+    // bass enhancement; Behringer compressor wants tighter (~5 / 80).
+    // Using a middle ground that works well for both modes.
+    m_cached.envAttackCoeff  = coeffFromMs( 8.0f, m_sampleRate);
+    m_cached.envReleaseCoeff = coeffFromMs(120.0f, m_sampleRate);
+}
+
+// ── HF nonlinearity variants ────────────────────────────────────
+//
+// Aphex: one-sided tanh approximates a diode across op-amp
+// feedback.  The negative half passes unshaped, the positive half
+// saturates softly.  Asymmetry generates both odd and even
+// harmonics; a DC block removes the resulting offset.
+static inline float aphexHfShape(float x) noexcept
+{
+    return (x >= 0.0f) ? std::tanh(x) : x;
+}
+
+// Behringer: symmetric tanh.  Pure odd-harmonic content, tighter
+// character.
+static inline float behringerHfShape(float x) noexcept
+{
+    return std::tanh(x);
+}
+
+// Single-pole DC block, a = 0.995.  Used on the Aphex HF path to
+// remove the offset introduced by one-sided clipping.
+static inline float dcBlock(float x, float& x1, float& y1) noexcept
+{
+    const float y = x - x1 + 0.995f * y1;
+    x1 = x;
+    y1 = y;
+    return y;
+}
+
+void ClientPudu::process(float* interleaved, int frames, int channels) noexcept
+{
+    if (frames <= 0) return;
+    if (channels != 1 && channels != 2) return;
+
+    recacheIfDirty();
+    const bool enabled = m_atomics.enabled.load(std::memory_order_acquire);
+
+    float inPeakLin  = 0.0f;
+    float outPeakLin = 0.0f;
+    double wetSumSq  = 0.0;
+    int    wetCount  = 0;
+
+    const bool isAphex = (m_cached.mode == static_cast<uint8_t>(Mode::Aphex));
+    const float dooDrive  = m_cached.dooDriveLin;
+    const float dooMix    = m_cached.dooMix;
+    const float pooDrive  = m_cached.pooDriveLin;
+    const float pooMix    = m_cached.pooMix;
+    const float envAttack  = m_cached.envAttackCoeff;
+    const float envRelease = m_cached.envReleaseCoeff;
+
+    for (int f = 0; f < frames; ++f) {
+        const float dryL = interleaved[f * channels];
+        const float dryR = (channels == 2)
+            ? interleaved[f * channels + 1] : dryL;
+
+        const float inAbs = std::max(std::fabs(dryL), std::fabs(dryR));
+        if (inAbs > inPeakLin) inPeakLin = inAbs;
+
+        // LF envelope follower (used by both modes on the LPF
+        // output).  Envelope feeds the dynamic gain that both
+        // algorithms use to shape the LF contribution.
+        const float lpfSideL = processBiquad(dryL, m_cached.lpf, m_chL.lpf);
+        const float lpfSideR = (channels == 2)
+            ? processBiquad(dryR, m_cached.lpf, m_chR.lpf)
+            : lpfSideL;
+        const float lpAbs = std::max(std::fabs(lpfSideL), std::fabs(lpfSideR));
+        const float alpha = (lpAbs > m_lfEnvLin) ? envAttack : envRelease;
+        m_lfEnvLin += alpha * (lpAbs - m_lfEnvLin);
+
+        // ── LF wet per mode ─────────────────────────────────────
+        // Aphex Big Bottom: LPF → soft saturation scaled by drive,
+        // with envelope-tracked dynamic EQ boost so quiet lows get
+        // more harmonics than loud ones (keeps it from muddying
+        // loud passages).  The envelope inverts: low envelope →
+        // more boost.
+        //
+        // Behringer SX3040: LPF → feed-forward compressor using
+        // the envelope as sidechain → all-pass phase rotator →
+        // mix.  No harmonic content; transient emphasis only.
+        float lfWetL = 0.0f;
+        float lfWetR = 0.0f;
+        if (isAphex) {
+            // Dynamic EQ: boost factor = 1 + drive * (1 - env)
+            // so quiet content gets full drive, loud gets less.
+            const float dynBoost = 1.0f + pooDrive * (1.0f - std::min(m_lfEnvLin, 1.0f));
+            lfWetL = std::tanh(lpfSideL * dynBoost) * 0.5f;
+            lfWetR = std::tanh(lpfSideR * dynBoost) * 0.5f;
+        } else {
+            // Compressor: slope curve reducing gain when envelope
+            // crosses threshold.  Threshold chosen relative to
+            // drive so the user's Drive knob maps to "how much
+            // compression" — more drive, lower threshold.
+            const float thr = 0.5f - 0.3f * std::log10(pooDrive + 0.1f);
+            float comp = 1.0f;
+            if (m_lfEnvLin > thr) {
+                // 4:1 ratio, feed-forward.
+                const float over = m_lfEnvLin / std::max(thr, 1e-6f);
+                comp = std::pow(over, -0.75f);   // 1 - 1/ratio = 0.75
+            }
+            // All-pass phase rotator on the compressed LF.
+            const float apL = processBiquad(lpfSideL * comp,
+                                            m_cached.allpass, m_chL.allpass);
+            const float apR = (channels == 2)
+                ? processBiquad(lpfSideR * comp,
+                                m_cached.allpass, m_chR.allpass)
+                : apL;
+            lfWetL = apL;
+            lfWetR = apR;
+        }
+
+        // ── HF wet per mode ─────────────────────────────────────
+        const float hpfSideL = processBiquad(dryL, m_cached.hpf, m_chL.hpf);
+        const float hpfSideR = (channels == 2)
+            ? processBiquad(dryR, m_cached.hpf, m_chR.hpf)
+            : hpfSideL;
+        float hfWetL, hfWetR;
+        if (isAphex) {
+            hfWetL = aphexHfShape(hpfSideL * dooDrive);
+            hfWetR = aphexHfShape(hpfSideR * dooDrive);
+            // Remove the DC offset from one-sided clipping.
+            hfWetL = dcBlock(hfWetL, m_chL.dcX1, m_chL.dcY1);
+            hfWetR = dcBlock(hfWetR, m_chR.dcX1, m_chR.dcY1);
+        } else {
+            hfWetL = behringerHfShape(hpfSideL * dooDrive);
+            hfWetR = behringerHfShape(hpfSideR * dooDrive);
+        }
+
+        // Sum: dry + pooMix * lfWet + dooMix * hfWet, with bypass
+        // short-circuit.
+        float outL = dryL;
+        float outR = dryR;
+        if (enabled) {
+            outL = dryL + pooMix * lfWetL + dooMix * hfWetL;
+            outR = dryR + pooMix * lfWetR + dooMix * hfWetR;
+
+            // Track wet content separately so the logo pulse
+            // reflects only the exciter contribution (not the dry).
+            const float wetL = pooMix * lfWetL + dooMix * hfWetL;
+            const float wetR = pooMix * lfWetR + dooMix * hfWetR;
+            wetSumSq += static_cast<double>(wetL) * wetL
+                      + static_cast<double>(wetR) * wetR;
+            wetCount += 2;
+        }
+
+        interleaved[f * channels] = outL;
+        if (channels == 2) interleaved[f * channels + 1] = outR;
+
+        const float outAbs = std::max(std::fabs(outL), std::fabs(outR));
+        if (outAbs > outPeakLin) outPeakLin = outAbs;
+    }
+
+    m_meters.inputPeakDb.store(linToDb(std::max(inPeakLin, 1e-6f)),
+                               std::memory_order_relaxed);
+    m_meters.outputPeakDb.store(linToDb(std::max(outPeakLin, 1e-6f)),
+                                std::memory_order_relaxed);
+    const float wetRms = (wetCount > 0)
+        ? static_cast<float>(std::sqrt(wetSumSq / wetCount))
+        : 0.0f;
+    m_meters.wetRmsDb.store(linToDb(std::max(wetRms, 1e-6f)),
+                            std::memory_order_relaxed);
+}
+
+} // namespace AetherSDR

--- a/src/core/ClientPudu.h
+++ b/src/core/ClientPudu.h
@@ -1,0 +1,164 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace AetherSDR {
+
+// Client-side TX exciter — TX DSP chain Phase 5 (#1661).  The
+// centrepiece of the PooDoo Audio™ chain.  Two parallel bands ("Poo"
+// on the low end and "Doo" on the high end), each with a mode-
+// selectable algorithm:
+//
+//   Mode A (Aphex):
+//     Doo = classic Aural Exciter — HPF → VGA → asymmetric diode
+//           soft-clip → DC block → attenuation.  Produces both odd
+//           and even harmonics.  Warm, "3-D" character.
+//     Poo = Big Bottom topology — LPF → envelope-follower dynamic
+//           EQ → soft saturation → attenuation.  Adds harmonic
+//           content to the low band, enhances perceived weight.
+//
+//   Mode B (Behringer SX3040):
+//     Doo = symmetric soft-saturation HPF → drive → tanh → mix.
+//           Odd harmonics only, tighter and brighter.
+//     Poo = frequency-selective compressor + 2nd-order all-pass
+//           phase rotator.  No harmonic content; dynamic transient
+//           emphasis with phase-aligned re-injection into dry.
+//
+// Both modes expose the same six user knobs — only the DSP blocks
+// under the hood swap when Mode toggles:
+//
+//   Poo: Drive (0..24 dB)       -- saturation depth (A) / compressor intensity (B)
+//        Tune  (50..160 Hz)     -- LPF corner
+//        Mix   (0..1)           -- wet blend into dry sum
+//   Doo: Tune      (1..10 kHz)  -- HPF corner
+//        Harmonics (0..24 dB)   -- drive into the nonlinearity
+//        Mix       (0..1)       -- wet blend into dry sum
+//
+// Thread model mirrors the other DSP modules: UI thread writes
+// atomics + bumps a version counter; audio thread reads the version
+// once per block and recaches derived values.  No locks, no
+// allocations in process(), no exceptions.
+class ClientPudu {
+public:
+    enum class Mode : uint8_t {
+        Aphex     = 0,   // Aural Exciter + Big Bottom
+        Behringer = 1,   // SX 3040 Sonic Exciter
+    };
+
+    ClientPudu();
+    ~ClientPudu() = default;
+
+    ClientPudu(const ClientPudu&)            = delete;
+    ClientPudu& operator=(const ClientPudu&) = delete;
+
+    void prepare(double sampleRate);
+
+    void setEnabled(bool on) noexcept;
+    bool isEnabled() const noexcept;
+
+    void  setMode(Mode m) noexcept;
+    Mode  mode() const noexcept;
+
+    // Poo (low band).
+    void  setPooDriveDb(float db) noexcept;          // 0..24 dB
+    float pooDriveDb() const noexcept;
+    void  setPooTuneHz(float hz) noexcept;           // 50..160 Hz
+    float pooTuneHz() const noexcept;
+    void  setPooMix(float v) noexcept;               // 0..1
+    float pooMix() const noexcept;
+
+    // Doo (high band).
+    void  setDooTuneHz(float hz) noexcept;           // 1000..10000 Hz
+    float dooTuneHz() const noexcept;
+    void  setDooHarmonicsDb(float db) noexcept;      // 0..24 dB
+    float dooHarmonicsDb() const noexcept;
+    void  setDooMix(float v) noexcept;               // 0..1
+    float dooMix() const noexcept;
+
+    // Audio thread — process in place.  channels must be 1 or 2.
+    void process(float* interleaved, int frames, int channels) noexcept;
+
+    // Audio thread — flush biquad + envelope + DC-block state.
+    void reset() noexcept;
+
+    // UI thread — read-only snapshots.
+    float inputPeakDb() const noexcept;
+    float outputPeakDb() const noexcept;
+    // Post-nonlinearity RMS in dB.  Drives the PooDoo logo pulse in
+    // the applet — dim at silence, bright when the exciter is
+    // actively adding content.
+    float wetRmsDb() const noexcept;
+
+    double sampleRate() const noexcept { return m_sampleRate; }
+
+    // Public because the cpp-local biquad helper takes references.
+    // Not part of the user-facing API.
+    struct BiquadCoef { float b0{1}, b1{0}, b2{0}, a1{0}, a2{0}; };
+    struct BiquadState { float z1{0}, z2{0}; };
+
+private:
+    struct Atomics {
+        std::atomic<bool>     enabled{false};
+        std::atomic<uint8_t>  mode{static_cast<uint8_t>(Mode::Aphex)};
+        std::atomic<float>    pooDriveDb{0.0f};
+        std::atomic<float>    pooTuneHz{100.0f};
+        std::atomic<float>    pooMix{0.5f};
+        std::atomic<float>    dooTuneHz{5000.0f};
+        std::atomic<float>    dooHarmonicsDb{6.0f};
+        std::atomic<float>    dooMix{0.5f};
+        std::atomic<uint64_t> version{0};
+    };
+
+    struct Cached {
+        uint8_t mode{0};
+        // HF path.
+        BiquadCoef hpf{};
+        float      dooDriveLin{1.0f};   // 10^(harmonics/20)
+        float      dooMix{0.5f};
+        // LF path.
+        BiquadCoef lpf{};
+        BiquadCoef allpass{};            // used in Behringer mode
+        float      pooDriveLin{1.0f};
+        float      pooMix{0.5f};
+        // LF dynamics (both modes, different coefficients).
+        float      envAttackCoeff{0.0f};
+        float      envReleaseCoeff{0.0f};
+    };
+
+    struct Meters {
+        std::atomic<float> inputPeakDb{-120.0f};
+        std::atomic<float> outputPeakDb{-120.0f};
+        std::atomic<float> wetRmsDb{-120.0f};
+    };
+
+    void recacheIfDirty() noexcept;
+
+    // Per-channel state bundles so stereo maintains independent
+    // biquad memories without tangling the process() loop.
+    struct ChannelState {
+        BiquadState hpf;
+        BiquadState lpf;
+        BiquadState allpass;
+        // Single-pole DC block on the Doo path (Aphex mode only —
+        // needed because one-sided clipping introduces DC offset).
+        float dcX1{0.0f};
+        float dcY1{0.0f};
+    };
+
+    double  m_sampleRate{24000.0};
+    Atomics m_atomics;
+    Cached  m_cached;
+    Meters  m_meters;
+
+    // Audio-thread state.
+    uint64_t     m_lastVersion{0};
+    ChannelState m_chL;
+    ChannelState m_chR;
+    // Envelope followers for the LF band.  Shared across modes —
+    // Aphex mode treats them as a dynamic-EQ level detector; Behringer
+    // mode treats them as a compressor sidechain.
+    float        m_lfEnvLin{0.0f};
+};
+
+} // namespace AetherSDR

--- a/src/core/ClientPuduMonitor.cpp
+++ b/src/core/ClientPuduMonitor.cpp
@@ -1,0 +1,228 @@
+#include "ClientPuduMonitor.h"
+
+#include <QDir>
+#include <QFile>
+#include <QIODevice>
+
+#include <algorithm>
+#include <cstring>
+
+namespace AetherSDR {
+
+namespace {
+
+// 10 ms playback cadence — 240 frames × 2 ch × 2 B = 960 B per chunk.
+// Match QsoRecorder exactly: longer intervals starve the audio sink
+// when Qt's timer scheduler coarsens (typical real intervals of
+// 16-33 ms under light load), producing dropouts / garbled output.
+constexpr int kPlaybackIntervalMs = 10;
+constexpr int kPlaybackChunkBytes =
+    kPlaybackIntervalMs * ClientPuduMonitor::kSampleRate / 1000
+    * ClientPuduMonitor::kBytesPerFrame;
+
+// Standard 44-byte RIFF/WAVE header for int16 stereo 24 kHz PCM.
+QByteArray makeWavHeader(quint32 payloadBytes)
+{
+    QByteArray h;
+    h.reserve(44);
+    auto u32 = [&](quint32 v) {
+        h.append(char(v & 0xFF));
+        h.append(char((v >> 8) & 0xFF));
+        h.append(char((v >> 16) & 0xFF));
+        h.append(char((v >> 24) & 0xFF));
+    };
+    auto u16 = [&](quint16 v) {
+        h.append(char(v & 0xFF));
+        h.append(char((v >> 8) & 0xFF));
+    };
+
+    h.append("RIFF", 4);
+    u32(36 + payloadBytes);
+    h.append("WAVE", 4);
+    h.append("fmt ", 4);
+    u32(16);                                                  // fmt chunk size
+    u16(1);                                                    // PCM
+    u16(ClientPuduMonitor::kChannels);
+    u32(ClientPuduMonitor::kSampleRate);
+    u32(ClientPuduMonitor::kSampleRate
+        * ClientPuduMonitor::kBytesPerFrame);                  // byte rate
+    u16(ClientPuduMonitor::kBytesPerFrame);                    // block align
+    u16(16);                                                   // bits / sample
+    h.append("data", 4);
+    u32(payloadBytes);
+    return h;
+}
+
+} // namespace
+
+ClientPuduMonitor::ClientPuduMonitor(QObject* parent) : QObject(parent)
+{
+    // Pre-size the buffer so the audio thread never reallocates.  Qt's
+    // QByteArray grows on demand; fill with zeros to force the
+    // allocation now rather than on first write.
+    m_buffer.fill('\0', kMaxBytes);
+
+    m_playTimer = new QTimer(this);
+    m_playTimer->setInterval(kPlaybackIntervalMs);
+    m_playTimer->setTimerType(Qt::PreciseTimer);
+    connect(m_playTimer, &QTimer::timeout,
+            this, &ClientPuduMonitor::onPlaybackTick);
+}
+
+int ClientPuduMonitor::recordedMs() const noexcept
+{
+    return m_recordedMs;
+}
+
+void ClientPuduMonitor::startRecording()
+{
+    // Idempotent.  Can't record while playing — caller should stop
+    // playback first; we just bail to avoid trampling playback state.
+    if (m_recording.load(std::memory_order_acquire)) return;
+    if (m_playing) return;
+
+    m_writeBytes.store(0, std::memory_order_release);
+    m_recordedBytes = 0;
+    m_recordedMs = 0;
+    m_recElapsed.restart();
+    m_recording.store(true, std::memory_order_release);
+    // Disconnect live RX audio for the entire record+playback cycle
+    // so we don't hear radio audio mixed with our capture/playback.
+    // Restored on playback end (not on record end — auto-play starts
+    // immediately after, and we want the mute to persist across the
+    // transition).
+    emit muteRxRequested(true);
+    emit recordingStarted();
+}
+
+void ClientPuduMonitor::stopRecording()
+{
+    // Try to flip the recording flag from true→false atomically.
+    // Whoever wins (user click, auto-stop handler, or external
+    // transition like mic-source change) finishes the stop work;
+    // later callers no-op.
+    bool wasRecording = true;
+    if (!m_recording.compare_exchange_strong(wasRecording, false,
+            std::memory_order_acq_rel)) {
+        return;
+    }
+
+    // Audio thread sees m_recording=false before any further writes
+    // via the acquire load in feedTxPostDsp().  Safe to read the
+    // write count.
+    m_recordedBytes = m_writeBytes.load(std::memory_order_acquire);
+    m_recordedMs    = static_cast<int>(m_recElapsed.elapsed());
+
+    writeWavFile();
+    emit recordingStopped(m_recordedMs);
+}
+
+void ClientPuduMonitor::onAutoStop()
+{
+    // Audio thread hit the 30-s cap and flipped m_recording=false
+    // itself.  Do the UI-side finalisation + emit signal.
+    if (m_recordedBytes == 0) {
+        m_recordedBytes = m_writeBytes.load(std::memory_order_acquire);
+        m_recordedMs    = static_cast<int>(m_recElapsed.elapsed());
+    }
+    writeWavFile();
+    emit recordingStopped(m_recordedMs);
+}
+
+void ClientPuduMonitor::startPlayback()
+{
+    if (m_playing) return;
+    if (m_recordedBytes <= 0) return;
+    m_playPos = 0;
+    m_playing = true;
+    m_playTimer->start();
+    // When playback is triggered as part of auto-play after a
+    // record (the record → stop → play transition), muteRxRequested
+    // was already fired at record start and the mute is still held,
+    // so this is a no-op.  When the user triggers playback manually
+    // from idle, this is the one that installs the mute.  Either
+    // way it's safe — MainWindow's handler is idempotent.
+    emit muteRxRequested(true);
+    emit playbackStarted();
+}
+
+void ClientPuduMonitor::stopPlayback()
+{
+    if (!m_playing) return;
+    m_playing = false;
+    m_playTimer->stop();
+    // End of the record+playback cycle — restore live RX audio.
+    emit muteRxRequested(false);
+    emit playbackStopped();
+}
+
+void ClientPuduMonitor::onPlaybackTick()
+{
+    if (!m_playing) return;
+    const int remaining = m_recordedBytes - m_playPos;
+    if (remaining <= 0) {
+        stopPlayback();
+        return;
+    }
+    const int take = std::min(remaining, kPlaybackChunkBytes);
+
+    // AudioEngine::feedDecodedSpeech() expects float32 interleaved
+    // stereo — not int16 (the sink is configured for float samples).
+    // QsoRecorder::onPlaybackTick does the same conversion.  Emitting
+    // raw int16 bytes would get reinterpreted as float32 by the sink
+    // and blow out speakers with garbage values.
+    const auto* src = reinterpret_cast<const int16_t*>(
+        m_buffer.constData() + m_playPos);
+    const int numSamples = take / static_cast<int>(sizeof(int16_t));
+    QByteArray floatPcm(numSamples * static_cast<int>(sizeof(float)),
+                        Qt::Uninitialized);
+    auto* dst = reinterpret_cast<float*>(floatPcm.data());
+    for (int i = 0; i < numSamples; ++i) {
+        dst[i] = static_cast<float>(src[i]) / 32768.0f;
+    }
+    emit playbackAudio(floatPcm);
+
+    m_playPos += take;
+    if (m_playPos >= m_recordedBytes) {
+        stopPlayback();
+    }
+}
+
+void ClientPuduMonitor::feedTxPostDsp(const QByteArray& pcm) noexcept
+{
+    // Fast-path skip when not recording — acquire load so writes that
+    // happened before we started recording are visible too.
+    if (!m_recording.load(std::memory_order_acquire)) return;
+    if (pcm.isEmpty()) return;
+
+    const int writeAt = m_writeBytes.load(std::memory_order_relaxed);
+    const int avail   = kMaxBytes - writeAt;
+    if (avail <= 0) return;
+    const int take = std::min(static_cast<int>(pcm.size()), avail);
+    std::memcpy(m_buffer.data() + writeAt, pcm.constData(), take);
+    const int newTotal = writeAt + take;
+    m_writeBytes.store(newTotal, std::memory_order_release);
+
+    if (newTotal >= kMaxBytes) {
+        // Cap hit — stop accepting further feeds and tell the UI
+        // thread to finalise + auto-start playback.
+        m_recording.store(false, std::memory_order_release);
+        QMetaObject::invokeMethod(this, "onAutoStop", Qt::QueuedConnection);
+    }
+}
+
+void ClientPuduMonitor::writeWavFile()
+{
+    // /tmp/pudu_monitor.wav — overwritten on each recording.  Purely
+    // for offline inspection; playback uses the in-memory buffer.
+    const QString path = QDir::temp().filePath("pudu_monitor.wav");
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) return;
+    const QByteArray header = makeWavHeader(
+        static_cast<quint32>(m_recordedBytes));
+    f.write(header);
+    f.write(m_buffer.constData(), m_recordedBytes);
+    f.close();
+}
+
+} // namespace AetherSDR

--- a/src/core/ClientPuduMonitor.h
+++ b/src/core/ClientPuduMonitor.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <QByteArray>
+#include <QElapsedTimer>
+#include <QObject>
+#include <QTimer>
+
+#include <atomic>
+#include <cstdint>
+
+namespace AetherSDR {
+
+// PUDU monitor — captures up to 30 seconds of post-DSP TX audio (the
+// output of the full client-side PooDoo™ chain) into an in-memory
+// buffer, then plays it back through the RX sink so the user can hear
+// what their chain is producing without keying the radio.  On stop a
+// WAV snapshot is dropped into /tmp for offline inspection; playback
+// itself reads the in-memory buffer, never the file.
+//
+// Threading:
+//  - feedTxPostDsp() runs on the audio worker thread.  Single writer,
+//    lock-free via atomics.  Bails out early when not recording.
+//  - Everything else (start/stop, playback tick, signals) runs on the
+//    UI thread.  Audio thread hands off via Qt queued invoke when the
+//    30-second cap is reached.
+class ClientPuduMonitor : public QObject {
+    Q_OBJECT
+
+public:
+    explicit ClientPuduMonitor(QObject* parent = nullptr);
+    ~ClientPuduMonitor() override = default;
+
+    // UI-thread transitions.  All idempotent — calling start while
+    // already started, or stop while already stopped, is a no-op.
+    void startRecording();
+    void stopRecording();
+    void startPlayback();
+    void stopPlayback();
+
+    bool isRecording()  const noexcept { return m_recording.load(std::memory_order_acquire); }
+    bool isPlaying()    const noexcept { return m_playing; }
+    bool hasRecording() const noexcept { return m_recordedBytes > 0; }
+    int  recordedMs()   const noexcept;
+
+    // Audio thread — appends int16 stereo 24 kHz PCM into the buffer
+    // while recording.  No-op otherwise.  Stops itself and queues the
+    // UI-thread auto-stop handler once the 30-s cap is reached.
+    void feedTxPostDsp(const QByteArray& int16stereo) noexcept;
+
+    // Sample-rate / channel-count assumed throughout the class.  Kept
+    // as constants so the WAV writer and playback chunk sizes can
+    // reference them directly.
+    static constexpr int kSampleRate  = 24000;
+    static constexpr int kChannels    = 2;
+    static constexpr int kBytesPerFrame = kChannels * 2;
+    static constexpr int kMaxSeconds  = 30;
+    static constexpr int kMaxBytes    = kMaxSeconds * kSampleRate * kBytesPerFrame;
+
+signals:
+    // State transitions for the UI.
+    void recordingStarted();
+    void recordingStopped(int durationMs);
+    void playbackStarted();
+    void playbackStopped();
+    // Playback tick payload — chunked float32 stereo 24 kHz (same
+    // format QsoRecorder feeds so it flows cleanly into
+    // AudioEngine::feedDecodedSpeech).
+    void playbackAudio(const QByteArray& float32stereo);
+    // Ask MainWindow to toggle the live RX audio feed off/on.  True
+    // = disconnect live RX (so we don't hear over our capture or
+    // playback), false = restore.  Held from recordingStarted
+    // through playbackStopped as one continuous mute window.
+    void muteRxRequested(bool mute);
+
+private slots:
+    // Posted from the audio thread when the 30-s buffer fills.
+    void onAutoStop();
+    // Playback QTimer tick — emits the next 20 ms chunk.
+    void onPlaybackTick();
+
+private:
+    void writeWavFile();
+
+    // ── Audio-thread-visible state ──────────────────────────────────
+    std::atomic<bool>     m_recording{false};
+    std::atomic<int>      m_writeBytes{0};
+    // Buffer is pre-sized to kMaxBytes at construction; the audio
+    // thread memcpys into it at m_writeBytes.  Data ownership stays
+    // with this object — never reassigned.
+    QByteArray            m_buffer;
+
+    // ── UI-thread-only state ────────────────────────────────────────
+    int                   m_recordedBytes{0};     // snapshot of m_writeBytes after stop
+    int                   m_recordedMs{0};
+    bool                  m_playing{false};
+    int                   m_playPos{0};
+    QTimer*               m_playTimer{nullptr};
+    QElapsedTimer         m_recElapsed;
+};
+
+} // namespace AetherSDR

--- a/src/core/ClientTube.cpp
+++ b/src/core/ClientTube.cpp
@@ -1,0 +1,290 @@
+#include "ClientTube.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr float kTwoPi = 6.283185307179586476f;
+
+float dbToLin(float db) noexcept
+{
+    return std::pow(10.0f, db * 0.05f);
+}
+
+float linToDb(float lin) noexcept
+{
+    return (lin > 1e-9f) ? 20.0f * std::log10(lin) : -180.0f;
+}
+
+float coeffFromMs(float ms, double sampleRate) noexcept
+{
+    if (ms <= 0.0f) return 1.0f;
+    const float tau = ms * 0.001f;
+    return 1.0f - std::exp(-1.0f / static_cast<float>(sampleRate * tau));
+}
+
+// Tilt filter coefficient — simple one-pole LP built from sample rate
+// and a corner near 2 kHz.  The tilt is applied as a weighted blend of
+// the LP-filtered signal and the original: positive tone emphasises
+// the HP component (input - lp), negative emphasises the LP.
+constexpr float kToneCornerHz = 2000.0f;
+float toneCoeff(double sampleRate) noexcept
+{
+    const float omega = kTwoPi * kToneCornerHz / static_cast<float>(sampleRate);
+    return omega / (omega + 1.0f);
+}
+
+} // namespace
+
+ClientTube::ClientTube() = default;
+
+void ClientTube::prepare(double sampleRate)
+{
+    m_sampleRate = sampleRate;
+    reset();
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+    recacheIfDirty();
+}
+
+void ClientTube::setEnabled(bool on) noexcept
+{
+    m_atomics.enabled.store(on, std::memory_order_release);
+}
+bool ClientTube::isEnabled() const noexcept
+{
+    return m_atomics.enabled.load(std::memory_order_acquire);
+}
+
+void ClientTube::setModel(Model m) noexcept
+{
+    m_atomics.model.store(static_cast<uint8_t>(m), std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+ClientTube::Model ClientTube::model() const noexcept
+{ return static_cast<Model>(m_atomics.model.load(std::memory_order_relaxed)); }
+
+void ClientTube::setDriveDb(float db) noexcept
+{
+    m_atomics.driveDb.store(std::clamp(db, 0.0f, 24.0f),
+                            std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientTube::driveDb() const noexcept
+{ return m_atomics.driveDb.load(std::memory_order_relaxed); }
+
+void ClientTube::setBiasAmount(float v) noexcept
+{
+    m_atomics.biasAmount.store(std::clamp(v, 0.0f, 1.0f),
+                               std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientTube::biasAmount() const noexcept
+{ return m_atomics.biasAmount.load(std::memory_order_relaxed); }
+
+void ClientTube::setTone(float v) noexcept
+{
+    m_atomics.tone.store(std::clamp(v, -1.0f, 1.0f),
+                         std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientTube::tone() const noexcept
+{ return m_atomics.tone.load(std::memory_order_relaxed); }
+
+void ClientTube::setOutputGainDb(float db) noexcept
+{
+    m_atomics.outputGainDb.store(std::clamp(db, -24.0f, 12.0f),
+                                 std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientTube::outputGainDb() const noexcept
+{ return m_atomics.outputGainDb.load(std::memory_order_relaxed); }
+
+void ClientTube::setDryWet(float v) noexcept
+{
+    m_atomics.dryWet.store(std::clamp(v, 0.0f, 1.0f),
+                           std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientTube::dryWet() const noexcept
+{ return m_atomics.dryWet.load(std::memory_order_relaxed); }
+
+void ClientTube::setEnvelopeAmount(float v) noexcept
+{
+    m_atomics.envelopeAmount.store(std::clamp(v, -1.0f, 1.0f),
+                                   std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientTube::envelopeAmount() const noexcept
+{ return m_atomics.envelopeAmount.load(std::memory_order_relaxed); }
+
+void ClientTube::setAttackMs(float ms) noexcept
+{
+    m_atomics.attackMs.store(std::clamp(ms, 0.1f, 30.0f),
+                             std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientTube::attackMs() const noexcept
+{ return m_atomics.attackMs.load(std::memory_order_relaxed); }
+
+void ClientTube::setReleaseMs(float ms) noexcept
+{
+    m_atomics.releaseMs.store(std::clamp(ms, 10.0f, 500.0f),
+                              std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientTube::releaseMs() const noexcept
+{ return m_atomics.releaseMs.load(std::memory_order_relaxed); }
+
+void ClientTube::reset() noexcept
+{
+    m_envLin = 0.0f;
+    m_toneStateL = 0.0f;
+    m_toneStateR = 0.0f;
+}
+
+float ClientTube::inputPeakDb() const noexcept
+{ return m_meters.inputPeakDb.load(std::memory_order_relaxed); }
+float ClientTube::outputPeakDb() const noexcept
+{ return m_meters.outputPeakDb.load(std::memory_order_relaxed); }
+float ClientTube::driveAppliedDb() const noexcept
+{ return m_meters.driveAppliedDb.load(std::memory_order_relaxed); }
+
+void ClientTube::recacheIfDirty() noexcept
+{
+    const uint64_t v = m_atomics.version.load(std::memory_order_acquire);
+    if (v == m_lastVersion) return;
+    m_lastVersion = v;
+
+    m_cached.model       = m_atomics.model.load(std::memory_order_relaxed);
+    m_cached.baseDriveLin = dbToLin(
+        m_atomics.driveDb.load(std::memory_order_relaxed));
+    m_cached.bias        = m_atomics.biasAmount.load(std::memory_order_relaxed);
+    m_cached.tone        = m_atomics.tone.load(std::memory_order_relaxed);
+    m_cached.outputLin   = dbToLin(
+        m_atomics.outputGainDb.load(std::memory_order_relaxed));
+    m_cached.dryWet      = m_atomics.dryWet.load(std::memory_order_relaxed);
+    m_cached.envAmount   = m_atomics.envelopeAmount.load(std::memory_order_relaxed);
+    m_cached.attackCoeff = coeffFromMs(
+        m_atomics.attackMs.load(std::memory_order_relaxed), m_sampleRate);
+    m_cached.releaseCoeff = coeffFromMs(
+        m_atomics.releaseMs.load(std::memory_order_relaxed), m_sampleRate);
+    m_cached.toneCoeff = toneCoeff(m_sampleRate);
+}
+
+float ClientTube::shape(float x) const noexcept
+{
+    const float bias = m_cached.bias;
+    // Asymmetric term — always non-negative, produces DC offset +
+    // even harmonics.  tanh-bounded so it never blows up at high
+    // drive; peak contribution capped at ±bias.
+    const float asym = bias * std::tanh(x * x);
+    switch (m_cached.model) {
+        case static_cast<uint8_t>(Model::A):   // soft tanh
+            return std::tanh(x) + asym;
+        case static_cast<uint8_t>(Model::B): { // hard clip + tanh hybrid
+            // Hard clip at ±1 followed by tanh softening — gives a
+            // stronger odd-harmonic character than pure tanh.
+            const float h = std::clamp(x, -1.0f, 1.0f);
+            return std::tanh(h * 1.3f) * 0.85f + asym;
+        }
+        case static_cast<uint8_t>(Model::C): { // asymmetric-dominant
+            // tanh-bounded asymmetric shaper — stronger even-harmonic
+            // content than A/B without the unbounded growth of raw
+            // x² terms.
+            const float t  = std::tanh(x);
+            const float a2 = std::tanh(x * x);
+            return 0.75f * t + (0.35f + 0.65f * bias) * a2;
+        }
+    }
+    return std::tanh(x);
+}
+
+void ClientTube::process(float* interleaved, int frames, int channels) noexcept
+{
+    if (frames <= 0) return;
+    if (channels != 1 && channels != 2) return;
+
+    recacheIfDirty();
+    const bool enabled = m_atomics.enabled.load(std::memory_order_acquire);
+
+    float inPeakLin  = 0.0f;
+    float outPeakLin = 0.0f;
+    float maxDriveLin = 0.0f;
+
+    const float baseDrive    = m_cached.baseDriveLin;
+    const float outputLin    = m_cached.outputLin;
+    const float dryWet       = m_cached.dryWet;
+    const float envAmount    = m_cached.envAmount;
+    const float attackCoeff  = m_cached.attackCoeff;
+    const float releaseCoeff = m_cached.releaseCoeff;
+    const float toneCoef     = m_cached.toneCoeff;
+    const float tone         = m_cached.tone;
+
+    for (int f = 0; f < frames; ++f) {
+        const float dryL = interleaved[f * channels];
+        const float dryR = (channels == 2)
+            ? interleaved[f * channels + 1] : dryL;
+
+        const float inAbs = std::max(std::fabs(dryL), std::fabs(dryR));
+        if (inAbs > inPeakLin) inPeakLin = inAbs;
+
+        // Envelope follower for dynamic drive.
+        const float alpha = (inAbs > m_envLin) ? attackCoeff : releaseCoeff;
+        m_envLin += alpha * (inAbs - m_envLin);
+
+        // Effective drive: baseDrive * (1 + envAmount * envLin).
+        //   envAmount = 0        → static drive (no modulation)
+        //   envAmount = +1       → at full-scale input, drive × 2
+        //   envAmount = -1       → at full-scale input, drive × 0
+        // Clamped to [0.1, 10] so an aggressive negative envelope at
+        // a loud level doesn't zero the drive entirely.
+        const float envMod  = 1.0f + envAmount * m_envLin;
+        const float drive   = std::clamp(baseDrive * envMod, 0.1f, 10.0f);
+        if (drive > maxDriveLin) maxDriveLin = drive;
+
+        // Per-channel tone pre-filter (simple one-pole LP with HP
+        // blend).  m_toneState holds the LP output; the shaper sees
+        // dry blended toward HP (tone > 0) or LP (tone < 0).
+        auto shapeChan = [&](float x, float& state) {
+            state += toneCoef * (x - state);
+            const float lp = state;
+            const float hp = x - state;
+            const float shaped = (tone >= 0.0f)
+                ? x + tone * (hp - x * 0.5f)      // brighten
+                : x + (-tone) * (lp - x * 0.5f);  // darken
+            return shape(shaped * drive);
+        };
+
+        const float wetL = shapeChan(dryL, m_toneStateL);
+        const float wetR = (channels == 2)
+            ? shapeChan(dryR, m_toneStateR)
+            : wetL;
+
+        // Parallel mix + output trim.  When disabled, pass dry
+        // straight through unmodified (not just bypass shape — also
+        // skip tone filtering so the signal is bit-identical).
+        float outL = dryL, outR = dryR;
+        if (enabled) {
+            outL = (dryL * (1.0f - dryWet) + wetL * dryWet) * outputLin;
+            outR = (dryR * (1.0f - dryWet) + wetR * dryWet) * outputLin;
+        }
+
+        interleaved[f * channels] = outL;
+        if (channels == 2) interleaved[f * channels + 1] = outR;
+
+        const float outAbs = std::max(std::fabs(outL), std::fabs(outR));
+        if (outAbs > outPeakLin) outPeakLin = outAbs;
+    }
+
+    m_meters.inputPeakDb.store(linToDb(std::max(inPeakLin, 1e-6f)),
+                               std::memory_order_relaxed);
+    m_meters.outputPeakDb.store(linToDb(std::max(outPeakLin, 1e-6f)),
+                                std::memory_order_relaxed);
+    m_meters.driveAppliedDb.store(linToDb(std::max(maxDriveLin, 1e-6f)),
+                                  std::memory_order_relaxed);
+}
+
+} // namespace AetherSDR

--- a/src/core/ClientTube.h
+++ b/src/core/ClientTube.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace AetherSDR {
+
+// Client-side tube saturator — TX DSP chain Phase 4 (#1661).  Per-
+// sample soft-clipping waveshaper that adds tube-like harmonic
+// warmth.  Modelled on Ableton's Dynamic Tube with three selectable
+// curve flavours:
+//
+//   Model A — Soft tanh (broad, gentle)
+//   Model B — Hard clip + tanh hybrid (odd harmonics, aggressive)
+//   Model C — Asymmetric (bias-dominant, even harmonics, warm)
+//
+// The "Dynamic" part: an envelope follower on the input modulates
+// drive so quiet passages stay clean while loud sections saturate
+// more.  Envelope amount + Attack + Release shape that behaviour.
+// A pre-tilt "Tone" filter shifts which part of the spectrum gets
+// pushed into the nonlinearity, and a parallel Dry/Wet mix lets
+// users blend processed + dry.
+//
+// Thread model mirrors ClientComp / ClientGate / ClientDeEss:
+// UI thread writes atomics + bumps a version counter; the audio
+// thread reads the version once per block and recaches derived
+// values.  No locks, no allocations, no exceptions.
+class ClientTube {
+public:
+    enum class Model : uint8_t {
+        A = 0,   // soft tanh
+        B = 1,   // hard clip + tanh hybrid
+        C = 2,   // asymmetric
+    };
+
+    ClientTube();
+    ~ClientTube() = default;
+
+    ClientTube(const ClientTube&)            = delete;
+    ClientTube& operator=(const ClientTube&) = delete;
+
+    void prepare(double sampleRate);
+
+    void setEnabled(bool on) noexcept;
+    bool isEnabled() const noexcept;
+
+    void  setModel(Model m) noexcept;
+    Model model() const noexcept;
+
+    // Core drive + asymmetry.
+    void  setDriveDb(float db) noexcept;             // 0..24 dB
+    float driveDb() const noexcept;
+    void  setBiasAmount(float v) noexcept;           // 0..1 (0 = symmetric)
+    float biasAmount() const noexcept;
+
+    // Pre-shaper tone: simple tilt filter.  -1 = all dark (cut HF
+    // before saturation), +1 = all bright (boost HF into the
+    // shaper), 0 = flat.
+    void  setTone(float v) noexcept;                 // -1..+1
+    float tone() const noexcept;
+
+    // Output trim + parallel mix.
+    void  setOutputGainDb(float db) noexcept;        // -24..+24 dB
+    float outputGainDb() const noexcept;
+    void  setDryWet(float v) noexcept;               // 0..1 (0 = dry, 1 = wet)
+    float dryWet() const noexcept;
+
+    // Dynamic drive modulation via input envelope.  Bipolar:
+    //   0     = static drive (no modulation)
+    //   +1    = louder input pushes drive higher (normal)
+    //   -1    = louder input REDUCES drive (reverse / ducking)
+    // Reverse envelope is a classic tube-preamp trick for keeping
+    // loud passages clean while adding harmonic warmth on quiet ones.
+    void  setEnvelopeAmount(float v) noexcept;       // -1..+1
+    float envelopeAmount() const noexcept;
+    void  setAttackMs(float ms) noexcept;            // 0.1..30 ms
+    float attackMs() const noexcept;
+    void  setReleaseMs(float ms) noexcept;           // 10..500 ms
+    float releaseMs() const noexcept;
+
+    // Audio thread — process in place.  channels must be 1 or 2.
+    void process(float* interleaved, int frames, int channels) noexcept;
+
+    // Audio thread — flush envelope + tone-filter state.
+    void reset() noexcept;
+
+    // UI thread — read-only snapshots.
+    float inputPeakDb() const noexcept;
+    float outputPeakDb() const noexcept;
+    float driveAppliedDb() const noexcept;   // dynamic instantaneous drive
+
+    double sampleRate() const noexcept { return m_sampleRate; }
+
+private:
+    struct Atomics {
+        std::atomic<bool>     enabled{false};
+        std::atomic<uint8_t>  model{static_cast<uint8_t>(Model::A)};
+        std::atomic<float>    driveDb{0.0f};
+        std::atomic<float>    biasAmount{0.0f};
+        std::atomic<float>    tone{0.0f};
+        std::atomic<float>    outputGainDb{0.0f};
+        std::atomic<float>    dryWet{1.0f};
+        std::atomic<float>    envelopeAmount{0.0f};
+        std::atomic<float>    attackMs{5.0f};
+        std::atomic<float>    releaseMs{35.0f};
+        std::atomic<uint64_t> version{0};
+    };
+
+    struct Cached {
+        uint8_t model{0};
+        float baseDriveLin{1.0f};      // 10^(driveDb/20)
+        float bias{0.0f};
+        float tone{0.0f};
+        float outputLin{1.0f};
+        float dryWet{1.0f};
+        float envAmount{0.0f};
+        float attackCoeff{0.0f};
+        float releaseCoeff{0.0f};
+        // One-pole tilt coefficient: y = x + a*(x - y_prev)
+        float toneCoeff{0.0f};
+    };
+
+    struct Meters {
+        std::atomic<float> inputPeakDb{-120.0f};
+        std::atomic<float> outputPeakDb{-120.0f};
+        std::atomic<float> driveAppliedDb{0.0f};
+    };
+
+    void recacheIfDirty() noexcept;
+    float shape(float x) const noexcept;   // waveshaper per Model + bias
+
+    double m_sampleRate{24000.0};
+    Atomics m_atomics;
+    Cached  m_cached;
+    Meters  m_meters;
+
+    // Audio-thread state.
+    uint64_t m_lastVersion{0};
+    float    m_envLin{0.0f};          // input peak envelope, linear
+    // One-pole tilt state (tone filter) per channel.  Implemented as
+    // a simple HP/LP blend driven by m_cached.tone — positive tone
+    // brightens, negative darkens before the shaper.
+    float    m_toneStateL{0.0f};
+    float    m_toneStateR{0.0f};
+};
+
+} // namespace AetherSDR

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -14,6 +14,10 @@
 #include "EqApplet.h"
 #include "ClientEqApplet.h"
 #include "ClientCompApplet.h"
+#include "ClientGateApplet.h"
+#include "ClientDeEssApplet.h"
+#include "ClientTubeApplet.h"
+#include "ClientPuduApplet.h"
 #include "ClientChainApplet.h"
 #include "CatControlApplet.h"
 #include "DaxApplet.h"
@@ -599,6 +603,10 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // wrapper provides the group's drag-handle + tray-toggle).
     m_clientEqApplet    = new ClientEqApplet;
     m_clientCompApplet  = new ClientCompApplet;
+    m_clientGateApplet  = new ClientGateApplet;
+    m_clientDeEssApplet = new ClientDeEssApplet;
+    m_clientTubeApplet  = new ClientTubeApplet;
+    m_clientPuduApplet  = new ClientPuduApplet;
     m_clientChainApplet = new ClientChainApplet;
 
     auto* txDsp = m_containerMgr->createContainer(
@@ -619,8 +627,12 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // pop-outable sub-containers since users commonly want them
     // floating while working on the chain.)
     if (txDsp) txDsp->insertChildWidget(-1, m_clientChainApplet);
-    makeChildContainer("ceq",   "CEQ",   m_clientEqApplet,    -1);
-    makeChildContainer("cmp",   "CMP",   m_clientCompApplet,  -1);
+    makeChildContainer("gate",  "GATE",  m_clientGateApplet,   -1);
+    makeChildContainer("ceq",   "CEQ",   m_clientEqApplet,     -1);
+    makeChildContainer("dess",  "DESS",  m_clientDeEssApplet,  -1);
+    makeChildContainer("cmp",   "CMP",   m_clientCompApplet,   -1);
+    makeChildContainer("tube",  "TUBE",  m_clientTubeApplet,   -1);
+    makeChildContainer("pudu",  "PUDU",  m_clientPuduApplet,   -1);
 
     // One-shot settings migration (#1713 Phase 4b): carry over the
     // legacy Applet_CHAIN visibility to the new Applet_TXDSP key so

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -28,6 +28,10 @@ class PhoneApplet;
 class EqApplet;
 class ClientEqApplet;
 class ClientCompApplet;
+class ClientGateApplet;
+class ClientDeEssApplet;
+class ClientTubeApplet;
+class ClientPuduApplet;
 class ClientChainApplet;
 class CatControlApplet;
 class DaxApplet;
@@ -62,6 +66,10 @@ public:
     EqApplet*       eqApplet()       { return m_eqApplet; }
     ClientEqApplet* clientEqApplet() { return m_clientEqApplet; }
     ClientCompApplet* clientCompApplet() { return m_clientCompApplet; }
+    ClientGateApplet* clientGateApplet() { return m_clientGateApplet; }
+    ClientDeEssApplet* clientDeEssApplet() { return m_clientDeEssApplet; }
+    ClientTubeApplet* clientTubeApplet() { return m_clientTubeApplet; }
+    ClientPuduApplet* clientPuduApplet() { return m_clientPuduApplet; }
     ClientChainApplet* clientChainApplet() { return m_clientChainApplet; }
     CatControlApplet* catControlApplet() { return m_catControlApplet; }
     DaxApplet*      daxApplet()      { return m_daxApplet; }
@@ -144,6 +152,10 @@ private:
     EqApplet*      m_eqApplet{nullptr};
     ClientEqApplet* m_clientEqApplet{nullptr};
     ClientCompApplet* m_clientCompApplet{nullptr};
+    ClientGateApplet* m_clientGateApplet{nullptr};
+    ClientDeEssApplet* m_clientDeEssApplet{nullptr};
+    ClientTubeApplet* m_clientTubeApplet{nullptr};
+    ClientPuduApplet* m_clientPuduApplet{nullptr};
     ClientChainApplet* m_clientChainApplet{nullptr};
     CatControlApplet* m_catControlApplet{nullptr};
     DaxApplet*     m_daxApplet{nullptr};

--- a/src/gui/ClientChainApplet.cpp
+++ b/src/gui/ClientChainApplet.cpp
@@ -1,10 +1,81 @@
 #include "ClientChainApplet.h"
 #include "ClientChainWidget.h"
+#include "core/ClientComp.h"
+#include "core/ClientDeEss.h"
+#include "core/ClientEq.h"
+#include "core/ClientGate.h"
+#include "core/ClientPudu.h"
+#include "core/ClientTube.h"
 
+#include <QButtonGroup>
+#include <QHBoxLayout>
 #include <QLabel>
+#include <QPushButton>
+#include <QSignalBlocker>
+#include <QTimer>
 #include <QVBoxLayout>
 
 namespace AetherSDR {
+
+namespace {
+
+// TX / RX mode-select buttons — checkable, part of an exclusive
+// group.  Checked state uses the amber PooDoo colour so the active
+// chain reads at a glance.
+const QString kModeBtnStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #2a4458; border-radius: 3px;"
+    "  color: #8aa8c0; font-size: 10px; font-weight: bold;"
+    "  padding: 2px 10px; min-width: 30px;"
+    "}"
+    "QPushButton:hover { background: #24384e; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e; color: #f2c14e; border: 1px solid #f2c14e;"
+    "}");
+
+// PUDU monitor icon buttons — modelled on VfoWidget's per-slice
+// record/play buttons (see src/gui/VfoWidget.cpp:414-454).  20x20,
+// rounded, unicode glyphs.  Pulsing is a 500 ms tick toggling
+// dim/bright via re-applied stylesheet.
+constexpr const char* kMonBtnBase =
+    "QPushButton { background: rgba(255,255,255,15); border: none; "
+    " border-radius: 10px; font-size: 11px; padding: 0; }"
+    "QPushButton:hover:enabled { background: rgba(255,255,255,40); }"
+    "QPushButton:disabled { color: #303030; "
+    " background: rgba(255,255,255,5); }";
+
+// Style fragments per state for the record/play buttons.  Idle red
+// is dimmed; active red is bright + filled.  Pulse alternates between
+// two levels.  Play mirrors with green colours.
+constexpr const char* kMonRecIdle  =
+    "QPushButton:enabled { color: #804040; }";
+constexpr const char* kMonRecActiveBright =
+    " color: #ff2020; background: rgba(255,50,50,60);";
+constexpr const char* kMonRecActiveDim =
+    " color: #601010; background: rgba(255,50,50,20);";
+constexpr const char* kMonPlayIdle =
+    "QPushButton:enabled { color: #406040; }";
+constexpr const char* kMonPlayActiveBright =
+    " color: #30d050; background: rgba(50,200,80,60);";
+constexpr const char* kMonPlayActiveDim =
+    " color: #103010; background: rgba(50,200,80,20);";
+
+// BYPASS — checkable toggle.  Idle: muted amber.  Checked: saturated
+// amber border + fill so an active bypass can't be missed.
+const QString kBypassBtnStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #4a3020; border-radius: 3px;"
+    "  color: #c8a070; font-size: 10px; font-weight: bold;"
+    "  padding: 2px 10px;"
+    "}"
+    "QPushButton:hover { background: #3a2818; color: #f2c14e;"
+    "                    border: 1px solid #f2c14e; }"
+    "QPushButton:checked {"
+    "  background: #4a3818; color: #f2c14e; border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #5a4a28; }");
+
+} // namespace
 
 ClientChainApplet::ClientChainApplet(QWidget* parent) : QWidget(parent)
 {
@@ -12,36 +83,360 @@ ClientChainApplet::ClientChainApplet(QWidget* parent) : QWidget(parent)
 
     auto* outer = new QVBoxLayout(this);
     outer->setContentsMargins(4, 4, 4, 4);
-    outer->setSpacing(2);
+    outer->setSpacing(4);
 
-    auto* hint = new QLabel(
-        "Click to edit · drag to reorder · right-click to bypass");
-    hint->setStyleSheet(
-        "QLabel { color: #607888; font-size: 9px;"
-        " background: transparent; border: none; }");
-    hint->setWordWrap(false);
-    outer->addWidget(hint);
+    // ── Header: TX | RX | BYPASS ────────────────────────────────
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(4);
 
+        auto* group = new QButtonGroup(this);
+        group->setExclusive(true);
+
+        m_txBtn = new QPushButton("TX");
+        m_txBtn->setCheckable(true);
+        m_txBtn->setStyleSheet(kModeBtnStyle);
+        m_txBtn->setFixedHeight(22);
+        m_txBtn->setToolTip("Show and edit the TX DSP chain");
+        m_txBtn->setChecked(true);
+        group->addButton(m_txBtn, static_cast<int>(ChainMode::Tx));
+        row->addWidget(m_txBtn);
+
+        m_rxBtn = new QPushButton("RX");
+        m_rxBtn->setCheckable(true);
+        m_rxBtn->setStyleSheet(kModeBtnStyle);
+        m_rxBtn->setFixedHeight(22);
+        m_rxBtn->setToolTip("Show and edit the RX DSP chain (coming soon)");
+        group->addButton(m_rxBtn, static_cast<int>(ChainMode::Rx));
+        row->addWidget(m_rxBtn);
+
+        // ── PUDU monitor buttons (right of the mode toggles) ────
+        // Small icon buttons for record/playback of the post-PUDU
+        // TX audio.  Separate from the mode toggles so the visual
+        // grouping stays intact.
+        row->addSpacing(6);
+
+        m_monRecBtn = new QPushButton(QString::fromUtf8("\xe2\x8f\xba"));   // ⏺
+        m_monRecBtn->setCheckable(true);
+        m_monRecBtn->setFixedSize(20, 20);
+        m_monRecBtn->setEnabled(false);
+        m_monRecBtn->setToolTip(
+            "Record up to 30 s of post-PooDoo™ TX audio (MIC must be set "
+            "to PC and DAX off).  Click again to stop; playback starts "
+            "automatically.");
+        connect(m_monRecBtn, &QPushButton::clicked, this, [this]() {
+            emit monitorRecordClicked();
+        });
+        row->addWidget(m_monRecBtn);
+
+        m_monPlayBtn = new QPushButton(QString::fromUtf8("\xe2\x96\xb6")); // ▶
+        m_monPlayBtn->setCheckable(true);
+        m_monPlayBtn->setFixedSize(20, 20);
+        m_monPlayBtn->setEnabled(false);
+        m_monPlayBtn->setToolTip(
+            "Play back the captured PooDoo™ audio.  Click again to "
+            "cancel playback.");
+        connect(m_monPlayBtn, &QPushButton::clicked, this, [this]() {
+            emit monitorPlayClicked();
+        });
+        row->addWidget(m_monPlayBtn);
+
+        // Pulse timers — lazy-start so idle buttons don't tick.
+        m_monRecPulse = new QTimer(this);
+        m_monRecPulse->setInterval(500);
+        connect(m_monRecPulse, &QTimer::timeout, this, [this]() {
+            m_monRecPulseDim = !m_monRecPulseDim;
+            applyRecordButtonStyle();
+        });
+        m_monPlayPulse = new QTimer(this);
+        m_monPlayPulse->setInterval(500);
+        connect(m_monPlayPulse, &QTimer::timeout, this, [this]() {
+            m_monPlayPulseDim = !m_monPlayPulseDim;
+            applyPlayButtonStyle();
+        });
+
+        applyRecordButtonStyle();
+        applyPlayButtonStyle();
+
+        row->addStretch();
+
+        m_bypassBtn = new QPushButton("BYPASS");
+        m_bypassBtn->setCheckable(true);
+        m_bypassBtn->setStyleSheet(kBypassBtnStyle);
+        m_bypassBtn->setFixedHeight(22);
+        m_bypassBtn->setToolTip(
+            "Disable every stage in the selected chain.  Click again "
+            "to restore the stages that were on before.");
+        connect(m_bypassBtn, &QPushButton::toggled,
+                this, &ClientChainApplet::onBypassToggled);
+        row->addWidget(m_bypassBtn);
+
+        connect(group, &QButtonGroup::idToggled, this,
+                [this](int id, bool checked) {
+            if (checked) setMode(static_cast<ChainMode>(id));
+        });
+
+        outer->addLayout(row);
+    }
+
+    // ── Chain strip (TX) + RX placeholder, stacked — only one visible
     m_chain = new ClientChainWidget;
     outer->addWidget(m_chain);
+
+    m_rxPlaceholder = new QLabel("Client RX chain — coming in a future phase");
+    m_rxPlaceholder->setAlignment(Qt::AlignCenter);
+    m_rxPlaceholder->setStyleSheet(
+        "QLabel { color: #607888; font-size: 10px; font-style: italic;"
+        "         background: #0e1b28; border: 1px dashed #243a4e;"
+        "         border-radius: 3px; padding: 14px; }");
+    m_rxPlaceholder->hide();
+    outer->addWidget(m_rxPlaceholder);
+
+    // ── Hint (below the chain) ──────────────────────────────────
+    m_hint = new QLabel(
+        "Click to edit · drag to reorder · right-click to bypass");
+    m_hint->setStyleSheet(
+        "QLabel { color: #607888; font-size: 9px;"
+        " background: transparent; border: none; }");
+    m_hint->setWordWrap(false);
+    outer->addWidget(m_hint);
 
     connect(m_chain, &ClientChainWidget::editRequested,
             this, &ClientChainApplet::editRequested);
     connect(m_chain, &ClientChainWidget::stageEnabledChanged,
             this, &ClientChainApplet::stageEnabledChanged);
-    // chainReordered is informational; the widget already pushed the
-    // new order to the engine.  No-op here for now.
 
     hide();  // hidden until toggled on from the applet tray
 }
 
 void ClientChainApplet::setAudioEngine(AudioEngine* engine)
 {
+    m_audio = engine;
     if (m_chain) m_chain->setAudioEngine(engine);
 }
 
 void ClientChainApplet::refreshFromEngine()
 {
+    if (m_chain) m_chain->update();
+}
+
+void ClientChainApplet::setMicInputReady(bool ready)
+{
+    if (m_chain) m_chain->setMicInputReady(ready);
+    m_micReady = ready;
+    updateMonitorButtonEnables();
+}
+
+void ClientChainApplet::setMonitorRecording(bool on)
+{
+    if (m_monRecording == on) return;
+    m_monRecording = on;
+    if (m_monRecBtn) {
+        QSignalBlocker b(m_monRecBtn);
+        m_monRecBtn->setChecked(on);
+    }
+    if (on) {
+        m_monRecPulseDim = false;
+        if (m_monRecPulse) m_monRecPulse->start();
+    } else if (m_monRecPulse) {
+        m_monRecPulse->stop();
+    }
+    applyRecordButtonStyle();
+    updateMonitorButtonEnables();
+}
+
+void ClientChainApplet::setMonitorPlaying(bool on)
+{
+    if (m_monPlaying == on) return;
+    m_monPlaying = on;
+    if (m_monPlayBtn) {
+        QSignalBlocker b(m_monPlayBtn);
+        m_monPlayBtn->setChecked(on);
+    }
+    if (on) {
+        m_monPlayPulseDim = false;
+        if (m_monPlayPulse) m_monPlayPulse->start();
+    } else if (m_monPlayPulse) {
+        m_monPlayPulse->stop();
+    }
+    applyPlayButtonStyle();
+    updateMonitorButtonEnables();
+}
+
+void ClientChainApplet::setMonitorHasRecording(bool has)
+{
+    if (m_monHasRecording == has) return;
+    m_monHasRecording = has;
+    updateMonitorButtonEnables();
+}
+
+void ClientChainApplet::applyRecordButtonStyle()
+{
+    if (!m_monRecBtn) return;
+    QString style = kMonBtnBase;
+    if (m_monRecording) {
+        style += "QPushButton { ";
+        style += m_monRecPulseDim ? kMonRecActiveDim : kMonRecActiveBright;
+        style += " }";
+    } else {
+        style += kMonRecIdle;
+    }
+    m_monRecBtn->setStyleSheet(style);
+}
+
+void ClientChainApplet::applyPlayButtonStyle()
+{
+    if (!m_monPlayBtn) return;
+    QString style = kMonBtnBase;
+    if (m_monPlaying) {
+        style += "QPushButton { ";
+        style += m_monPlayPulseDim ? kMonPlayActiveDim : kMonPlayActiveBright;
+        style += " }";
+    } else {
+        style += kMonPlayIdle;
+    }
+    m_monPlayBtn->setStyleSheet(style);
+}
+
+void ClientChainApplet::updateMonitorButtonEnables()
+{
+    // Record: enabled when MIC is ready AND we're not mid-playback.
+    //   - While recording, stays enabled so the user can click it to
+    //     stop (the button itself is the stop target).
+    // Play: enabled when we have a recording AND we're not mid-record.
+    //   - While playing, stays enabled so the user can click to cancel.
+    if (m_monRecBtn) {
+        const bool en = m_monRecording
+            || (m_micReady && !m_monPlaying);
+        m_monRecBtn->setEnabled(en);
+    }
+    if (m_monPlayBtn) {
+        const bool en = m_monPlaying
+            || (m_monHasRecording && !m_monRecording);
+        m_monPlayBtn->setEnabled(en);
+    }
+}
+
+void ClientChainApplet::setTxActive(bool active)
+{
+    if (m_chain) m_chain->setTxActive(active);
+}
+
+void ClientChainApplet::setMode(ChainMode m)
+{
+    if (m == m_mode) return;
+    m_mode = m;
+
+    const bool tx = (m == ChainMode::Tx);
+    if (m_chain)          m_chain->setVisible(tx);
+    if (m_rxPlaceholder)  m_rxPlaceholder->setVisible(!tx);
+    // Hint text only makes sense for TX since that's the only
+    // interactive chain today.
+    if (m_hint)           m_hint->setVisible(tx);
+}
+
+void ClientChainApplet::onBypassToggled(bool checked)
+{
+    if (!m_audio) return;
+    if (m_mode != ChainMode::Tx) {
+        // RX mode: no DSP yet.  Leave the button in whatever state
+        // the user clicked — it's a no-op until the RX chain ships.
+        return;
+    }
+
+    // Dispatch on stage so we can route to the right engine getter
+    // and settings-save function in one place.  Returns true if the
+    // stage is currently enabled.
+    auto setStageEnabled = [&](AudioEngine::TxChainStage stage, bool on) {
+        switch (stage) {
+            case AudioEngine::TxChainStage::Eq:
+                if (auto* d = m_audio->clientEqTx()) {
+                    d->setEnabled(on);
+                    m_audio->saveClientEqSettings();
+                }
+                break;
+            case AudioEngine::TxChainStage::Comp:
+                if (auto* d = m_audio->clientCompTx()) {
+                    d->setEnabled(on);
+                    m_audio->saveClientCompSettings();
+                }
+                break;
+            case AudioEngine::TxChainStage::Gate:
+                if (auto* d = m_audio->clientGateTx()) {
+                    d->setEnabled(on);
+                    m_audio->saveClientGateSettings();
+                }
+                break;
+            case AudioEngine::TxChainStage::DeEss:
+                if (auto* d = m_audio->clientDeEssTx()) {
+                    d->setEnabled(on);
+                    m_audio->saveClientDeEssSettings();
+                }
+                break;
+            case AudioEngine::TxChainStage::Tube:
+                if (auto* d = m_audio->clientTubeTx()) {
+                    d->setEnabled(on);
+                    m_audio->saveClientTubeSettings();
+                }
+                break;
+            case AudioEngine::TxChainStage::Enh:   // PUDU slot
+                if (auto* d = m_audio->clientPuduTx()) {
+                    d->setEnabled(on);
+                    m_audio->saveClientPuduSettings();
+                }
+                break;
+            case AudioEngine::TxChainStage::None:
+                break;
+        }
+        emit stageEnabledChanged(stage, on);
+    };
+
+    auto isEnabled = [&](AudioEngine::TxChainStage stage) {
+        switch (stage) {
+            case AudioEngine::TxChainStage::Eq:
+                return m_audio->clientEqTx() && m_audio->clientEqTx()->isEnabled();
+            case AudioEngine::TxChainStage::Comp:
+                return m_audio->clientCompTx() && m_audio->clientCompTx()->isEnabled();
+            case AudioEngine::TxChainStage::Gate:
+                return m_audio->clientGateTx() && m_audio->clientGateTx()->isEnabled();
+            case AudioEngine::TxChainStage::DeEss:
+                return m_audio->clientDeEssTx() && m_audio->clientDeEssTx()->isEnabled();
+            case AudioEngine::TxChainStage::Tube:
+                return m_audio->clientTubeTx() && m_audio->clientTubeTx()->isEnabled();
+            case AudioEngine::TxChainStage::Enh:
+                return m_audio->clientPuduTx() && m_audio->clientPuduTx()->isEnabled();
+            case AudioEngine::TxChainStage::None:
+                return false;
+        }
+        return false;
+    };
+
+    static const QVector<AudioEngine::TxChainStage> kAllStages{
+        AudioEngine::TxChainStage::Eq,
+        AudioEngine::TxChainStage::Comp,
+        AudioEngine::TxChainStage::Gate,
+        AudioEngine::TxChainStage::DeEss,
+        AudioEngine::TxChainStage::Tube,
+        AudioEngine::TxChainStage::Enh,
+    };
+
+    if (checked) {
+        // Snapshot whatever was on, then kill them all.
+        m_bypassSnapshot.clear();
+        for (auto s : kAllStages) {
+            if (isEnabled(s)) {
+                m_bypassSnapshot.append(s);
+                setStageEnabled(s, false);
+            }
+        }
+    } else {
+        // Restore only the stages we had on before.  If the user
+        // flipped anything on manually while bypass was active,
+        // those survive here because they're not in the snapshot.
+        for (auto s : m_bypassSnapshot) setStageEnabled(s, true);
+        m_bypassSnapshot.clear();
+    }
+
     if (m_chain) m_chain->update();
 }
 

--- a/src/gui/ClientChainApplet.h
+++ b/src/gui/ClientChainApplet.h
@@ -4,38 +4,99 @@
 
 #include <QWidget>
 
+class QLabel;
+class QPushButton;
+
 namespace AetherSDR {
 
 class ClientChainWidget;
 
-// Docked "CHAIN" tile — wraps ClientChainWidget with the applet chrome
-// so the TX DSP chain appears in the applet tray alongside CEQ and
-// CMP.  Clicking a stage opens its editor (signal forwarded to
-// MainWindow); dragging reorders the chain in place.
+// Docked chain tile — header with [TX] [RX] [BYPASS] buttons, the
+// chain strip, and an interaction hint at the bottom.
+//
+// TX and RX buttons form an exclusive pair that selects which chain
+// the widget displays.  TX is the working client-side DSP chain
+// (six stages, all implemented).  RX is reserved for the future
+// client-side RX DSP chain — until then, switching to RX shows a
+// placeholder.
+//
+// BYPASS is a one-click action that disables every stage in the
+// currently-selected chain.  Users re-enable individual stages via
+// the chain widget's right-click menu or the per-stage applet tiles.
 class ClientChainApplet : public QWidget {
     Q_OBJECT
 
 public:
+    enum class ChainMode { Tx, Rx };
+
     explicit ClientChainApplet(QWidget* parent = nullptr);
 
     void setAudioEngine(AudioEngine* engine);
-
-    // Call after any external change to TX DSP state (e.g. the user
-    // toggled bypass from a floating editor) so the chain strip
-    // repaints with the new bypass state.
     void refreshFromEngine();
 
-signals:
-    // Forwarded from the internal widget — MainWindow maps each stage
-    // to the corresponding editor.
-    void editRequested(AudioEngine::TxChainStage stage);
+    // Forwarded to the internal chain widget — see ClientChainWidget::
+    // setMicInputReady.  MainWindow calls this whenever TransmitModel
+    // reports a mic-state change (which covers both mic source and DAX
+    // on/off).  Also drives the record button's enable state — no
+    // audio to capture when the chain isn't in the signal path.
+    void setMicInputReady(bool ready);
 
-    // Forwarded — MainWindow uses this to show / hide the stage's
-    // applet tile in sync with its DSP bypass state.
+    // Forwarded — pulses the TX endpoint red when we're actively
+    // transmitting on our own slice.  Driven by TransmitModel::
+    // moxChanged from MainWindow.
+    void setTxActive(bool active);
+
+    // PUDU monitor state — MainWindow drives these from the monitor's
+    // state signals.  Each toggles button appearance, pulse, and the
+    // mutual-exclusion enable state of the other button.
+    void setMonitorRecording(bool on);
+    void setMonitorPlaying(bool on);
+    void setMonitorHasRecording(bool has);
+
+signals:
+    void editRequested(AudioEngine::TxChainStage stage);
     void stageEnabledChanged(AudioEngine::TxChainStage stage, bool enabled);
 
+    // User clicked the record or play button.  MainWindow decides
+    // whether this is a start or a stop based on current monitor
+    // state (click on a pulsing button = stop).
+    void monitorRecordClicked();
+    void monitorPlayClicked();
+
 private:
+    void setMode(ChainMode m);
+    // Click handler for the BYPASS toggle.  On check: records which
+    // TX stages are currently enabled, disables them all.  On uncheck:
+    // re-enables just the stages that were on before.  Manual changes
+    // between clicks are preserved only for stages not in the snapshot.
+    void onBypassToggled(bool checked);
+
+    // Applies the per-button stylesheet based on role + current state
+    // (idle/active/pulse-bright/pulse-dim/disabled).  Separate method
+    // so the pulse timer can call it cheaply at each tick.
+    void applyRecordButtonStyle();
+    void applyPlayButtonStyle();
+    void updateMonitorButtonEnables();
+
+    AudioEngine*       m_audio{nullptr};
     ClientChainWidget* m_chain{nullptr};
+    QLabel*            m_rxPlaceholder{nullptr};
+    QLabel*            m_hint{nullptr};
+    QPushButton*       m_txBtn{nullptr};
+    QPushButton*       m_rxBtn{nullptr};
+    QPushButton*       m_bypassBtn{nullptr};
+    QPushButton*       m_monRecBtn{nullptr};
+    QPushButton*       m_monPlayBtn{nullptr};
+    class QTimer*      m_monRecPulse{nullptr};
+    class QTimer*      m_monPlayPulse{nullptr};
+    bool               m_monRecPulseDim{false};
+    bool               m_monPlayPulseDim{false};
+    bool               m_monRecording{false};
+    bool               m_monPlaying{false};
+    bool               m_monHasRecording{false};
+    bool               m_micReady{false};
+    ChainMode          m_mode{ChainMode::Tx};
+    QVector<AudioEngine::TxChainStage> m_bypassSnapshot;  // stages that were on before BYPASS
 };
 
 } // namespace AetherSDR

--- a/src/gui/ClientChainWidget.cpp
+++ b/src/gui/ClientChainWidget.cpp
@@ -1,6 +1,10 @@
 #include "ClientChainWidget.h"
 #include "core/ClientComp.h"
 #include "core/ClientEq.h"
+#include "core/ClientGate.h"
+#include "core/ClientDeEss.h"
+#include "core/ClientTube.h"
+#include "core/ClientPudu.h"
 
 #include <QAction>
 #include <QContextMenuEvent>
@@ -16,6 +20,7 @@
 #include <QPainterPath>
 #include <QPaintEvent>
 #include <QPen>
+#include <QTimer>
 #include <QToolTip>
 #include <algorithm>
 #include <cmath>
@@ -54,6 +59,17 @@ const QColor kBgActive     ("#14253a");
 const QColor kBorderIdle   ("#2a3a4a");
 const QColor kBorderActive ("#4db8d4");
 const QColor kBorderGrey   ("#1e2a38");
+// MIC endpoint "ready" state — matches RxApplet's SQL-button green
+// so users recognise the visual language across the sidebar.
+const QColor kBgMicReady   ("#006040");
+const QColor kBorderMicReady("#00a060");
+const QColor kTextMicReady ("#00ff88");
+// TX endpoint "active" state — red, pulsing via setTxActive().
+// Two shades lerped by the pulse factor give a breathing effect.
+const QColor kBgTxActiveDim ("#3a1010");
+const QColor kBgTxActiveHot ("#c03030");
+const QColor kBorderTxActive("#ff4040");
+const QColor kTextTxActive  ("#ff9090");
 const QColor kConnector    ("#2a3a4a");
 const QColor kTextLabel    ("#c8d8e8");
 const QColor kTextDim      ("#506070");
@@ -71,7 +87,7 @@ QString stageLabel(AudioEngine::TxChainStage s)
         case AudioEngine::TxChainStage::DeEss: return "DESS";
         case AudioEngine::TxChainStage::Comp:  return "COMP";
         case AudioEngine::TxChainStage::Tube:  return "TUBE";
-        case AudioEngine::TxChainStage::Enh:   return "ENH";
+        case AudioEngine::TxChainStage::Enh:   return "PUDU";
         case AudioEngine::TxChainStage::None:  return "";
     }
     return "";
@@ -97,12 +113,47 @@ void ClientChainWidget::setAudioEngine(AudioEngine* engine)
     update();
 }
 
+void ClientChainWidget::setMicInputReady(bool ready)
+{
+    if (m_micInputReady == ready) return;
+    m_micInputReady = ready;
+    update();
+}
+
+void ClientChainWidget::setTxActive(bool active)
+{
+    if (m_txActive == active) return;
+    m_txActive = active;
+    if (active) {
+        // Lazy-create the pulse timer once, then keep it for reuse.
+        if (!m_txPulseTimer) {
+            m_txPulseTimer = new QTimer(this);
+            m_txPulseTimer->setInterval(33);   // ~30 fps
+            m_txPulseTimer->setTimerType(Qt::PreciseTimer);
+            connect(m_txPulseTimer, &QTimer::timeout, this, [this]() {
+                m_txPulsePhase += 0.033f;       // seconds per tick
+                update();
+            });
+        }
+        m_txPulsePhase = 0.0f;
+        m_txPulseTimer->start();
+    } else if (m_txPulseTimer) {
+        m_txPulseTimer->stop();
+    }
+    update();
+}
+
 bool ClientChainWidget::isStageImplemented(AudioEngine::TxChainStage s) const
 {
-    // Only EQ and Comp have DSP today; Gate / DeEss / Tube / Enh are
-    // placeholders (no-op pass-through in applyClientTxDsp).
+    // All six TX DSP stages are now implemented.  The Enh slot hosts
+    // the PUDU exciter (Phase 5) — the enum name is legacy; the
+    // user-facing label is PUDU (see stageLabel above).
     return s == AudioEngine::TxChainStage::Eq
-        || s == AudioEngine::TxChainStage::Comp;
+        || s == AudioEngine::TxChainStage::Comp
+        || s == AudioEngine::TxChainStage::Gate
+        || s == AudioEngine::TxChainStage::DeEss
+        || s == AudioEngine::TxChainStage::Tube
+        || s == AudioEngine::TxChainStage::Enh;
 }
 
 bool ClientChainWidget::isStageBypassed(AudioEngine::TxChainStage s) const
@@ -113,8 +164,16 @@ bool ClientChainWidget::isStageBypassed(AudioEngine::TxChainStage s) const
             return !(m_audio->clientEqTx() && m_audio->clientEqTx()->isEnabled());
         case AudioEngine::TxChainStage::Comp:
             return !(m_audio->clientCompTx() && m_audio->clientCompTx()->isEnabled());
+        case AudioEngine::TxChainStage::Gate:
+            return !(m_audio->clientGateTx() && m_audio->clientGateTx()->isEnabled());
+        case AudioEngine::TxChainStage::DeEss:
+            return !(m_audio->clientDeEssTx() && m_audio->clientDeEssTx()->isEnabled());
+        case AudioEngine::TxChainStage::Tube:
+            return !(m_audio->clientTubeTx() && m_audio->clientTubeTx()->isEnabled());
+        case AudioEngine::TxChainStage::Enh:   // PUDU slot
+            return !(m_audio->clientPuduTx() && m_audio->clientPuduTx()->isEnabled());
         default:
-            return true;   // unimplemented stages read as bypassed
+            return true;
     }
 }
 
@@ -352,11 +411,43 @@ void ClientChainWidget::paintEvent(QPaintEvent*)
         const bool lastEndpoint  = (i == m_boxes.size() - 1);
 
         if (b.isEndpoint) {
-            // MIC / TX sinks.
-            p.setBrush(kBgEndpoint);
-            p.setPen(QPen(kBorderGrey, 1.0));
+            // MIC / TX sinks.  Colour treatment depends on which
+            // endpoint + current state:
+            //   MIC + ready    → SQL-green (routed through PooDoo)
+            //   TX  + tx active → pulsing red (1 Hz sine breathing)
+            //   otherwise      → dim endpoint grey
+            const bool micReady = firstEndpoint && m_micInputReady;
+            const bool txActive = lastEndpoint && m_txActive;
+
+            QBrush bodyBrush(kBgEndpoint);
+            QColor borderCol = kBorderGrey;
+            QColor textCol   = kTextLabel;
+
+            if (micReady) {
+                bodyBrush = kBgMicReady;
+                borderCol = kBorderMicReady;
+                textCol   = kTextMicReady;
+            } else if (txActive) {
+                // Smooth 1 Hz breathing: pulse factor sweeps
+                // sin(2πt) rescaled to 0..1.  Lerp the body fill
+                // between dim-red and hot-red so it "glows."
+                const float pulse = 0.5f + 0.5f *
+                    std::sin(m_txPulsePhase * 2.0f * 3.14159265f);
+                const int r = static_cast<int>(kBgTxActiveDim.red()   +
+                    pulse * (kBgTxActiveHot.red()   - kBgTxActiveDim.red()));
+                const int g = static_cast<int>(kBgTxActiveDim.green() +
+                    pulse * (kBgTxActiveHot.green() - kBgTxActiveDim.green()));
+                const int bl = static_cast<int>(kBgTxActiveDim.blue() +
+                    pulse * (kBgTxActiveHot.blue()  - kBgTxActiveDim.blue()));
+                bodyBrush = QColor(r, g, bl);
+                borderCol = kBorderTxActive;
+                textCol   = kTextTxActive;
+            }
+
+            p.setBrush(bodyBrush);
+            p.setPen(QPen(borderCol, 1.0));
             p.drawRoundedRect(b.rect, kRadius, kRadius);
-            p.setPen(kTextLabel);
+            p.setPen(textCol);
             p.drawText(b.rect, Qt::AlignCenter,
                        firstEndpoint ? "MIC" : (lastEndpoint ? "TX" : ""));
             continue;
@@ -517,6 +608,18 @@ void ClientChainWidget::contextMenuEvent(QContextMenuEvent* ev)
         } else if (stage == AudioEngine::TxChainStage::Comp && m_audio->clientCompTx()) {
             m_audio->clientCompTx()->setEnabled(newEnabled);
             m_audio->saveClientCompSettings();
+        } else if (stage == AudioEngine::TxChainStage::Gate && m_audio->clientGateTx()) {
+            m_audio->clientGateTx()->setEnabled(newEnabled);
+            m_audio->saveClientGateSettings();
+        } else if (stage == AudioEngine::TxChainStage::DeEss && m_audio->clientDeEssTx()) {
+            m_audio->clientDeEssTx()->setEnabled(newEnabled);
+            m_audio->saveClientDeEssSettings();
+        } else if (stage == AudioEngine::TxChainStage::Tube && m_audio->clientTubeTx()) {
+            m_audio->clientTubeTx()->setEnabled(newEnabled);
+            m_audio->saveClientTubeSettings();
+        } else if (stage == AudioEngine::TxChainStage::Enh && m_audio->clientPuduTx()) {
+            m_audio->clientPuduTx()->setEnabled(newEnabled);
+            m_audio->saveClientPuduSettings();
         }
         emit stageEnabledChanged(stage, newEnabled);
         update();

--- a/src/gui/ClientChainWidget.h
+++ b/src/gui/ClientChainWidget.h
@@ -30,6 +30,20 @@ public:
     // safe — the widget renders the chain grey until bound.
     void setAudioEngine(AudioEngine* engine);
 
+    // Visual indicator for whether the user's TX input is routed to
+    // the client-side DSP chain.  Required for PooDoo Audio to
+    // actually shape what goes out: mic source = PC AND radio DAX
+    // TX is off.  When true, the MIC endpoint box turns green —
+    // matches the SQL-button green in RxApplet — telling the user
+    // "your setup is actually going through PooDoo."
+    void setMicInputReady(bool ready);
+
+    // Pulse the TX endpoint red when we are actively transmitting
+    // on our own slice.  Filtered upstream (TransmitModel only sets
+    // isTransmitting() true when m_txOwnedByUs is true), so MultiFlex
+    // transmissions from other clients don't trigger the pulse.
+    void setTxActive(bool active);
+
 signals:
     // Fired when the user clicks a processor stage.  MainWindow maps
     // the stage to the correct editor and opens it.  Endpoint
@@ -79,6 +93,10 @@ private:
     bool isStageBypassed(AudioEngine::TxChainStage s) const;
 
     AudioEngine* m_audio{nullptr};
+    bool         m_micInputReady{false};
+    bool         m_txActive{false};
+    class QTimer* m_txPulseTimer{nullptr};
+    float        m_txPulsePhase{0.0f};   // seconds since pulse start
 
     // Drag state — tracks the press point and the drag target once
     // the mouse has moved far enough to distinguish click from drag.

--- a/src/gui/ClientCompKnob.cpp
+++ b/src/gui/ClientCompKnob.cpp
@@ -1,5 +1,6 @@
 #include "ClientCompKnob.h"
 
+#include <QFontMetrics>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPainterPath>
@@ -70,6 +71,13 @@ void ClientCompKnob::setLabelFormat(LabelFormat fmt)
     update();
 }
 
+void ClientCompKnob::setCenterLabelMode(bool on)
+{
+    if (m_centerLabel == on) return;
+    m_centerLabel = on;
+    update();
+}
+
 void ClientCompKnob::setValue(float physical)
 {
     m_physical = std::clamp(physical, m_minPhys, m_maxPhys);
@@ -107,16 +115,42 @@ void ClientCompKnob::paintEvent(QPaintEvent*)
 
     const int w = width();
     const int h = height();
-    const int diameter = std::min(w - 4, h - 24);  // leave room for text rows
-    const QRectF ring((w - diameter) * 0.5f, 12.0f, diameter, diameter);
+    // Center-label mode reclaims the 12-px label row above the ring.
+    // The ring uses almost all remaining height — the 270° arc sweep
+    // (225° → -45°) leaves a 90° gap at the bottom (4:30 → 7:30),
+    // which is where the value readout lives.  Reserving a separate
+    // "row" below the ring creates a visible gap; overlapping the
+    // empty arc sector keeps the readout snug against the knob.
+    const int topRow    = m_centerLabel ?  0 : 12;
+    const int bottomRow = 4;
+    const int diameter  = std::min(w - 4, h - topRow - bottomRow);
+    const QRectF ring((w - diameter) * 0.5f,
+                      static_cast<float>(topRow),
+                      diameter, diameter);
 
-    // Label (above the ring).
+    // Label — above the ring in classic mode, centred inside the
+    // ring in center-label mode.  Centred text is rendered AFTER
+    // the arc + pointer so it reads on top cleanly.
     QFont labelFont = p.font();
     labelFont.setPixelSize(9);
     labelFont.setBold(true);
-    p.setFont(labelFont);
-    p.setPen(kLabelColor);
-    p.drawText(QRectF(0, 0, w, 12), Qt::AlignCenter, m_label);
+    if (!m_centerLabel) {
+        // Shrink-to-fit: longer labels ("Threshold", "Release") on
+        // narrow knobs would otherwise truncate with "..." — scale
+        // the font down in 1-px steps until the rendered width fits
+        // the widget, floor at 7 px.
+        int pixelSize = 9;
+        QFontMetrics fm(labelFont);
+        const float maxWidth = std::max(8.0f, static_cast<float>(w) - 2.0f);
+        while (fm.horizontalAdvance(m_label) > maxWidth && pixelSize > 7) {
+            --pixelSize;
+            labelFont.setPixelSize(pixelSize);
+            fm = QFontMetrics(labelFont);
+        }
+        p.setFont(labelFont);
+        p.setPen(kLabelColor);
+        p.drawText(QRectF(0, 0, w, 12), Qt::AlignCenter, m_label);
+    }
 
     // Background ring.
     const qreal thick = std::max(2.0, diameter * 0.10);
@@ -152,13 +186,48 @@ void ClientCompKnob::paintEvent(QPaintEvent*)
     p.setPen(pointerPen);
     p.drawLine(pIn, pOut);
 
-    // Value text beneath the ring.
+    // Center-label mode: draw the parameter name centred inside the
+    // ring.  Start at 25 % of diameter (good for 3-4 letter labels),
+    // then shrink-to-fit if the word is longer — keeps "Threshold",
+    // "Release" etc. from spilling past the arc on small knobs.
+    if (m_centerLabel && !m_label.isEmpty()) {
+        QFont centerFont = p.font();
+        centerFont.setBold(true);
+        int pixelSize = std::max(8, diameter / 4);
+        centerFont.setPixelSize(pixelSize);
+
+        // Max text width is the knob interior, less a ring-thickness
+        // pad on each side so text never kisses the arc.
+        const float maxTextWidth = std::max(
+            8.0f,
+            static_cast<float>(diameter) - 4.0f * static_cast<float>(thick));
+        QFontMetrics fm(centerFont);
+        while (fm.horizontalAdvance(m_label) > maxTextWidth
+               && pixelSize > 7) {
+            --pixelSize;
+            centerFont.setPixelSize(pixelSize);
+            fm = QFontMetrics(centerFont);
+        }
+
+        p.setFont(centerFont);
+        p.setPen(kLabelColor);
+        p.drawText(ring, Qt::AlignCenter, m_label);
+    }
+
+    // Value text — positioned inside the empty bottom sector of the
+    // 270° arc (between the 4:30 and 7:30 sweep endpoints).  The
+    // sector starts at y = ring_center + arc_radius * sin(45°),
+    // which works out to ~82 % of the diameter from the ring top.
     QFont valFont = p.font();
-    valFont.setPixelSize(9);
+    valFont.setPixelSize(11);
     valFont.setBold(false);
     p.setFont(valFont);
     p.setPen(kValueColor);
-    p.drawText(QRectF(0, h - 12, w, 12), Qt::AlignCenter, formatValue());
+    const int valueY = topRow + static_cast<int>(diameter * 0.82f);
+    const int valueH = std::max(13, h - valueY);
+    p.drawText(QRectF(0, valueY, w, valueH),
+               Qt::AlignHCenter | Qt::AlignTop,
+               formatValue());
 }
 
 void ClientCompKnob::mousePressEvent(QMouseEvent* ev)

--- a/src/gui/ClientCompKnob.h
+++ b/src/gui/ClientCompKnob.h
@@ -46,6 +46,13 @@ public:
     using LabelFormat = std::function<QString(float)>;
     void setLabelFormat(LabelFormat fmt);
 
+    // Center-label mode — draws the parameter label INSIDE the knob
+    // ring instead of above it.  Used by the PUDU applet/editor to
+    // fit 6 knobs on one row without the label row above eating
+    // vertical space.  The value readout still lives below.
+    void setCenterLabelMode(bool on);
+    bool isCenterLabelMode() const { return m_centerLabel; }
+
     // Programmatic setter — e.g. loadClientCompSettings on startup.
     void setValue(float physical);
     float value() const { return m_physical; }
@@ -78,6 +85,7 @@ private:
     bool        m_dragging{false};
     int         m_dragStartY{0};
     float       m_dragStartNorm{0.0f};
+    bool        m_centerLabel{false};
 };
 
 } // namespace AetherSDR

--- a/src/gui/ClientDeEssApplet.cpp
+++ b/src/gui/ClientDeEssApplet.cpp
@@ -1,0 +1,197 @@
+#include "ClientDeEssApplet.h"
+#include "ClientDeEssCurveWidget.h"
+#include "MeterSmoother.h"
+#include "core/AudioEngine.h"
+#include "core/ClientDeEss.h"
+
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QSignalBlocker>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QTimer>
+#include <QElapsedTimer>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+// GR mini-strip for the de-esser.  File-scope so the applet can hold
+// a typed pointer.  Max reduction ≤ 24 dB so scale the full bar to
+// that range.
+class ClientDeEssGrBar : public QWidget {
+public:
+    explicit ClientDeEssGrBar(QWidget* parent = nullptr) : QWidget(parent)
+    {
+        setFixedHeight(10);
+
+        m_animTimer.setTimerType(Qt::PreciseTimer);
+        m_animTimer.setInterval(kMeterSmootherIntervalMs);
+        connect(&m_animTimer, &QTimer::timeout, this, [this]() {
+            if (!m_smooth.tick(m_animElapsed.restart()))
+                m_animTimer.stop();
+            update();
+        });
+    }
+
+    void setGrDb(float grDb)
+    {
+        if (std::fabs(grDb - m_grDb) < 0.05f) return;
+        m_grDb = grDb;
+        constexpr float kMaxGr = 24.0f;
+        m_smooth.setTarget(std::clamp(-m_grDb, 0.0f, kMaxGr) / kMaxGr);
+        if (!m_smooth.needsAnimation()) {
+            if (m_animTimer.isActive()) m_animTimer.stop();
+            update();
+        } else if (!m_animTimer.isActive()) {
+            m_animElapsed.restart();
+            m_animTimer.start();
+        }
+    }
+
+protected:
+    void paintEvent(QPaintEvent*) override
+    {
+        QPainter p(this);
+        const QRectF r = rect();
+        p.fillRect(r, QColor("#0a1420"));
+        constexpr float kMaxGr = 24.0f;
+        const float frac = m_smooth.value();
+        if (frac > 0.0f) {
+            const float w = frac * r.width();
+            QRectF fill(r.right() - w, r.top() + 1.0, w, r.height() - 2.0);
+            p.fillRect(fill, QColor("#d47272"));   // soft red — matches curve
+        }
+        // -6 dB tick (typical amount)
+        const float tickX = r.right() - (6.0f / kMaxGr) * r.width();
+        p.setPen(QPen(QColor("#2a4458"), 1.0));
+        p.drawLine(QPointF(tickX, r.top()), QPointF(tickX, r.bottom()));
+    }
+
+private:
+    float         m_grDb{0.0f};
+    MeterSmoother m_smooth;
+    QTimer        m_animTimer;
+    QElapsedTimer m_animElapsed;
+};
+
+namespace {
+
+const QString kEnableStyle =
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 11px; font-weight: bold; padding: 2px 10px;"
+    "}"
+    "QPushButton:hover { background: #204060; }"
+    "QPushButton:checked {"
+    "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
+    "}";
+
+constexpr const char* kEditStyle =
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 11px; padding: 2px 10px;"
+    "}"
+    "QPushButton:hover { background: #204060; }";
+
+} // namespace
+
+ClientDeEssApplet::ClientDeEssApplet(QWidget* parent) : QWidget(parent)
+{
+    buildUI();
+    hide();
+}
+
+void ClientDeEssApplet::buildUI()
+{
+    setStyleSheet("QWidget { background: transparent; }");
+
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(4, 4, 4, 4);
+    outer->setSpacing(4);
+
+    m_curve = new ClientDeEssCurveWidget;
+    m_curve->setCompactMode(true);
+    m_curve->setMinimumHeight(90);
+    outer->addWidget(m_curve, 1);
+
+    m_grBar = new ClientDeEssGrBar;
+    outer->addWidget(m_grBar);
+
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(4);
+
+        m_enable = new QPushButton("Enable");
+        m_enable->setCheckable(true);
+        m_enable->setStyleSheet(kEnableStyle);
+        m_enable->setFixedHeight(22);
+        row->addWidget(m_enable);
+
+        row->addStretch();
+
+        m_edit = new QPushButton("Edit…");
+        m_edit->setStyleSheet(kEditStyle);
+        m_edit->setFixedHeight(22);
+        m_edit->setToolTip("Open the de-esser editor");
+        row->addWidget(m_edit);
+
+        connect(m_enable, &QPushButton::toggled, this,
+                &ClientDeEssApplet::onEnableToggled);
+        connect(m_edit, &QPushButton::clicked, this, [this]() {
+            emit editRequested();
+        });
+
+        outer->addLayout(row);
+    }
+
+    m_meterTimer = new QTimer(this);
+    m_meterTimer->setInterval(33);
+    connect(m_meterTimer, &QTimer::timeout, this, &ClientDeEssApplet::tickMeter);
+}
+
+void ClientDeEssApplet::setAudioEngine(AudioEngine* engine)
+{
+    m_audio = engine;
+    if (!m_audio) return;
+    m_curve->setDeEss(m_audio->clientDeEssTx());
+    syncEnableFromEngine();
+    m_meterTimer->start();
+}
+
+void ClientDeEssApplet::syncEnableFromEngine()
+{
+    if (!m_audio || !m_enable) return;
+    ClientDeEss* d = m_audio->clientDeEssTx();
+    QSignalBlocker b(m_enable);
+    m_enable->setChecked(d && d->isEnabled());
+    if (m_curve) m_curve->update();
+}
+
+void ClientDeEssApplet::refreshEnableFromEngine()
+{
+    syncEnableFromEngine();
+}
+
+void ClientDeEssApplet::onEnableToggled(bool on)
+{
+    if (!m_audio) return;
+    ClientDeEss* d = m_audio->clientDeEssTx();
+    if (!d) return;
+    d->setEnabled(on);
+    m_audio->saveClientDeEssSettings();
+    if (m_curve) m_curve->update();
+}
+
+void ClientDeEssApplet::tickMeter()
+{
+    if (!m_audio || !m_grBar) return;
+    ClientDeEss* d = m_audio->clientDeEssTx();
+    if (!d) return;
+    const float gr = d->gainReductionDb();
+    m_grBar->setGrDb(gr);
+    m_grDb = gr;
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientDeEssApplet.h
+++ b/src/gui/ClientDeEssApplet.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientDeEssCurveWidget;
+class ClientDeEssGrBar;
+
+// Docked tile for the client-side TX de-esser.  View-only — shows the
+// sidechain bandpass response curve with a live ball at the current
+// centre frequency, a compact GR strip, and Enable / Edit buttons.
+// Interactive editor lives in ClientDeEssEditor (floating).
+class ClientDeEssApplet : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientDeEssApplet(QWidget* parent = nullptr);
+
+    void setAudioEngine(AudioEngine* engine);
+    void refreshEnableFromEngine();
+
+signals:
+    void editRequested();
+
+private:
+    void buildUI();
+    void syncEnableFromEngine();
+    void onEnableToggled(bool on);
+    void tickMeter();
+
+    AudioEngine*            m_audio{nullptr};
+    QPushButton*            m_enable{nullptr};
+    QPushButton*            m_edit{nullptr};
+    ClientDeEssCurveWidget* m_curve{nullptr};
+    ClientDeEssGrBar*       m_grBar{nullptr};
+    QTimer*                 m_meterTimer{nullptr};
+
+    float m_grDb{0.0f};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientDeEssCurveWidget.cpp
+++ b/src/gui/ClientDeEssCurveWidget.cpp
@@ -1,0 +1,202 @@
+#include "ClientDeEssCurveWidget.h"
+#include "core/ClientDeEss.h"
+
+#include <QPainter>
+#include <QPainterPath>
+#include <QPaintEvent>
+#include <QPen>
+#include <QRadialGradient>
+#include <QTimer>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr float kBallSmoothAlpha = 0.30f;
+constexpr float kTwoPi = 6.283185307179586476f;
+
+const QColor kBgColor       ("#0a1420");
+const QColor kGridColor     ("#1e3040");
+const QColor kGridMajorColor("#2a4458");
+const QColor kAxisLabelColor("#607888");
+const QColor kCurveColor    ("#d47272");   // soft red — "sibilant band"
+const QColor kThreshColor   ("#4db8d4");
+const QColor kBallGlowColor ("#ffd070");
+const QColor kBallCoreColor ("#ffffff");
+
+// Log-freq major ticks.
+const float kFreqMajor[] = { 100.0f, 500.0f, 1000.0f, 2000.0f,
+                             5000.0f, 10000.0f };
+
+} // namespace
+
+ClientDeEssCurveWidget::ClientDeEssCurveWidget(QWidget* parent) : QWidget(parent)
+{
+    setMinimumHeight(80);
+    setAttribute(Qt::WA_OpaquePaintEvent, false);
+    m_pollTimer = new QTimer(this);
+    m_pollTimer->setInterval(33);
+    connect(m_pollTimer, &QTimer::timeout, this, [this]() {
+        if (!m_deEss) return;
+        const float target = m_deEss->sidechainPeakDb();
+        m_lastScDb += kBallSmoothAlpha * (target - m_lastScDb);
+        update();
+    });
+}
+
+void ClientDeEssCurveWidget::setDeEss(ClientDeEss* d)
+{
+    m_deEss = d;
+    if (m_deEss) m_pollTimer->start();
+    else         m_pollTimer->stop();
+    update();
+}
+
+void ClientDeEssCurveWidget::setCompactMode(bool on)
+{
+    if (on == m_compact) return;
+    m_compact = on;
+    update();
+}
+
+float ClientDeEssCurveWidget::hzToX(float hz) const
+{
+    const float lhz = std::log10(std::max(hz, 1.0f));
+    const float lmin = std::log10(kMinHz);
+    const float lmax = std::log10(kMaxHz);
+    const float t = (lhz - lmin) / (lmax - lmin);
+    return static_cast<float>(rect().left()) + t * rect().width();
+}
+
+float ClientDeEssCurveWidget::dbToY(float db) const
+{
+    const float t = (db - kMinDb) / (kMaxDb - kMinDb);
+    return static_cast<float>(rect().bottom()) - t * rect().height();
+}
+
+float ClientDeEssCurveWidget::bandpassMagDb(float hz) const
+{
+    if (!m_deEss || m_deEss->sampleRate() <= 0.0) return kMinDb;
+    const float fc = m_deEss->frequencyHz();
+    const float q  = std::max(0.1f, m_deEss->q());
+    const float fs = static_cast<float>(m_deEss->sampleRate());
+
+    // RBJ bandpass (constant 0 dB peak) — same coefficients as the DSP.
+    const float omega = kTwoPi * fc / fs;
+    const float sinw  = std::sin(omega);
+    const float cosw  = std::cos(omega);
+    const float alpha = sinw / (2.0f * q);
+
+    const float a0 = 1.0f + alpha;
+    const float b0 =  alpha         / a0;
+    const float b1 =  0.0f;
+    const float b2 = -alpha         / a0;
+    const float a1n = (-2.0f * cosw) / a0;
+    const float a2n = (1.0f - alpha) / a0;
+
+    const float w = kTwoPi * hz / fs;
+    // |H(e^jw)|^2 = |B|^2 / |A|^2.
+    // B = b0 + b1 e^-jw + b2 e^-j2w; A = 1 + a1 e^-jw + a2 e^-j2w.
+    const float cw = std::cos(w);
+    const float sw = std::sin(w);
+    const float c2w = std::cos(2.0f * w);
+    const float s2w = std::sin(2.0f * w);
+
+    const float bReal = b0 + b1 * cw + b2 * c2w;
+    const float bImag =     -b1 * sw - b2 * s2w;
+    const float aReal = 1.0f + a1n * cw + a2n * c2w;
+    const float aImag =      -a1n * sw - a2n * s2w;
+
+    const float bMag2 = bReal * bReal + bImag * bImag;
+    const float aMag2 = aReal * aReal + aImag * aImag;
+    if (aMag2 < 1e-12f) return kMinDb;
+    const float mag2 = bMag2 / aMag2;
+    return 10.0f * std::log10(std::max(mag2, 1e-12f));
+}
+
+void ClientDeEssCurveWidget::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    const QRectF r = rect();
+    p.fillRect(r, kBgColor);
+
+    // Grid — vertical at major freqs, horizontal at 0 / -12 / -24.
+    p.save();
+    p.setPen(QPen(kGridColor, 1.0));
+    for (float db : { 0.0f, -12.0f, -24.0f }) {
+        const float y = dbToY(db);
+        p.drawLine(QPointF(r.left(), y), QPointF(r.right(), y));
+    }
+    p.setPen(QPen(kGridMajorColor, 1.0));
+    for (float f : kFreqMajor) {
+        const float x = hzToX(f);
+        p.drawLine(QPointF(x, r.top()), QPointF(x, r.bottom()));
+        if (!m_compact) {
+            p.setPen(kAxisLabelColor);
+            QFont font = p.font();
+            font.setPixelSize(8);
+            p.setFont(font);
+            const QString lbl = (f >= 1000.0f)
+                ? QString::number(int(f / 1000.0f)) + "k"
+                : QString::number(int(f));
+            p.drawText(QPointF(x + 2.0f, r.bottom() - 2.0f), lbl);
+            p.setPen(QPen(kGridMajorColor, 1.0));
+        }
+    }
+    p.restore();
+
+    // Bandpass magnitude curve.
+    if (m_deEss) {
+        QPainterPath path;
+        constexpr int steps = 121;
+        for (int i = 0; i < steps; ++i) {
+            const float t   = static_cast<float>(i) / (steps - 1);
+            // Log sweep across kMinHz..kMaxHz.
+            const float lhz = std::log10(kMinHz)
+                + t * (std::log10(kMaxHz) - std::log10(kMinHz));
+            const float hz  = std::pow(10.0f, lhz);
+            const float db  = std::clamp(bandpassMagDb(hz), kMinDb, kMaxDb);
+            const QPointF pt(hzToX(hz), dbToY(db));
+            if (i == 0) path.moveTo(pt);
+            else        path.lineTo(pt);
+        }
+        QPen curvePen(kCurveColor, m_compact ? 1.5 : 2.0);
+        curvePen.setJoinStyle(Qt::RoundJoin);
+        curvePen.setCapStyle(Qt::RoundCap);
+        p.setPen(curvePen);
+        p.drawPath(path);
+
+        // Live ball at (centreFreq, sidechain level) — tracks energy
+        // flowing through the bandpass.  Mapped onto the magnitude
+        // curve at the current centre so it reads as "this is what
+        // the detector sees."
+        const float scDb = std::clamp(m_lastScDb, kMinDb, kMaxDb);
+        const float x = hzToX(m_deEss->frequencyHz());
+        const float y = dbToY(scDb);
+        const float glow = m_compact ? 6.0f : 9.0f;
+        QRadialGradient g(QPointF(x, y), glow);
+        QColor gc = kBallGlowColor; gc.setAlpha(200);
+        g.setColorAt(0.0, gc);
+        gc.setAlpha(0);
+        g.setColorAt(1.0, gc);
+        p.setBrush(g);
+        p.setPen(Qt::NoPen);
+        p.drawEllipse(QPointF(x, y), glow, glow);
+        p.setBrush(kBallCoreColor);
+        p.drawEllipse(QPointF(x, y), m_compact ? 2.0 : 3.0,
+                                      m_compact ? 2.0 : 3.0);
+
+        // Threshold horizontal line — dim cyan.
+        QColor tc = kThreshColor; tc.setAlpha(150);
+        p.setPen(QPen(tc, 1.2, Qt::DashLine));
+        const float yT = dbToY(std::clamp(m_deEss->thresholdDb(),
+                                          kMinDb, kMaxDb));
+        p.drawLine(QPointF(r.left(), yT), QPointF(r.right(), yT));
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientDeEssCurveWidget.h
+++ b/src/gui/ClientDeEssCurveWidget.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <QWidget>
+
+class QTimer;
+
+namespace AetherSDR {
+
+class ClientDeEss;
+
+// Compact sidechain response display for the docked de-esser tile.
+// Draws the biquad bandpass magnitude curve across 100 Hz .. 12 kHz
+// (log-frequency), with a vertical marker at the threshold level on
+// a dB scale, and a live dot tracking the sidechain envelope so the
+// user can see when the de-esser is triggering.
+//
+// Thread model: ClientDeEss parameter + meter reads are already
+// atomic internally, so paintEvent + polling QTimer are UI-thread
+// safe without extra locking.
+class ClientDeEssCurveWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientDeEssCurveWidget(QWidget* parent = nullptr);
+
+    void setDeEss(ClientDeEss* d);
+    ClientDeEss* deEss() const { return m_deEss; }
+
+    void setCompactMode(bool on);
+
+    // Frequency range drawn on the X axis (log scale).
+    static constexpr float kMinHz = 100.0f;
+    static constexpr float kMaxHz = 12000.0f;
+    // dB range on the Y axis for the magnitude plot.
+    static constexpr float kMinDb = -40.0f;
+    static constexpr float kMaxDb =  12.0f;
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+
+private:
+    float hzToX(float hz) const;
+    float dbToY(float db) const;
+    // RBJ bandpass magnitude at `hz` using the current filter params.
+    float bandpassMagDb(float hz) const;
+
+    ClientDeEss* m_deEss{nullptr};
+    QTimer*      m_pollTimer{nullptr};
+    bool         m_compact{false};
+    float        m_lastScDb{-120.0f};   // smoothed sidechain ball dB
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientDeEssEditor.cpp
+++ b/src/gui/ClientDeEssEditor.cpp
@@ -1,0 +1,326 @@
+#include "ClientDeEssEditor.h"
+#include "ClientCompKnob.h"
+#include "ClientDeEssCurveWidget.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ClientDeEss.h"
+
+#include <QCloseEvent>
+#include <QHBoxLayout>
+#include <QHideEvent>
+#include <QMoveEvent>
+#include <QPushButton>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kDefaultWidth  = 720;
+constexpr int kDefaultHeight = 340;
+
+constexpr const char* kWindowStyle =
+    "QWidget { background: #08121d; color: #d7e7f2; }"
+    "QLabel  { background: transparent; color: #8aa8c0; font-size: 11px; }";
+
+const QString kBypassStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #0e1b28;"
+    "  color: #8aa8c0;"
+    "  border: 1px solid #243a4e;"
+    "  border-radius: 3px;"
+    "  font-size: 11px;"
+    "  font-weight: bold;"
+    "  padding: 3px 12px;"
+    "}"
+    "QPushButton:hover { background: #1a2a3a; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e;"
+    "  color: #f2c14e;"
+    "  border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #4a3a1e; }");
+
+} // namespace
+
+ClientDeEssEditor::ClientDeEssEditor(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent, Qt::Window)
+    , m_audio(engine)
+{
+    setWindowTitle("Client De-esser");
+    setStyleSheet(kWindowStyle);
+    resize(kDefaultWidth, kDefaultHeight);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(8, 8, 8, 8);
+    root->setSpacing(6);
+
+    // Header: Bypass
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(8);
+
+        m_bypass = new QPushButton("Bypass");
+        m_bypass->setCheckable(true);
+        m_bypass->setStyleSheet(kBypassStyle);
+        m_bypass->setFixedHeight(22);
+        m_bypass->setToolTip(
+            "Bypass the de-esser (signal passes through unfiltered)");
+        row->addWidget(m_bypass);
+
+        connect(m_bypass, &QPushButton::toggled, this, [this](bool bypassed) {
+            if (!m_audio || !m_audio->clientDeEssTx()) return;
+            m_audio->clientDeEssTx()->setEnabled(!bypassed);
+            m_audio->saveClientDeEssSettings();
+            emit bypassToggled(bypassed);
+        });
+
+        row->addStretch();
+        root->addLayout(row);
+    }
+
+    // Body: 3-column — left knobs | big curve | right knobs
+    auto* body = new QHBoxLayout;
+    body->setSpacing(12);
+
+    // Left column: Frequency / Q / Threshold
+    auto* left = new QVBoxLayout;
+    left->setSpacing(10);
+
+    m_freq = new ClientCompKnob;
+    m_freq->setLabel("Frequency");
+    m_freq->setCenterLabelMode(true);
+    m_freq->setRange(1000.0f, 12000.0f);
+    m_freq->setDefault(6000.0f);
+    // Log sweep across 1..12 kHz so the knob resolution matches how
+    // ears perceive frequency (doubles are equidistant).
+    m_freq->setValueFromNorm([](float n) {
+        return 1000.0f * std::pow(12.0f, n);       // 1 → 12 kHz
+    });
+    m_freq->setNormFromValue([](float v) {
+        return std::log(std::max(1000.0f, v) / 1000.0f)
+               / std::log(12.0f);
+    });
+    m_freq->setLabelFormat([](float v) {
+        return (v >= 1000.0f)
+            ? QString::number(v / 1000.0f, 'f', 2) + " kHz"
+            : QString::number(v, 'f', 0) + " Hz";
+    });
+    m_freq->setFixedSize(96, 96);
+    connect(m_freq, &ClientCompKnob::valueChanged,
+            this, &ClientDeEssEditor::applyFrequency);
+    left->addWidget(m_freq, 0, Qt::AlignHCenter);
+
+    m_q = new ClientCompKnob;
+    m_q->setLabel("Q");
+    m_q->setCenterLabelMode(true);
+    m_q->setRange(0.5f, 5.0f);
+    m_q->setDefault(2.0f);
+    m_q->setValueFromNorm([](float n) { return 0.5f + n * 4.5f; });
+    m_q->setNormFromValue([](float v) { return (v - 0.5f) / 4.5f; });
+    m_q->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 2);
+    });
+    m_q->setFixedSize(96, 96);
+    connect(m_q, &ClientCompKnob::valueChanged,
+            this, &ClientDeEssEditor::applyQ);
+    left->addWidget(m_q, 0, Qt::AlignHCenter);
+
+    m_threshold = new ClientCompKnob;
+    m_threshold->setLabel("Threshold");
+    m_threshold->setCenterLabelMode(true);
+    m_threshold->setRange(-60.0f, 0.0f);
+    m_threshold->setDefault(-30.0f);
+    m_threshold->setValueFromNorm([](float n) { return -60.0f + n * 60.0f; });
+    m_threshold->setNormFromValue([](float v) { return (v + 60.0f) / 60.0f; });
+    m_threshold->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 1) + " dB";
+    });
+    m_threshold->setFixedSize(96, 96);
+    connect(m_threshold, &ClientCompKnob::valueChanged,
+            this, &ClientDeEssEditor::applyThreshold);
+    left->addWidget(m_threshold, 0, Qt::AlignHCenter);
+
+    left->addStretch();
+    body->addLayout(left, 0);
+
+    // Center: sidechain bandpass response curve (bigger than the
+    // applet's compact version — shows labels, threshold line, ball).
+    m_curve = new ClientDeEssCurveWidget;
+    m_curve->setCompactMode(false);
+    m_curve->setMinimumHeight(200);
+    body->addWidget(m_curve, 1);
+
+    // Right column: Amount / Attack / Release
+    auto* right = new QVBoxLayout;
+    right->setSpacing(10);
+
+    m_amount = new ClientCompKnob;
+    m_amount->setLabel("Amount");
+    m_amount->setCenterLabelMode(true);
+    m_amount->setRange(-24.0f, 0.0f);
+    m_amount->setDefault(-6.0f);
+    m_amount->setValueFromNorm([](float n) { return -24.0f + n * 24.0f; });
+    m_amount->setNormFromValue([](float v) { return (v + 24.0f) / 24.0f; });
+    m_amount->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 1) + " dB";
+    });
+    m_amount->setFixedSize(96, 96);
+    connect(m_amount, &ClientCompKnob::valueChanged,
+            this, &ClientDeEssEditor::applyAmount);
+    right->addWidget(m_amount, 0, Qt::AlignHCenter);
+
+    m_attack = new ClientCompKnob;
+    m_attack->setLabel("Attack");
+    m_attack->setCenterLabelMode(true);
+    m_attack->setRange(0.1f, 30.0f);
+    m_attack->setDefault(1.0f);
+    m_attack->setValueFromNorm([](float n) {
+        return 0.1f * std::pow(300.0f, n);         // 0.1..30 ms
+    });
+    m_attack->setNormFromValue([](float v) {
+        return std::log(std::max(0.1f, v) / 0.1f) / std::log(300.0f);
+    });
+    m_attack->setLabelFormat([](float v) {
+        return QString::number(v, 'f', v < 10.0f ? 2 : 1) + " ms";
+    });
+    m_attack->setFixedSize(96, 96);
+    connect(m_attack, &ClientCompKnob::valueChanged,
+            this, &ClientDeEssEditor::applyAttack);
+    right->addWidget(m_attack, 0, Qt::AlignHCenter);
+
+    m_release = new ClientCompKnob;
+    m_release->setLabel("Release");
+    m_release->setCenterLabelMode(true);
+    m_release->setRange(10.0f, 500.0f);
+    m_release->setDefault(100.0f);
+    m_release->setValueFromNorm([](float n) {
+        return 10.0f * std::pow(50.0f, n);         // 10..500 ms
+    });
+    m_release->setNormFromValue([](float v) {
+        return std::log(std::max(10.0f, v) / 10.0f) / std::log(50.0f);
+    });
+    m_release->setLabelFormat([](float v) {
+        return QString::number(v, 'f', v < 100.0f ? 1 : 0) + " ms";
+    });
+    m_release->setFixedSize(96, 96);
+    connect(m_release, &ClientCompKnob::valueChanged,
+            this, &ClientDeEssEditor::applyRelease);
+    right->addWidget(m_release, 0, Qt::AlignHCenter);
+
+    right->addStretch();
+    body->addLayout(right, 0);
+
+    root->addLayout(body);
+
+    // Bind the curve to the de-esser so it starts polling.
+    if (m_audio && m_audio->clientDeEssTx()) {
+        m_curve->setDeEss(m_audio->clientDeEssTx());
+    }
+
+    syncControlsFromEngine();
+}
+
+ClientDeEssEditor::~ClientDeEssEditor() = default;
+
+void ClientDeEssEditor::showForTx()
+{
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+}
+
+void ClientDeEssEditor::syncControlsFromEngine()
+{
+    if (!m_audio || !m_audio->clientDeEssTx()) return;
+    ClientDeEss* d = m_audio->clientDeEssTx();
+    m_restoring = true;
+
+    { QSignalBlocker b(m_bypass);    m_bypass->setChecked(!d->isEnabled()); }
+    { QSignalBlocker b(m_freq);      m_freq->setValue(d->frequencyHz()); }
+    { QSignalBlocker b(m_q);         m_q->setValue(d->q()); }
+    { QSignalBlocker b(m_threshold); m_threshold->setValue(d->thresholdDb()); }
+    { QSignalBlocker b(m_amount);    m_amount->setValue(d->amountDb()); }
+    { QSignalBlocker b(m_attack);    m_attack->setValue(d->attackMs()); }
+    { QSignalBlocker b(m_release);   m_release->setValue(d->releaseMs()); }
+
+    m_restoring = false;
+}
+
+void ClientDeEssEditor::applyFrequency(float hz)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientDeEssTx()->setFrequencyHz(hz);
+    m_audio->saveClientDeEssSettings();
+    if (m_curve) m_curve->update();
+}
+void ClientDeEssEditor::applyQ(float q)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientDeEssTx()->setQ(q);
+    m_audio->saveClientDeEssSettings();
+    if (m_curve) m_curve->update();
+}
+void ClientDeEssEditor::applyThreshold(float db)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientDeEssTx()->setThresholdDb(db);
+    m_audio->saveClientDeEssSettings();
+    if (m_curve) m_curve->update();
+}
+void ClientDeEssEditor::applyAmount(float db)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientDeEssTx()->setAmountDb(db);
+    m_audio->saveClientDeEssSettings();
+}
+void ClientDeEssEditor::applyAttack(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientDeEssTx()->setAttackMs(ms);
+    m_audio->saveClientDeEssSettings();
+}
+void ClientDeEssEditor::applyRelease(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientDeEssTx()->setReleaseMs(ms);
+    m_audio->saveClientDeEssSettings();
+}
+
+void ClientDeEssEditor::saveGeometryToSettings()
+{
+    if (m_restoring) return;
+    AppSettings::instance().setValue(
+        "ClientDeEssEditorGeometry",
+        QString::fromLatin1(saveGeometry().toBase64()));
+}
+
+void ClientDeEssEditor::restoreGeometryFromSettings()
+{
+    m_restoring = true;
+    const QString b64 = AppSettings::instance()
+        .value("ClientDeEssEditorGeometry", "").toString();
+    if (!b64.isEmpty()) {
+        restoreGeometry(QByteArray::fromBase64(b64.toLatin1()));
+    }
+    m_restoring = false;
+}
+
+void ClientDeEssEditor::closeEvent(QCloseEvent* ev)
+{ saveGeometryToSettings(); QWidget::closeEvent(ev); }
+void ClientDeEssEditor::moveEvent(QMoveEvent* ev)
+{ saveGeometryToSettings(); QWidget::moveEvent(ev); }
+void ClientDeEssEditor::resizeEvent(QResizeEvent* ev)
+{ saveGeometryToSettings(); QWidget::resizeEvent(ev); }
+void ClientDeEssEditor::showEvent(QShowEvent* ev)
+{ QWidget::showEvent(ev); }
+void ClientDeEssEditor::hideEvent(QHideEvent* ev)
+{ saveGeometryToSettings(); QWidget::hideEvent(ev); }
+
+} // namespace AetherSDR

--- a/src/gui/ClientDeEssEditor.h
+++ b/src/gui/ClientDeEssEditor.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompKnob;             // reused — generic rotary knob
+class ClientDeEssCurveWidget;
+
+// Floating editor for the client-side de-esser.  Three-column layout
+// inspired by Ableton's Compressor (the de-esser preset), using our
+// actual de-esser parameters:
+//
+//   ┌─ bypass ──────────────────── × ┐
+//   │ ┌──────┐ ┌────────────┐ ┌────┐ │
+//   │ │ FREQ │ │            │ │ AMT│ │
+//   │ │      │ │  bandpass  │ │    │ │
+//   │ │  Q   │ │  response  │ │ ATK│ │
+//   │ │      │ │  + live    │ │    │ │
+//   │ │ THR  │ │  ball      │ │ REL│ │
+//   │ └──────┘ └────────────┘ └────┘ │
+//   └────────────────────────────────┘
+class ClientDeEssEditor : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientDeEssEditor(AudioEngine* engine, QWidget* parent = nullptr);
+    ~ClientDeEssEditor() override;
+
+    void showForTx();
+
+signals:
+    void bypassToggled(bool bypassed);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+    void syncControlsFromEngine();
+
+    void applyFrequency(float hz);
+    void applyQ(float q);
+    void applyThreshold(float db);
+    void applyAmount(float db);
+    void applyAttack(float ms);
+    void applyRelease(float ms);
+
+    AudioEngine*            m_audio{nullptr};
+    ClientDeEssCurveWidget* m_curve{nullptr};
+    ClientCompKnob*         m_freq{nullptr};
+    ClientCompKnob*         m_q{nullptr};
+    ClientCompKnob*         m_threshold{nullptr};
+    ClientCompKnob*         m_amount{nullptr};
+    ClientCompKnob*         m_attack{nullptr};
+    ClientCompKnob*         m_release{nullptr};
+    QPushButton*            m_bypass{nullptr};
+    bool                    m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientGateApplet.cpp
+++ b/src/gui/ClientGateApplet.cpp
@@ -1,0 +1,200 @@
+#include "ClientGateApplet.h"
+#include "ClientGateCurveWidget.h"
+#include "MeterSmoother.h"
+#include "core/AudioEngine.h"
+#include "core/ClientGate.h"
+
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QSignalBlocker>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QTimer>
+#include <QElapsedTimer>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+// Gain-reduction mini-strip for the applet.  Named at file scope (not
+// an anonymous namespace) so ClientGateApplet.h can forward-declare it
+// and keep a typed pointer.  Fill motion uses the shared MeterSmoother
+// ballistics so it reads identically to the compressor GR strip.
+class ClientGateGrBar : public QWidget {
+public:
+    explicit ClientGateGrBar(QWidget* parent = nullptr) : QWidget(parent)
+    {
+        setFixedHeight(10);
+
+        m_animTimer.setTimerType(Qt::PreciseTimer);
+        m_animTimer.setInterval(kMeterSmootherIntervalMs);
+        connect(&m_animTimer, &QTimer::timeout, this, [this]() {
+            if (!m_smooth.tick(m_animElapsed.restart()))
+                m_animTimer.stop();
+            update();
+        });
+    }
+
+    void setGrDb(float grDb)
+    {
+        if (std::fabs(grDb - m_grDb) < 0.05f) return;
+        m_grDb = grDb;
+        // Gate attenuation can be much deeper than comp — 40 dB scale
+        // reads better for a gate tile.
+        constexpr float kMaxGr = 40.0f;
+        m_smooth.setTarget(std::clamp(-m_grDb, 0.0f, kMaxGr) / kMaxGr);
+        if (!m_smooth.needsAnimation()) {
+            if (m_animTimer.isActive()) m_animTimer.stop();
+            update();
+        } else if (!m_animTimer.isActive()) {
+            m_animElapsed.restart();
+            m_animTimer.start();
+        }
+    }
+
+protected:
+    void paintEvent(QPaintEvent*) override
+    {
+        QPainter p(this);
+        const QRectF r = rect();
+        p.fillRect(r, QColor("#0a1420"));
+        constexpr float kMaxGr = 40.0f;
+        const float frac = m_smooth.value();
+        if (frac > 0.0f) {
+            const float w = frac * r.width();
+            QRectF fill(r.right() - w, r.top() + 1.0, w, r.height() - 2.0);
+            p.fillRect(fill, QColor("#c8a040"));   // amber — matches curve
+        }
+        // -15 dB tick (soft-expander default floor)
+        const float tickX = r.right() - (15.0f / kMaxGr) * r.width();
+        p.setPen(QPen(QColor("#2a4458"), 1.0));
+        p.drawLine(QPointF(tickX, r.top()), QPointF(tickX, r.bottom()));
+    }
+
+private:
+    float         m_grDb{0.0f};
+    MeterSmoother m_smooth;
+    QTimer        m_animTimer;
+    QElapsedTimer m_animElapsed;
+};
+
+namespace {
+
+const QString kEnableStyle =
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 11px; font-weight: bold; padding: 2px 10px;"
+    "}"
+    "QPushButton:hover { background: #204060; }"
+    "QPushButton:checked {"
+    "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
+    "}";
+
+constexpr const char* kEditStyle =
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 11px; padding: 2px 10px;"
+    "}"
+    "QPushButton:hover { background: #204060; }";
+
+} // namespace
+
+ClientGateApplet::ClientGateApplet(QWidget* parent) : QWidget(parent)
+{
+    buildUI();
+    hide();
+}
+
+void ClientGateApplet::buildUI()
+{
+    setStyleSheet("QWidget { background: transparent; }");
+
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(4, 4, 4, 4);
+    outer->setSpacing(4);
+
+    m_curve = new ClientGateCurveWidget;
+    m_curve->setCompactMode(true);
+    m_curve->setMinimumHeight(90);
+    outer->addWidget(m_curve, 1);
+
+    m_grBar = new ClientGateGrBar;
+    outer->addWidget(m_grBar);
+
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(4);
+
+        m_enable = new QPushButton("Enable");
+        m_enable->setCheckable(true);
+        m_enable->setStyleSheet(kEnableStyle);
+        m_enable->setFixedHeight(22);
+        row->addWidget(m_enable);
+
+        row->addStretch();
+
+        m_edit = new QPushButton("Edit…");
+        m_edit->setStyleSheet(kEditStyle);
+        m_edit->setFixedHeight(22);
+        m_edit->setToolTip("Open the client gate editor");
+        row->addWidget(m_edit);
+
+        connect(m_enable, &QPushButton::toggled, this,
+                &ClientGateApplet::onEnableToggled);
+        connect(m_edit, &QPushButton::clicked, this, [this]() {
+            emit editRequested();
+        });
+
+        outer->addLayout(row);
+    }
+
+    m_meterTimer = new QTimer(this);
+    m_meterTimer->setInterval(33);
+    connect(m_meterTimer, &QTimer::timeout, this, &ClientGateApplet::tickMeter);
+}
+
+void ClientGateApplet::setAudioEngine(AudioEngine* engine)
+{
+    m_audio = engine;
+    if (!m_audio) return;
+    m_curve->setGate(m_audio->clientGateTx());
+    syncEnableFromEngine();
+    m_meterTimer->start();
+}
+
+void ClientGateApplet::syncEnableFromEngine()
+{
+    if (!m_audio || !m_enable) return;
+    ClientGate* g = m_audio->clientGateTx();
+    QSignalBlocker b(m_enable);
+    m_enable->setChecked(g && g->isEnabled());
+    if (m_curve) m_curve->update();
+}
+
+void ClientGateApplet::refreshEnableFromEngine()
+{
+    syncEnableFromEngine();
+}
+
+void ClientGateApplet::onEnableToggled(bool on)
+{
+    if (!m_audio) return;
+    ClientGate* g = m_audio->clientGateTx();
+    if (!g) return;
+    g->setEnabled(on);
+    m_audio->saveClientGateSettings();
+    if (m_curve) m_curve->update();
+}
+
+void ClientGateApplet::tickMeter()
+{
+    if (!m_audio || !m_grBar) return;
+    ClientGate* g = m_audio->clientGateTx();
+    if (!g) return;
+    const float gr = g->gainReductionDb();
+    m_grBar->setGrDb(gr);
+    m_grDb = gr;
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientGateApplet.h
+++ b/src/gui/ClientGateApplet.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientGateCurveWidget;
+class ClientGateGrBar;
+
+// Docked tile for the client-side TX gate / expander.  View-only —
+// shows the static transfer curve with a live ball at the current
+// input level, plus a compact horizontal gain-reduction strip, plus
+// Enable / Edit… buttons.  The interactive editor lives in a separate
+// floating window (ClientGateEditor).
+//
+// Single-path (TX only) to match ClientCompApplet — gates on a ham
+// RX feed are a rare configuration and can be added later if asked for.
+class ClientGateApplet : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientGateApplet(QWidget* parent = nullptr);
+
+    void setAudioEngine(AudioEngine* engine);
+
+    // Pull the Enable toggle state from the bound ClientGate.  Called
+    // by MainWindow after the floating editor toggles its bypass button
+    // so both views stay in sync.
+    void refreshEnableFromEngine();
+
+signals:
+    void editRequested();
+
+private:
+    void buildUI();
+    void syncEnableFromEngine();
+    void onEnableToggled(bool on);
+    void tickMeter();
+
+    AudioEngine*           m_audio{nullptr};
+    QPushButton*           m_enable{nullptr};
+    QPushButton*           m_edit{nullptr};
+    ClientGateCurveWidget* m_curve{nullptr};
+    ClientGateGrBar*       m_grBar{nullptr};
+    QTimer*                m_meterTimer{nullptr};
+
+    float m_grDb{0.0f};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientGateCurveWidget.cpp
+++ b/src/gui/ClientGateCurveWidget.cpp
@@ -1,0 +1,209 @@
+#include "ClientGateCurveWidget.h"
+#include "core/ClientGate.h"
+
+#include <QPainter>
+#include <QPainterPath>
+#include <QPaintEvent>
+#include <QPen>
+#include <QRadialGradient>
+#include <QTimer>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr float kBallSmoothAlpha = 0.30f;
+
+const QColor kBgColor       ("#0a1420");
+const QColor kGridColor     ("#1e3040");
+const QColor kGridMajorColor("#2a4458");
+const QColor kAxisLabelColor("#607888");
+const QColor kIdentityColor ("#2a3a4a");
+const QColor kCurveColor    ("#c8a040");   // amber — reads as gate/expander
+const QColor kBallGlowColor ("#ffd070");
+const QColor kBallCoreColor ("#ffffff");
+
+// -80..0 dB range with matching majors; gate can attenuate much
+// deeper than comp, so the grid needs to show the full -80 floor.
+const float kMajorTicks[] = { 0.0f, -20.0f, -40.0f, -60.0f, -80.0f };
+const float kMinorTicks[] = { -10.0f, -30.0f, -50.0f, -70.0f };
+
+} // namespace
+
+ClientGateCurveWidget::ClientGateCurveWidget(QWidget* parent) : QWidget(parent)
+{
+    setMinimumHeight(80);
+    setAttribute(Qt::WA_OpaquePaintEvent, false);
+    m_pollTimer = new QTimer(this);
+    m_pollTimer->setInterval(33);
+    connect(m_pollTimer, &QTimer::timeout, this, [this]() {
+        if (!m_gate) return;
+        const float target = m_gate->inputPeakDb();
+        m_lastInputDb += kBallSmoothAlpha * (target - m_lastInputDb);
+        update();
+    });
+}
+
+void ClientGateCurveWidget::setGate(ClientGate* gate)
+{
+    m_gate = gate;
+    if (m_gate) m_pollTimer->start();
+    else        m_pollTimer->stop();
+    update();
+}
+
+void ClientGateCurveWidget::setCompactMode(bool on)
+{
+    if (on == m_compact) return;
+    m_compact = on;
+    update();
+}
+
+float ClientGateCurveWidget::dbToX(float db) const
+{
+    const float t = (db - kMinDb) / (kMaxDb - kMinDb);
+    return static_cast<float>(rect().left()) + t * rect().width();
+}
+
+float ClientGateCurveWidget::dbToY(float db) const
+{
+    const float t = (db - kMinDb) / (kMaxDb - kMinDb);
+    return static_cast<float>(rect().bottom()) - t * rect().height();
+}
+
+float ClientGateCurveWidget::curveOutputDb(float inDb) const
+{
+    if (!m_gate) return inDb;
+    // Downward expander static curve:
+    //   shortfall = T - in
+    //   if shortfall <= 0  → gain = 0 (unity, above threshold)
+    //   else                 gain = max(-shortfall * (ratio-1), floor)
+    const float T         = m_gate->thresholdDb();
+    const float ratio     = std::max(1.0f, m_gate->ratio());
+    const float floorDb   = m_gate->floorDb();
+    const float slope     = ratio - 1.0f;
+    const float shortfall = T - inDb;
+    float gain = 0.0f;
+    if (shortfall > 0.0f) gain = std::max(-shortfall * slope, floorDb);
+    return inDb + gain;
+}
+
+void ClientGateCurveWidget::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    const QRectF r = rect();
+    p.fillRect(r, kBgColor);
+    drawGrid(p, r);
+    drawCurve(p, r);
+    if (m_gate) drawBall(p, r);
+}
+
+void ClientGateCurveWidget::drawGrid(QPainter& p, const QRectF& r) const
+{
+    p.save();
+
+    const QPen minorPen(kGridColor, 1.0);
+    const QPen majorPen(kGridMajorColor, 1.0);
+
+    p.setPen(minorPen);
+    for (float db : kMinorTicks) {
+        const float x = dbToX(db);
+        p.drawLine(QPointF(x, r.top()), QPointF(x, r.bottom()));
+        const float y = dbToY(db);
+        p.drawLine(QPointF(r.left(), y), QPointF(r.right(), y));
+    }
+
+    p.setPen(majorPen);
+    QFont f = p.font();
+    f.setPixelSize(m_compact ? 7 : 9);
+    p.setFont(f);
+
+    for (float db : kMajorTicks) {
+        const float x = dbToX(db);
+        p.drawLine(QPointF(x, r.top()), QPointF(x, r.bottom()));
+        const float y = dbToY(db);
+        p.drawLine(QPointF(r.left(), y), QPointF(r.right(), y));
+
+        if (!m_compact && db != 0.0f && db != kMinDb) {
+            p.setPen(kAxisLabelColor);
+            p.drawText(QPointF(x + 2.0f, r.bottom() - 2.0f),
+                       QString::number(static_cast<int>(db)));
+            p.drawText(QPointF(r.left() + 2.0f, y - 2.0f),
+                       QString::number(static_cast<int>(db)));
+            p.setPen(majorPen);
+        }
+    }
+
+    // Identity diagonal — dim reference showing where the curve sits
+    // when the gate is fully open (above threshold).
+    p.setPen(QPen(kIdentityColor, 1.0, Qt::DashLine));
+    p.drawLine(QPointF(dbToX(kMinDb), dbToY(kMinDb)),
+               QPointF(dbToX(kMaxDb), dbToY(kMaxDb)));
+
+    p.restore();
+}
+
+void ClientGateCurveWidget::drawCurve(QPainter& p, const QRectF& r) const
+{
+    if (!m_gate) return;
+
+    p.save();
+
+    QPainterPath path;
+    constexpr int steps = 161;                     // 80 dB range, 0.5 dB/step
+    for (int i = 0; i < steps; ++i) {
+        const float t     = static_cast<float>(i) / (steps - 1);
+        const float inDb  = kMinDb + t * (kMaxDb - kMinDb);
+        const float outDb = std::clamp(curveOutputDb(inDb), kMinDb, kMaxDb);
+        const QPointF pt(dbToX(inDb), dbToY(outDb));
+        if (i == 0) path.moveTo(pt);
+        else        path.lineTo(pt);
+    }
+
+    QPen curvePen(kCurveColor, m_compact ? 1.5 : 2.0);
+    curvePen.setJoinStyle(Qt::RoundJoin);
+    curvePen.setCapStyle(Qt::RoundCap);
+    p.setPen(curvePen);
+    p.drawPath(path);
+
+    // Threshold dot at the knee corner so the user's eye locks on it.
+    if (!m_compact) {
+        const float T = m_gate->thresholdDb();
+        const QPointF t(dbToX(T), dbToY(curveOutputDb(T)));
+        p.setBrush(kCurveColor);
+        p.setPen(Qt::NoPen);
+        p.drawEllipse(t, 3.0, 3.0);
+    }
+
+    p.restore();
+}
+
+void ClientGateCurveWidget::drawBall(QPainter& p, const QRectF& r) const
+{
+    if (!m_gate) return;
+    const float inDb  = std::clamp(m_lastInputDb, kMinDb, kMaxDb);
+    const float outDb = std::clamp(curveOutputDb(inDb), kMinDb, kMaxDb);
+    const QPointF pt(dbToX(inDb), dbToY(outDb));
+
+    p.save();
+    const float glow = m_compact ? 8.0f : 11.0f;
+    QRadialGradient g(pt, glow);
+    QColor glowColor = kBallGlowColor;
+    glowColor.setAlpha(200);
+    g.setColorAt(0.0, glowColor);
+    glowColor.setAlpha(0);
+    g.setColorAt(1.0, glowColor);
+    p.setBrush(g);
+    p.setPen(Qt::NoPen);
+    p.drawEllipse(pt, glow, glow);
+
+    p.setBrush(kBallCoreColor);
+    p.drawEllipse(pt, m_compact ? 2.5 : 3.5, m_compact ? 2.5 : 3.5);
+    p.restore();
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientGateCurveWidget.h
+++ b/src/gui/ClientGateCurveWidget.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <QWidget>
+
+class QTimer;
+
+namespace AetherSDR {
+
+class ClientGate;
+
+// Read-only transfer curve for the client-side gate / expander.  Draws
+// the static gain curve — unity above threshold, sloped attenuation
+// below threshold clamped to `floor` — with a glowing ball sliding
+// along the curve at the current input envelope level.  Visual
+// language mirrors ClientCompCurveWidget so the two tiles read as a
+// family.
+//
+// Thread model: ClientGate parameter + meter reads are already atomic
+// internally, so paintEvent + the polling QTimer are both safe on the
+// UI thread without extra locking.
+class ClientGateCurveWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientGateCurveWidget(QWidget* parent = nullptr);
+
+    void setGate(ClientGate* gate);
+    ClientGate* gate() const { return m_gate; }
+
+    // Compact mode: thinner gridlines, no axis labels.  On in the
+    // docked applet, off in the editor canvas.
+    void setCompactMode(bool on);
+
+    static constexpr float kMinDb = -80.0f;
+    static constexpr float kMaxDb =   0.0f;
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+
+    float dbToX(float db) const;
+    float dbToY(float db) const;
+
+    // Static curve: output level in dB for a given input level in dB,
+    // using the current threshold / ratio / floor / return from m_gate.
+    float curveOutputDb(float inDb) const;
+
+    void drawGrid(QPainter& p, const QRectF& rect) const;
+    void drawCurve(QPainter& p, const QRectF& rect) const;
+    void drawBall(QPainter& p, const QRectF& rect) const;
+
+    QTimer*     m_pollTimer{nullptr};
+    ClientGate* m_gate{nullptr};
+    bool        m_compact{false};
+    float       m_lastInputDb{-120.0f};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientGateEditor.cpp
+++ b/src/gui/ClientGateEditor.cpp
@@ -1,0 +1,489 @@
+#include "ClientGateEditor.h"
+#include "ClientCompKnob.h"
+#include "ClientGateLevelView.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ClientGate.h"
+
+#include <QCloseEvent>
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QHideEvent>
+#include <QLabel>
+#include <QMoveEvent>
+#include <QPushButton>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kDefaultWidth  = 760;
+constexpr int kDefaultHeight = 380;
+
+constexpr const char* kWindowStyle =
+    "QWidget { background: #08121d; color: #d7e7f2; }"
+    "QLabel  { background: transparent; color: #8aa8c0; font-size: 11px; }";
+
+const QString kBypassStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #0e1b28;"
+    "  color: #8aa8c0;"
+    "  border: 1px solid #243a4e;"
+    "  border-radius: 3px;"
+    "  font-size: 11px;"
+    "  font-weight: bold;"
+    "  padding: 3px 12px;"
+    "}"
+    "QPushButton:hover { background: #1a2a3a; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e;"
+    "  color: #f2c14e;"
+    "  border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #4a3a1e; }");
+
+// Flip (Expander/Gate) — two custom checked states instead of the
+// usual idle→active swap: Expander (unchecked) uses the SQL/MIC
+// green palette, Gate (checked) uses the amber palette that marks
+// more-aggressive settings elsewhere in the chain.  The colour
+// itself tells you which mode you're in without reading the label.
+const QString kFlipStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #006040; border: 1px solid #00a060; border-radius: 3px;"
+    "  color: #00ff88; font-size: 10px; font-weight: bold; padding: 3px 6px;"
+    "}"
+    "QPushButton:hover { background: #007050; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e; color: #f2c14e; border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #4a3a1e; }");
+
+// Lookahead dropdown values in ms.  0 disables the delay line; 1 and
+// 1.5 ms match Ableton's preset options; 3 / 5 added for users who
+// want more headroom for very fast transients at the cost of latency.
+const QList<float> kLookaheadOptions{ 0.0f, 1.0f, 1.5f, 3.0f, 5.0f };
+
+} // namespace
+
+ClientGateEditor::ClientGateEditor(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent, Qt::Window)
+    , m_audio(engine)
+{
+    setWindowTitle("Client Gate");
+    setStyleSheet(kWindowStyle);
+    resize(kDefaultWidth, kDefaultHeight);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(8, 8, 8, 8);
+    root->setSpacing(6);
+
+    // ── Header: Bypass ────────────────────────────────────────────
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(8);
+
+        m_bypass = new QPushButton("Bypass");
+        m_bypass->setCheckable(true);
+        m_bypass->setStyleSheet(kBypassStyle);
+        m_bypass->setFixedHeight(22);
+        m_bypass->setToolTip(
+            "Bypass the gate (signal passes through untouched)");
+        row->addWidget(m_bypass);
+
+        connect(m_bypass, &QPushButton::toggled, this, [this](bool bypassed) {
+            if (!m_audio || !m_audio->clientGateTx()) return;
+            m_audio->clientGateTx()->setEnabled(!bypassed);
+            m_audio->saveClientGateSettings();
+            emit bypassToggled(bypassed);
+        });
+
+        row->addStretch();
+
+        root->addLayout(row);
+    }
+
+    // ── Main body: left control column + right level view ─────────
+    auto* body = new QHBoxLayout;
+    body->setSpacing(12);
+
+    // Left column: threshold, return, flip/lookahead
+    auto* left = new QVBoxLayout;
+    left->setSpacing(8);
+
+    // Threshold — the single largest control, matches Ableton's big
+    // top-left knob.  -80..0 dB linear.
+    m_threshold = new ClientCompKnob;
+    m_threshold->setLabel("Threshold");
+    m_threshold->setCenterLabelMode(true);
+    m_threshold->setRange(-80.0f, 0.0f);
+    m_threshold->setDefault(-40.0f);
+    m_threshold->setValueFromNorm([](float n) { return -80.0f + n * 80.0f; });
+    m_threshold->setNormFromValue([](float v) { return (v + 80.0f) / 80.0f; });
+    m_threshold->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 1) + " dB";
+    });
+    m_threshold->setFixedSize(120, 120);
+    connect(m_threshold, &ClientCompKnob::valueChanged,
+            this, &ClientGateEditor::applyThreshold);
+    left->addWidget(m_threshold, 0, Qt::AlignHCenter);
+
+    // Return — hysteresis, 0..20 dB linear.
+    m_returnKnob = new ClientCompKnob;
+    m_returnKnob->setLabel("Return");
+    m_returnKnob->setCenterLabelMode(true);
+    m_returnKnob->setRange(0.0f, 20.0f);
+    m_returnKnob->setDefault(2.0f);
+    m_returnKnob->setValueFromNorm([](float n) { return n * 20.0f; });
+    m_returnKnob->setNormFromValue([](float v) { return v / 20.0f; });
+    m_returnKnob->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 2) + " dB";
+    });
+    m_returnKnob->setFixedSize(80, 80);
+    connect(m_returnKnob, &ClientCompKnob::valueChanged,
+            this, &ClientGateEditor::applyReturn);
+    left->addWidget(m_returnKnob, 0, Qt::AlignHCenter);
+
+    // Flip / Lookahead — a narrow stacked pair sitting under the
+    // Return knob to match the Ableton footprint.
+    {
+        auto* flipRow = new QVBoxLayout;
+        flipRow->setSpacing(4);
+
+        m_flip = new QPushButton("Flip");
+        m_flip->setCheckable(true);
+        m_flip->setStyleSheet(kFlipStyle);
+        m_flip->setFixedHeight(22);
+        m_flip->setToolTip(
+            "Flip between downward Expander (gentle) and Gate (hard) "
+            "modes.  Snaps ratio + floor to preset pairs; other knobs "
+            "stay where you left them.");
+        connect(m_flip, &QPushButton::toggled, this, [this](bool checked) {
+            applyMode(checked ? 1 : 0);
+        });
+        flipRow->addWidget(m_flip);
+
+        auto* lookWrap = new QVBoxLayout;
+        lookWrap->setSpacing(2);
+        auto* lookLbl = new QLabel("Lookahead");
+        lookLbl->setAlignment(Qt::AlignCenter);
+        lookWrap->addWidget(lookLbl);
+        m_lookahead = new QComboBox;
+        for (float v : kLookaheadOptions) {
+            const QString label = (v <= 0.0f)
+                ? "Off" : (QString::number(v, 'g', 2) + " ms");
+            m_lookahead->addItem(label, v);
+        }
+        connect(m_lookahead,
+                QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this](int i) {
+            if (i < 0 || i >= kLookaheadOptions.size()) return;
+            applyLookahead(kLookaheadOptions[i]);
+        });
+        lookWrap->addWidget(m_lookahead);
+        flipRow->addLayout(lookWrap);
+
+        left->addLayout(flipRow);
+    }
+
+    left->addStretch();
+    body->addLayout(left, 0);
+
+    // Right side: level view + bottom knob row
+    auto* right = new QVBoxLayout;
+    right->setSpacing(8);
+
+    m_levelView = new ClientGateLevelView;
+    right->addWidget(m_levelView, 1);
+
+    // Bottom row: Attack, Hold, Release, Floor (small knobs).
+    auto* bottom = new QHBoxLayout;
+    bottom->setSpacing(8);
+
+    auto makeBottomKnob = [](const QString& label) {
+        auto* k = new ClientCompKnob;
+        k->setLabel(label);
+        k->setCenterLabelMode(true);
+        k->setFixedSize(72, 72);
+        return k;
+    };
+
+    // Attack: 0.1..100 ms exponential.
+    m_attack = makeBottomKnob("Attack");
+    m_attack->setRange(0.1f, 100.0f);
+    m_attack->setDefault(0.5f);
+    m_attack->setValueFromNorm([](float n) {
+        return 0.1f * std::pow(1000.0f, n);           // 0.1 → 100
+    });
+    m_attack->setNormFromValue([](float v) {
+        return std::log(std::max(0.1f, v) / 0.1f) / std::log(1000.0f);
+    });
+    m_attack->setLabelFormat([](float v) {
+        return QString::number(v, 'f', v < 10.0f ? 2 : 1) + " ms";
+    });
+    connect(m_attack, &ClientCompKnob::valueChanged,
+            this, &ClientGateEditor::applyAttack);
+    bottom->addWidget(m_attack, 0, Qt::AlignHCenter);
+
+    // Hold: 0..500 ms linear.
+    m_hold = makeBottomKnob("Hold");
+    m_hold->setRange(0.0f, 500.0f);
+    m_hold->setDefault(20.0f);
+    m_hold->setValueFromNorm([](float n) { return n * 500.0f; });
+    m_hold->setNormFromValue([](float v) { return v / 500.0f; });
+    m_hold->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 1) + " ms";
+    });
+    connect(m_hold, &ClientCompKnob::valueChanged,
+            this, &ClientGateEditor::applyHold);
+    bottom->addWidget(m_hold, 0, Qt::AlignHCenter);
+
+    // Release: 5..2000 ms exponential.
+    m_release = makeBottomKnob("Release");
+    m_release->setRange(5.0f, 2000.0f);
+    m_release->setDefault(100.0f);
+    m_release->setValueFromNorm([](float n) {
+        return 5.0f * std::pow(400.0f, n);           // 5 → 2000
+    });
+    m_release->setNormFromValue([](float v) {
+        return std::log(std::max(5.0f, v) / 5.0f) / std::log(400.0f);
+    });
+    m_release->setLabelFormat([](float v) {
+        return QString::number(v, 'f', v < 100.0f ? 1 : 0) + " ms";
+    });
+    connect(m_release, &ClientCompKnob::valueChanged,
+            this, &ClientGateEditor::applyRelease);
+    bottom->addWidget(m_release, 0, Qt::AlignHCenter);
+
+    // Floor: -80..0 dB linear.
+    m_floor = makeBottomKnob("Floor");
+    m_floor->setRange(-80.0f, 0.0f);
+    m_floor->setDefault(-15.0f);
+    m_floor->setValueFromNorm([](float n) { return -80.0f + n * 80.0f; });
+    m_floor->setNormFromValue([](float v) { return (v + 80.0f) / 80.0f; });
+    m_floor->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 1) + " dB";
+    });
+    connect(m_floor, &ClientCompKnob::valueChanged,
+            this, &ClientGateEditor::applyFloor);
+    bottom->addWidget(m_floor, 0, Qt::AlignHCenter);
+
+    // Ratio tucked in alongside — not in the vanilla Ableton layout,
+    // but necessary because Ableton's Gate is pure-gate and we need
+    // ratio for the expander half of the combined module.  1..10 —
+    // capped below hard-gate ∞:1 so the knob has finer resolution
+    // across the musically useful range.
+    m_ratio = makeBottomKnob("Ratio");
+    m_ratio->setRange(1.0f, 10.0f);
+    m_ratio->setDefault(2.0f);
+    m_ratio->setValueFromNorm([](float n) {
+        return 1.0f + n * 9.0f;                       // linear 1..10
+    });
+    m_ratio->setNormFromValue([](float v) { return (v - 1.0f) / 9.0f; });
+    m_ratio->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 1) + ":1";
+    });
+    connect(m_ratio, &ClientCompKnob::valueChanged,
+            this, &ClientGateEditor::applyRatio);
+    bottom->addWidget(m_ratio, 0, Qt::AlignHCenter);
+
+    right->addLayout(bottom);
+
+    body->addLayout(right, 1);
+
+    root->addLayout(body);
+
+    // Bind the level view to the gate once so it starts polling.
+    if (m_audio && m_audio->clientGateTx()) {
+        m_levelView->setGate(m_audio->clientGateTx());
+    }
+
+    // Initial sync from the engine state.
+    syncControlsFromEngine();
+}
+
+ClientGateEditor::~ClientGateEditor() = default;
+
+void ClientGateEditor::showForTx()
+{
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+}
+
+void ClientGateEditor::syncControlsFromEngine()
+{
+    if (!m_audio || !m_audio->clientGateTx()) return;
+    ClientGate* g = m_audio->clientGateTx();
+
+    m_restoring = true;
+
+    {
+        QSignalBlocker b(m_bypass);
+        m_bypass->setChecked(!g->isEnabled());
+    }
+    {
+        QSignalBlocker b(m_flip);
+        m_flip->setChecked(g->mode() == ClientGate::Mode::Gate);
+        m_flip->setText(g->mode() == ClientGate::Mode::Gate ? "Gate" : "Expander");
+    }
+    {
+        QSignalBlocker b(m_threshold);  m_threshold->setValue(g->thresholdDb());
+    }
+    {
+        QSignalBlocker b(m_returnKnob); m_returnKnob->setValue(g->returnDb());
+    }
+    {
+        QSignalBlocker b(m_ratio);      m_ratio->setValue(g->ratio());
+    }
+    {
+        QSignalBlocker b(m_attack);     m_attack->setValue(g->attackMs());
+    }
+    {
+        QSignalBlocker b(m_hold);       m_hold->setValue(g->holdMs());
+    }
+    {
+        QSignalBlocker b(m_release);    m_release->setValue(g->releaseMs());
+    }
+    {
+        QSignalBlocker b(m_floor);      m_floor->setValue(g->floorDb());
+    }
+    {
+        QSignalBlocker b(m_lookahead);
+        const float la = g->lookaheadMs();
+        int bestIdx = 0;
+        float bestDiff = 1e9f;
+        for (int i = 0; i < kLookaheadOptions.size(); ++i) {
+            const float d = std::fabs(kLookaheadOptions[i] - la);
+            if (d < bestDiff) { bestDiff = d; bestIdx = i; }
+        }
+        m_lookahead->setCurrentIndex(bestIdx);
+    }
+
+    m_restoring = false;
+}
+
+void ClientGateEditor::applyThreshold(float db)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientGateTx()->setThresholdDb(db);
+    m_audio->saveClientGateSettings();
+    if (m_levelView) m_levelView->update();
+}
+
+void ClientGateEditor::applyReturn(float db)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientGateTx()->setReturnDb(db);
+    m_audio->saveClientGateSettings();
+    if (m_levelView) m_levelView->update();
+}
+
+void ClientGateEditor::applyRatio(float ratio)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientGateTx()->setRatio(ratio);
+    m_audio->saveClientGateSettings();
+}
+
+void ClientGateEditor::applyAttack(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientGateTx()->setAttackMs(ms);
+    m_audio->saveClientGateSettings();
+}
+
+void ClientGateEditor::applyHold(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientGateTx()->setHoldMs(ms);
+    m_audio->saveClientGateSettings();
+}
+
+void ClientGateEditor::applyRelease(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientGateTx()->setReleaseMs(ms);
+    m_audio->saveClientGateSettings();
+}
+
+void ClientGateEditor::applyFloor(float db)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientGateTx()->setFloorDb(db);
+    m_audio->saveClientGateSettings();
+}
+
+void ClientGateEditor::applyLookahead(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientGateTx()->setLookaheadMs(ms);
+    m_audio->saveClientGateSettings();
+}
+
+void ClientGateEditor::applyMode(int modeIdx)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientGateTx()->setMode(
+        modeIdx == 1 ? ClientGate::Mode::Gate : ClientGate::Mode::Expander);
+    m_audio->saveClientGateSettings();
+    // Mode snaps ratio + floor; re-sync so the knobs show the new values.
+    syncControlsFromEngine();
+}
+
+// ── Geometry persistence ─────────────────────────────────────────
+
+void ClientGateEditor::saveGeometryToSettings()
+{
+    if (m_restoring) return;
+    AppSettings::instance().setValue(
+        "ClientGateEditorGeometry", QString::fromLatin1(saveGeometry().toBase64()));
+}
+
+void ClientGateEditor::restoreGeometryFromSettings()
+{
+    m_restoring = true;
+    const QString b64 = AppSettings::instance()
+        .value("ClientGateEditorGeometry", "").toString();
+    if (!b64.isEmpty()) {
+        restoreGeometry(QByteArray::fromBase64(b64.toLatin1()));
+    }
+    m_restoring = false;
+}
+
+void ClientGateEditor::closeEvent(QCloseEvent* ev)
+{
+    saveGeometryToSettings();
+    QWidget::closeEvent(ev);
+}
+
+void ClientGateEditor::moveEvent(QMoveEvent* ev)
+{
+    saveGeometryToSettings();
+    QWidget::moveEvent(ev);
+}
+
+void ClientGateEditor::resizeEvent(QResizeEvent* ev)
+{
+    saveGeometryToSettings();
+    QWidget::resizeEvent(ev);
+}
+
+void ClientGateEditor::showEvent(QShowEvent* ev)
+{
+    QWidget::showEvent(ev);
+}
+
+void ClientGateEditor::hideEvent(QHideEvent* ev)
+{
+    saveGeometryToSettings();
+    QWidget::hideEvent(ev);
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientGateEditor.h
+++ b/src/gui/ClientGateEditor.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <QWidget>
+
+class QComboBox;
+class QLabel;
+class QPushButton;
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompKnob;    // reused — generic rotary knob
+class ClientGateLevelView;
+
+// Floating editor for the client-side TX gate / expander — layout
+// modelled on Ableton Live's Gate device.  One instance lives on
+// MainWindow; calling showForTx() raises the window and binds it to
+// AudioEngine::clientGateTx().  Geometry persists via AppSettings
+// (`ClientGateEditorGeometry` key).
+//
+// Layout:
+//   ┌─ bypass ──────────────────── × ┐
+//   │ ┌──────┐  ┌──────────────────┐ │
+//   │ │ THR  │  │                  │ │
+//   │ │      │  │   level view     │ │
+//   │ │ RET  │  │   (Ableton-style)│ │
+//   │ │      │  │                  │ │
+//   │ │ Flip │  │                  │ │
+//   │ │ Look │  │                  │ │
+//   │ └──────┘  └──────────────────┘ │
+//   │   [ATK] [HLD] [REL] [FLR]      │
+//   └────────────────────────────────┘
+class ClientGateEditor : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientGateEditor(AudioEngine* engine, QWidget* parent = nullptr);
+    ~ClientGateEditor() override;
+
+    void showForTx();
+
+signals:
+    // Fired when bypass toggles.  Docked applet subscribes to keep
+    // its Enable button in sync.
+    void bypassToggled(bool bypassed);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+    void syncControlsFromEngine();
+
+    // Parameter commit — all control signals land here; each writes
+    // the engine + persists via AppSettings.
+    void applyThreshold(float db);
+    void applyReturn(float db);
+    void applyRatio(float ratio);
+    void applyAttack(float ms);
+    void applyHold(float ms);
+    void applyRelease(float ms);
+    void applyFloor(float db);
+    void applyLookahead(float ms);
+    void applyMode(int modeIdx);   // 0=Expander, 1=Gate
+
+    AudioEngine*          m_audio{nullptr};
+    ClientGateLevelView*  m_levelView{nullptr};
+    ClientCompKnob*       m_threshold{nullptr};
+    ClientCompKnob*       m_returnKnob{nullptr};
+    ClientCompKnob*       m_ratio{nullptr};
+    ClientCompKnob*       m_attack{nullptr};
+    ClientCompKnob*       m_hold{nullptr};
+    ClientCompKnob*       m_release{nullptr};
+    ClientCompKnob*       m_floor{nullptr};
+    QPushButton*          m_flip{nullptr};
+    QComboBox*            m_lookahead{nullptr};
+    QPushButton*          m_bypass{nullptr};
+    bool                  m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientGateLevelView.cpp
+++ b/src/gui/ClientGateLevelView.cpp
@@ -1,0 +1,218 @@
+#include "ClientGateLevelView.h"
+#include "core/ClientGate.h"
+
+#include <QPainter>
+#include <QPainterPath>
+#include <QPaintEvent>
+#include <QPen>
+#include <QTimer>
+#include <algorithm>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kHistoryCount = 120;      // ~4 s at 30 Hz
+constexpr int kPollMs       = 33;
+
+const QColor kBgColor     ("#0a1420");
+const QColor kFrameColor  ("#2a3a4a");
+const QColor kGridColor   ("#1e3040");
+const QColor kAxisLabel   ("#607888");
+const QColor kInputColor  ("#f0f4f8");   // white input outline
+const QColor kAudibleColor("#f2c14e");   // amber — audio that passes through
+const QColor kReduceColor ("#1f2a38");   // dark gray reduction overlay
+const QColor kThreshColor ("#4db8d4");   // cyan threshold lines
+const QColor kPeakColor   ("#e8a540");   // amber peak bar
+
+// dB ticks shown on the left gutter.
+const float kTicks[] = { 6.0f, 0.0f, -6.0f, -12.0f, -18.0f,
+                         -24.0f, -36.0f, -50.0f, -70.0f };
+
+constexpr int   kGutterPx  = 28;   // left label gutter
+constexpr int   kPeakBarPx = 8;    // right-edge peak strip
+
+} // namespace
+
+ClientGateLevelView::ClientGateLevelView(QWidget* parent) : QWidget(parent)
+{
+    setMinimumSize(240, 160);
+    setAttribute(Qt::WA_OpaquePaintEvent, false);
+
+    m_history.assign(kHistoryCount, Sample{kBottomDb, 0.0f});
+
+    m_timer = new QTimer(this);
+    m_timer->setInterval(kPollMs);
+    connect(m_timer, &QTimer::timeout, this, &ClientGateLevelView::tick);
+}
+
+void ClientGateLevelView::setGate(ClientGate* gate)
+{
+    m_gate = gate;
+    if (m_gate) m_timer->start();
+    else        m_timer->stop();
+    update();
+}
+
+void ClientGateLevelView::tick()
+{
+    if (!m_gate) return;
+    Sample s;
+    s.inputDb = std::clamp(m_gate->inputPeakDb(), kBottomDb, kTopDb);
+    s.grDb    = std::clamp(m_gate->gainReductionDb(), -80.0f, 0.0f);
+    m_history[m_writeIdx] = s;
+    m_writeIdx = (m_writeIdx + 1) % kHistoryCount;
+    update();
+}
+
+float ClientGateLevelView::dbToY(float db) const
+{
+    const float t = (db - kBottomDb) / (kTopDb - kBottomDb);
+    const float top    = 4.0f;
+    const float bottom = static_cast<float>(height()) - 4.0f;
+    return bottom - t * (bottom - top);
+}
+
+void ClientGateLevelView::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    const QRectF full = rect();
+    p.fillRect(full, kBgColor);
+
+    // Plot region: inset the left gutter for dB labels and the right
+    // strip for the peak bar.
+    const QRectF plot(full.left() + kGutterPx, full.top() + 4,
+                      full.width() - kGutterPx - kPeakBarPx - 4,
+                      full.height() - 8);
+
+    // Frame the plot.
+    p.setPen(QPen(kFrameColor, 1.0));
+    p.drawRect(plot);
+
+    // Horizontal grid + labels.
+    QFont f = p.font();
+    f.setPixelSize(9);
+    p.setFont(f);
+    for (float db : kTicks) {
+        const float y = dbToY(db);
+        p.setPen(QPen(kGridColor, 1.0));
+        p.drawLine(QPointF(plot.left(), y), QPointF(plot.right(), y));
+        p.setPen(kAxisLabel);
+        QString s = (db > 0.0f ? "+" : "") + QString::number(static_cast<int>(db));
+        p.drawText(QPointF(full.left() + 2.0f, y + 3.0f), s);
+    }
+
+    // History plot — newest sample at the right edge, older scrolling
+    // left.  Draw order (bottom to top visually so later strokes
+    // paint over earlier ones cleanly):
+    //   1. Audible band — from plot.bottom up to (input + grDb),
+    //      filled amber.  Represents the portion of the signal that
+    //      actually makes it through the gate.
+    //   2. Gated band — from (input + grDb) up to input level,
+    //      filled dark gray.  Represents the gain being "taken away"
+    //      from the input.
+    //   3. Input top-edge outline in bright white so the original
+    //      signal envelope stays legible on top of the fills.
+    p.save();
+    p.setClipRect(plot);
+
+    const float colW = plot.width() / float(kHistoryCount);
+
+    // ── Audible band (amber) ───────────────────────────────────
+    QPainterPath audiblePath;
+    for (int i = 0; i < kHistoryCount; ++i) {
+        const int idx = (m_writeIdx + i) % kHistoryCount;
+        const Sample& s = m_history[idx];
+        const float x = plot.right() - (kHistoryCount - 1 - i) * colW;
+        // When gate is fully open, grDb = 0 → yGr = yIn; the amber
+        // band touches the input outline.  When the gate closes,
+        // grDb is negative and yGr sits lower → amber band shrinks,
+        // revealing the gray gated band above it.
+        const float yGr = dbToY(s.inputDb + s.grDb);
+        if (i == 0) audiblePath.moveTo(x, yGr);
+        else        audiblePath.lineTo(x, yGr);
+    }
+    audiblePath.lineTo(plot.right(), plot.bottom());
+    audiblePath.lineTo(plot.left(),  plot.bottom());
+    audiblePath.closeSubpath();
+
+    QColor audibleFill = kAudibleColor; audibleFill.setAlpha(90);
+    p.setBrush(audibleFill);
+    p.setPen(Qt::NoPen);
+    p.drawPath(audiblePath);
+
+    // ── Gated band (dark gray) ──────────────────────────────────
+    QPainterPath gatedPath;
+    for (int i = 0; i < kHistoryCount; ++i) {
+        const int idx = (m_writeIdx + i) % kHistoryCount;
+        const Sample& s = m_history[idx];
+        const float x = plot.right() - (kHistoryCount - 1 - i) * colW;
+        const float yIn = dbToY(s.inputDb);
+        if (i == 0) gatedPath.moveTo(x, yIn);
+        else        gatedPath.lineTo(x, yIn);
+    }
+    for (int i = kHistoryCount - 1; i >= 0; --i) {
+        const int idx = (m_writeIdx + i) % kHistoryCount;
+        const Sample& s = m_history[idx];
+        const float x = plot.right() - (kHistoryCount - 1 - i) * colW;
+        const float yGr = dbToY(s.inputDb + s.grDb);
+        gatedPath.lineTo(x, yGr);
+    }
+    gatedPath.closeSubpath();
+
+    p.setBrush(kReduceColor);
+    p.setPen(Qt::NoPen);
+    p.drawPath(gatedPath);
+
+    // ── Input top outline ───────────────────────────────────────
+    QPainterPath inputOutline;
+    for (int i = 0; i < kHistoryCount; ++i) {
+        const int idx = (m_writeIdx + i) % kHistoryCount;
+        const Sample& s = m_history[idx];
+        const float x = plot.right() - (kHistoryCount - 1 - i) * colW;
+        const float yIn = dbToY(s.inputDb);
+        if (i == 0) inputOutline.moveTo(x, yIn);
+        else        inputOutline.lineTo(x, yIn);
+    }
+    p.setPen(QPen(kInputColor, 1.2));
+    p.setBrush(Qt::NoBrush);
+    p.drawPath(inputOutline);
+
+    p.restore();
+
+    // Threshold lines.
+    if (m_gate) {
+        const float T  = m_gate->thresholdDb();
+        const float Tc = T - m_gate->returnDb();
+        QPen pen(kThreshColor, 1.5);
+        p.setPen(pen);
+        const float yT  = dbToY(std::clamp(T,  kBottomDb, kTopDb));
+        p.drawLine(QPointF(plot.left(), yT), QPointF(plot.right(), yT));
+        QColor returnCol = kThreshColor; returnCol.setAlpha(180);
+        p.setPen(QPen(returnCol, 1.2));
+        const float yTc = dbToY(std::clamp(Tc, kBottomDb, kTopDb));
+        p.drawLine(QPointF(plot.left(), yTc), QPointF(plot.right(), yTc));
+    }
+
+    // Peak bar on the right edge — current input level in amber.
+    {
+        const QRectF bar(full.right() - kPeakBarPx - 2, plot.top(),
+                         kPeakBarPx, plot.height());
+        p.fillRect(bar, kBgColor);
+        p.setPen(QPen(kFrameColor, 1.0));
+        p.drawRect(bar);
+
+        if (m_gate) {
+            const float inDb = std::clamp(
+                m_gate->inputPeakDb(), kBottomDb, kTopDb);
+            const float yIn = dbToY(inDb);
+            const QRectF fill(bar.left() + 1, yIn,
+                              bar.width() - 2, bar.bottom() - yIn - 1);
+            p.fillRect(fill, kPeakColor);
+        }
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientGateLevelView.h
+++ b/src/gui/ClientGateLevelView.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <QWidget>
+#include <vector>
+
+class QTimer;
+
+namespace AetherSDR {
+
+class ClientGate;
+
+// Scrolling level-history view for the Gate editor — mirrors Ableton's
+// Gate device layout: dB scale on the left, time running right-to-left
+// with the newest sample at the right edge, input peak drawn as a
+// white outline, gain-reduction overlaid as a dark-gray fill under
+// the input, and a pair of cyan horizontal lines at threshold (upper)
+// and threshold - return (lower) showing the hysteresis band.
+//
+// Sampling: the bound ClientGate's inputPeakDb() and
+// gainReductionDb() are polled at ~30 Hz and pushed into a ring
+// buffer (~2 s of history at 30 Hz ≈ 60 samples).  Low-freq signal
+// so cheap to paint; the widget is the focal point of the editor.
+class ClientGateLevelView : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientGateLevelView(QWidget* parent = nullptr);
+
+    void setGate(ClientGate* gate);
+
+    // dB extents of the vertical axis.  Matches the editor label row.
+    static constexpr float kTopDb    =   6.0f;
+    static constexpr float kBottomDb = -70.0f;
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+
+private:
+    void tick();
+
+    float dbToY(float db) const;
+
+    ClientGate* m_gate{nullptr};
+    QTimer*     m_timer{nullptr};
+
+    struct Sample {
+        float inputDb;
+        float grDb;
+    };
+    std::vector<Sample> m_history;
+    int                 m_writeIdx{0};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientPuduApplet.cpp
+++ b/src/gui/ClientPuduApplet.cpp
@@ -1,0 +1,354 @@
+#include "ClientPuduApplet.h"
+#include "ClientCompKnob.h"
+#include "PooDooLogo.h"
+#include "core/AudioEngine.h"
+#include "core/ClientPudu.h"
+
+#include <QButtonGroup>
+#include <QFrame>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QSignalBlocker>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+const QString kEnableStyle =
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 11px; font-weight: bold; padding: 2px 10px;"
+    "}"
+    "QPushButton:hover { background: #204060; }"
+    "QPushButton:checked {"
+    "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
+    "}";
+
+constexpr const char* kEditStyle =
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 11px; padding: 2px 10px;"
+    "}"
+    "QPushButton:hover { background: #204060; }";
+
+const QString kModeStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #2a4458; border-radius: 3px;"
+    "  color: #8aa8c0; font-size: 11px; font-weight: bold;"
+    "  padding: 3px 14px; min-width: 26px;"
+    "}"
+    "QPushButton:hover { background: #24384e; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e; color: #f2c14e; border: 1px solid #f2c14e;"
+    "}");
+
+// "|─── text ───|" group label: horizontal line, centred text, horizontal line.
+QWidget* makeBracketLabel(const QString& text)
+{
+    auto* w = new QWidget;
+    auto* h = new QHBoxLayout(w);
+    h->setContentsMargins(0, 0, 0, 0);
+    h->setSpacing(4);
+
+    auto* leftLine = new QFrame;
+    leftLine->setFrameShape(QFrame::HLine);
+    leftLine->setFrameShadow(QFrame::Plain);
+    leftLine->setStyleSheet("QFrame { color: #4a5a6a; }");
+
+    auto* lbl = new QLabel(text);
+    lbl->setStyleSheet("QLabel { color: #c8d8e8; font-weight: bold; "
+                       "font-size: 10px; }");
+    lbl->setAlignment(Qt::AlignCenter);
+
+    auto* rightLine = new QFrame;
+    rightLine->setFrameShape(QFrame::HLine);
+    rightLine->setFrameShadow(QFrame::Plain);
+    rightLine->setStyleSheet("QFrame { color: #4a5a6a; }");
+
+    h->addWidget(leftLine, 1);
+    h->addWidget(lbl);
+    h->addWidget(rightLine, 1);
+    return w;
+}
+
+} // namespace
+
+ClientPuduApplet::ClientPuduApplet(QWidget* parent) : QWidget(parent)
+{
+    buildUI();
+    hide();
+}
+
+void ClientPuduApplet::buildUI()
+{
+    setStyleSheet("QWidget { background: transparent; }");
+
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(4, 4, 4, 4);
+    outer->setSpacing(4);
+
+    // ── Logo ────────────────────────────────────────────────────
+    m_logo = new PooDooLogo;
+    m_logo->setMinimumHeight(40);
+    outer->addWidget(m_logo);
+
+    // ── A/B mode toggle ─────────────────────────────────────────
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(4);
+        row->addStretch();
+        auto* group = new QButtonGroup(this);
+        group->setExclusive(true);
+
+        m_modeA = new QPushButton("A");
+        m_modeA->setCheckable(true);
+        m_modeA->setStyleSheet(kModeStyle);
+        m_modeA->setFixedHeight(22);
+        m_modeA->setToolTip("Aphex Aural Exciter + Big Bottom — warm, asymmetric harmonics");
+        group->addButton(m_modeA, 0);
+        row->addWidget(m_modeA);
+
+        m_modeB = new QPushButton("B");
+        m_modeB->setCheckable(true);
+        m_modeB->setStyleSheet(kModeStyle);
+        m_modeB->setFixedHeight(22);
+        m_modeB->setToolTip("Behringer SX 3040 Sonic Exciter — tighter, compressor-based bass");
+        group->addButton(m_modeB, 1);
+        row->addWidget(m_modeB);
+        row->addStretch();
+
+        connect(group, &QButtonGroup::idToggled, this,
+                [this](int id, bool checked) {
+            if (checked) onModeToggled(id);
+        });
+
+        outer->addLayout(row);
+    }
+
+    // ── Knob row — all 6 on one line with Poo | gap | Doo grouping ──
+    //
+    // Grid layout: row 0 = bracket labels, row 1 = knobs.  Knobs
+    // occupy columns 0-2 (Poo) and 4-6 (Doo); column 3 is a fixed
+    // spacer separating the two groups.
+    {
+        auto* grid = new QGridLayout;
+        grid->setContentsMargins(0, 0, 0, 0);
+        grid->setHorizontalSpacing(0);
+        grid->setVerticalSpacing(1);
+        grid->setColumnMinimumWidth(3, 8);    // gap between Poo and Doo
+
+        grid->addWidget(makeBracketLabel("Poo"), 0, 0, 1, 3);
+        grid->addWidget(makeBracketLabel("Doo"), 0, 4, 1, 3);
+
+        auto makeKnob = [](const QString& label) {
+            auto* k = new ClientCompKnob;
+            k->setLabel(label);
+            k->setCenterLabelMode(true);
+            // 260 px panel budget: 6 × 38 = 228 + 10 px gap +
+            // margins comfortably inside the container.  Ring +
+            // value row fit in ~48 px vertical.
+            k->setFixedSize(38, 48);
+            return k;
+        };
+
+        m_pooDrive = makeKnob("Drive");
+        m_pooDrive->setRange(0.0f, 24.0f);
+        m_pooDrive->setDefault(6.0f);
+        m_pooDrive->setValueFromNorm([](float n) { return n * 24.0f; });
+        m_pooDrive->setNormFromValue([](float v) { return v / 24.0f; });
+        m_pooDrive->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + " dB";
+        });
+        connect(m_pooDrive, &ClientCompKnob::valueChanged,
+                this, &ClientPuduApplet::applyPooDrive);
+        grid->addWidget(m_pooDrive, 1, 0, Qt::AlignHCenter);
+
+        m_pooTune = makeKnob("Tune");
+        m_pooTune->setRange(50.0f, 160.0f);
+        m_pooTune->setDefault(100.0f);
+        m_pooTune->setValueFromNorm([](float n) { return 50.0f + n * 110.0f; });
+        m_pooTune->setNormFromValue([](float v) { return (v - 50.0f) / 110.0f; });
+        m_pooTune->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 0) + " Hz";
+        });
+        connect(m_pooTune, &ClientCompKnob::valueChanged,
+                this, &ClientPuduApplet::applyPooTune);
+        grid->addWidget(m_pooTune, 1, 1, Qt::AlignHCenter);
+
+        m_pooMix = makeKnob("Mix");
+        m_pooMix->setRange(0.0f, 1.0f);
+        m_pooMix->setDefault(0.3f);
+        m_pooMix->setValueFromNorm([](float n) { return n; });
+        m_pooMix->setNormFromValue([](float v) { return v; });
+        m_pooMix->setLabelFormat([](float v) {
+            return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+        });
+        connect(m_pooMix, &ClientCompKnob::valueChanged,
+                this, &ClientPuduApplet::applyPooMix);
+        grid->addWidget(m_pooMix, 1, 2, Qt::AlignHCenter);
+
+        m_dooTune = makeKnob("Tune");
+        m_dooTune->setRange(1000.0f, 10000.0f);
+        m_dooTune->setDefault(5000.0f);
+        m_dooTune->setValueFromNorm([](float n) {
+            return 1000.0f * std::pow(10.0f, n);
+        });
+        m_dooTune->setNormFromValue([](float v) {
+            return std::log10(std::max(1000.0f, v) / 1000.0f);
+        });
+        m_dooTune->setLabelFormat([](float v) {
+            return (v >= 1000.0f)
+                ? QString::number(v / 1000.0f, 'f', 1) + " kHz"
+                : QString::number(v, 'f', 0) + " Hz";
+        });
+        connect(m_dooTune, &ClientCompKnob::valueChanged,
+                this, &ClientPuduApplet::applyDooTune);
+        grid->addWidget(m_dooTune, 1, 4, Qt::AlignHCenter);
+
+        m_dooHarmonics = makeKnob("Air");
+        m_dooHarmonics->setRange(0.0f, 24.0f);
+        m_dooHarmonics->setDefault(6.0f);
+        m_dooHarmonics->setValueFromNorm([](float n) { return n * 24.0f; });
+        m_dooHarmonics->setNormFromValue([](float v) { return v / 24.0f; });
+        m_dooHarmonics->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + " dB";
+        });
+        connect(m_dooHarmonics, &ClientCompKnob::valueChanged,
+                this, &ClientPuduApplet::applyDooHarmonics);
+        grid->addWidget(m_dooHarmonics, 1, 5, Qt::AlignHCenter);
+
+        m_dooMix = makeKnob("Mix");
+        m_dooMix->setRange(0.0f, 1.0f);
+        m_dooMix->setDefault(0.3f);
+        m_dooMix->setValueFromNorm([](float n) { return n; });
+        m_dooMix->setNormFromValue([](float v) { return v; });
+        m_dooMix->setLabelFormat([](float v) {
+            return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+        });
+        connect(m_dooMix, &ClientCompKnob::valueChanged,
+                this, &ClientPuduApplet::applyDooMix);
+        grid->addWidget(m_dooMix, 1, 6, Qt::AlignHCenter);
+
+        outer->addLayout(grid);
+    }
+
+    // ── Enable / Edit row ───────────────────────────────────────
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(4);
+        m_enable = new QPushButton("Enable");
+        m_enable->setCheckable(true);
+        m_enable->setStyleSheet(kEnableStyle);
+        m_enable->setFixedHeight(22);
+        row->addWidget(m_enable);
+        row->addStretch();
+        m_edit = new QPushButton("Edit…");
+        m_edit->setStyleSheet(kEditStyle);
+        m_edit->setFixedHeight(22);
+        m_edit->setToolTip("Open the PUDU editor");
+        row->addWidget(m_edit);
+
+        connect(m_enable, &QPushButton::toggled, this,
+                &ClientPuduApplet::onEnableToggled);
+        connect(m_edit, &QPushButton::clicked, this, [this]() {
+            emit editRequested();
+        });
+        outer->addLayout(row);
+    }
+}
+
+void ClientPuduApplet::setAudioEngine(AudioEngine* engine)
+{
+    m_audio = engine;
+    if (!m_audio) return;
+    if (m_logo) m_logo->setPudu(m_audio->clientPuduTx());
+    syncControlsFromEngine();
+}
+
+void ClientPuduApplet::syncControlsFromEngine()
+{
+    if (!m_audio || !m_audio->clientPuduTx()) return;
+    ClientPudu* p = m_audio->clientPuduTx();
+
+    m_restoring = true;
+    { QSignalBlocker b(m_enable); m_enable->setChecked(p->isEnabled()); }
+    {
+        const bool isA = (p->mode() == ClientPudu::Mode::Aphex);
+        QSignalBlocker ba(m_modeA);
+        QSignalBlocker bb(m_modeB);
+        m_modeA->setChecked(isA);
+        m_modeB->setChecked(!isA);
+    }
+    { QSignalBlocker b(m_pooDrive);     m_pooDrive->setValue(p->pooDriveDb()); }
+    { QSignalBlocker b(m_pooTune);      m_pooTune->setValue(p->pooTuneHz()); }
+    { QSignalBlocker b(m_pooMix);       m_pooMix->setValue(p->pooMix()); }
+    { QSignalBlocker b(m_dooTune);      m_dooTune->setValue(p->dooTuneHz()); }
+    { QSignalBlocker b(m_dooHarmonics); m_dooHarmonics->setValue(p->dooHarmonicsDb()); }
+    { QSignalBlocker b(m_dooMix);       m_dooMix->setValue(p->dooMix()); }
+    m_restoring = false;
+}
+
+void ClientPuduApplet::refreshEnableFromEngine()
+{
+    syncControlsFromEngine();
+}
+
+void ClientPuduApplet::onEnableToggled(bool on)
+{
+    if (m_restoring || !m_audio) return;
+    ClientPudu* p = m_audio->clientPuduTx();
+    if (!p) return;
+    p->setEnabled(on);
+    m_audio->saveClientPuduSettings();
+}
+
+void ClientPuduApplet::onModeToggled(int id)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setMode(
+        id == 1 ? ClientPudu::Mode::Behringer : ClientPudu::Mode::Aphex);
+    m_audio->saveClientPuduSettings();
+}
+
+void ClientPuduApplet::applyPooDrive(float db)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setPooDriveDb(db);
+    m_audio->saveClientPuduSettings();
+}
+void ClientPuduApplet::applyPooTune(float hz)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setPooTuneHz(hz);
+    m_audio->saveClientPuduSettings();
+}
+void ClientPuduApplet::applyPooMix(float v)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setPooMix(v);
+    m_audio->saveClientPuduSettings();
+}
+void ClientPuduApplet::applyDooTune(float hz)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setDooTuneHz(hz);
+    m_audio->saveClientPuduSettings();
+}
+void ClientPuduApplet::applyDooHarmonics(float db)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setDooHarmonicsDb(db);
+    m_audio->saveClientPuduSettings();
+}
+void ClientPuduApplet::applyDooMix(float v)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setDooMix(v);
+    m_audio->saveClientPuduSettings();
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientPuduApplet.h
+++ b/src/gui/ClientPuduApplet.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompKnob;       // reused — generic rotary knob
+class PooDooLogo;
+
+// Docked tile for the PUDU exciter — centrepiece of the PooDoo Audio™
+// chain.  Layout:
+//
+//   ┌──────── PooDoo™ logo (pulses with wet RMS) ────────┐
+//   │                                                    │
+//   │  ┌─────── A | B mode toggle ───────┐               │
+//   │                                                    │
+//   │  Poo: [Drive] [Tune] [Mix]                         │
+//   │  Doo: [Tune] [Harmonics] [Mix]                     │
+//   │                                                    │
+//   │  [Enable]                                 [Edit…]  │
+//   └────────────────────────────────────────────────────┘
+class ClientPuduApplet : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientPuduApplet(QWidget* parent = nullptr);
+
+    void setAudioEngine(AudioEngine* engine);
+    void refreshEnableFromEngine();
+
+signals:
+    void editRequested();
+
+private:
+    void buildUI();
+    void syncControlsFromEngine();
+    void onEnableToggled(bool on);
+    void onModeToggled(int id);
+
+    void applyPooDrive(float db);
+    void applyPooTune(float hz);
+    void applyPooMix(float v);
+    void applyDooTune(float hz);
+    void applyDooHarmonics(float db);
+    void applyDooMix(float v);
+
+    AudioEngine*    m_audio{nullptr};
+    PooDooLogo*     m_logo{nullptr};
+    QPushButton*    m_modeA{nullptr};
+    QPushButton*    m_modeB{nullptr};
+    QPushButton*    m_enable{nullptr};
+    QPushButton*    m_edit{nullptr};
+    ClientCompKnob* m_pooDrive{nullptr};
+    ClientCompKnob* m_pooTune{nullptr};
+    ClientCompKnob* m_pooMix{nullptr};
+    ClientCompKnob* m_dooTune{nullptr};
+    ClientCompKnob* m_dooHarmonics{nullptr};
+    ClientCompKnob* m_dooMix{nullptr};
+    bool            m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientPuduEditor.cpp
+++ b/src/gui/ClientPuduEditor.cpp
@@ -1,0 +1,381 @@
+#include "ClientPuduEditor.h"
+#include "ClientCompKnob.h"
+#include "PooDooLogo.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ClientPudu.h"
+
+#include <QButtonGroup>
+#include <QCloseEvent>
+#include <QFrame>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QHideEvent>
+#include <QLabel>
+#include <QMoveEvent>
+#include <QPushButton>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kDefaultWidth  = 640;
+constexpr int kDefaultHeight = 360;
+
+constexpr const char* kWindowStyle =
+    "QWidget { background: #08121d; color: #d7e7f2; }"
+    "QLabel  { background: transparent; color: #8aa8c0; font-size: 11px; }";
+
+const QString kBypassStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #0e1b28; color: #8aa8c0;"
+    "  border: 1px solid #243a4e; border-radius: 3px;"
+    "  font-size: 11px; font-weight: bold; padding: 3px 12px;"
+    "}"
+    "QPushButton:hover { background: #1a2a3a; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e; color: #f2c14e; border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #4a3a1e; }");
+
+const QString kModeStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #2a4458; border-radius: 3px;"
+    "  color: #8aa8c0; font-size: 12px; font-weight: bold;"
+    "  padding: 4px 20px; min-width: 34px;"
+    "}"
+    "QPushButton:hover { background: #24384e; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e; color: #f2c14e; border: 1px solid #f2c14e;"
+    "}");
+
+// "|─── text ───|" group label: horizontal line, centred text, horizontal line.
+QWidget* makeBracketLabel(const QString& text)
+{
+    auto* w = new QWidget;
+    auto* h = new QHBoxLayout(w);
+    h->setContentsMargins(0, 0, 0, 0);
+    h->setSpacing(6);
+
+    auto* leftLine = new QFrame;
+    leftLine->setFrameShape(QFrame::HLine);
+    leftLine->setFrameShadow(QFrame::Plain);
+    leftLine->setStyleSheet("QFrame { color: #5a6a7a; }");
+
+    auto* lbl = new QLabel(text);
+    lbl->setStyleSheet("QLabel { color: #c8d8e8; font-weight: bold; "
+                       "font-size: 13px; letter-spacing: 2px; }");
+    lbl->setAlignment(Qt::AlignCenter);
+
+    auto* rightLine = new QFrame;
+    rightLine->setFrameShape(QFrame::HLine);
+    rightLine->setFrameShadow(QFrame::Plain);
+    rightLine->setStyleSheet("QFrame { color: #5a6a7a; }");
+
+    h->addWidget(leftLine, 1);
+    h->addWidget(lbl);
+    h->addWidget(rightLine, 1);
+    return w;
+}
+
+} // namespace
+
+ClientPuduEditor::ClientPuduEditor(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent, Qt::Window)
+    , m_audio(engine)
+{
+    setWindowTitle(QString::fromUtf8("PooDoo\xe2\x84\xa2 Audio — PUDU"));
+    setStyleSheet(kWindowStyle);
+    resize(kDefaultWidth, kDefaultHeight);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(12, 10, 12, 10);
+    root->setSpacing(8);
+
+    // ── Header: Bypass on the left, A/B on the right ────────────
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(8);
+
+        m_bypass = new QPushButton("Bypass");
+        m_bypass->setCheckable(true);
+        m_bypass->setStyleSheet(kBypassStyle);
+        m_bypass->setFixedHeight(24);
+        m_bypass->setToolTip(
+            "Bypass PUDU (signal passes through with no exciter contribution)");
+        row->addWidget(m_bypass);
+        connect(m_bypass, &QPushButton::toggled, this, [this](bool bypassed) {
+            if (!m_audio || !m_audio->clientPuduTx()) return;
+            m_audio->clientPuduTx()->setEnabled(!bypassed);
+            m_audio->saveClientPuduSettings();
+            emit bypassToggled(bypassed);
+        });
+
+        row->addStretch();
+
+        auto* group = new QButtonGroup(this);
+        group->setExclusive(true);
+        m_modeA = new QPushButton("A");
+        m_modeA->setCheckable(true);
+        m_modeA->setStyleSheet(kModeStyle);
+        m_modeA->setFixedHeight(24);
+        m_modeA->setToolTip("Aphex Aural Exciter + Big Bottom — warm, asymmetric harmonics");
+        group->addButton(m_modeA, 0);
+        row->addWidget(m_modeA);
+
+        m_modeB = new QPushButton("B");
+        m_modeB->setCheckable(true);
+        m_modeB->setStyleSheet(kModeStyle);
+        m_modeB->setFixedHeight(24);
+        m_modeB->setToolTip("Behringer SX 3040 Sonic Exciter — tight, compressor-based bass");
+        group->addButton(m_modeB, 1);
+        row->addWidget(m_modeB);
+
+        connect(group, &QButtonGroup::idToggled, this,
+                [this](int id, bool checked) {
+            if (checked) onModeToggled(id);
+        });
+
+        root->addLayout(row);
+    }
+
+    // ── Logo (big in the editor) ────────────────────────────────
+    m_logo = new PooDooLogo;
+    m_logo->setMinimumHeight(80);
+    root->addWidget(m_logo);
+
+    // Breathing room between the wordmark's underline and the
+    // Poo/Doo bracket labels below.
+    root->addSpacing(40);
+
+    // ── Knob row: all 6 on one line with Poo | gap | Doo grouping ──
+    //
+    // Grid: row 0 = bracket group labels (|─Poo─| and |─Doo─|),
+    // row 1 = knobs.  Columns 0-2 host Poo; column 3 is a fixed
+    // spacer separating the two groups; columns 4-6 host Doo.
+    {
+        auto* grid = new QGridLayout;
+        grid->setContentsMargins(0, 0, 0, 0);
+        grid->setHorizontalSpacing(12);
+        grid->setVerticalSpacing(4);
+        grid->setColumnMinimumWidth(3, 32);   // gap between Poo and Doo
+
+        grid->addWidget(makeBracketLabel("Poo"), 0, 0, 1, 3);
+        grid->addWidget(makeBracketLabel("Doo"), 0, 4, 1, 3);
+
+        auto makeKnob = [](const QString& label) {
+            auto* k = new ClientCompKnob;
+            k->setLabel(label);
+            k->setCenterLabelMode(true);
+            // Tighter vertical footprint in center-label mode since
+            // the label sits inside the ring now.  Ring + value row.
+            k->setFixedSize(88, 92);
+            return k;
+        };
+
+        m_pooDrive = makeKnob("Drive");
+        m_pooDrive->setRange(0.0f, 24.0f);
+        m_pooDrive->setDefault(6.0f);
+        m_pooDrive->setValueFromNorm([](float n) { return n * 24.0f; });
+        m_pooDrive->setNormFromValue([](float v) { return v / 24.0f; });
+        m_pooDrive->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + " dB";
+        });
+        connect(m_pooDrive, &ClientCompKnob::valueChanged,
+                this, &ClientPuduEditor::applyPooDrive);
+        grid->addWidget(m_pooDrive, 1, 0, Qt::AlignHCenter);
+
+        m_pooTune = makeKnob("Tune");
+        m_pooTune->setRange(50.0f, 160.0f);
+        m_pooTune->setDefault(100.0f);
+        m_pooTune->setValueFromNorm([](float n) { return 50.0f + n * 110.0f; });
+        m_pooTune->setNormFromValue([](float v) { return (v - 50.0f) / 110.0f; });
+        m_pooTune->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 0) + " Hz";
+        });
+        connect(m_pooTune, &ClientCompKnob::valueChanged,
+                this, &ClientPuduEditor::applyPooTune);
+        grid->addWidget(m_pooTune, 1, 1, Qt::AlignHCenter);
+
+        m_pooMix = makeKnob("Mix");
+        m_pooMix->setRange(0.0f, 1.0f);
+        m_pooMix->setDefault(0.3f);
+        m_pooMix->setValueFromNorm([](float n) { return n; });
+        m_pooMix->setNormFromValue([](float v) { return v; });
+        m_pooMix->setLabelFormat([](float v) {
+            return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+        });
+        connect(m_pooMix, &ClientCompKnob::valueChanged,
+                this, &ClientPuduEditor::applyPooMix);
+        grid->addWidget(m_pooMix, 1, 2, Qt::AlignHCenter);
+
+        m_dooTune = makeKnob("Tune");
+        m_dooTune->setRange(1000.0f, 10000.0f);
+        m_dooTune->setDefault(5000.0f);
+        m_dooTune->setValueFromNorm([](float n) {
+            return 1000.0f * std::pow(10.0f, n);
+        });
+        m_dooTune->setNormFromValue([](float v) {
+            return std::log10(std::max(1000.0f, v) / 1000.0f);
+        });
+        m_dooTune->setLabelFormat([](float v) {
+            return (v >= 1000.0f)
+                ? QString::number(v / 1000.0f, 'f', 1) + " kHz"
+                : QString::number(v, 'f', 0) + " Hz";
+        });
+        connect(m_dooTune, &ClientCompKnob::valueChanged,
+                this, &ClientPuduEditor::applyDooTune);
+        grid->addWidget(m_dooTune, 1, 4, Qt::AlignHCenter);
+
+        m_dooHarmonics = makeKnob("Air");
+        m_dooHarmonics->setRange(0.0f, 24.0f);
+        m_dooHarmonics->setDefault(6.0f);
+        m_dooHarmonics->setValueFromNorm([](float n) { return n * 24.0f; });
+        m_dooHarmonics->setNormFromValue([](float v) { return v / 24.0f; });
+        m_dooHarmonics->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + " dB";
+        });
+        connect(m_dooHarmonics, &ClientCompKnob::valueChanged,
+                this, &ClientPuduEditor::applyDooHarmonics);
+        grid->addWidget(m_dooHarmonics, 1, 5, Qt::AlignHCenter);
+
+        m_dooMix = makeKnob("Mix");
+        m_dooMix->setRange(0.0f, 1.0f);
+        m_dooMix->setDefault(0.3f);
+        m_dooMix->setValueFromNorm([](float n) { return n; });
+        m_dooMix->setNormFromValue([](float v) { return v; });
+        m_dooMix->setLabelFormat([](float v) {
+            return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+        });
+        connect(m_dooMix, &ClientCompKnob::valueChanged,
+                this, &ClientPuduEditor::applyDooMix);
+        grid->addWidget(m_dooMix, 1, 6, Qt::AlignHCenter);
+
+        root->addLayout(grid);
+    }
+
+    root->addStretch();
+
+    if (m_audio && m_audio->clientPuduTx()) {
+        m_logo->setPudu(m_audio->clientPuduTx());
+    }
+
+    syncControlsFromEngine();
+}
+
+ClientPuduEditor::~ClientPuduEditor() = default;
+
+void ClientPuduEditor::showForTx()
+{
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+}
+
+void ClientPuduEditor::syncControlsFromEngine()
+{
+    if (!m_audio || !m_audio->clientPuduTx()) return;
+    ClientPudu* p = m_audio->clientPuduTx();
+    m_restoring = true;
+
+    { QSignalBlocker b(m_bypass); m_bypass->setChecked(!p->isEnabled()); }
+    {
+        const bool isA = (p->mode() == ClientPudu::Mode::Aphex);
+        QSignalBlocker ba(m_modeA);
+        QSignalBlocker bb(m_modeB);
+        m_modeA->setChecked(isA);
+        m_modeB->setChecked(!isA);
+    }
+    { QSignalBlocker b(m_pooDrive);     m_pooDrive->setValue(p->pooDriveDb()); }
+    { QSignalBlocker b(m_pooTune);      m_pooTune->setValue(p->pooTuneHz()); }
+    { QSignalBlocker b(m_pooMix);       m_pooMix->setValue(p->pooMix()); }
+    { QSignalBlocker b(m_dooTune);      m_dooTune->setValue(p->dooTuneHz()); }
+    { QSignalBlocker b(m_dooHarmonics); m_dooHarmonics->setValue(p->dooHarmonicsDb()); }
+    { QSignalBlocker b(m_dooMix);       m_dooMix->setValue(p->dooMix()); }
+
+    m_restoring = false;
+}
+
+void ClientPuduEditor::onModeToggled(int id)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setMode(
+        id == 1 ? ClientPudu::Mode::Behringer : ClientPudu::Mode::Aphex);
+    m_audio->saveClientPuduSettings();
+}
+
+void ClientPuduEditor::applyPooDrive(float db)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setPooDriveDb(db);
+    m_audio->saveClientPuduSettings();
+}
+void ClientPuduEditor::applyPooTune(float hz)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setPooTuneHz(hz);
+    m_audio->saveClientPuduSettings();
+}
+void ClientPuduEditor::applyPooMix(float v)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setPooMix(v);
+    m_audio->saveClientPuduSettings();
+}
+void ClientPuduEditor::applyDooTune(float hz)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setDooTuneHz(hz);
+    m_audio->saveClientPuduSettings();
+}
+void ClientPuduEditor::applyDooHarmonics(float db)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setDooHarmonicsDb(db);
+    m_audio->saveClientPuduSettings();
+}
+void ClientPuduEditor::applyDooMix(float v)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientPuduTx()->setDooMix(v);
+    m_audio->saveClientPuduSettings();
+}
+
+void ClientPuduEditor::saveGeometryToSettings()
+{
+    if (m_restoring) return;
+    AppSettings::instance().setValue(
+        "ClientPuduEditorGeometry",
+        QString::fromLatin1(saveGeometry().toBase64()));
+}
+
+void ClientPuduEditor::restoreGeometryFromSettings()
+{
+    m_restoring = true;
+    const QString b64 = AppSettings::instance()
+        .value("ClientPuduEditorGeometry", "").toString();
+    if (!b64.isEmpty()) {
+        restoreGeometry(QByteArray::fromBase64(b64.toLatin1()));
+    }
+    m_restoring = false;
+}
+
+void ClientPuduEditor::closeEvent(QCloseEvent* ev)
+{ saveGeometryToSettings(); QWidget::closeEvent(ev); }
+void ClientPuduEditor::moveEvent(QMoveEvent* ev)
+{ saveGeometryToSettings(); QWidget::moveEvent(ev); }
+void ClientPuduEditor::resizeEvent(QResizeEvent* ev)
+{ saveGeometryToSettings(); QWidget::resizeEvent(ev); }
+void ClientPuduEditor::showEvent(QShowEvent* ev)
+{ QWidget::showEvent(ev); }
+void ClientPuduEditor::hideEvent(QHideEvent* ev)
+{ saveGeometryToSettings(); QWidget::hideEvent(ev); }
+
+} // namespace AetherSDR

--- a/src/gui/ClientPuduEditor.h
+++ b/src/gui/ClientPuduEditor.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompKnob;
+class PooDooLogo;
+
+// Floating editor for the PUDU exciter.  Same six knobs + A/B toggle
+// + logo as the docked applet, just at larger scale with dedicated
+// geometry persistence.  Keeps the cognitive load low — users don't
+// have to re-learn a separate UI in the floating window.
+class ClientPuduEditor : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientPuduEditor(AudioEngine* engine, QWidget* parent = nullptr);
+    ~ClientPuduEditor() override;
+
+    void showForTx();
+
+signals:
+    void bypassToggled(bool bypassed);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+    void syncControlsFromEngine();
+
+    void onModeToggled(int id);
+    void applyPooDrive(float db);
+    void applyPooTune(float hz);
+    void applyPooMix(float v);
+    void applyDooTune(float hz);
+    void applyDooHarmonics(float db);
+    void applyDooMix(float v);
+
+    AudioEngine*    m_audio{nullptr};
+    PooDooLogo*     m_logo{nullptr};
+    QPushButton*    m_bypass{nullptr};
+    QPushButton*    m_modeA{nullptr};
+    QPushButton*    m_modeB{nullptr};
+    ClientCompKnob* m_pooDrive{nullptr};
+    ClientCompKnob* m_pooTune{nullptr};
+    ClientCompKnob* m_pooMix{nullptr};
+    ClientCompKnob* m_dooTune{nullptr};
+    ClientCompKnob* m_dooHarmonics{nullptr};
+    ClientCompKnob* m_dooMix{nullptr};
+    bool            m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientTubeApplet.cpp
+++ b/src/gui/ClientTubeApplet.cpp
@@ -1,0 +1,113 @@
+#include "ClientTubeApplet.h"
+#include "ClientTubeCurveWidget.h"
+#include "core/AudioEngine.h"
+#include "core/ClientTube.h"
+
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QSignalBlocker>
+
+namespace AetherSDR {
+
+namespace {
+
+const QString kEnableStyle =
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 11px; font-weight: bold; padding: 2px 10px;"
+    "}"
+    "QPushButton:hover { background: #204060; }"
+    "QPushButton:checked {"
+    "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
+    "}";
+
+constexpr const char* kEditStyle =
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 11px; padding: 2px 10px;"
+    "}"
+    "QPushButton:hover { background: #204060; }";
+
+} // namespace
+
+ClientTubeApplet::ClientTubeApplet(QWidget* parent) : QWidget(parent)
+{
+    buildUI();
+    hide();
+}
+
+void ClientTubeApplet::buildUI()
+{
+    setStyleSheet("QWidget { background: transparent; }");
+
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(4, 4, 4, 4);
+    outer->setSpacing(4);
+
+    m_curve = new ClientTubeCurveWidget;
+    m_curve->setCompactMode(true);
+    m_curve->setMinimumHeight(90);
+    outer->addWidget(m_curve, 1);
+
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(4);
+
+        m_enable = new QPushButton("Enable");
+        m_enable->setCheckable(true);
+        m_enable->setStyleSheet(kEnableStyle);
+        m_enable->setFixedHeight(22);
+        row->addWidget(m_enable);
+
+        row->addStretch();
+
+        m_edit = new QPushButton("Edit…");
+        m_edit->setStyleSheet(kEditStyle);
+        m_edit->setFixedHeight(22);
+        m_edit->setToolTip("Open the dynamic tube editor");
+        row->addWidget(m_edit);
+
+        connect(m_enable, &QPushButton::toggled, this,
+                &ClientTubeApplet::onEnableToggled);
+        connect(m_edit, &QPushButton::clicked, this, [this]() {
+            emit editRequested();
+        });
+
+        outer->addLayout(row);
+    }
+}
+
+void ClientTubeApplet::setAudioEngine(AudioEngine* engine)
+{
+    m_audio = engine;
+    if (!m_audio) return;
+    m_curve->setTube(m_audio->clientTubeTx());
+    syncEnableFromEngine();
+}
+
+void ClientTubeApplet::syncEnableFromEngine()
+{
+    if (!m_audio || !m_enable) return;
+    ClientTube* t = m_audio->clientTubeTx();
+    QSignalBlocker b(m_enable);
+    m_enable->setChecked(t && t->isEnabled());
+    if (m_curve) m_curve->update();
+}
+
+void ClientTubeApplet::refreshEnableFromEngine()
+{
+    syncEnableFromEngine();
+}
+
+void ClientTubeApplet::onEnableToggled(bool on)
+{
+    if (!m_audio) return;
+    ClientTube* t = m_audio->clientTubeTx();
+    if (!t) return;
+    t->setEnabled(on);
+    m_audio->saveClientTubeSettings();
+    if (m_curve) m_curve->update();
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientTubeApplet.h
+++ b/src/gui/ClientTubeApplet.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientTubeCurveWidget;
+
+// Docked tile for the client-side TX dynamic tube saturator.  Shows
+// the transfer curve (which bends with Drive / Bias / Model) and a
+// live input ball, plus Enable / Edit buttons.  Interactive editor
+// is in ClientTubeEditor.
+class ClientTubeApplet : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientTubeApplet(QWidget* parent = nullptr);
+
+    void setAudioEngine(AudioEngine* engine);
+    void refreshEnableFromEngine();
+
+signals:
+    void editRequested();
+
+private:
+    void buildUI();
+    void syncEnableFromEngine();
+    void onEnableToggled(bool on);
+
+    AudioEngine*           m_audio{nullptr};
+    QPushButton*           m_enable{nullptr};
+    QPushButton*           m_edit{nullptr};
+    ClientTubeCurveWidget* m_curve{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientTubeCurveWidget.cpp
+++ b/src/gui/ClientTubeCurveWidget.cpp
@@ -1,0 +1,163 @@
+#include "ClientTubeCurveWidget.h"
+#include "core/ClientTube.h"
+
+#include <QPainter>
+#include <QPainterPath>
+#include <QPaintEvent>
+#include <QPen>
+#include <QRadialGradient>
+#include <QTimer>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr float kBallSmoothAlpha = 0.30f;
+
+const QColor kBgColor       ("#0a1420");
+const QColor kFrameColor    ("#2a3a4a");
+const QColor kGridColor     ("#1e3040");
+const QColor kAxisColor     ("#2a4458");
+const QColor kCurveColor    ("#4db8d4");   // cyan
+const QColor kBallGlowColor ("#ffd070");
+const QColor kBallCoreColor ("#ffffff");
+
+float dbToLin(float db) noexcept
+{
+    return std::pow(10.0f, db * 0.05f);
+}
+
+} // namespace
+
+ClientTubeCurveWidget::ClientTubeCurveWidget(QWidget* parent) : QWidget(parent)
+{
+    setMinimumHeight(80);
+    setAttribute(Qt::WA_OpaquePaintEvent, false);
+    m_pollTimer = new QTimer(this);
+    m_pollTimer->setInterval(33);
+    connect(m_pollTimer, &QTimer::timeout, this, [this]() {
+        if (!m_tube) return;
+        // Convert peak dB to linear amplitude for ball placement.
+        const float targetLin = dbToLin(m_tube->inputPeakDb());
+        m_lastInputLin += kBallSmoothAlpha * (targetLin - m_lastInputLin);
+        update();
+    });
+}
+
+void ClientTubeCurveWidget::setTube(ClientTube* t)
+{
+    m_tube = t;
+    if (m_tube) m_pollTimer->start();
+    else        m_pollTimer->stop();
+    update();
+}
+
+void ClientTubeCurveWidget::setCompactMode(bool on)
+{
+    if (on == m_compact) return;
+    m_compact = on;
+    update();
+}
+
+float ClientTubeCurveWidget::xToPx(float x) const
+{
+    const float t = (x + kAxisLimit) / (2.0f * kAxisLimit);
+    return static_cast<float>(rect().left()) + t * rect().width();
+}
+
+float ClientTubeCurveWidget::yToPx(float y) const
+{
+    const float t = (y + kAxisLimit) / (2.0f * kAxisLimit);
+    return static_cast<float>(rect().bottom()) - t * rect().height();
+}
+
+float ClientTubeCurveWidget::evalCurve(float x) const
+{
+    if (!m_tube) return x;
+    const float drive = dbToLin(m_tube->driveDb());
+    const float bias  = m_tube->biasAmount();
+    const int   model = static_cast<int>(m_tube->model());
+    const float xd    = x * drive;
+    const float asym  = bias * std::tanh(xd * xd);
+
+    switch (model) {
+        case 0:   // Model A — soft tanh
+            return std::tanh(xd) + asym;
+        case 1: { // Model B — hard clip + tanh hybrid
+            const float h = std::clamp(xd, -1.0f, 1.0f);
+            return std::tanh(h * 1.3f) * 0.85f + asym;
+        }
+        case 2: { // Model C — asymmetric-dominant
+            const float t  = std::tanh(xd);
+            const float a2 = std::tanh(xd * xd);
+            return 0.75f * t + (0.35f + 0.65f * bias) * a2;
+        }
+    }
+    return std::tanh(xd);
+}
+
+void ClientTubeCurveWidget::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    const QRectF r = rect();
+    p.fillRect(r, kBgColor);
+
+    // Grid — a few reference lines at ±0.5, ±1.0.
+    p.setPen(QPen(kGridColor, 1.0));
+    for (float v : { -1.0f, -0.5f, 0.5f, 1.0f }) {
+        p.drawLine(QPointF(xToPx(v), r.top()), QPointF(xToPx(v), r.bottom()));
+        p.drawLine(QPointF(r.left(), yToPx(v)), QPointF(r.right(), yToPx(v)));
+    }
+
+    // Centre axes — slightly brighter.
+    p.setPen(QPen(kAxisColor, 1.0));
+    p.drawLine(QPointF(xToPx(0.0f), r.top()),  QPointF(xToPx(0.0f), r.bottom()));
+    p.drawLine(QPointF(r.left(), yToPx(0.0f)), QPointF(r.right(), yToPx(0.0f)));
+
+    // Transfer curve.
+    if (m_tube) {
+        QPainterPath path;
+        constexpr int steps = 161;
+        for (int i = 0; i < steps; ++i) {
+            const float t = static_cast<float>(i) / (steps - 1);
+            const float x = -kAxisLimit + t * (2.0f * kAxisLimit);
+            const float y = std::clamp(evalCurve(x), -kAxisLimit, kAxisLimit);
+            const QPointF pt(xToPx(x), yToPx(y));
+            if (i == 0) path.moveTo(pt);
+            else        path.lineTo(pt);
+        }
+        QPen curvePen(kCurveColor, m_compact ? 1.5 : 2.0);
+        curvePen.setJoinStyle(Qt::RoundJoin);
+        curvePen.setCapStyle(Qt::RoundCap);
+        p.setPen(curvePen);
+        p.drawPath(path);
+
+        // Live ball at (input, curveOutput(input)).
+        const float x  = std::clamp(m_lastInputLin, -kAxisLimit, kAxisLimit);
+        const float y  = std::clamp(evalCurve(x), -kAxisLimit, kAxisLimit);
+        const QPointF pt(xToPx(x), yToPx(y));
+        const float glow = m_compact ? 7.0f : 10.0f;
+        QRadialGradient g(pt, glow);
+        QColor gc = kBallGlowColor; gc.setAlpha(200);
+        g.setColorAt(0.0, gc);
+        gc.setAlpha(0);
+        g.setColorAt(1.0, gc);
+        p.setBrush(g);
+        p.setPen(Qt::NoPen);
+        p.drawEllipse(pt, glow, glow);
+        p.setBrush(kBallCoreColor);
+        p.drawEllipse(pt, m_compact ? 2.2 : 3.0,
+                          m_compact ? 2.2 : 3.0);
+    }
+
+    // Frame.
+    p.setPen(QPen(kFrameColor, 1.0));
+    p.setBrush(Qt::NoBrush);
+    p.drawRect(r.adjusted(0.5, 0.5, -0.5, -0.5));
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientTubeCurveWidget.h
+++ b/src/gui/ClientTubeCurveWidget.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <QWidget>
+
+class QTimer;
+
+namespace AetherSDR {
+
+class ClientTube;
+
+// Transfer-curve display for the tube saturator.  X axis is input
+// amplitude in [-1.5, +1.5] (so the curve shows how the shaper
+// behaves above full scale as well as below); Y axis is output
+// amplitude over the same range.  The curve bends according to the
+// current Model / Drive / Bias values.  A live ball tracks the
+// instantaneous input amplitude along the curve so the user can see
+// which part of the transfer function the signal is riding on.
+class ClientTubeCurveWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientTubeCurveWidget(QWidget* parent = nullptr);
+
+    void setTube(ClientTube* t);
+    ClientTube* tube() const { return m_tube; }
+
+    void setCompactMode(bool on);
+
+    static constexpr float kAxisLimit = 1.5f;   // display range on both axes
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+
+private:
+    float xToPx(float x) const;
+    float yToPx(float y) const;
+    // Evaluate the current model's transfer function at input x.
+    // Mirrors ClientTube::shape() math but takes only the user's
+    // current Drive + Bias into account (no envelope modulation —
+    // the curve shows the static response).
+    float evalCurve(float x) const;
+
+    ClientTube* m_tube{nullptr};
+    QTimer*     m_pollTimer{nullptr};
+    bool        m_compact{false};
+    float       m_lastInputLin{0.0f};   // smoothed ball position
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientTubeEditor.cpp
+++ b/src/gui/ClientTubeEditor.cpp
@@ -1,0 +1,443 @@
+#include "ClientTubeEditor.h"
+#include "ClientCompKnob.h"
+#include "ClientTubeCurveWidget.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ClientTube.h"
+
+#include <QButtonGroup>
+#include <QCloseEvent>
+#include <QHBoxLayout>
+#include <QHideEvent>
+#include <QLabel>
+#include <QMoveEvent>
+#include <QPushButton>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kDefaultWidth  = 720;
+constexpr int kDefaultHeight = 360;
+
+constexpr const char* kWindowStyle =
+    "QWidget { background: #08121d; color: #d7e7f2; }"
+    "QLabel  { background: transparent; color: #8aa8c0; font-size: 11px; }";
+
+const QString kBypassStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #0e1b28;"
+    "  color: #8aa8c0;"
+    "  border: 1px solid #243a4e;"
+    "  border-radius: 3px;"
+    "  font-size: 11px;"
+    "  font-weight: bold;"
+    "  padding: 3px 12px;"
+    "}"
+    "QPushButton:hover { background: #1a2a3a; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e;"
+    "  color: #f2c14e;"
+    "  border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #4a3a1e; }");
+
+const QString kModelStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #2a4458; border-radius: 3px;"
+    "  color: #8aa8c0; font-size: 11px; font-weight: bold;"
+    "  padding: 3px 10px; min-width: 26px;"
+    "}"
+    "QPushButton:hover { background: #24384e; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e; color: #f2c14e; border: 1px solid #f2c14e;"
+    "}");
+
+} // namespace
+
+ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent, Qt::Window)
+    , m_audio(engine)
+{
+    setWindowTitle("Dynamic Tube");
+    setStyleSheet(kWindowStyle);
+    resize(kDefaultWidth, kDefaultHeight);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(8, 8, 8, 8);
+    root->setSpacing(6);
+
+    // Header: Bypass
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(8);
+
+        m_bypass = new QPushButton("Bypass");
+        m_bypass->setCheckable(true);
+        m_bypass->setStyleSheet(kBypassStyle);
+        m_bypass->setFixedHeight(22);
+        m_bypass->setToolTip(
+            "Bypass the tube saturator (signal passes through unshaped)");
+        row->addWidget(m_bypass);
+
+        connect(m_bypass, &QPushButton::toggled, this, [this](bool bypassed) {
+            if (!m_audio || !m_audio->clientTubeTx()) return;
+            m_audio->clientTubeTx()->setEnabled(!bypassed);
+            m_audio->saveClientTubeSettings();
+            emit bypassToggled(bypassed);
+        });
+
+        row->addStretch();
+        root->addLayout(row);
+    }
+
+    auto* body = new QHBoxLayout;
+    body->setSpacing(12);
+
+    // ── Left column: Dry/Wet, Output, Drive ─────────────────────────
+    auto* left = new QVBoxLayout;
+    left->setSpacing(10);
+
+    m_dryWet = new ClientCompKnob;
+    m_dryWet->setLabel("Dry/Wet");
+    m_dryWet->setCenterLabelMode(true);
+    m_dryWet->setRange(0.0f, 1.0f);
+    m_dryWet->setDefault(1.0f);
+    m_dryWet->setValueFromNorm([](float n) { return n; });
+    m_dryWet->setNormFromValue([](float v) { return v; });
+    m_dryWet->setLabelFormat([](float v) {
+        return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+    });
+    m_dryWet->setFixedSize(80, 80);
+    connect(m_dryWet, &ClientCompKnob::valueChanged,
+            this, &ClientTubeEditor::applyDryWet);
+    left->addWidget(m_dryWet, 0, Qt::AlignHCenter);
+
+    m_output = new ClientCompKnob;
+    m_output->setLabel("Output");
+    m_output->setCenterLabelMode(true);
+    m_output->setRange(-24.0f, 12.0f);
+    m_output->setDefault(0.0f);
+    m_output->setValueFromNorm([](float n) { return -24.0f + n * 36.0f; });
+    m_output->setNormFromValue([](float v) { return (v + 24.0f) / 36.0f; });
+    m_output->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 2) + " dB";
+    });
+    m_output->setFixedSize(80, 80);
+    connect(m_output, &ClientCompKnob::valueChanged,
+            this, &ClientTubeEditor::applyOutput);
+    left->addWidget(m_output, 0, Qt::AlignHCenter);
+
+    m_drive = new ClientCompKnob;
+    m_drive->setLabel("Drive");
+    m_drive->setCenterLabelMode(true);
+    m_drive->setRange(0.0f, 24.0f);
+    m_drive->setDefault(0.0f);
+    m_drive->setValueFromNorm([](float n) { return n * 24.0f; });
+    m_drive->setNormFromValue([](float v) { return v / 24.0f; });
+    m_drive->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 2) + " dB";
+    });
+    m_drive->setFixedSize(80, 80);
+    connect(m_drive, &ClientCompKnob::valueChanged,
+            this, &ClientTubeEditor::applyDrive);
+    left->addWidget(m_drive, 0, Qt::AlignHCenter);
+
+    left->addStretch();
+    body->addLayout(left, 0);
+
+    // ── Centre column: curve + model buttons + Tone/Bias ────────────
+    auto* center = new QVBoxLayout;
+    center->setSpacing(6);
+
+    m_curve = new ClientTubeCurveWidget;
+    m_curve->setCompactMode(false);
+    m_curve->setMinimumHeight(180);
+    center->addWidget(m_curve, 1);
+
+    // Model A / B / C row
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(4);
+        row->addStretch();
+
+        m_modelGroup = new QButtonGroup(this);
+        m_modelGroup->setExclusive(true);
+
+        auto addModelBtn = [&](const QString& label, int idx) {
+            auto* btn = new QPushButton(label);
+            btn->setCheckable(true);
+            btn->setStyleSheet(kModelStyle);
+            btn->setFixedHeight(22);
+            m_modelGroup->addButton(btn, idx);
+            row->addWidget(btn);
+            return btn;
+        };
+        m_modelA = addModelBtn("A", 0);
+        m_modelB = addModelBtn("B", 1);
+        m_modelC = addModelBtn("C", 2);
+        row->addStretch();
+
+        connect(m_modelGroup, &QButtonGroup::idToggled, this,
+                [this](int id, bool checked) {
+            if (checked) applyModel(id);
+        });
+
+        center->addLayout(row);
+    }
+
+    // Tone + Bias row
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(12);
+        row->addStretch();
+
+        m_tone = new ClientCompKnob;
+        m_tone->setLabel("Tone");
+        m_tone->setCenterLabelMode(true);
+        m_tone->setRange(-1.0f, 1.0f);
+        m_tone->setDefault(0.0f);
+        m_tone->setValueFromNorm([](float n) { return -1.0f + n * 2.0f; });
+        m_tone->setNormFromValue([](float v) { return (v + 1.0f) / 2.0f; });
+        m_tone->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 2);
+        });
+        m_tone->setFixedSize(68, 68);
+        connect(m_tone, &ClientCompKnob::valueChanged,
+                this, &ClientTubeEditor::applyTone);
+        row->addWidget(m_tone, 0, Qt::AlignHCenter);
+
+        m_bias = new ClientCompKnob;
+        m_bias->setLabel("Bias");
+        m_bias->setCenterLabelMode(true);
+        m_bias->setRange(0.0f, 1.0f);
+        m_bias->setDefault(0.0f);
+        m_bias->setValueFromNorm([](float n) { return n; });
+        m_bias->setNormFromValue([](float v) { return v; });
+        m_bias->setLabelFormat([](float v) {
+            return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+        });
+        m_bias->setFixedSize(68, 68);
+        connect(m_bias, &ClientCompKnob::valueChanged,
+                this, &ClientTubeEditor::applyBias);
+        row->addWidget(m_bias, 0, Qt::AlignHCenter);
+
+        row->addStretch();
+        center->addLayout(row);
+    }
+
+    body->addLayout(center, 1);
+
+    // ── Right column: Envelope / Attack / Release ───────────────────
+    auto* right = new QVBoxLayout;
+    right->setSpacing(10);
+
+    m_envelope = new ClientCompKnob;
+    m_envelope->setLabel("Envelope");
+    m_envelope->setCenterLabelMode(true);
+    m_envelope->setRange(-1.0f, 1.0f);
+    m_envelope->setDefault(0.0f);
+    m_envelope->setValueFromNorm([](float n) { return -1.0f + n * 2.0f; });
+    m_envelope->setNormFromValue([](float v) { return (v + 1.0f) / 2.0f; });
+    m_envelope->setLabelFormat([](float v) {
+        const int pct = static_cast<int>(v * 100.0f + (v >= 0 ? 0.5f : -0.5f));
+        return QString::number(pct) + " %";
+    });
+    m_envelope->setFixedSize(80, 80);
+    connect(m_envelope, &ClientCompKnob::valueChanged,
+            this, &ClientTubeEditor::applyEnvelope);
+    right->addWidget(m_envelope, 0, Qt::AlignHCenter);
+
+    m_attack = new ClientCompKnob;
+    m_attack->setLabel("Attack");
+    m_attack->setCenterLabelMode(true);
+    m_attack->setRange(0.1f, 30.0f);
+    m_attack->setDefault(5.0f);
+    m_attack->setValueFromNorm([](float n) {
+        return 0.1f * std::pow(300.0f, n);
+    });
+    m_attack->setNormFromValue([](float v) {
+        return std::log(std::max(0.1f, v) / 0.1f) / std::log(300.0f);
+    });
+    m_attack->setLabelFormat([](float v) {
+        return QString::number(v, 'f', v < 10.0f ? 2 : 1) + " ms";
+    });
+    m_attack->setFixedSize(72, 72);
+    connect(m_attack, &ClientCompKnob::valueChanged,
+            this, &ClientTubeEditor::applyAttack);
+    right->addWidget(m_attack, 0, Qt::AlignHCenter);
+
+    m_release = new ClientCompKnob;
+    m_release->setLabel("Release");
+    m_release->setCenterLabelMode(true);
+    m_release->setRange(10.0f, 500.0f);
+    m_release->setDefault(35.0f);
+    m_release->setValueFromNorm([](float n) {
+        return 10.0f * std::pow(50.0f, n);
+    });
+    m_release->setNormFromValue([](float v) {
+        return std::log(std::max(10.0f, v) / 10.0f) / std::log(50.0f);
+    });
+    m_release->setLabelFormat([](float v) {
+        return QString::number(v, 'f', v < 100.0f ? 2 : 1) + " ms";
+    });
+    m_release->setFixedSize(72, 72);
+    connect(m_release, &ClientCompKnob::valueChanged,
+            this, &ClientTubeEditor::applyRelease);
+    right->addWidget(m_release, 0, Qt::AlignHCenter);
+
+    right->addStretch();
+    body->addLayout(right, 0);
+
+    root->addLayout(body);
+
+    if (m_audio && m_audio->clientTubeTx()) {
+        m_curve->setTube(m_audio->clientTubeTx());
+    }
+
+    syncControlsFromEngine();
+}
+
+ClientTubeEditor::~ClientTubeEditor() = default;
+
+void ClientTubeEditor::showForTx()
+{
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+}
+
+void ClientTubeEditor::syncControlsFromEngine()
+{
+    if (!m_audio || !m_audio->clientTubeTx()) return;
+    ClientTube* t = m_audio->clientTubeTx();
+    m_restoring = true;
+
+    { QSignalBlocker b(m_bypass);  m_bypass->setChecked(!t->isEnabled()); }
+    {
+        const int idx = static_cast<int>(t->model());
+        QPushButton* btn = (idx == 1) ? m_modelB
+                          : (idx == 2) ? m_modelC
+                          : m_modelA;
+        QSignalBlocker b(m_modelGroup);
+        btn->setChecked(true);
+    }
+    { QSignalBlocker b(m_drive);    m_drive->setValue(t->driveDb()); }
+    { QSignalBlocker b(m_bias);     m_bias->setValue(t->biasAmount()); }
+    { QSignalBlocker b(m_tone);     m_tone->setValue(t->tone()); }
+    { QSignalBlocker b(m_output);   m_output->setValue(t->outputGainDb()); }
+    { QSignalBlocker b(m_dryWet);   m_dryWet->setValue(t->dryWet()); }
+    { QSignalBlocker b(m_envelope); m_envelope->setValue(t->envelopeAmount()); }
+    { QSignalBlocker b(m_attack);   m_attack->setValue(t->attackMs()); }
+    { QSignalBlocker b(m_release);  m_release->setValue(t->releaseMs()); }
+
+    m_restoring = false;
+}
+
+void ClientTubeEditor::applyModel(int idx)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientTubeTx()->setModel(
+        idx == 1 ? ClientTube::Model::B :
+        idx == 2 ? ClientTube::Model::C :
+                   ClientTube::Model::A);
+    m_audio->saveClientTubeSettings();
+    if (m_curve) m_curve->update();
+}
+
+void ClientTubeEditor::applyDrive(float db)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientTubeTx()->setDriveDb(db);
+    m_audio->saveClientTubeSettings();
+    if (m_curve) m_curve->update();
+}
+
+void ClientTubeEditor::applyBias(float v)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientTubeTx()->setBiasAmount(v);
+    m_audio->saveClientTubeSettings();
+    if (m_curve) m_curve->update();
+}
+
+void ClientTubeEditor::applyTone(float v)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientTubeTx()->setTone(v);
+    m_audio->saveClientTubeSettings();
+}
+
+void ClientTubeEditor::applyOutput(float db)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientTubeTx()->setOutputGainDb(db);
+    m_audio->saveClientTubeSettings();
+}
+
+void ClientTubeEditor::applyDryWet(float v)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientTubeTx()->setDryWet(v);
+    m_audio->saveClientTubeSettings();
+}
+
+void ClientTubeEditor::applyEnvelope(float v)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientTubeTx()->setEnvelopeAmount(v);
+    m_audio->saveClientTubeSettings();
+}
+
+void ClientTubeEditor::applyAttack(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientTubeTx()->setAttackMs(ms);
+    m_audio->saveClientTubeSettings();
+}
+
+void ClientTubeEditor::applyRelease(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientTubeTx()->setReleaseMs(ms);
+    m_audio->saveClientTubeSettings();
+}
+
+void ClientTubeEditor::saveGeometryToSettings()
+{
+    if (m_restoring) return;
+    AppSettings::instance().setValue(
+        "ClientTubeEditorGeometry",
+        QString::fromLatin1(saveGeometry().toBase64()));
+}
+
+void ClientTubeEditor::restoreGeometryFromSettings()
+{
+    m_restoring = true;
+    const QString b64 = AppSettings::instance()
+        .value("ClientTubeEditorGeometry", "").toString();
+    if (!b64.isEmpty()) {
+        restoreGeometry(QByteArray::fromBase64(b64.toLatin1()));
+    }
+    m_restoring = false;
+}
+
+void ClientTubeEditor::closeEvent(QCloseEvent* ev)
+{ saveGeometryToSettings(); QWidget::closeEvent(ev); }
+void ClientTubeEditor::moveEvent(QMoveEvent* ev)
+{ saveGeometryToSettings(); QWidget::moveEvent(ev); }
+void ClientTubeEditor::resizeEvent(QResizeEvent* ev)
+{ saveGeometryToSettings(); QWidget::resizeEvent(ev); }
+void ClientTubeEditor::showEvent(QShowEvent* ev)
+{ QWidget::showEvent(ev); }
+void ClientTubeEditor::hideEvent(QHideEvent* ev)
+{ saveGeometryToSettings(); QWidget::hideEvent(ev); }
+
+} // namespace AetherSDR

--- a/src/gui/ClientTubeEditor.h
+++ b/src/gui/ClientTubeEditor.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+class QButtonGroup;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompKnob;         // reused — generic rotary knob
+class ClientTubeCurveWidget;
+
+// Floating editor for the client-side dynamic tube saturator.
+// Layout mirrors Ableton's Dynamic Tube device:
+//
+//   ┌─ bypass ──────────────────── × ┐
+//   │ ┌──────┐ ┌─────────┐ ┌──────┐ │
+//   │ │DryWet│ │  curve  │ │ ENV  │ │
+//   │ │      │ │         │ │      │ │
+//   │ │ Out  │ │         │ │ ATK  │ │
+//   │ │      │ │ [A B C] │ │      │ │
+//   │ │Drive │ │  Tone   │ │ REL  │ │
+//   │ │      │ │  Bias   │ │      │ │
+//   │ └──────┘ └─────────┘ └──────┘ │
+//   └────────────────────────────────┘
+class ClientTubeEditor : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientTubeEditor(AudioEngine* engine, QWidget* parent = nullptr);
+    ~ClientTubeEditor() override;
+
+    void showForTx();
+
+signals:
+    void bypassToggled(bool bypassed);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+    void syncControlsFromEngine();
+
+    void applyModel(int idx);   // 0=A, 1=B, 2=C
+    void applyDrive(float db);
+    void applyBias(float v);
+    void applyTone(float v);
+    void applyOutput(float db);
+    void applyDryWet(float v);
+    void applyEnvelope(float v);
+    void applyAttack(float ms);
+    void applyRelease(float ms);
+
+    AudioEngine*           m_audio{nullptr};
+    ClientTubeCurveWidget* m_curve{nullptr};
+    ClientCompKnob*        m_dryWet{nullptr};
+    ClientCompKnob*        m_output{nullptr};
+    ClientCompKnob*        m_drive{nullptr};
+    ClientCompKnob*        m_tone{nullptr};
+    ClientCompKnob*        m_bias{nullptr};
+    ClientCompKnob*        m_envelope{nullptr};
+    ClientCompKnob*        m_attack{nullptr};
+    ClientCompKnob*        m_release{nullptr};
+    QPushButton*           m_modelA{nullptr};
+    QPushButton*           m_modelB{nullptr};
+    QPushButton*           m_modelC{nullptr};
+    QButtonGroup*          m_modelGroup{nullptr};
+    QPushButton*           m_bypass{nullptr};
+    bool                   m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -28,9 +28,21 @@
 #include "ClientEqEditor.h"
 #include "ClientCompApplet.h"
 #include "ClientCompEditor.h"
+#include "ClientGateApplet.h"
+#include "ClientGateEditor.h"
+#include "ClientDeEssApplet.h"
+#include "ClientDeEssEditor.h"
+#include "ClientTubeApplet.h"
+#include "ClientTubeEditor.h"
+#include "ClientPuduApplet.h"
+#include "ClientPuduEditor.h"
 #include "ClientChainApplet.h"
 #include "core/ClientComp.h"
 #include "core/ClientEq.h"
+#include "core/ClientGate.h"
+#include "core/ClientDeEss.h"
+#include "core/ClientTube.h"
+#include "core/ClientPudu.h"
 #include "CatControlApplet.h"
 #include "DaxApplet.h"
 #include "TciApplet.h"
@@ -297,6 +309,31 @@ MainWindow::MainWindow(QWidget* parent)
                        m_audio, &AudioEngine::feedAudioData);
         } else {
             connect(m_radioModel.panStream(), &PanadapterStream::audioDataReady,
+                    m_audio, &AudioEngine::feedAudioData);
+        }
+    });
+
+    // PUDU TX monitor — captures post-PooDoo TX int16 audio, plays
+    // back through the RX sink so the user can hear what their chain
+    // is producing without keying the radio.  Registered with
+    // AudioEngine so its tap hook picks it up on the audio thread.
+    m_puduMonitor = new ClientPuduMonitor(this);
+    m_audio->setTxPostDspMonitor(m_puduMonitor);
+    connect(m_puduMonitor, &ClientPuduMonitor::playbackAudio,
+            m_audio, &AudioEngine::feedDecodedSpeech);
+    // Disconnect live RX audio while the monitor is recording or
+    // playing so the user hears ONLY the captured PooDoo audio.
+    // Mirrors QsoRecorder's muteRxRequested handling — merely setting
+    // the sink volume to 0 would mute our playback too.
+    connect(m_puduMonitor, &ClientPuduMonitor::muteRxRequested,
+            this, [this](bool mute) {
+        if (mute) {
+            disconnect(m_radioModel.panStream(),
+                       &PanadapterStream::audioDataReady,
+                       m_audio, &AudioEngine::feedAudioData);
+        } else {
+            connect(m_radioModel.panStream(),
+                    &PanadapterStream::audioDataReady,
                     m_audio, &AudioEngine::feedAudioData);
         }
     });
@@ -837,6 +874,27 @@ MainWindow::MainWindow(QWidget* parent)
             // Reset to full gain — radio handles hardware mic gain
             m_audio->setPcMicGain(100);
             audioStopTx();
+        }
+        // PooDoo Audio readiness indicator — turn the chain widget's
+        // MIC endpoint green when the TX input is actually flowing
+        // through the client DSP chain: mic source = PC AND radio
+        // DAX TX is off.  Any other combination routes audio around
+        // our DSP, so the green cue would mislead.  The TX pulse
+        // is gated on the same readiness so it only fires when
+        // PooDoo is actually doing something during transmit.
+        if (m_appletPanel && m_appletPanel->clientChainApplet()) {
+            const auto& tx = m_radioModel.transmitModel();
+            const bool ready = (tx.micSelection() == "PC") && !tx.daxOn();
+            m_appletPanel->clientChainApplet()->setMicInputReady(ready);
+            m_appletPanel->clientChainApplet()->setTxActive(
+                ready && tx.isTransmitting());
+
+            // If the user pulls the plug on readiness mid-recording
+            // (mic source away from PC, or DAX back on), stop the
+            // recording — auto-play kicks in via recordingStopped.
+            if (!ready && m_puduMonitor && m_puduMonitor->isRecording()) {
+                m_puduMonitor->stopRecording();
+            }
         }
     });
 #ifdef Q_OS_MAC
@@ -2039,6 +2097,82 @@ MainWindow::MainWindow(QWidget* parent)
         m_clientCompEditor->showForTx();
     });
 
+    // ── Client Gate applet: TX downward expander / noise gate (#1661 Phase 2) ─
+    m_appletPanel->clientGateApplet()->setAudioEngine(m_audio);
+    connect(m_appletPanel->clientGateApplet(), &ClientGateApplet::editRequested,
+            this, [this]() {
+        if (!m_clientGateEditor) {
+            m_clientGateEditor = new ClientGateEditor(m_audio, this);
+            connect(m_clientGateEditor, &ClientGateEditor::bypassToggled,
+                    this, [this](bool bypassed) {
+                if (m_appletPanel && m_appletPanel->clientGateApplet())
+                    m_appletPanel->clientGateApplet()->refreshEnableFromEngine();
+                if (m_appletPanel && m_appletPanel->clientChainApplet())
+                    m_appletPanel->clientChainApplet()->refreshFromEngine();
+                if (m_appletPanel)
+                    m_appletPanel->setAppletVisible("GATE", !bypassed);
+            });
+        }
+        m_clientGateEditor->showForTx();
+    });
+
+    // ── Client De-esser applet: TX sidechain-filtered dynamics (#1661 Phase 3) ─
+    m_appletPanel->clientDeEssApplet()->setAudioEngine(m_audio);
+    connect(m_appletPanel->clientDeEssApplet(), &ClientDeEssApplet::editRequested,
+            this, [this]() {
+        if (!m_clientDeEssEditor) {
+            m_clientDeEssEditor = new ClientDeEssEditor(m_audio, this);
+            connect(m_clientDeEssEditor, &ClientDeEssEditor::bypassToggled,
+                    this, [this](bool bypassed) {
+                if (m_appletPanel && m_appletPanel->clientDeEssApplet())
+                    m_appletPanel->clientDeEssApplet()->refreshEnableFromEngine();
+                if (m_appletPanel && m_appletPanel->clientChainApplet())
+                    m_appletPanel->clientChainApplet()->refreshFromEngine();
+                if (m_appletPanel)
+                    m_appletPanel->setAppletVisible("DESS", !bypassed);
+            });
+        }
+        m_clientDeEssEditor->showForTx();
+    });
+
+    // ── Client Tube applet: TX dynamic tube saturator (#1661 Phase 4) ────────
+    m_appletPanel->clientTubeApplet()->setAudioEngine(m_audio);
+    connect(m_appletPanel->clientTubeApplet(), &ClientTubeApplet::editRequested,
+            this, [this]() {
+        if (!m_clientTubeEditor) {
+            m_clientTubeEditor = new ClientTubeEditor(m_audio, this);
+            connect(m_clientTubeEditor, &ClientTubeEditor::bypassToggled,
+                    this, [this](bool bypassed) {
+                if (m_appletPanel && m_appletPanel->clientTubeApplet())
+                    m_appletPanel->clientTubeApplet()->refreshEnableFromEngine();
+                if (m_appletPanel && m_appletPanel->clientChainApplet())
+                    m_appletPanel->clientChainApplet()->refreshFromEngine();
+                if (m_appletPanel)
+                    m_appletPanel->setAppletVisible("TUBE", !bypassed);
+            });
+        }
+        m_clientTubeEditor->showForTx();
+    });
+
+    // ── Client PUDU applet: TX exciter — PooDoo™ centrepiece (#1661 Phase 5) ─
+    m_appletPanel->clientPuduApplet()->setAudioEngine(m_audio);
+    connect(m_appletPanel->clientPuduApplet(), &ClientPuduApplet::editRequested,
+            this, [this]() {
+        if (!m_clientPuduEditor) {
+            m_clientPuduEditor = new ClientPuduEditor(m_audio, this);
+            connect(m_clientPuduEditor, &ClientPuduEditor::bypassToggled,
+                    this, [this](bool bypassed) {
+                if (m_appletPanel && m_appletPanel->clientPuduApplet())
+                    m_appletPanel->clientPuduApplet()->refreshEnableFromEngine();
+                if (m_appletPanel && m_appletPanel->clientChainApplet())
+                    m_appletPanel->clientChainApplet()->refreshFromEngine();
+                if (m_appletPanel)
+                    m_appletPanel->setAppletVisible("PUDU", !bypassed);
+            });
+        }
+        m_clientPuduEditor->showForTx();
+    });
+
     // ── TX signal-chain applet (#1661) ──────────────────────────────────────
     // Visual strip showing MIC → stages → TX with per-stage bypass +
     // drag-drop reorder.  Clicking a stage opens its floating editor
@@ -2051,6 +2185,82 @@ MainWindow::MainWindow(QWidget* parent)
     // stageEnabledChanged → setAppletVisible here.  Initial state is
     // seeded from the engine below so settings persist across launches.
     m_appletPanel->clientChainApplet()->setAudioEngine(m_audio);
+    // Seed the PooDoo MIC-ready + TX-pulse indicators from current
+    // state — subsequent changes flow through the TransmitModel
+    // signal connections above (micStateChanged + moxChanged).
+    {
+        const auto& tx = m_radioModel.transmitModel();
+        const bool ready = (tx.micSelection() == "PC") && !tx.daxOn();
+        m_appletPanel->clientChainApplet()->setMicInputReady(ready);
+        m_appletPanel->clientChainApplet()->setTxActive(
+            ready && tx.isTransmitting());
+    }
+    // Pulse the TX endpoint red when we're transmitting AND PooDoo
+    // is actually in the signal path (MIC=PC and DAX off).  Otherwise
+    // the pulse would lie about what's being processed.
+    connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
+            this, [this](bool txActive) {
+        if (!m_appletPanel || !m_appletPanel->clientChainApplet()) return;
+        const auto& tx = m_radioModel.transmitModel();
+        const bool ready = (tx.micSelection() == "PC") && !tx.daxOn();
+        m_appletPanel->clientChainApplet()->setTxActive(ready && txActive);
+    });
+
+    // ── PUDU monitor wiring ─────────────────────────────────────
+    auto* chainApplet = m_appletPanel->clientChainApplet();
+    chainApplet->setMonitorHasRecording(m_puduMonitor->hasRecording());
+
+    // User-click → start/stop based on current monitor state.  The
+    // monitor's own signals drive the button visuals back.
+    connect(chainApplet, &ClientChainApplet::monitorRecordClicked,
+            this, [this]() {
+        if (m_puduMonitor->isRecording()) {
+            m_puduMonitor->stopRecording();
+        } else {
+            // Don't record while playing — button shouldn't be
+            // enabled in that state, but guard anyway.
+            if (m_puduMonitor->isPlaying()) m_puduMonitor->stopPlayback();
+            m_puduMonitor->startRecording();
+        }
+    });
+    connect(chainApplet, &ClientChainApplet::monitorPlayClicked,
+            this, [this]() {
+        if (m_puduMonitor->isPlaying()) {
+            m_puduMonitor->stopPlayback();
+        } else {
+            m_puduMonitor->startPlayback();
+        }
+    });
+
+    // Monitor state → UI updates.  RX audio gating is handled
+    // separately via the muteRxRequested wiring above.
+    connect(m_puduMonitor, &ClientPuduMonitor::recordingStarted,
+            this, [this]() {
+        if (m_appletPanel && m_appletPanel->clientChainApplet())
+            m_appletPanel->clientChainApplet()->setMonitorRecording(true);
+    });
+    connect(m_puduMonitor, &ClientPuduMonitor::recordingStopped,
+            this, [this](int /*durationMs*/) {
+        if (m_appletPanel && m_appletPanel->clientChainApplet()) {
+            auto* a = m_appletPanel->clientChainApplet();
+            a->setMonitorRecording(false);
+            a->setMonitorHasRecording(true);
+        }
+        // Auto-start playback — the mute stays installed across the
+        // transition because the monitor only emits muteRxRequested
+        // (false) at stopPlayback().
+        m_puduMonitor->startPlayback();
+    });
+    connect(m_puduMonitor, &ClientPuduMonitor::playbackStarted,
+            this, [this]() {
+        if (m_appletPanel && m_appletPanel->clientChainApplet())
+            m_appletPanel->clientChainApplet()->setMonitorPlaying(true);
+    });
+    connect(m_puduMonitor, &ClientPuduMonitor::playbackStopped,
+            this, [this]() {
+        if (m_appletPanel && m_appletPanel->clientChainApplet())
+            m_appletPanel->clientChainApplet()->setMonitorPlaying(false);
+    });
     if (m_audio && m_audio->clientEqTx()) {
         m_appletPanel->setAppletVisible(
             "CEQ", m_audio->clientEqTx()->isEnabled());
@@ -2058,6 +2268,22 @@ MainWindow::MainWindow(QWidget* parent)
     if (m_audio && m_audio->clientCompTx()) {
         m_appletPanel->setAppletVisible(
             "CMP", m_audio->clientCompTx()->isEnabled());
+    }
+    if (m_audio && m_audio->clientGateTx()) {
+        m_appletPanel->setAppletVisible(
+            "GATE", m_audio->clientGateTx()->isEnabled());
+    }
+    if (m_audio && m_audio->clientDeEssTx()) {
+        m_appletPanel->setAppletVisible(
+            "DESS", m_audio->clientDeEssTx()->isEnabled());
+    }
+    if (m_audio && m_audio->clientTubeTx()) {
+        m_appletPanel->setAppletVisible(
+            "TUBE", m_audio->clientTubeTx()->isEnabled());
+    }
+    if (m_audio && m_audio->clientPuduTx()) {
+        m_appletPanel->setAppletVisible(
+            "PUDU", m_audio->clientPuduTx()->isEnabled());
     }
     connect(m_appletPanel->clientChainApplet(),
             &ClientChainApplet::stageEnabledChanged,
@@ -2070,6 +2296,23 @@ MainWindow::MainWindow(QWidget* parent)
             m_appletPanel->setAppletVisible("CMP", enabled);
             if (m_appletPanel->clientCompApplet())
                 m_appletPanel->clientCompApplet()->refreshEnableFromEngine();
+        } else if (stage == AudioEngine::TxChainStage::Gate) {
+            m_appletPanel->setAppletVisible("GATE", enabled);
+            if (m_appletPanel->clientGateApplet())
+                m_appletPanel->clientGateApplet()->refreshEnableFromEngine();
+        } else if (stage == AudioEngine::TxChainStage::DeEss) {
+            m_appletPanel->setAppletVisible("DESS", enabled);
+            if (m_appletPanel->clientDeEssApplet())
+                m_appletPanel->clientDeEssApplet()->refreshEnableFromEngine();
+        } else if (stage == AudioEngine::TxChainStage::Tube) {
+            m_appletPanel->setAppletVisible("TUBE", enabled);
+            if (m_appletPanel->clientTubeApplet())
+                m_appletPanel->clientTubeApplet()->refreshEnableFromEngine();
+        } else if (stage == AudioEngine::TxChainStage::Enh) {
+            // Enh slot hosts the PUDU exciter.
+            m_appletPanel->setAppletVisible("PUDU", enabled);
+            if (m_appletPanel->clientPuduApplet())
+                m_appletPanel->clientPuduApplet()->refreshEnableFromEngine();
         }
     });
     connect(m_appletPanel->clientChainApplet(),
@@ -2109,8 +2352,68 @@ MainWindow::MainWindow(QWidget* parent)
                 }
                 m_clientCompEditor->showForTx();
                 break;
+            case AudioEngine::TxChainStage::Gate:
+                if (!m_clientGateEditor) {
+                    m_clientGateEditor = new ClientGateEditor(m_audio, this);
+                    connect(m_clientGateEditor, &ClientGateEditor::bypassToggled,
+                            this, [this](bool bypassed) {
+                        if (m_appletPanel && m_appletPanel->clientGateApplet())
+                            m_appletPanel->clientGateApplet()->refreshEnableFromEngine();
+                        if (m_appletPanel && m_appletPanel->clientChainApplet())
+                            m_appletPanel->clientChainApplet()->refreshFromEngine();
+                        if (m_appletPanel)
+                            m_appletPanel->setAppletVisible("GATE", !bypassed);
+                    });
+                }
+                m_clientGateEditor->showForTx();
+                break;
+            case AudioEngine::TxChainStage::DeEss:
+                if (!m_clientDeEssEditor) {
+                    m_clientDeEssEditor = new ClientDeEssEditor(m_audio, this);
+                    connect(m_clientDeEssEditor, &ClientDeEssEditor::bypassToggled,
+                            this, [this](bool bypassed) {
+                        if (m_appletPanel && m_appletPanel->clientDeEssApplet())
+                            m_appletPanel->clientDeEssApplet()->refreshEnableFromEngine();
+                        if (m_appletPanel && m_appletPanel->clientChainApplet())
+                            m_appletPanel->clientChainApplet()->refreshFromEngine();
+                        if (m_appletPanel)
+                            m_appletPanel->setAppletVisible("DESS", !bypassed);
+                    });
+                }
+                m_clientDeEssEditor->showForTx();
+                break;
+            case AudioEngine::TxChainStage::Tube:
+                if (!m_clientTubeEditor) {
+                    m_clientTubeEditor = new ClientTubeEditor(m_audio, this);
+                    connect(m_clientTubeEditor, &ClientTubeEditor::bypassToggled,
+                            this, [this](bool bypassed) {
+                        if (m_appletPanel && m_appletPanel->clientTubeApplet())
+                            m_appletPanel->clientTubeApplet()->refreshEnableFromEngine();
+                        if (m_appletPanel && m_appletPanel->clientChainApplet())
+                            m_appletPanel->clientChainApplet()->refreshFromEngine();
+                        if (m_appletPanel)
+                            m_appletPanel->setAppletVisible("TUBE", !bypassed);
+                    });
+                }
+                m_clientTubeEditor->showForTx();
+                break;
+            case AudioEngine::TxChainStage::Enh:
+                // Enh slot hosts PUDU.
+                if (!m_clientPuduEditor) {
+                    m_clientPuduEditor = new ClientPuduEditor(m_audio, this);
+                    connect(m_clientPuduEditor, &ClientPuduEditor::bypassToggled,
+                            this, [this](bool bypassed) {
+                        if (m_appletPanel && m_appletPanel->clientPuduApplet())
+                            m_appletPanel->clientPuduApplet()->refreshEnableFromEngine();
+                        if (m_appletPanel && m_appletPanel->clientChainApplet())
+                            m_appletPanel->clientChainApplet()->refreshFromEngine();
+                        if (m_appletPanel)
+                            m_appletPanel->setAppletVisible("PUDU", !bypassed);
+                    });
+                }
+                m_clientPuduEditor->showForTx();
+                break;
             default:
-                // Gate / DeEss / Tube / Enh — no editor yet.
                 break;
         }
     });

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -14,6 +14,7 @@
 #include "core/WanConnection.h"
 #include "core/CwDecoder.h"
 #include "core/QsoRecorder.h"
+#include "core/ClientPuduMonitor.h"
 #include "core/DxClusterClient.h"
 #ifdef HAVE_MQTT
 #include "core/MqttClient.h"
@@ -160,6 +161,7 @@ private:
     AudioEngine*      m_audio{nullptr};
     QThread*          m_audioThread{nullptr};
     QsoRecorder*      m_qsoRecorder{nullptr};
+    ClientPuduMonitor* m_puduMonitor{nullptr};
     BandSettings      m_bandSettings;
     // 8-channel CAT: each channel (A-H) binds to a slice index (0-7)
     static constexpr int kCatChannels = 8;
@@ -306,6 +308,10 @@ private:
     QDialog* m_reconnectDlg{nullptr}; // shown on unexpected disconnect, dismissed on reconnect
     class ClientEqEditor* m_clientEqEditor{nullptr}; // lazy — created on first Edit… click
     class ClientCompEditor* m_clientCompEditor{nullptr}; // lazy — created on first Edit… click
+    class ClientGateEditor* m_clientGateEditor{nullptr}; // lazy — created on first Edit… click
+    class ClientDeEssEditor* m_clientDeEssEditor{nullptr}; // lazy — created on first Edit… click
+    class ClientTubeEditor* m_clientTubeEditor{nullptr}; // lazy — created on first Edit… click
+    class ClientPuduEditor* m_clientPuduEditor{nullptr}; // lazy — created on first Edit… click
 
     // Applet-panel pop-out support (#1713 Phase 6).  When floating,
     // the panel lives inside m_appletPanelFloatWindow and its splitter

--- a/src/gui/PooDooLogo.cpp
+++ b/src/gui/PooDooLogo.cpp
@@ -1,0 +1,107 @@
+#include "PooDooLogo.h"
+#include "core/ClientPudu.h"
+
+#include <QFont>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QRadialGradient>
+#include <QTimer>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr float kSmoothAlpha = 0.25f;
+constexpr float kMinDb = -60.0f;   // treat quieter than this as "off"
+constexpr float kMaxDb =   0.0f;   // full pulse at 0 dBFS wet RMS
+
+} // namespace
+
+PooDooLogo::PooDooLogo(QWidget* parent) : QWidget(parent)
+{
+    setMinimumHeight(42);
+    setAttribute(Qt::WA_OpaquePaintEvent, false);
+
+    m_timer = new QTimer(this);
+    m_timer->setInterval(33);
+    connect(m_timer, &QTimer::timeout, this, &PooDooLogo::tick);
+}
+
+void PooDooLogo::setPudu(ClientPudu* p)
+{
+    m_pudu = p;
+    if (m_pudu) m_timer->start();
+    else        m_timer->stop();
+    update();
+}
+
+void PooDooLogo::tick()
+{
+    if (!m_pudu) return;
+    const float target = m_pudu->wetRmsDb();
+    m_smoothedWetDb += kSmoothAlpha * (target - m_smoothedWetDb);
+    update();
+}
+
+void PooDooLogo::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    const QRectF r = rect();
+
+    // Background — nothing, lets the applet background show through.
+
+    // Pulse intensity 0..1 mapped from smoothedWetDb in [kMinDb, kMaxDb].
+    const float pulse = std::clamp(
+        (m_smoothedWetDb - kMinDb) / (kMaxDb - kMinDb), 0.0f, 1.0f);
+
+    // Colour — amber with alpha scaled by pulse.  Even at rest we
+    // want the logo visible (text is always legible), so text alpha
+    // has a floor; the GLOW is what pulses dramatically.
+    const int textAlpha = 180 + static_cast<int>(pulse * 75.0f);
+    QColor textColor(0xf2, 0xc1, 0x4e, std::clamp(textAlpha, 0, 255));
+
+    // Glow — a radial gradient centred on the logo, intensity scales
+    // with pulse.  Fully off at rest (alpha 0) → bright amber halo
+    // when the exciter is working hard.
+    if (pulse > 0.02f) {
+        const QPointF centre = r.center();
+        const float radius = r.width() * 0.55f;
+        QRadialGradient glow(centre, radius);
+        QColor glowColor = textColor;
+        glowColor.setAlpha(static_cast<int>(pulse * 120.0f));
+        glow.setColorAt(0.0, glowColor);
+        glowColor.setAlpha(0);
+        glow.setColorAt(1.0, glowColor);
+        p.setBrush(glow);
+        p.setPen(Qt::NoPen);
+        p.drawEllipse(centre, radius, radius * 0.6);
+    }
+
+    // PooDoo™ wordmark — bold amber text, centred.
+    QFont f = p.font();
+    f.setFamily("Arial Black");        // bold, closest to a logo face
+    f.setPixelSize(static_cast<int>(r.height() * 0.55f));
+    f.setWeight(QFont::Black);
+    p.setFont(f);
+
+    const QString wordmark = QString::fromUtf8("PooDoo\xe2\x84\xa2");
+    p.setPen(textColor);
+    p.drawText(r, Qt::AlignCenter, wordmark);
+
+    // Subtle scanline / chrome underline — a horizontal dim line
+    // under the text grounds the logo visually.  Alpha also pulses
+    // so the whole mark feels tied together.
+    QColor underline(0x5a, 0x3a, 0x0e,
+                     80 + static_cast<int>(pulse * 120.0f));
+    p.setPen(QPen(underline, 1.2));
+    const float uy = r.bottom() - 3.0f;
+    const float ux1 = r.left() + r.width() * 0.15f;
+    const float ux2 = r.right() - r.width() * 0.15f;
+    p.drawLine(QPointF(ux1, uy), QPointF(ux2, uy));
+}
+
+} // namespace AetherSDR

--- a/src/gui/PooDooLogo.h
+++ b/src/gui/PooDooLogo.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QWidget>
+
+class QTimer;
+
+namespace AetherSDR {
+
+class ClientPudu;
+
+// PooDoo™ Audio logo — the pulsing centrepiece of the PUDU applet.
+// Renders "PooDoo™" in a bold amber typeface with a soft glow whose
+// brightness scales with the bound ClientPudu's wetRmsDb() — dim
+// when bypassed, bright when the exciter is actively adding content.
+//
+// The logo is a passive read-only widget.  It polls the engine at
+// ~30 Hz via an internal QTimer and repaints when the RMS
+// meaningfully changes.
+class PooDooLogo : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit PooDooLogo(QWidget* parent = nullptr);
+
+    void setPudu(ClientPudu* p);
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+
+private:
+    void tick();
+
+    ClientPudu* m_pudu{nullptr};
+    QTimer*     m_timer{nullptr};
+    float       m_smoothedWetDb{-120.0f};   // smoothed level for pulse
+};
+
+} // namespace AetherSDR

--- a/tests/client_deess_test.cpp
+++ b/tests/client_deess_test.cpp
@@ -1,0 +1,326 @@
+// Standalone test harness for ClientDeEss DSP.
+// Build: produced by CMake as `client_deess_test` target.
+// Run:   ./build/client_deess_test
+// Exit code 0 on all pass, 1 on any failure.
+
+#include "core/ClientDeEss.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using AetherSDR::ClientDeEss;
+
+namespace {
+
+constexpr double kSampleRate = 24000.0;
+constexpr int    kBlockSize  = 128;
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-54s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+std::vector<float> makeTone(double freq, int frames, float amplitude)
+{
+    std::vector<float> buf(frames * 2);
+    const double twoPi = 6.283185307179586476;
+    for (int i = 0; i < frames; ++i) {
+        const float s = amplitude * static_cast<float>(
+            std::sin(twoPi * freq * i / kSampleRate));
+        buf[i * 2]     = s;
+        buf[i * 2 + 1] = s;
+    }
+    return buf;
+}
+
+float peakAbsStereo(const float* data, int frames)
+{
+    float peak = 0.0f;
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) {
+        peak = std::max(peak, std::fabs(data[i]));
+    }
+    return peak;
+}
+
+void processBlocks(ClientDeEss& d, float* buf, int frames)
+{
+    int remaining = frames;
+    float* p = buf;
+    while (remaining > 0) {
+        const int n = std::min(kBlockSize, remaining);
+        d.process(p, n, 2);
+        p += n * 2;
+        remaining -= n;
+    }
+}
+
+bool anyNaNorInf(const float* data, int frames)
+{
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) {
+        if (!std::isfinite(data[i])) return true;
+    }
+    return false;
+}
+
+float linToDb(float lin)
+{
+    return (lin > 1e-9f) ? 20.0f * std::log10(lin) : -180.0f;
+}
+
+float dbToLin(float db)
+{
+    return std::pow(10.0f, db * 0.05f);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+void testBypass()
+{
+    ClientDeEss d;
+    d.prepare(kSampleRate);
+    d.setEnabled(false);
+
+    const int frames = 1024;
+    auto ref = makeTone(5000.0, frames, dbToLin(-6.0f));
+    auto out = ref;
+    processBlocks(d, out.data(), frames);
+
+    float maxDiff = 0.0f;
+    for (size_t i = 0; i < out.size(); ++i)
+        maxDiff = std::max(maxDiff, std::fabs(out[i] - ref[i]));
+
+    report("bypass: disabled passes through unchanged",
+           maxDiff < 1e-6f,
+           "maxDiff=" + std::to_string(maxDiff));
+}
+
+// Low-frequency signal (below the sidechain band) should NOT trigger
+// attenuation even at loud levels.
+void testLowFreqPassthrough()
+{
+    ClientDeEss d;
+    d.prepare(kSampleRate);
+    d.setEnabled(true);
+    d.setFrequencyHz(6000.0f);
+    d.setQ(2.0f);
+    d.setThresholdDb(-40.0f);
+    d.setAmountDb(-12.0f);
+    d.setAttackMs(1.0f);
+    d.setReleaseMs(50.0f);
+
+    // 300 Hz at -6 dBFS — well below the sibilant band.
+    const float amp = dbToLin(-6.0f);
+    auto buf = makeTone(300.0, 12000, amp);   // 500 ms, let envelope settle
+    processBlocks(d, buf.data(), 12000);
+
+    const int tailFrames = 512;
+    auto tail = makeTone(300.0, tailFrames, amp);
+    processBlocks(d, tail.data(), tailFrames);
+
+    const float outPeak = peakAbsStereo(tail.data(), tailFrames);
+    const float grDb = linToDb(outPeak / amp);
+
+    // Should be within a fraction of a dB of unity — the bandpass
+    // rejects 300 Hz enough that the detector stays below threshold.
+    report("low-freq: below-band tone passes untouched",
+           std::fabs(grDb) < 0.5f,
+           "GR=" + std::to_string(grDb) + " dB");
+}
+
+// High-frequency signal in the sidechain band, above threshold, should
+// produce attenuation clamped at `amountDb`.
+void testSibilantAttenuated()
+{
+    ClientDeEss d;
+    d.prepare(kSampleRate);
+    d.setEnabled(true);
+    d.setFrequencyHz(6000.0f);
+    d.setQ(2.0f);
+    d.setThresholdDb(-40.0f);
+    d.setAmountDb(-8.0f);
+    d.setAttackMs(0.5f);
+    d.setReleaseMs(50.0f);
+
+    // 6 kHz at -6 dBFS — smack in the sidechain band, well above threshold.
+    const float amp = dbToLin(-6.0f);
+    auto buf = makeTone(6000.0, 12000, amp);
+    processBlocks(d, buf.data(), 12000);
+
+    const int tailFrames = 512;
+    auto tail = makeTone(6000.0, tailFrames, amp);
+    processBlocks(d, tail.data(), tailFrames);
+
+    const float outPeak = peakAbsStereo(tail.data(), tailFrames);
+    const float grDb = linToDb(outPeak / amp);
+
+    // Expected: attenuation clamped at amountDb (-8 dB).  Allow ±1 dB.
+    report("sibilant: HF band above threshold clamps to amount",
+           grDb < 0.0f && std::fabs(grDb - (-8.0f)) < 1.0f,
+           "GR=" + std::to_string(grDb) + " dB (amount=-8)");
+}
+
+// Amount clamp: with amountDb = -3 dB, even a very loud HF tone must
+// not attenuate by more than ~3 dB.
+void testAmountClamp()
+{
+    ClientDeEss d;
+    d.prepare(kSampleRate);
+    d.setEnabled(true);
+    d.setFrequencyHz(6000.0f);
+    d.setQ(2.0f);
+    d.setThresholdDb(-50.0f);
+    d.setAmountDb(-3.0f);
+    d.setAttackMs(0.5f);
+    d.setReleaseMs(50.0f);
+
+    const float amp = dbToLin(-2.0f);
+    auto buf = makeTone(6000.0, 12000, amp);
+    processBlocks(d, buf.data(), 12000);
+
+    const int tailFrames = 512;
+    auto tail = makeTone(6000.0, tailFrames, amp);
+    processBlocks(d, tail.data(), tailFrames);
+
+    const float outPeak = peakAbsStereo(tail.data(), tailFrames);
+    const float grDb = linToDb(outPeak / amp);
+
+    report("amount: reduction capped at -3 dB",
+           grDb >= -3.5f,
+           "GR=" + std::to_string(grDb) + " dB (should be ≥ -3.5)");
+}
+
+// Moving the frequency knob should steer the sidechain band: a
+// 2 kHz tone that triggered attenuation at freq=2000 should be
+// untouched at freq=10000.
+void testFrequencySteering()
+{
+    ClientDeEss d;
+    d.prepare(kSampleRate);
+    d.setEnabled(true);
+    d.setQ(2.0f);
+    d.setThresholdDb(-40.0f);
+    d.setAmountDb(-12.0f);
+    d.setAttackMs(0.5f);
+    d.setReleaseMs(50.0f);
+
+    const float amp = dbToLin(-6.0f);
+
+    // Tuned to 2 kHz — a 2 kHz tone should trigger attenuation.
+    d.setFrequencyHz(2000.0f);
+    d.reset();
+    auto a = makeTone(2000.0, 12000, amp);
+    processBlocks(d, a.data(), 12000);
+    auto aTail = makeTone(2000.0, 512, amp);
+    processBlocks(d, aTail.data(), 512);
+    const float grLow = linToDb(peakAbsStereo(aTail.data(), 512) / amp);
+
+    // Move the sidechain up to 10 kHz; same 2 kHz tone should now
+    // slip past it.
+    d.setFrequencyHz(10000.0f);
+    d.reset();
+    auto b = makeTone(2000.0, 12000, amp);
+    processBlocks(d, b.data(), 12000);
+    auto bTail = makeTone(2000.0, 512, amp);
+    processBlocks(d, bTail.data(), 512);
+    const float grHigh = linToDb(peakAbsStereo(bTail.data(), 512) / amp);
+
+    // With a broad Q=2 bandpass at 10 kHz the 2 kHz tone still leaks
+    // some reduction (skirt rolloff, not brick-wall).  The point is
+    // that steering produces a significantly different gate response
+    // — require at least 5 dB more reduction on the in-tune side.
+    report("frequency: steering changes what counts as sibilant",
+           grLow < grHigh - 5.0f,
+           "grLow=" + std::to_string(grLow)
+           + " grHigh=" + std::to_string(grHigh));
+}
+
+// Sanity: complex tone with AM modulation produces finite output, no
+// NaN/Inf, peak doesn't exceed input.
+void testTransientSanity()
+{
+    ClientDeEss d;
+    d.prepare(kSampleRate);
+    d.setEnabled(true);
+    d.setFrequencyHz(5000.0f);
+    d.setQ(2.0f);
+    d.setThresholdDb(-30.0f);
+    d.setAmountDb(-8.0f);
+    d.setAttackMs(1.0f);
+    d.setReleaseMs(100.0f);
+
+    const int frames = 24000;
+    std::vector<float> buf(frames * 2);
+    const double twoPi = 6.283185307179586476;
+    for (int i = 0; i < frames; ++i) {
+        // Mix of a low-frequency (vowel) and a high-frequency (sibilant)
+        // component with varying amplitude.
+        const float env = 0.3f + 0.3f
+            * static_cast<float>(std::sin(twoPi * 3.0 * i / kSampleRate));
+        const float s = env * (
+            0.6f * static_cast<float>(std::sin(twoPi * 500.0  * i / kSampleRate))
+          + 0.4f * static_cast<float>(std::sin(twoPi * 5500.0 * i / kSampleRate)));
+        buf[i * 2]     = s;
+        buf[i * 2 + 1] = s;
+    }
+    const float inPeak = peakAbsStereo(buf.data(), frames);
+    processBlocks(d, buf.data(), frames);
+    const float outPeak = peakAbsStereo(buf.data(), frames);
+
+    report("transient: mixed voice + sibilant stays finite",
+           !anyNaNorInf(buf.data(), frames) && outPeak <= inPeak + 1e-5f,
+           "inPeak=" + std::to_string(inPeak)
+           + " outPeak=" + std::to_string(outPeak));
+}
+
+void testReset()
+{
+    ClientDeEss d;
+    d.prepare(kSampleRate);
+    d.setEnabled(true);
+    d.setFrequencyHz(6000.0f);
+    d.setThresholdDb(-40.0f);
+    d.setAmountDb(-8.0f);
+
+    const float amp = dbToLin(-6.0f);
+    auto buf = makeTone(6000.0, 4800, amp);
+    processBlocks(d, buf.data(), 4800);
+
+    d.reset();
+
+    std::vector<float> sil(1024, 0.0f);
+    d.process(sil.data(), 512, 2);
+    report("reset: no NaN/Inf after flush + silence",
+           !anyNaNorInf(sil.data(), 512));
+}
+
+} // namespace
+
+int main()
+{
+    std::printf("ClientDeEss test harness @ %.0f Hz, %d-frame blocks\n\n",
+                kSampleRate, kBlockSize);
+
+    testBypass();
+    testLowFreqPassthrough();
+    testSibilantAttenuated();
+    testAmountClamp();
+    testFrequencySteering();
+    testTransientSanity();
+    testReset();
+
+    std::printf("\n%s (%d failure%s)\n",
+                g_failed == 0 ? "ALL PASS" : "FAILED",
+                g_failed, g_failed == 1 ? "" : "s");
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/client_gate_test.cpp
+++ b/tests/client_gate_test.cpp
@@ -1,0 +1,544 @@
+// Standalone test harness for ClientGate DSP.
+// Build: produced by CMake as `client_gate_test` target.
+// Run:   ./build/client_gate_test
+// Exit code 0 on all pass, 1 on any failure.
+
+#include "core/ClientGate.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using AetherSDR::ClientGate;
+
+namespace {
+
+constexpr double kSampleRate = 24000.0;
+constexpr int    kBlockSize  = 128;
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-52s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+std::vector<float> makeTone(double freq, int frames, float amplitude)
+{
+    std::vector<float> buf(frames * 2);
+    const double twoPi = 6.283185307179586476;
+    for (int i = 0; i < frames; ++i) {
+        const float s = amplitude * static_cast<float>(
+            std::sin(twoPi * freq * i / kSampleRate));
+        buf[i * 2]     = s;
+        buf[i * 2 + 1] = s;
+    }
+    return buf;
+}
+
+std::vector<float> makeSilence(int frames)
+{
+    return std::vector<float>(frames * 2, 0.0f);
+}
+
+float peakAbsStereo(const float* data, int frames)
+{
+    float peak = 0.0f;
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) {
+        peak = std::max(peak, std::fabs(data[i]));
+    }
+    return peak;
+}
+
+void processBlocks(ClientGate& gate, float* buf, int frames)
+{
+    int remaining = frames;
+    float* p = buf;
+    while (remaining > 0) {
+        const int n = std::min(kBlockSize, remaining);
+        gate.process(p, n, 2);
+        p += n * 2;
+        remaining -= n;
+    }
+}
+
+bool anyNaNorInf(const float* data, int frames)
+{
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) {
+        if (!std::isfinite(data[i])) return true;
+    }
+    return false;
+}
+
+float linToDb(float lin)
+{
+    return (lin > 1e-9f) ? 20.0f * std::log10(lin) : -180.0f;
+}
+
+float dbToLin(float db)
+{
+    return std::pow(10.0f, db * 0.05f);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+// Disabled gate = pure pass-through on any input.
+void testBypass()
+{
+    ClientGate gate;
+    gate.prepare(kSampleRate);
+    gate.setEnabled(false);
+
+    const int frames = 1024;
+    auto ref = makeTone(1000.0, frames, 0.001f);  // very quiet: -60 dBFS
+    auto out = ref;
+    processBlocks(gate, out.data(), frames);
+
+    float maxDiff = 0.0f;
+    for (size_t i = 0; i < out.size(); ++i)
+        maxDiff = std::max(maxDiff, std::fabs(out[i] - ref[i]));
+
+    report("bypass: disabled passes through unchanged",
+           maxDiff < 1e-6f,
+           "maxDiff=" + std::to_string(maxDiff));
+}
+
+// Signal well above threshold → unity gain (no attenuation).
+void testAboveThresholdPassthrough()
+{
+    ClientGate gate;
+    gate.prepare(kSampleRate);
+    gate.setEnabled(true);
+    gate.setThresholdDb(-40.0f);
+    gate.setRatio(10.0f);
+    gate.setAttackMs(0.5f);
+    gate.setReleaseMs(50.0f);
+    gate.setHoldMs(0.0f);
+    gate.setFloorDb(-40.0f);
+
+    // Prime envelope with a long burst at -6 dBFS.
+    const float ampIn = dbToLin(-6.0f);
+    auto buf = makeTone(1000.0, 4800, ampIn);  // 200 ms
+    processBlocks(gate, buf.data(), 4800);
+
+    // Now measure the trailing block — envelope is fully settled.
+    const int tailFrames = 512;
+    auto tail = makeTone(1000.0, tailFrames, ampIn);
+    processBlocks(gate, tail.data(), tailFrames);
+
+    const float outPeak = peakAbsStereo(tail.data(), tailFrames);
+    const float grDb = linToDb(outPeak / ampIn);
+
+    report("above-threshold: unity gain (no reduction)",
+           std::fabs(grDb) < 0.5f,
+           "GR=" + std::to_string(grDb) + " dB");
+}
+
+// Signal below threshold, soft expander (ratio 2:1, floor -15 dB):
+// expected reduction = min(floor, (T - env) * (ratio - 1))
+// with env = -50 dBFS, T = -40 dB, r = 2 → shortfall 10, slope 1 → -10 dB
+void testExpanderBelowThreshold()
+{
+    ClientGate gate;
+    gate.prepare(kSampleRate);
+    gate.setEnabled(true);
+    gate.setThresholdDb(-40.0f);
+    gate.setRatio(2.0f);
+    gate.setAttackMs(0.5f);
+    gate.setReleaseMs(10.0f);       // fast release so envelope settles quickly
+    gate.setHoldMs(0.0f);
+    gate.setFloorDb(-40.0f);        // deep enough not to clamp the -10 dB expected
+
+    const float ampIn = dbToLin(-50.0f);
+    // Long burst for envelope + gain to settle.
+    auto prime = makeTone(1000.0, 24000, ampIn);  // 1 s
+    processBlocks(gate, prime.data(), 24000);
+
+    const int tailFrames = 512;
+    auto tail = makeTone(1000.0, tailFrames, ampIn);
+    processBlocks(gate, tail.data(), tailFrames);
+
+    const float outPeak = peakAbsStereo(tail.data(), tailFrames);
+    const float grDb = linToDb(outPeak / ampIn);
+
+    // Expected ≈ -10 dB; allow ±1.5 dB for envelope ripple at low frequency.
+    report("expander: -50 dBFS → ~-10 dB reduction (2:1)",
+           std::fabs(grDb - (-10.0f)) < 1.5f,
+           "GR=" + std::to_string(grDb) + " dB (expected ~-10)");
+}
+
+// Hard gate (ratio 10:1): signal far below threshold gets clamped to `floor`.
+void testGateClampsToRange()
+{
+    ClientGate gate;
+    gate.prepare(kSampleRate);
+    gate.setEnabled(true);
+    gate.setThresholdDb(-30.0f);
+    gate.setRatio(10.0f);
+    gate.setAttackMs(0.5f);
+    gate.setReleaseMs(10.0f);
+    gate.setHoldMs(0.0f);
+    gate.setFloorDb(-40.0f);
+
+    // With env 60 dB below threshold and slope 9, raw curve demands -540 dB;
+    // the floor clamp must cap it at -40 dB.
+    const float ampIn = dbToLin(-90.0f);
+    auto prime = makeTone(1000.0, 24000, ampIn);
+    processBlocks(gate, prime.data(), 24000);
+
+    const int tailFrames = 512;
+    auto tail = makeTone(1000.0, tailFrames, ampIn);
+    processBlocks(gate, tail.data(), tailFrames);
+
+    const float outPeak = peakAbsStereo(tail.data(), tailFrames);
+    const float grDb = linToDb(outPeak / ampIn);
+
+    report("gate: far-below-threshold clamps to floor",
+           std::fabs(grDb - (-40.0f)) < 1.5f,
+           "GR=" + std::to_string(grDb) + " dB (floor=-40)");
+}
+
+// Hold: after signal drops below threshold, gain should stay at its open
+// value for `holdMs` before starting to close.
+void testHoldFreezesGain()
+{
+    ClientGate gate;
+    gate.prepare(kSampleRate);
+    gate.setEnabled(true);
+    gate.setThresholdDb(-40.0f);
+    gate.setRatio(10.0f);
+    gate.setAttackMs(0.1f);
+    gate.setReleaseMs(500.0f);   // slow release so hold effect is visible
+    gate.setHoldMs(50.0f);       // 50 ms hold = 1200 samples @ 24 kHz
+    gate.setFloorDb(-40.0f);
+
+    // Open the gate with a -6 dBFS burst for 100 ms.
+    const float ampLoud = dbToLin(-6.0f);
+    auto open = makeTone(1000.0, 2400, ampLoud);
+    processBlocks(gate, open.data(), 2400);
+
+    // Now feed silence.  The envelope drops instantly (well, over the
+    // attack coefficient one sample at a time, but attack is fast).
+    // During the first 50 ms of silence the gain should stay at ~0 dB
+    // (gate still held open) — we test at t=25 ms into the hold.
+    auto sil = makeSilence(600);  // 25 ms
+    processBlocks(gate, sil.data(), 600);
+    const float grDuringHold = gate.gainReductionDb();
+
+    // Then continue into the release region (past hold).  Another 25 ms
+    // brings us to 50 ms which is right at the boundary; skip ahead to
+    // sample 2000+ to be safely past it with a slow 500 ms release
+    // already chewing on the gain.
+    sil = makeSilence(2000);
+    processBlocks(gate, sil.data(), 2000);
+    const float grAfterHold = gate.gainReductionDb();
+
+    // During hold: no reduction (gate still open).
+    // After hold: some reduction (release underway) but nowhere near -40
+    // yet thanks to the slow release.
+    const bool holdOk    = std::fabs(grDuringHold) < 0.5f;
+    const bool releaseOk = grAfterHold < -0.5f && grAfterHold > -20.0f;
+
+    report("hold: gain frozen during hold window",
+           holdOk && releaseOk,
+           "grHold=" + std::to_string(grDuringHold)
+           + " grAfter=" + std::to_string(grAfterHold));
+}
+
+// Mode toggle: Expander sets ratio 2 / floor -15; Gate sets ratio 10 / floor -40.
+// Other params (threshold/attack/release/hold) are preserved.
+void testModeToggle()
+{
+    ClientGate gate;
+    gate.prepare(kSampleRate);
+
+    gate.setThresholdDb(-35.0f);
+    gate.setAttackMs(2.0f);
+    gate.setReleaseMs(150.0f);
+    gate.setHoldMs(30.0f);
+
+    gate.setMode(ClientGate::Mode::Expander);
+    const bool expOk =
+        std::fabs(gate.ratio() - 2.0f) < 0.01f &&
+        std::fabs(gate.floorDb() - (-15.0f)) < 0.01f &&
+        std::fabs(gate.thresholdDb() - (-35.0f)) < 0.01f &&
+        std::fabs(gate.attackMs() - 2.0f) < 0.01f &&
+        std::fabs(gate.releaseMs() - 150.0f) < 0.01f &&
+        std::fabs(gate.holdMs() - 30.0f) < 0.01f;
+
+    gate.setMode(ClientGate::Mode::Gate);
+    const bool gateOk =
+        std::fabs(gate.ratio() - 10.0f) < 0.01f &&
+        std::fabs(gate.floorDb() - (-40.0f)) < 0.01f &&
+        std::fabs(gate.thresholdDb() - (-35.0f)) < 0.01f &&
+        std::fabs(gate.attackMs() - 2.0f) < 0.01f &&
+        std::fabs(gate.releaseMs() - 150.0f) < 0.01f &&
+        std::fabs(gate.holdMs() - 30.0f) < 0.01f;
+
+    report("mode: Expander/Gate snap ratio+floor, preserve other knobs",
+           expOk && gateOk);
+}
+
+// Stereo linking: different L/R amplitudes → same gain applied to both.
+void testStereoLinking()
+{
+    ClientGate gate;
+    gate.prepare(kSampleRate);
+    gate.setEnabled(true);
+    gate.setThresholdDb(-30.0f);
+    gate.setRatio(4.0f);
+    gate.setAttackMs(0.5f);
+    gate.setReleaseMs(10.0f);
+    gate.setHoldMs(0.0f);
+    gate.setFloorDb(-40.0f);
+
+    const int frames = 24000;  // 1 s
+    std::vector<float> buf(frames * 2);
+    const float ampL = dbToLin(-50.0f);
+    const float ampR = dbToLin(-45.0f);  // 5 dB louder — drives the envelope
+    const double twoPi = 6.283185307179586476;
+    for (int i = 0; i < frames; ++i) {
+        const float s = static_cast<float>(
+            std::sin(twoPi * 1000.0 * i / kSampleRate));
+        buf[i * 2]     = ampL * s;
+        buf[i * 2 + 1] = ampR * s;
+    }
+    processBlocks(gate, buf.data(), frames);
+
+    // Measure ratio of output peak L vs R in the tail.  Should equal
+    // ampL / ampR (same gain applied, L remains 5 dB quieter).
+    const int tailStart = frames - 512;
+    float pkL = 0.0f, pkR = 0.0f;
+    for (int i = tailStart; i < frames; ++i) {
+        pkL = std::max(pkL, std::fabs(buf[i * 2]));
+        pkR = std::max(pkR, std::fabs(buf[i * 2 + 1]));
+    }
+    const float ratioDb = linToDb(pkL / pkR);
+    const float expected = linToDb(ampL / ampR);  // -5 dB
+
+    report("stereo: identical gain applied to L and R",
+           std::fabs(ratioDb - expected) < 0.3f,
+           "L/R=" + std::to_string(ratioDb) + " expected=-5");
+}
+
+// Attack time: starting from fully closed (silence), a loud step should
+// reach near-unity within a handful of attack time-constants.
+void testAttackTiming()
+{
+    ClientGate gate;
+    gate.prepare(kSampleRate);
+    gate.setEnabled(true);
+    gate.setThresholdDb(-30.0f);
+    gate.setRatio(10.0f);
+    gate.setAttackMs(5.0f);
+    gate.setReleaseMs(200.0f);
+    gate.setHoldMs(0.0f);
+    gate.setFloorDb(-40.0f);
+
+    // Start with a full second of silence so the gate is fully closed
+    // at -floor (-40 dB reduction).
+    auto sil = makeSilence(24000);
+    processBlocks(gate, sil.data(), 24000);
+    const float grClosed = gate.gainReductionDb();
+    const bool closedOk = std::fabs(grClosed - (-40.0f)) < 3.0f;
+
+    // Hit it with a loud tone.  After 10× attack (50 ms = 1200 samples)
+    // the gate should be open (GR within 1 dB of 0).
+    const float amp = dbToLin(-6.0f);
+    auto burst = makeTone(1000.0, 1200, amp);
+    processBlocks(gate, burst.data(), 1200);
+    const float grOpen = gate.gainReductionDb();
+    const bool openedOk = std::fabs(grOpen) < 1.0f;
+
+    report("attack: opens within ~10× τ after loud onset",
+           closedOk && openedOk,
+           "closedGR=" + std::to_string(grClosed)
+           + " openedGR=" + std::to_string(grOpen));
+}
+
+// Reset clears envelope + hold state.
+void testReset()
+{
+    ClientGate gate;
+    gate.prepare(kSampleRate);
+    gate.setEnabled(true);
+    gate.setThresholdDb(-30.0f);
+    gate.setRatio(10.0f);
+    gate.setAttackMs(0.5f);
+    gate.setReleaseMs(50.0f);
+    gate.setHoldMs(100.0f);
+    gate.setFloorDb(-40.0f);
+
+    // Open gate, then drop to silence mid-hold.
+    const float amp = dbToLin(-6.0f);
+    auto burst = makeTone(1000.0, 2400, amp);
+    processBlocks(gate, burst.data(), 2400);
+
+    gate.reset();
+
+    // After reset with silence, envelope should be zero and gain
+    // should track toward floor from that fresh state.  Just check
+    // no NaN/Inf and that processing still works.
+    auto sil = makeSilence(1024);
+    processBlocks(gate, sil.data(), 1024);
+
+    report("reset: no NaN/Inf after flush + fresh block",
+           !anyNaNorInf(sil.data(), 1024));
+}
+
+// Sanity: AM tone crossing threshold repeatedly produces finite output
+// with no NaNs / Infs and output peak ≤ input peak.
+void testTransientSanity()
+{
+    ClientGate gate;
+    gate.prepare(kSampleRate);
+    gate.setEnabled(true);
+    gate.setThresholdDb(-30.0f);
+    gate.setRatio(6.0f);
+    gate.setAttackMs(1.0f);
+    gate.setReleaseMs(100.0f);
+    gate.setHoldMs(20.0f);
+    gate.setFloorDb(-30.0f);
+
+    const int frames = 24000;
+    std::vector<float> buf(frames * 2);
+    const double twoPi = 6.283185307179586476;
+    for (int i = 0; i < frames; ++i) {
+        const float env = 0.3f + 0.3f
+            * static_cast<float>(std::sin(twoPi * 3.0 * i / kSampleRate));
+        const float s = env * static_cast<float>(
+            std::sin(twoPi * 1000.0 * i / kSampleRate));
+        buf[i * 2]     = s;
+        buf[i * 2 + 1] = s;
+    }
+    const float inPeak = peakAbsStereo(buf.data(), frames);
+    processBlocks(gate, buf.data(), frames);
+    const float outPeak = peakAbsStereo(buf.data(), frames);
+
+    report("transient: AM tone finite + output ≤ input peak",
+           !anyNaNorInf(buf.data(), frames) && outPeak <= inPeak + 1e-5f,
+           "inPeak=" + std::to_string(inPeak)
+           + " outPeak=" + std::to_string(outPeak));
+}
+
+// Return (hysteresis): once the gate is open, it should stay open until
+// the envelope drops below threshold - returnDb.  Test by priming open
+// at a loud level, then feeding a level between close-threshold and
+// threshold — gate should remain open despite being below the opening
+// threshold.
+void testReturnHysteresis()
+{
+    ClientGate gate;
+    gate.prepare(kSampleRate);
+    gate.setEnabled(true);
+    gate.setThresholdDb(-30.0f);
+    gate.setReturnDb(6.0f);        // close-threshold = -36 dB
+    gate.setRatio(10.0f);
+    gate.setAttackMs(0.1f);
+    gate.setReleaseMs(50.0f);
+    gate.setHoldMs(0.0f);
+    gate.setFloorDb(-40.0f);
+
+    // Open the gate with a loud burst.
+    const float ampLoud = dbToLin(-6.0f);
+    auto open = makeTone(1000.0, 2400, ampLoud);   // 100 ms
+    processBlocks(gate, open.data(), 2400);
+
+    // Drop to -33 dBFS (below threshold -30, above close-threshold -36).
+    // Gate should REMAIN open despite being below the opening threshold.
+    const float ampMid = dbToLin(-33.0f);
+    auto mid = makeTone(1000.0, 12000, ampMid);    // 500 ms
+    processBlocks(gate, mid.data(), 12000);
+    const float grInBand = gate.gainReductionDb();
+
+    // Now drop below the close-threshold → gate should close and
+    // curve attenuation should kick in.
+    const float ampQuiet = dbToLin(-45.0f);
+    auto quiet = makeTone(1000.0, 24000, ampQuiet); // 1 s
+    processBlocks(gate, quiet.data(), 24000);
+    const float grClosed = gate.gainReductionDb();
+
+    report("return: gate stays open in hysteresis band",
+           std::fabs(grInBand) < 0.5f && grClosed < -5.0f,
+           "grInBand=" + std::to_string(grInBand)
+           + " grClosed=" + std::to_string(grClosed));
+}
+
+// Lookahead: with N samples of lookahead the first N samples of a
+// loud tone should pass through at the previous (attenuated) gain,
+// because those samples were already in the delay line BEFORE the
+// detector saw the loud signal.  The gate should start opening
+// "N samples early" relative to when the user hears it in the output.
+// We verify the delay line is in use by comparing a lookahead=0 run
+// vs lookahead=1 ms: the lookahead version should delay the output
+// by exactly 24 samples (1 ms @ 24 kHz).
+void testLookaheadDelay()
+{
+    const int frames = 4800;
+    const int la = 24;  // 1 ms @ 24 kHz
+
+    // Build an impulse train: quiet for the first 1000 samples, then
+    // a single full-scale spike, then quiet.
+    auto makeImpulse = [frames](int spikeAt) {
+        std::vector<float> buf(frames * 2, 0.0f);
+        buf[spikeAt * 2]     = 1.0f;
+        buf[spikeAt * 2 + 1] = 1.0f;
+        return buf;
+    };
+
+    // Configure: gate bypassed (enabled=false), so the delay line is
+    // the ONLY effect — we can measure delay in isolation.
+    ClientGate gate;
+    gate.prepare(kSampleRate);
+    gate.setEnabled(false);
+    gate.setLookaheadMs(1.0f);
+
+    auto buf = makeImpulse(1000);
+    processBlocks(gate, buf.data(), frames);
+
+    // Find the position of the first non-zero sample.
+    int firstNonZero = -1;
+    for (int i = 0; i < frames; ++i) {
+        if (std::fabs(buf[i * 2]) > 0.1f) { firstNonZero = i; break; }
+    }
+
+    report("lookahead: signal delayed by exactly N samples",
+           firstNonZero == 1000 + la,
+           "spikeAt=1000 lookahead=" + std::to_string(la)
+           + " foundAt=" + std::to_string(firstNonZero));
+}
+
+} // namespace
+
+int main()
+{
+    std::printf("ClientGate test harness @ %.0f Hz, %d-frame blocks\n\n",
+                kSampleRate, kBlockSize);
+
+    testBypass();
+    testAboveThresholdPassthrough();
+    testExpanderBelowThreshold();
+    testGateClampsToRange();
+    testHoldFreezesGain();
+    testModeToggle();
+    testStereoLinking();
+    testAttackTiming();
+    testReset();
+    testTransientSanity();
+    testReturnHysteresis();
+    testLookaheadDelay();
+
+    std::printf("\n%s (%d failure%s)\n",
+                g_failed == 0 ? "ALL PASS" : "FAILED",
+                g_failed, g_failed == 1 ? "" : "s");
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/client_pudu_test.cpp
+++ b/tests/client_pudu_test.cpp
@@ -1,0 +1,379 @@
+// Standalone test harness for ClientPudu DSP.
+// CMake target `client_pudu_test`.  Exit 0 = pass.
+
+#include "core/ClientPudu.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using AetherSDR::ClientPudu;
+
+namespace {
+
+constexpr double kSampleRate = 24000.0;
+constexpr int    kBlockSize  = 128;
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-56s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+std::vector<float> makeTone(double freq, int frames, float amplitude)
+{
+    std::vector<float> buf(frames * 2);
+    const double twoPi = 6.283185307179586476;
+    for (int i = 0; i < frames; ++i) {
+        const float s = amplitude * static_cast<float>(
+            std::sin(twoPi * freq * i / kSampleRate));
+        buf[i * 2]     = s;
+        buf[i * 2 + 1] = s;
+    }
+    return buf;
+}
+
+float peakAbsStereo(const float* data, int frames)
+{
+    float peak = 0.0f;
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) peak = std::max(peak, std::fabs(data[i]));
+    return peak;
+}
+
+float rmsStereo(const float* data, int frames)
+{
+    double sumSq = 0.0;
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) sumSq += data[i] * data[i];
+    return static_cast<float>(std::sqrt(sumSq / samples));
+}
+
+// Crude even-harmonic detector: DC (mean) of rectified signal rises
+// when the waveform is asymmetric.  A pure symmetric tanh of a sine
+// has zero mean (odd-only); one-sided clipping has non-zero mean.
+// We measure mean(x) over several cycles as a proxy for asymmetry.
+float meanDC(const float* data, int frames)
+{
+    double sum = 0.0;
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) sum += data[i];
+    return static_cast<float>(sum / samples);
+}
+
+void processBlocks(ClientPudu& p, float* buf, int frames)
+{
+    int remaining = frames;
+    float* ptr = buf;
+    while (remaining > 0) {
+        const int n = std::min(kBlockSize, remaining);
+        p.process(ptr, n, 2);
+        ptr += n * 2;
+        remaining -= n;
+    }
+}
+
+bool anyNaNorInf(const float* data, int frames)
+{
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) {
+        if (!std::isfinite(data[i])) return true;
+    }
+    return false;
+}
+
+float linToDb(float lin)
+{
+    return (lin > 1e-9f) ? 20.0f * std::log10(lin) : -180.0f;
+}
+
+float dbToLin(float db)
+{
+    return std::pow(10.0f, db * 0.05f);
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+void testBypass()
+{
+    ClientPudu p;
+    p.prepare(kSampleRate);
+    p.setEnabled(false);
+    p.setPooMix(1.0f);
+    p.setDooMix(1.0f);
+    p.setPooDriveDb(24.0f);
+    p.setDooHarmonicsDb(24.0f);
+
+    const int frames = 1024;
+    auto ref = makeTone(1000.0, frames, dbToLin(-6.0f));
+    auto out = ref;
+    processBlocks(p, out.data(), frames);
+
+    float maxDiff = 0.0f;
+    for (size_t i = 0; i < out.size(); ++i)
+        maxDiff = std::max(maxDiff, std::fabs(out[i] - ref[i]));
+
+    report("bypass: disabled passes through unchanged",
+           maxDiff < 1e-6f,
+           "maxDiff=" + std::to_string(maxDiff));
+}
+
+// Zero mix: both bands at 0% wet → output = dry (enabled is true,
+// but the wet-dry sum adds nothing).
+void testZeroMix()
+{
+    ClientPudu p;
+    p.prepare(kSampleRate);
+    p.setEnabled(true);
+    p.setMode(ClientPudu::Mode::Aphex);
+    p.setPooMix(0.0f);
+    p.setDooMix(0.0f);
+    p.setPooDriveDb(24.0f);
+    p.setDooHarmonicsDb(24.0f);
+
+    const int frames = 1024;
+    auto ref = makeTone(1000.0, frames, dbToLin(-6.0f));
+    auto out = ref;
+    processBlocks(p, out.data(), frames);
+
+    float maxDiff = 0.0f;
+    for (size_t i = 0; i < out.size(); ++i)
+        maxDiff = std::max(maxDiff, std::fabs(out[i] - ref[i]));
+
+    report("zero mix: both bands at 0% return dry",
+           maxDiff < 1e-4f,
+           "maxDiff=" + std::to_string(maxDiff));
+}
+
+// Aphex HF mode: asymmetric clipping on a 5 kHz tone in the Doo
+// band should produce measurable DC offset (pre-DC-block).  We
+// can't measure the pre-DC-block signal externally, but we CAN
+// verify that the output's symmetry metric differs from the
+// Behringer-mode output for the same input.
+void testAphexDooAddsAsymmetry()
+{
+    auto runMode = [](ClientPudu::Mode m) {
+        ClientPudu p;
+        p.prepare(kSampleRate);
+        p.setEnabled(true);
+        p.setMode(m);
+        p.setPooMix(0.0f);             // Poo band off
+        p.setDooMix(1.0f);
+        p.setDooTuneHz(2000.0f);       // well below the 5 kHz tone
+        p.setDooHarmonicsDb(18.0f);    // heavy drive
+        p.setPooTuneHz(100.0f);
+
+        auto buf = makeTone(5000.0, 2400, dbToLin(-6.0f));
+        processBlocks(p, buf.data(), 2400);
+        return rmsStereo(buf.data(), 2400);
+    };
+
+    const float rmsA = runMode(ClientPudu::Mode::Aphex);
+    const float rmsB = runMode(ClientPudu::Mode::Behringer);
+
+    // Both modes produce non-zero RMS (they're adding harmonics);
+    // Aphex typically yields more output energy due to one-sided
+    // clipping pushing half the waveform harder.
+    report("mode toggle: A and B produce distinct HF outputs",
+           rmsA != rmsB && rmsA > 0.01f && rmsB > 0.01f,
+           "rmsA=" + std::to_string(rmsA)
+           + " rmsB=" + std::to_string(rmsB));
+}
+
+// Above-band tone (10 kHz) with Doo tuned low (2 kHz) should still
+// excite Doo; below-band tone (200 Hz) should pass through with no
+// HF contribution.  Tests the HPF is doing its job.
+void testDooHPFRejectsLows()
+{
+    ClientPudu p;
+    p.prepare(kSampleRate);
+    p.setEnabled(true);
+    p.setMode(ClientPudu::Mode::Aphex);
+    p.setPooMix(0.0f);
+    p.setDooMix(1.0f);
+    p.setDooTuneHz(5000.0f);
+    p.setDooHarmonicsDb(12.0f);
+
+    // 200 Hz tone — well below the HPF corner; Doo path should be
+    // quiet, output ≈ dry.
+    const float amp = dbToLin(-6.0f);
+    auto buf = makeTone(200.0, 2400, amp);
+    const float inRms = rmsStereo(buf.data(), 2400);
+    processBlocks(p, buf.data(), 2400);
+    const float outRms = rmsStereo(buf.data(), 2400);
+
+    // Output should be very close to dry input RMS since the HPF
+    // shoves most of the 200 Hz content aside.
+    const float ratioDb = linToDb(outRms / inRms);
+    report("Doo HPF: 200 Hz tone barely excites the HF band",
+           std::fabs(ratioDb) < 1.0f,
+           "outRms/inRms=" + std::to_string(ratioDb) + " dB");
+}
+
+// Poo band: a 100 Hz tone with drive + mix should produce a
+// detectable output difference vs dry.  Test in Aphex mode where
+// the LF saturation adds harmonics.
+void testPooLFAphex()
+{
+    ClientPudu p;
+    p.prepare(kSampleRate);
+    p.setEnabled(true);
+    p.setMode(ClientPudu::Mode::Aphex);
+    p.setPooMix(1.0f);
+    p.setDooMix(0.0f);
+    p.setPooTuneHz(120.0f);
+    p.setPooDriveDb(18.0f);
+
+    const float amp = dbToLin(-12.0f);
+    auto buf = makeTone(80.0, 4800, amp);
+    const float inRms = rmsStereo(buf.data(), 4800);
+    processBlocks(p, buf.data(), 4800);
+    const float outRms = rmsStereo(buf.data(), 4800);
+
+    // Expect output RMS noticeably higher than input — dry + wet
+    // adds bass content.
+    report("Poo band (Aphex): saturation adds LF content",
+           outRms > inRms * 1.1f,
+           "inRms=" + std::to_string(inRms)
+           + " outRms=" + std::to_string(outRms));
+}
+
+// Behringer Poo: a 100 Hz tone with the bass processor should
+// produce output different from dry, but without generating
+// excessive harmonic content (phase rotator + compressor, not a
+// waveshaper).
+void testPooLFBehringer()
+{
+    ClientPudu p;
+    p.prepare(kSampleRate);
+    p.setEnabled(true);
+    p.setMode(ClientPudu::Mode::Behringer);
+    p.setPooMix(1.0f);
+    p.setDooMix(0.0f);
+    p.setPooTuneHz(120.0f);
+    p.setPooDriveDb(18.0f);
+
+    const float amp = dbToLin(-12.0f);
+    auto dry = makeTone(80.0, 4800, amp);
+    auto out = dry;
+    processBlocks(p, out.data(), 4800);
+
+    // Confirm output differs from dry (the compressor + all-pass
+    // alters the signal) and stays finite.
+    float maxDiff = 0.0f;
+    for (size_t i = 0; i < out.size(); ++i)
+        maxDiff = std::max(maxDiff, std::fabs(out[i] - dry[i]));
+
+    report("Poo band (Behringer): compressor + all-pass alters LF",
+           maxDiff > 1e-3f && !anyNaNorInf(out.data(), 4800),
+           "maxDiff=" + std::to_string(maxDiff));
+}
+
+// Wet RMS meter: with both bands active on a busy signal, the
+// wetRmsDb() snapshot should be well above -120 dB (silence).
+void testWetRmsMeter()
+{
+    ClientPudu p;
+    p.prepare(kSampleRate);
+    p.setEnabled(true);
+    p.setMode(ClientPudu::Mode::Aphex);
+    p.setPooMix(1.0f);
+    p.setDooMix(1.0f);
+    p.setPooDriveDb(12.0f);
+    p.setDooHarmonicsDb(12.0f);
+
+    auto buf = makeTone(3000.0, 2400, dbToLin(-6.0f));
+    processBlocks(p, buf.data(), 2400);
+
+    const float wetDb = p.wetRmsDb();
+    report("wet RMS meter: active exciter publishes non-zero wet RMS",
+           wetDb > -60.0f,
+           "wetRmsDb=" + std::to_string(wetDb));
+}
+
+// Reset: after processing, reset() + silence → finite, quiet output.
+void testReset()
+{
+    ClientPudu p;
+    p.prepare(kSampleRate);
+    p.setEnabled(true);
+    p.setMode(ClientPudu::Mode::Aphex);
+    p.setPooMix(1.0f);
+    p.setDooMix(1.0f);
+    p.setPooDriveDb(18.0f);
+    p.setDooHarmonicsDb(18.0f);
+
+    auto buf = makeTone(1000.0, 4800, dbToLin(-6.0f));
+    processBlocks(p, buf.data(), 4800);
+
+    p.reset();
+
+    std::vector<float> sil(1024, 0.0f);
+    p.process(sil.data(), 512, 2);
+    report("reset: no NaN/Inf after flush + silence",
+           !anyNaNorInf(sil.data(), 512));
+}
+
+// Sanity: complex signal with max drive + both bands stays finite.
+void testTransientSanity()
+{
+    ClientPudu p;
+    p.prepare(kSampleRate);
+    p.setEnabled(true);
+    p.setMode(ClientPudu::Mode::Aphex);
+    p.setPooMix(1.0f);
+    p.setDooMix(1.0f);
+    p.setPooDriveDb(24.0f);
+    p.setDooHarmonicsDb(24.0f);
+    p.setPooTuneHz(100.0f);
+    p.setDooTuneHz(3000.0f);
+
+    const int frames = 12000;
+    std::vector<float> buf(frames * 2);
+    const double twoPi = 6.283185307179586476;
+    for (int i = 0; i < frames; ++i) {
+        const float env = 0.3f + 0.3f
+            * static_cast<float>(std::sin(twoPi * 3.0 * i / kSampleRate));
+        const float s = env * (
+            0.5f * static_cast<float>(std::sin(twoPi * 80.0   * i / kSampleRate))
+          + 0.5f * static_cast<float>(std::sin(twoPi * 4500.0 * i / kSampleRate)));
+        buf[i * 2]     = s;
+        buf[i * 2 + 1] = s;
+    }
+    processBlocks(p, buf.data(), frames);
+
+    report("transient: max-drive + both bands stays finite",
+           !anyNaNorInf(buf.data(), frames)
+             && peakAbsStereo(buf.data(), frames) < 5.0f,
+           "peak=" + std::to_string(peakAbsStereo(buf.data(), frames)));
+}
+
+} // namespace
+
+int main()
+{
+    std::printf("ClientPudu test harness @ %.0f Hz, %d-frame blocks\n\n",
+                kSampleRate, kBlockSize);
+
+    testBypass();
+    testZeroMix();
+    testAphexDooAddsAsymmetry();
+    testDooHPFRejectsLows();
+    testPooLFAphex();
+    testPooLFBehringer();
+    testWetRmsMeter();
+    testReset();
+    testTransientSanity();
+
+    std::printf("\n%s (%d failure%s)\n",
+                g_failed == 0 ? "ALL PASS" : "FAILED",
+                g_failed, g_failed == 1 ? "" : "s");
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/client_tube_test.cpp
+++ b/tests/client_tube_test.cpp
@@ -1,0 +1,416 @@
+// Standalone test harness for ClientTube DSP.
+// Build: CMake target `client_tube_test`.  Exit 0 = pass.
+
+#include "core/ClientTube.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using AetherSDR::ClientTube;
+
+namespace {
+
+constexpr double kSampleRate = 24000.0;
+constexpr int    kBlockSize  = 128;
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-54s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+std::vector<float> makeTone(double freq, int frames, float amplitude)
+{
+    std::vector<float> buf(frames * 2);
+    const double twoPi = 6.283185307179586476;
+    for (int i = 0; i < frames; ++i) {
+        const float s = amplitude * static_cast<float>(
+            std::sin(twoPi * freq * i / kSampleRate));
+        buf[i * 2]     = s;
+        buf[i * 2 + 1] = s;
+    }
+    return buf;
+}
+
+float peakAbsStereo(const float* data, int frames)
+{
+    float peak = 0.0f;
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) {
+        peak = std::max(peak, std::fabs(data[i]));
+    }
+    return peak;
+}
+
+float rmsStereo(const float* data, int frames)
+{
+    double sumSq = 0.0;
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) sumSq += data[i] * data[i];
+    return static_cast<float>(std::sqrt(sumSq / samples));
+}
+
+void processBlocks(ClientTube& t, float* buf, int frames)
+{
+    int remaining = frames;
+    float* p = buf;
+    while (remaining > 0) {
+        const int n = std::min(kBlockSize, remaining);
+        t.process(p, n, 2);
+        p += n * 2;
+        remaining -= n;
+    }
+}
+
+bool anyNaNorInf(const float* data, int frames)
+{
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) {
+        if (!std::isfinite(data[i])) return true;
+    }
+    return false;
+}
+
+float linToDb(float lin)
+{
+    return (lin > 1e-9f) ? 20.0f * std::log10(lin) : -180.0f;
+}
+
+float dbToLin(float db)
+{
+    return std::pow(10.0f, db * 0.05f);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+void testBypass()
+{
+    ClientTube t;
+    t.prepare(kSampleRate);
+    t.setEnabled(false);
+
+    const int frames = 1024;
+    auto ref = makeTone(1000.0, frames, dbToLin(-6.0f));
+    auto out = ref;
+    processBlocks(t, out.data(), frames);
+
+    float maxDiff = 0.0f;
+    for (size_t i = 0; i < out.size(); ++i)
+        maxDiff = std::max(maxDiff, std::fabs(out[i] - ref[i]));
+
+    report("bypass: disabled passes through unchanged",
+           maxDiff < 1e-6f,
+           "maxDiff=" + std::to_string(maxDiff));
+}
+
+// Drive = 0 dB, dryWet = 100% wet: signal is shaped but at unity
+// drive the waveshaper barely alters a -20 dBFS tone.
+void testLowDrivePreservesShape()
+{
+    ClientTube t;
+    t.prepare(kSampleRate);
+    t.setEnabled(true);
+    t.setModel(ClientTube::Model::A);
+    t.setDriveDb(0.0f);
+    t.setBiasAmount(0.0f);
+    t.setTone(0.0f);
+    t.setOutputGainDb(0.0f);
+    t.setDryWet(1.0f);
+    t.setEnvelopeAmount(0.0f);
+
+    const float amp = dbToLin(-20.0f);
+    auto buf = makeTone(1000.0, 4800, amp);
+    processBlocks(t, buf.data(), 4800);
+
+    const int tailFrames = 512;
+    auto tail = makeTone(1000.0, tailFrames, amp);
+    processBlocks(t, tail.data(), tailFrames);
+
+    const float outPeak = peakAbsStereo(tail.data(), tailFrames);
+    // At -20 dBFS with unity drive, tanh(x) ≈ x.  Expect < 0.5 dB delta.
+    const float delta = linToDb(outPeak / amp);
+    report("low-drive: -20 dBFS stays ~unchanged at drive=0 dB",
+           std::fabs(delta) < 0.5f,
+           "delta=" + std::to_string(delta) + " dB");
+}
+
+// Heavy drive (+18 dB) on a -3 dBFS tone should clip the tops and
+// bottoms near ±1 — output peak caps at or below ±1.0.
+void testHeavyDriveClips()
+{
+    ClientTube t;
+    t.prepare(kSampleRate);
+    t.setEnabled(true);
+    t.setModel(ClientTube::Model::A);
+    t.setDriveDb(18.0f);
+    t.setBiasAmount(0.0f);
+    t.setDryWet(1.0f);
+    t.setOutputGainDb(0.0f);
+    t.setEnvelopeAmount(0.0f);
+
+    const float amp = dbToLin(-3.0f);
+    auto buf = makeTone(1000.0, 4800, amp);
+    processBlocks(t, buf.data(), 4800);
+
+    const float outPeak = peakAbsStereo(buf.data(), 4800);
+    report("heavy-drive: output stays bounded (tanh saturation)",
+           outPeak <= 1.01f && outPeak > 0.9f,
+           "outPeak=" + std::to_string(outPeak));
+}
+
+// Bias adds DC / even-harmonic content — RMS should rise slightly
+// while a pure tanh at symmetric bias=0 would produce ~zero DC.
+void testBiasAddsAsymmetry()
+{
+    auto runOnce = [](float bias) {
+        ClientTube t;
+        t.prepare(kSampleRate);
+        t.setEnabled(true);
+        t.setModel(ClientTube::Model::A);
+        t.setDriveDb(12.0f);
+        t.setBiasAmount(bias);
+        t.setDryWet(1.0f);
+        t.setOutputGainDb(0.0f);
+        t.setEnvelopeAmount(0.0f);
+
+        auto buf = makeTone(1000.0, 4800, dbToLin(-6.0f));
+        processBlocks(t, buf.data(), 4800);
+
+        double dc = 0.0;
+        const int samples = 4800 * 2;
+        for (int i = 0; i < samples; ++i) dc += buf[i];
+        return static_cast<float>(dc / samples);
+    };
+
+    const float dcSym  = std::fabs(runOnce(0.0f));
+    const float dcAsym = std::fabs(runOnce(1.0f));
+
+    // Symmetric bias=0 should have near-zero DC; bias=1 should show
+    // measurable DC offset from the asymmetric term.
+    report("bias: asymmetric shaper introduces DC offset",
+           dcSym < 1e-3f && dcAsym > 5e-3f,
+           "dc_sym=" + std::to_string(dcSym)
+           + " dc_asym=" + std::to_string(dcAsym));
+}
+
+// Dry/Wet blend: at 0% the output is the dry signal unchanged.
+void testDryWetZero()
+{
+    ClientTube t;
+    t.prepare(kSampleRate);
+    t.setEnabled(true);
+    t.setDriveDb(24.0f);         // heavy drive — would distort if wet
+    t.setDryWet(0.0f);           // fully dry
+    t.setOutputGainDb(0.0f);
+    t.setEnvelopeAmount(0.0f);
+
+    const float amp = dbToLin(-6.0f);
+    auto ref = makeTone(1000.0, 1024, amp);
+    auto out = ref;
+    processBlocks(t, out.data(), 1024);
+
+    float maxDiff = 0.0f;
+    for (size_t i = 0; i < out.size(); ++i)
+        maxDiff = std::max(maxDiff, std::fabs(out[i] - ref[i]));
+
+    report("dry/wet: 0% wet returns dry signal",
+           maxDiff < 1e-5f,
+           "maxDiff=" + std::to_string(maxDiff));
+}
+
+// Envelope positive: quiet input → low drive; loud input → high drive.
+// Compare heavy drive + envAmount=+1 on two tones at different levels —
+// loud tone should be more distorted (higher THD proxy: RMS/peak ratio
+// diverges from pure sine's 1/sqrt(2)).
+void testEnvelopePositive()
+{
+    auto driveRMS = [](float inputDb) {
+        ClientTube t;
+        t.prepare(kSampleRate);
+        t.setEnabled(true);
+        t.setModel(ClientTube::Model::A);
+        t.setDriveDb(12.0f);
+        t.setBiasAmount(0.0f);
+        t.setTone(0.0f);
+        t.setDryWet(1.0f);
+        t.setOutputGainDb(0.0f);
+        t.setEnvelopeAmount(1.0f);       // loud → more drive
+        t.setAttackMs(0.5f);
+        t.setReleaseMs(20.0f);
+
+        auto buf = makeTone(1000.0, 12000, dbToLin(inputDb));
+        processBlocks(t, buf.data(), 12000);
+        // Measure the trailing block after envelope settles.
+        return peakAbsStereo(buf.data() + (12000 - 512) * 2, 512);
+    };
+
+    const float quietPeak = driveRMS(-40.0f);
+    const float loudPeak  = driveRMS(-3.0f);
+
+    // Loud signal should clamp near 1.0 (envelope-boosted drive
+    // tips into tanh clipping).  Quiet signal stays well below the
+    // tanh knee — baseDrive still amplifies it but envelope barely
+    // modulates (envLin ≈ 0 at -40 dBFS), so output stays linear.
+    const bool loudClips   = loudPeak > 0.85f;
+    const bool quietLinear = quietPeak < 0.3f;   // well below tanh knee
+
+    report("envelope +1: loud saturates, quiet stays linear",
+           loudClips && quietLinear,
+           "quiet=" + std::to_string(quietPeak)
+           + " loud=" + std::to_string(loudPeak));
+}
+
+// Envelope negative: same loud input should NOT push into clipping as
+// hard because high input level pulls drive DOWN.  Peak should stay
+// below the positive-envelope loud case.
+void testEnvelopeNegative()
+{
+    auto loudPeakAtEnv = [](float env) {
+        ClientTube t;
+        t.prepare(kSampleRate);
+        t.setEnabled(true);
+        t.setModel(ClientTube::Model::A);
+        t.setDriveDb(12.0f);
+        t.setBiasAmount(0.0f);
+        t.setTone(0.0f);
+        t.setDryWet(1.0f);
+        t.setOutputGainDb(0.0f);
+        t.setEnvelopeAmount(env);
+        t.setAttackMs(0.5f);
+        t.setReleaseMs(20.0f);
+
+        auto buf = makeTone(1000.0, 12000, dbToLin(-3.0f));
+        processBlocks(t, buf.data(), 12000);
+        return peakAbsStereo(buf.data() + (12000 - 512) * 2, 512);
+    };
+
+    const float posPeak = loudPeakAtEnv(+1.0f);
+    const float negPeak = loudPeakAtEnv(-1.0f);
+
+    // Negative envelope should produce a lower peak on the same loud
+    // input because drive is scaled DOWN when input is loud.
+    report("envelope -1: reverse modulation reduces saturation on loud input",
+           negPeak < posPeak - 0.05f,
+           "pos=" + std::to_string(posPeak)
+           + " neg=" + std::to_string(negPeak));
+}
+
+// Three models produce audibly distinct outputs on the same input.
+// Quick sanity: running A/B/C with identical settings should yield
+// different RMS values (they're different curves).
+void testModelsDiffer()
+{
+    auto modelRms = [](ClientTube::Model m) {
+        ClientTube t;
+        t.prepare(kSampleRate);
+        t.setEnabled(true);
+        t.setModel(m);
+        t.setDriveDb(12.0f);
+        t.setBiasAmount(0.5f);
+        t.setTone(0.0f);
+        t.setDryWet(1.0f);
+        t.setOutputGainDb(0.0f);
+        t.setEnvelopeAmount(0.0f);
+
+        auto buf = makeTone(1000.0, 4800, dbToLin(-6.0f));
+        processBlocks(t, buf.data(), 4800);
+        return rmsStereo(buf.data(), 4800);
+    };
+
+    const float a = modelRms(ClientTube::Model::A);
+    const float b = modelRms(ClientTube::Model::B);
+    const float c = modelRms(ClientTube::Model::C);
+
+    const bool aDiffersB = std::fabs(a - b) > 0.005f;
+    const bool bDiffersC = std::fabs(b - c) > 0.005f;
+    const bool aDiffersC = std::fabs(a - c) > 0.005f;
+
+    report("models: A / B / C produce distinct outputs",
+           aDiffersB && bDiffersC && aDiffersC,
+           "A=" + std::to_string(a)
+           + " B=" + std::to_string(b)
+           + " C=" + std::to_string(c));
+}
+
+// Sanity: complex signal stays finite + bounded at max drive.
+void testTransientSanity()
+{
+    ClientTube t;
+    t.prepare(kSampleRate);
+    t.setEnabled(true);
+    t.setModel(ClientTube::Model::B);
+    t.setDriveDb(24.0f);
+    t.setBiasAmount(0.8f);
+    t.setTone(0.5f);
+    t.setDryWet(1.0f);
+    t.setOutputGainDb(6.0f);
+    t.setEnvelopeAmount(-0.5f);
+
+    const int frames = 24000;
+    std::vector<float> buf(frames * 2);
+    const double twoPi = 6.283185307179586476;
+    for (int i = 0; i < frames; ++i) {
+        const float env = 0.3f + 0.3f
+            * static_cast<float>(std::sin(twoPi * 3.0 * i / kSampleRate));
+        const float s = env * static_cast<float>(
+            std::sin(twoPi * 800.0 * i / kSampleRate));
+        buf[i * 2]     = s;
+        buf[i * 2 + 1] = s;
+    }
+    processBlocks(t, buf.data(), frames);
+
+    report("transient: max-drive AM tone stays finite + bounded",
+           !anyNaNorInf(buf.data(), frames)
+             && peakAbsStereo(buf.data(), frames) < 5.0f,
+           "peak=" + std::to_string(peakAbsStereo(buf.data(), frames)));
+}
+
+void testReset()
+{
+    ClientTube t;
+    t.prepare(kSampleRate);
+    t.setEnabled(true);
+    t.setDriveDb(12.0f);
+    t.setDryWet(1.0f);
+
+    auto buf = makeTone(1000.0, 4800, dbToLin(-6.0f));
+    processBlocks(t, buf.data(), 4800);
+
+    t.reset();
+    std::vector<float> sil(1024, 0.0f);
+    t.process(sil.data(), 512, 2);
+    report("reset: no NaN/Inf after flush + silence",
+           !anyNaNorInf(sil.data(), 512));
+}
+
+} // namespace
+
+int main()
+{
+    std::printf("ClientTube test harness @ %.0f Hz, %d-frame blocks\n\n",
+                kSampleRate, kBlockSize);
+
+    testBypass();
+    testLowDrivePreservesShape();
+    testHeavyDriveClips();
+    testBiasAddsAsymmetry();
+    testDryWetZero();
+    testEnvelopePositive();
+    testEnvelopeNegative();
+    testModelsDiffer();
+    testTransientSanity();
+    testReset();
+
+    std::printf("\n%s (%d failure%s)\n",
+                g_failed == 0 ? "ALL PASS" : "FAILED",
+                g_failed, g_failed == 1 ? "" : "s");
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
- ClientGate: DSP for TX Phase 2 gate/expander + 12-test harness
- AudioEngine + CHAIN: wire ClientGate into TX DSP chain
- ClientGate UI: applet + Ableton-style floating editor + MainWindow wiring
- ClientDeEss: DSP for TX Phase 3 de-esser + 7-test harness
- AudioEngine + CHAIN: wire ClientDeEss into TX DSP chain
- ClientGateLevelView: fix diamond-X rendering artifact
- ClientDeEss UI: applet + 3-column editor + MainWindow wiring
- ClientTube: DSP for TX Phase 4 dynamic tube saturator + 10 tests
- AudioEngine + CHAIN: wire ClientTube into TX DSP chain
- ClientTube UI: applet + 3-column Dynamic Tube editor + wiring
- ClientPudu: DSP for TX Phase 5 exciter + 9-test harness
- AudioEngine + CHAIN: wire ClientPudu into TX DSP chain
- ClientPudu UI: PooDoo logo + applet + editor + wiring
- ClientCompKnob: center-label mode + shrink-to-fit + value-in-arc-sector
- ClientEq: honour user Q on HP/LP cascade as resonance multiplier
- ClientGate: amber audible tint, green Expander toggle, 10:1 max ratio
- Chain widget + applet: TX/RX mode, BYPASS, MIC-ready, TX pulse, monitor btns
- ClientPuduMonitor: record + play post-PooDoo TX audio
- ClientTubeEditor + ClientDeEssEditor: center-label mode + uniform sizing
