### PR TITLE
CHAIN-driven TX DSP: click-bypass, applet knobs, chain-ordered stack

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -630,7 +630,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     makeChildContainer("gate",  "GATE",  m_clientGateApplet,   -1);
     makeChildContainer("ceq",   "CEQ",   m_clientEqApplet,     -1);
     makeChildContainer("dess",  "DESS",  m_clientDeEssApplet,  -1);
-    makeChildContainer("cmp",   "CMP",   m_clientCompApplet,   -1);
+    makeChildContainer("cmp",   "COMPRESSOR",   m_clientCompApplet,   -1);
     makeChildContainer("tube",  "TUBE",  m_clientTubeApplet,   -1);
     makeChildContainer("pudu",  "PUDU",  m_clientPuduApplet,   -1);
 
@@ -648,13 +648,13 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // Register the composite tx_dsp container as one tile in the
     // applet tray — users toggle it, drag it, and pop it out as a
     // unit.  Individual section pop-outs happen via each sub-
-    // container's own titlebar inside.  Button label is "VUDU"
-    // (VooDoo Audio) — a nod to the ham-radio term for tailored
-    // audio processing.  Settings ID stays TXDSP for persistence.
+    // container's own titlebar inside.  Button label is "PUDU" —
+    // matches the exciter stage name and the PooDoo™ Audio brand.
+    // Settings ID stays TXDSP for persistence.
     {
-        auto entry = makeEntry("TXDSP", "VUDU", txDsp, false,
+        auto entry = makeEntry("TXDSP", "PUDU", txDsp, false,
                                btnRow2, btnLayout2);
-        if (entry.btn) entry.btn->setText("VUDU");
+        if (entry.btn) entry.btn->setText("PUDU");
         m_appletOrder.append(entry);
     }
 
@@ -874,6 +874,44 @@ void AppletPanel::setMaxSlices(int maxSlices)
 void AppletPanel::updateSliceButtons(const QList<SliceModel*>& slices, int activeSliceId)
 {
     m_rxApplet->updateSliceButtons(slices, activeSliceId);
+}
+
+void AppletPanel::setTxDspChainOrder(
+    const QVector<AudioEngine::TxChainStage>& stages)
+{
+    if (!m_containerMgr) return;
+    auto* parent = m_containerMgr->container("tx_dsp");
+    if (!parent) return;
+
+    // Map enum → child-container id.  Stages not present in the chain
+    // are ignored (they stay wherever they currently sit; their tiles
+    // should have been hidden via stageEnabledChanged anyway).
+    auto idFor = [](AudioEngine::TxChainStage s) -> QString {
+        switch (s) {
+            case AudioEngine::TxChainStage::Gate:  return "gate";
+            case AudioEngine::TxChainStage::Eq:    return "ceq";
+            case AudioEngine::TxChainStage::DeEss: return "dess";
+            case AudioEngine::TxChainStage::Comp:  return "cmp";
+            case AudioEngine::TxChainStage::Tube:  return "tube";
+            case AudioEngine::TxChainStage::Enh:   return "pudu";
+            case AudioEngine::TxChainStage::None:  return {};
+        }
+        return {};
+    };
+
+    // Pluck each ordered child out of its current position and re-
+    // insert at the end.  Walking the list in chain order rebuilds the
+    // parent body in the desired order without touching CHAIN itself —
+    // CHAIN lives at index 0 and isn't in the ordered set, so it stays
+    // put as the earlier siblings migrate to the end around it.
+    for (auto s : stages) {
+        const QString id = idFor(s);
+        if (id.isEmpty()) continue;
+        auto* child = m_containerMgr->container(id);
+        if (!child) continue;
+        parent->removeChildWidget(child);
+        parent->insertChildWidget(-1, child);
+    }
 }
 
 

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "core/AudioEngine.h"
+
 #include <QWidget>
 #include <QMap>
 #include <QStringList>
@@ -97,6 +99,11 @@ public:
     // external state (e.g. the CHAIN widget mirrors DSP bypass onto
     // CEQ and CMP tile visibility).  No-op for unknown IDs.
     void setAppletVisible(const QString& id, bool visible);
+
+    // Reorder the TX DSP sub-containers inside the "tx_dsp" parent to
+    // mirror the CHAIN's current stage order.  Call whenever the user
+    // drags to reorder the chain; the applet tiles follow.
+    void setTxDspChainOrder(const QVector<AudioEngine::TxChainStage>& stages);
 
     // ── Container system (Phase 4a groundwork, #1713) ───────────
     //

--- a/src/gui/ClientChainApplet.cpp
+++ b/src/gui/ClientChainApplet.cpp
@@ -205,6 +205,8 @@ ClientChainApplet::ClientChainApplet(QWidget* parent) : QWidget(parent)
             this, &ClientChainApplet::editRequested);
     connect(m_chain, &ClientChainWidget::stageEnabledChanged,
             this, &ClientChainApplet::stageEnabledChanged);
+    connect(m_chain, &ClientChainWidget::chainReordered,
+            this, &ClientChainApplet::chainReordered);
 
     hide();  // hidden until toggled on from the applet tray
 }

--- a/src/gui/ClientChainApplet.h
+++ b/src/gui/ClientChainApplet.h
@@ -56,6 +56,10 @@ public:
 signals:
     void editRequested(AudioEngine::TxChainStage stage);
     void stageEnabledChanged(AudioEngine::TxChainStage stage, bool enabled);
+    // Emitted after the user drags a stage to a new position.  MainWindow
+    // subscribes so the applet-panel sub-container order can be kept
+    // in lock-step with the chain order.
+    void chainReordered();
 
     // User clicked the record or play button.  MainWindow decides
     // whether this is a start or a stop based on current monitor

--- a/src/gui/ClientChainWidget.cpp
+++ b/src/gui/ClientChainWidget.cpp
@@ -7,6 +7,7 @@
 #include "core/ClientPudu.h"
 
 #include <QAction>
+#include <QApplication>
 #include <QContextMenuEvent>
 #include <QDrag>
 #include <QDragEnterEvent>
@@ -104,6 +105,18 @@ ClientChainWidget::ClientChainWidget(QWidget* parent) : QWidget(parent)
     // Height is computed in rebuildLayout() once we know the box count
     // and the snake row count — start with a single-row default.
     setMinimumHeight(kBoxHeight + 2 * kMarginY);
+
+    // Deferred single-click timer — toggles bypass on fire, cancelled
+    // by a double-click arriving within the double-click interval.
+    m_clickTimer = new QTimer(this);
+    m_clickTimer->setSingleShot(true);
+    connect(m_clickTimer, &QTimer::timeout, this, [this]() {
+        if (m_pendingClickIdx >= 0) {
+            const int idx = m_pendingClickIdx;
+            m_pendingClickIdx = -1;
+            toggleStageBypass(idx);
+        }
+    });
 }
 
 void ClientChainWidget::setAudioEngine(AudioEngine* engine)
@@ -559,17 +572,92 @@ void ClientChainWidget::mouseMoveEvent(QMouseEvent* ev)
     update();
 }
 
+void ClientChainWidget::mouseReleaseEvent(QMouseEvent* ev)
+{
+    if (ev->button() != Qt::LeftButton) { QWidget::mouseReleaseEvent(ev); return; }
+    // If m_pressIndex was cleared by mouseMoveEvent (drag started) the
+    // release isn't a click — skip.  Otherwise it's a genuine single
+    // click; defer the bypass-toggle until the double-click interval
+    // elapses so a follow-up double-click can cancel it and open the
+    // editor instead.
+    if (m_pressIndex < 0) return;
+    const int idx = m_pressIndex;
+    m_pressIndex = -1;
+    if (idx < 0 || idx >= m_boxes.size()) return;
+    if (m_boxes[idx].isEndpoint) return;
+    m_pendingClickIdx = idx;
+    if (m_clickTimer) {
+        m_clickTimer->start(QApplication::doubleClickInterval());
+    }
+    ev->accept();
+}
+
 void ClientChainWidget::mouseDoubleClickEvent(QMouseEvent* ev)
 {
-    // Treat single-click on a stage as "open editor" via
-    // mouseReleaseEvent logic.  We use double-click as a shortcut that
-    // also opens the editor for discoverability.
+    // Double-click = open editor.  Cancel the deferred bypass toggle
+    // queued by the preceding single-click release.
     if (ev->button() != Qt::LeftButton) return;
+    if (m_clickTimer && m_clickTimer->isActive()) m_clickTimer->stop();
+    m_pendingClickIdx = -1;
+
     const int idx = hitTest(ev->position());
     if (idx < 0 || m_boxes[idx].isEndpoint) return;
     if (!isStageImplemented(m_boxes[idx].stage)) return;
     emit editRequested(m_boxes[idx].stage);
     ev->accept();
+}
+
+void ClientChainWidget::toggleStageBypass(int boxIdx)
+{
+    if (!m_audio) return;
+    if (boxIdx < 0 || boxIdx >= m_boxes.size()) return;
+    if (m_boxes[boxIdx].isEndpoint) return;
+    const auto stage = m_boxes[boxIdx].stage;
+    if (!isStageImplemented(stage)) return;
+
+    const bool newEnabled = isStageBypassed(stage);   // was off → turn on
+    switch (stage) {
+        case AudioEngine::TxChainStage::Eq:
+            if (m_audio->clientEqTx()) {
+                m_audio->clientEqTx()->setEnabled(newEnabled);
+                m_audio->saveClientEqSettings();
+            }
+            break;
+        case AudioEngine::TxChainStage::Comp:
+            if (m_audio->clientCompTx()) {
+                m_audio->clientCompTx()->setEnabled(newEnabled);
+                m_audio->saveClientCompSettings();
+            }
+            break;
+        case AudioEngine::TxChainStage::Gate:
+            if (m_audio->clientGateTx()) {
+                m_audio->clientGateTx()->setEnabled(newEnabled);
+                m_audio->saveClientGateSettings();
+            }
+            break;
+        case AudioEngine::TxChainStage::DeEss:
+            if (m_audio->clientDeEssTx()) {
+                m_audio->clientDeEssTx()->setEnabled(newEnabled);
+                m_audio->saveClientDeEssSettings();
+            }
+            break;
+        case AudioEngine::TxChainStage::Tube:
+            if (m_audio->clientTubeTx()) {
+                m_audio->clientTubeTx()->setEnabled(newEnabled);
+                m_audio->saveClientTubeSettings();
+            }
+            break;
+        case AudioEngine::TxChainStage::Enh:
+            if (m_audio->clientPuduTx()) {
+                m_audio->clientPuduTx()->setEnabled(newEnabled);
+                m_audio->saveClientPuduSettings();
+            }
+            break;
+        default:
+            return;
+    }
+    emit stageEnabledChanged(stage, newEnabled);
+    update();
 }
 
 void ClientChainWidget::contextMenuEvent(QContextMenuEvent* ev)

--- a/src/gui/ClientChainWidget.h
+++ b/src/gui/ClientChainWidget.h
@@ -65,6 +65,7 @@ protected:
     void paintEvent(QPaintEvent* ev) override;
     void mousePressEvent(QMouseEvent* ev) override;
     void mouseMoveEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
     void mouseDoubleClickEvent(QMouseEvent* ev) override;
     void contextMenuEvent(QContextMenuEvent* ev) override;
     void dragEnterEvent(QDragEnterEvent* ev) override;
@@ -92,6 +93,11 @@ private:
     bool isStageImplemented(AudioEngine::TxChainStage s) const;
     bool isStageBypassed(AudioEngine::TxChainStage s) const;
 
+    // Helper: toggle bypass on the stage at m_boxes[idx], saving settings
+    // and emitting stageEnabledChanged.  Used by the deferred single-
+    // click handler and by the right-click menu.
+    void toggleStageBypass(int boxIdx);
+
     AudioEngine* m_audio{nullptr};
     bool         m_micInputReady{false};
     bool         m_txActive{false};
@@ -103,6 +109,12 @@ private:
     QPoint m_pressPos;
     int    m_pressIndex{-1};
     int    m_dropIndex{-1};      // where the drag is currently hovering (drawn as an insertion line)
+
+    // Deferred single-click → toggle-bypass timer.  Single click fires
+    // after QApplication::doubleClickInterval() so a genuine double
+    // click (editor-open) can cancel it before it fires.
+    class QTimer* m_clickTimer{nullptr};
+    int           m_pendingClickIdx{-1};
 };
 
 } // namespace AetherSDR

--- a/src/gui/ClientCompApplet.cpp
+++ b/src/gui/ClientCompApplet.cpp
@@ -1,5 +1,6 @@
 #include "ClientCompApplet.h"
 #include "ClientCompCurveWidget.h"
+#include "ClientCompKnob.h"
 #include "MeterSmoother.h"
 #include "core/AudioEngine.h"
 #include "core/ClientComp.h"
@@ -122,32 +123,102 @@ void ClientCompApplet::buildUI()
     m_grBar = new ClientCompGrBar;
     outer->addWidget(m_grBar);
 
+    // Enable / Edit buttons removed — CHAIN widget handles bypass
+    // (single-click) and editor-open (double-click).
+
+    // Five-knob tuning row — Thresh, Ratio, Attack, Release, Makeup.
+    // Mappings match ClientCompEditor.
     {
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
 
-        m_enable = new QPushButton("Enable");
-        m_enable->setCheckable(true);
-        m_enable->setStyleSheet(kEnableStyle);
-        m_enable->setFixedHeight(22);
-        row->addWidget(m_enable);
+        auto makeKnob = [](const QString& label) {
+            auto* k = new ClientCompKnob;
+            k->setLabel(label);
+            k->setCenterLabelMode(true);
+            k->setFixedSize(38, 48);
+            return k;
+        };
 
-        row->addStretch();
-
-        m_edit = new QPushButton("Edit…");
-        m_edit->setStyleSheet(kEditStyle);
-        m_edit->setFixedHeight(22);
-        m_edit->setToolTip("Open the client compressor editor");
-        row->addWidget(m_edit);
-
-        connect(m_enable, &QPushButton::toggled, this,
-                &ClientCompApplet::onEnableToggled);
-        connect(m_edit, &QPushButton::clicked, this, [this]() {
-            emit editRequested();
+        m_thresh = makeKnob("Thresh");
+        m_thresh->setRange(-60.0f, 0.0f);
+        m_thresh->setDefault(-18.0f);
+        m_thresh->setValueFromNorm([](float n) { return -60.0f + n * 60.0f; });
+        m_thresh->setNormFromValue([](float v) { return (v + 60.0f) / 60.0f; });
+        m_thresh->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + " dB";
         });
+        row->addWidget(m_thresh);
+
+        m_ratio = makeKnob("Ratio");
+        m_ratio->setRange(1.0f, 20.0f);
+        m_ratio->setDefault(3.0f);
+        m_ratio->setValueFromNorm([](float n) {
+            return 1.0f * std::pow(20.0f, n);
+        });
+        m_ratio->setNormFromValue([](float v) {
+            if (v <= 1.0f) return 0.0f;
+            return std::log(v) / std::log(20.0f);
+        });
+        m_ratio->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 2) + ":1";
+        });
+        row->addWidget(m_ratio);
+
+        m_attack = makeKnob("Attack");
+        m_attack->setRange(0.1f, 300.0f);
+        m_attack->setDefault(20.0f);
+        m_attack->setValueFromNorm([](float n) {
+            return 0.1f * std::pow(3000.0f, n);
+        });
+        m_attack->setNormFromValue([](float v) {
+            if (v <= 0.1f) return 0.0f;
+            return std::log(v / 0.1f) / std::log(3000.0f);
+        });
+        m_attack->setLabelFormat([](float v) {
+            return v < 10.0f ? QString::number(v, 'f', 1) + " ms"
+                              : QString::number(v, 'f', 0) + " ms";
+        });
+        row->addWidget(m_attack);
+
+        m_release = makeKnob("Release");
+        m_release->setRange(5.0f, 2000.0f);
+        m_release->setDefault(200.0f);
+        m_release->setValueFromNorm([](float n) {
+            return 5.0f * std::pow(400.0f, n);
+        });
+        m_release->setNormFromValue([](float v) {
+            if (v <= 5.0f) return 0.0f;
+            return std::log(v / 5.0f) / std::log(400.0f);
+        });
+        m_release->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 0) + " ms";
+        });
+        row->addWidget(m_release);
+
+        m_makeup = makeKnob("Makeup");
+        m_makeup->setRange(-12.0f, 24.0f);
+        m_makeup->setDefault(0.0f);
+        m_makeup->setLabelFormat([](float v) {
+            return (v >= 0.0f ? "+" : "") + QString::number(v, 'f', 1) + " dB";
+        });
+        row->addWidget(m_makeup);
 
         outer->addLayout(row);
     }
+
+    auto wire = [this](ClientCompKnob* k, auto setter) {
+        connect(k, &ClientCompKnob::valueChanged, this, [this, setter](float v) {
+            if (!m_audio || !m_audio->clientCompTx()) return;
+            (m_audio->clientCompTx()->*setter)(v);
+            m_audio->saveClientCompSettings();
+        });
+    };
+    wire(m_thresh,  &ClientComp::setThresholdDb);
+    wire(m_ratio,   &ClientComp::setRatio);
+    wire(m_attack,  &ClientComp::setAttackMs);
+    wire(m_release, &ClientComp::setReleaseMs);
+    wire(m_makeup,  &ClientComp::setMakeupDb);
 
     m_meterTimer = new QTimer(this);
     m_meterTimer->setInterval(33);
@@ -165,11 +236,14 @@ void ClientCompApplet::setAudioEngine(AudioEngine* engine)
 
 void ClientCompApplet::syncEnableFromEngine()
 {
-    if (!m_audio || !m_enable) return;
-    ClientComp* c = m_audio->clientCompTx();
-    QSignalBlocker b(m_enable);
-    m_enable->setChecked(c && c->isEnabled());
     if (m_curve) m_curve->update();
+    if (!m_audio || !m_audio->clientCompTx()) return;
+    ClientComp* c = m_audio->clientCompTx();
+    if (m_thresh)  { QSignalBlocker b(m_thresh);  m_thresh->setValue(c->thresholdDb()); }
+    if (m_ratio)   { QSignalBlocker b(m_ratio);   m_ratio->setValue(c->ratio()); }
+    if (m_attack)  { QSignalBlocker b(m_attack);  m_attack->setValue(c->attackMs()); }
+    if (m_release) { QSignalBlocker b(m_release); m_release->setValue(c->releaseMs()); }
+    if (m_makeup)  { QSignalBlocker b(m_makeup);  m_makeup->setValue(c->makeupDb()); }
 }
 
 void ClientCompApplet::refreshEnableFromEngine()
@@ -195,6 +269,12 @@ void ClientCompApplet::tickMeter()
     const float gr = c->gainReductionDb();
     m_grBar->setGrDb(gr);
     m_grDb = gr;
+
+    if (m_thresh)  { QSignalBlocker b(m_thresh);  m_thresh->setValue(c->thresholdDb()); }
+    if (m_ratio)   { QSignalBlocker b(m_ratio);   m_ratio->setValue(c->ratio()); }
+    if (m_attack)  { QSignalBlocker b(m_attack);  m_attack->setValue(c->attackMs()); }
+    if (m_release) { QSignalBlocker b(m_release); m_release->setValue(c->releaseMs()); }
+    if (m_makeup)  { QSignalBlocker b(m_makeup);  m_makeup->setValue(c->makeupDb()); }
 }
 
 } // namespace AetherSDR

--- a/src/gui/ClientCompApplet.h
+++ b/src/gui/ClientCompApplet.h
@@ -10,6 +10,7 @@ namespace AetherSDR {
 class AudioEngine;
 class ClientCompCurveWidget;
 class ClientCompGrBar;
+class ClientCompKnob;
 
 // Docked dashboard tile for the client-side TX compressor.  View-only —
 // shows the transfer curve with a live "ball" at the current envelope
@@ -50,6 +51,12 @@ private:
     QPushButton*          m_edit{nullptr};
     ClientCompCurveWidget* m_curve{nullptr};
     ClientCompGrBar*      m_grBar{nullptr};   // narrow horizontal GR strip
+    // Five-knob tuning row — Thresh, Ratio, Attack, Release, Makeup.
+    ClientCompKnob*       m_thresh{nullptr};
+    ClientCompKnob*       m_ratio{nullptr};
+    ClientCompKnob*       m_attack{nullptr};
+    ClientCompKnob*       m_release{nullptr};
+    ClientCompKnob*       m_makeup{nullptr};
     QTimer*               m_meterTimer{nullptr};
 
     // Latest GR dB (0 = no reduction, negative = active).  Paint is

--- a/src/gui/ClientCompEditor.cpp
+++ b/src/gui/ClientCompEditor.cpp
@@ -9,7 +9,6 @@
 #include "core/ClientComp.h"
 
 #include <QCloseEvent>
-#include <QComboBox>
 #include <QHBoxLayout>
 #include <QHideEvent>
 #include <QLabel>
@@ -75,34 +74,8 @@ ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
     root->setContentsMargins(8, 8, 8, 8);
     root->setSpacing(6);
 
-    // ── Header strip: bypass + chain-order segmented picker ─────────
-    {
-        auto* row = new QHBoxLayout;
-        row->setSpacing(8);
-
-        m_bypass = new QPushButton("Bypass");
-        m_bypass->setCheckable(true);
-        m_bypass->setStyleSheet(kBypassStyle);
-        m_bypass->setFixedHeight(22);
-        m_bypass->setToolTip("Bypass the compressor (signal passes through unshaped)");
-        row->addWidget(m_bypass);
-
-        row->addStretch();
-
-        auto* lbl = new QLabel("Chain:");
-        row->addWidget(lbl);
-
-        m_chainOrder = new QComboBox;
-        m_chainOrder->addItem("CMP → EQ");
-        m_chainOrder->addItem("EQ → CMP");
-        m_chainOrder->setToolTip(
-            "Signal flow order from the mic to the radio. "
-            "CMP→EQ colours the raw mic first then shapes it. "
-            "EQ→CMP shapes first then tames peaks.");
-        row->addWidget(m_chainOrder);
-
-        root->addLayout(row);
-    }
+    // Bypass moved to the CHAIN widget's single-click gesture — nothing
+    // here in the header.
 
     // ── Main body: knobs column | canvas | meters | makeup/limiter ──
     {
@@ -115,6 +88,7 @@ ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
             col->setSpacing(4);
 
             m_ratio = new ClientCompKnob;
+            m_ratio->setCenterLabelMode(true);
             m_ratio->setLabel("Ratio");
             m_ratio->setRange(1.0f, 20.0f);
             m_ratio->setDefault(3.0f);
@@ -130,9 +104,11 @@ ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
             m_ratio->setLabelFormat([](float v) {
                 return QString::number(v, 'f', 2) + " :1";
             });
+            m_ratio->setFixedSize(76, 76);
             col->addWidget(m_ratio);
 
             m_attack = new ClientCompKnob;
+            m_attack->setCenterLabelMode(true);
             m_attack->setLabel("Attack");
             m_attack->setRange(0.1f, 300.0f);
             m_attack->setDefault(20.0f);
@@ -147,9 +123,11 @@ ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
                 return v < 10.0f ? QString::number(v, 'f', 1) + " ms"
                                   : QString::number(v, 'f', 0) + " ms";
             });
+            m_attack->setFixedSize(76, 76);
             col->addWidget(m_attack);
 
             m_release = new ClientCompKnob;
+            m_release->setCenterLabelMode(true);
             m_release->setLabel("Release");
             m_release->setRange(5.0f, 2000.0f);
             m_release->setDefault(200.0f);
@@ -163,15 +141,18 @@ ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
             m_release->setLabelFormat([](float v) {
                 return QString::number(v, 'f', 0) + " ms";
             });
+            m_release->setFixedSize(76, 76);
             col->addWidget(m_release);
 
             m_knee = new ClientCompKnob;
+            m_knee->setCenterLabelMode(true);
             m_knee->setLabel("Knee");
             m_knee->setRange(0.0f, 24.0f);
             m_knee->setDefault(6.0f);
             m_knee->setLabelFormat([](float v) {
                 return QString::number(v, 'f', 1) + " dB";
             });
+            m_knee->setFixedSize(76, 76);
             col->addWidget(m_knee);
 
             col->addStretch();
@@ -225,21 +206,25 @@ ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
             col->addWidget(m_limiterEnable);
 
             m_ceiling = new ClientCompKnob;
+            m_ceiling->setCenterLabelMode(true);
             m_ceiling->setLabel("Ceiling");
             m_ceiling->setRange(-24.0f, 0.0f);
             m_ceiling->setDefault(-1.0f);
             m_ceiling->setLabelFormat([](float v) {
                 return QString::number(v, 'f', 1) + " dB";
             });
+            m_ceiling->setFixedSize(76, 76);
             col->addWidget(m_ceiling);
 
             m_makeup = new ClientCompKnob;
+            m_makeup->setCenterLabelMode(true);
             m_makeup->setLabel("Makeup");
             m_makeup->setRange(-12.0f, 24.0f);
             m_makeup->setDefault(0.0f);
             m_makeup->setLabelFormat([](float v) {
                 return (v >= 0.0f ? "+" : "") + QString::number(v, 'f', 1) + " dB";
             });
+            m_makeup->setFixedSize(76, 76);
             col->addWidget(m_makeup);
             col->addStretch();
             body->addLayout(col);
@@ -252,26 +237,6 @@ ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
     if (m_audio && m_audio->clientCompTx()) {
         m_canvas->setComp(m_audio->clientCompTx());
     }
-
-    connect(m_bypass, &QPushButton::toggled, this, [this](bool checked) {
-        if (!m_audio) return;
-        ClientComp* c = m_audio->clientCompTx();
-        if (!c) return;
-        // "Bypass checked" means the effect is bypassed → comp disabled.
-        c->setEnabled(!checked);
-        m_audio->saveClientCompSettings();
-        emit bypassToggled(checked);
-        if (m_canvas) m_canvas->update();
-    });
-
-    connect(m_chainOrder,
-            QOverload<int>::of(&QComboBox::currentIndexChanged),
-            this, [this](int idx) {
-        if (!m_audio) return;
-        m_audio->setTxChainOrder(
-            idx == 1 ? AudioEngine::TxChainOrder::EqThenComp
-                     : AudioEngine::TxChainOrder::CompThenEq);
-    });
 
     connect(m_canvas, &ClientCompEditorCanvas::thresholdChanged,
             this, &ClientCompEditor::applyThreshold);
@@ -320,8 +285,6 @@ void ClientCompEditor::syncControlsFromEngine()
     if (!m_audio) return;
     ClientComp* c = m_audio->clientCompTx();
     if (!c) return;
-    QSignalBlocker bb(m_bypass);
-    QSignalBlocker bco(m_chainOrder);
     QSignalBlocker br(m_ratio);
     QSignalBlocker ba(m_attack);
     QSignalBlocker brl(m_release);
@@ -330,9 +293,6 @@ void ClientCompEditor::syncControlsFromEngine()
     QSignalBlocker bce(m_ceiling);
     QSignalBlocker ble(m_limiterEnable);
 
-    m_bypass->setChecked(!c->isEnabled());
-    m_chainOrder->setCurrentIndex(
-        m_audio->txChainOrder() == AudioEngine::TxChainOrder::EqThenComp ? 1 : 0);
     m_ratio->setValue(c->ratio());
     m_attack->setValue(c->attackMs());
     m_release->setValue(c->releaseMs());
@@ -363,6 +323,20 @@ void ClientCompEditor::tickMeters()
     }
     if (m_limiterEnable) {
         m_limiterEnable->setActive(c->limiterActive() && c->limiterEnabled());
+    }
+
+    // Mirror parameter changes made in the applet tile (or other
+    // surfaces) back onto the editor knobs.  QSignalBlocker prevents
+    // a feedback loop through the valueChanged handlers.
+    if (m_ratio)   { QSignalBlocker b(m_ratio);   m_ratio->setValue(c->ratio()); }
+    if (m_attack)  { QSignalBlocker b(m_attack);  m_attack->setValue(c->attackMs()); }
+    if (m_release) { QSignalBlocker b(m_release); m_release->setValue(c->releaseMs()); }
+    if (m_knee)    { QSignalBlocker b(m_knee);    m_knee->setValue(c->kneeDb()); }
+    if (m_makeup)  { QSignalBlocker b(m_makeup);  m_makeup->setValue(c->makeupDb()); }
+    if (m_ceiling) { QSignalBlocker b(m_ceiling); m_ceiling->setValue(c->limiterCeilingDb()); }
+    if (m_threshFader) {
+        QSignalBlocker b(m_threshFader);
+        m_threshFader->setThresholdDb(c->thresholdDb());
     }
 }
 

--- a/src/gui/ClientCompEditor.h
+++ b/src/gui/ClientCompEditor.h
@@ -2,7 +2,6 @@
 
 #include <QWidget>
 
-class QComboBox;
 class QLabel;
 class QPushButton;
 class QTimer;
@@ -89,7 +88,6 @@ private:
     ClientCompMeter*         m_outputMeter{nullptr};
     QPushButton*             m_bypass{nullptr};
     ClientCompLimiterButton* m_limiterEnable{nullptr};
-    QComboBox*               m_chainOrder{nullptr};
     QTimer*                  m_meterTimer{nullptr};
     bool                     m_restoring{false};
 };

--- a/src/gui/ClientCompKnob.cpp
+++ b/src/gui/ClientCompKnob.cpp
@@ -187,13 +187,15 @@ void ClientCompKnob::paintEvent(QPaintEvent*)
     p.drawLine(pIn, pOut);
 
     // Center-label mode: draw the parameter name centred inside the
-    // ring.  Start at 25 % of diameter (good for 3-4 letter labels),
-    // then shrink-to-fit if the word is longer — keeps "Threshold",
-    // "Release" etc. from spilling past the arc on small knobs.
+    // ring.  The cap is sized so a 6-char label like "Thresh" /
+    // "Release" fits inside the ring WITHOUT shrinking — every label
+    // then renders at the same size, whether it's "Hold" or "Return".
+    // Without the cap the shrink-to-fit fires only on long labels and
+    // short labels bloat, visually inconsistent across the row.
     if (m_centerLabel && !m_label.isEmpty()) {
         QFont centerFont = p.font();
         centerFont.setBold(true);
-        int pixelSize = std::max(8, diameter / 4);
+        int pixelSize = std::max(8, diameter / 6);
         centerFont.setPixelSize(pixelSize);
 
         // Max text width is the knob interior, less a ring-thickness

--- a/src/gui/ClientDeEssApplet.cpp
+++ b/src/gui/ClientDeEssApplet.cpp
@@ -1,4 +1,5 @@
 #include "ClientDeEssApplet.h"
+#include "ClientCompKnob.h"
 #include "ClientDeEssCurveWidget.h"
 #include "MeterSmoother.h"
 #include "core/AudioEngine.h"
@@ -119,32 +120,84 @@ void ClientDeEssApplet::buildUI()
     m_grBar = new ClientDeEssGrBar;
     outer->addWidget(m_grBar);
 
+    // Enable / Edit buttons removed — CHAIN widget handles bypass
+    // (single-click) and editor-open (double-click).
+
+    // Four-knob tuning row — Freq, Q, Thresh, Amount.  Mappings mirror
+    // ClientDeEssEditor.
     {
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
 
-        m_enable = new QPushButton("Enable");
-        m_enable->setCheckable(true);
-        m_enable->setStyleSheet(kEnableStyle);
-        m_enable->setFixedHeight(22);
-        row->addWidget(m_enable);
+        auto makeKnob = [](const QString& label) {
+            auto* k = new ClientCompKnob;
+            k->setLabel(label);
+            k->setCenterLabelMode(true);
+            k->setFixedSize(38, 48);
+            return k;
+        };
 
-        row->addStretch();
-
-        m_edit = new QPushButton("Edit…");
-        m_edit->setStyleSheet(kEditStyle);
-        m_edit->setFixedHeight(22);
-        m_edit->setToolTip("Open the de-esser editor");
-        row->addWidget(m_edit);
-
-        connect(m_enable, &QPushButton::toggled, this,
-                &ClientDeEssApplet::onEnableToggled);
-        connect(m_edit, &QPushButton::clicked, this, [this]() {
-            emit editRequested();
+        m_freq = makeKnob("Freq");
+        m_freq->setRange(1000.0f, 12000.0f);
+        m_freq->setDefault(6000.0f);
+        m_freq->setValueFromNorm([](float n) {
+            return 1000.0f * std::pow(12.0f, n);
         });
+        m_freq->setNormFromValue([](float v) {
+            return std::log(std::max(1000.0f, v) / 1000.0f)
+                   / std::log(12.0f);
+        });
+        m_freq->setLabelFormat([](float v) {
+            return (v >= 1000.0f)
+                ? QString::number(v / 1000.0f, 'f', 1) + " kHz"
+                : QString::number(v, 'f', 0) + " Hz";
+        });
+        row->addWidget(m_freq);
+
+        m_q = makeKnob("Q");
+        m_q->setRange(0.5f, 5.0f);
+        m_q->setDefault(2.0f);
+        m_q->setValueFromNorm([](float n) { return 0.5f + n * 4.5f; });
+        m_q->setNormFromValue([](float v) { return (v - 0.5f) / 4.5f; });
+        m_q->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 2);
+        });
+        row->addWidget(m_q);
+
+        m_thresh = makeKnob("Thresh");
+        m_thresh->setRange(-60.0f, 0.0f);
+        m_thresh->setDefault(-30.0f);
+        m_thresh->setValueFromNorm([](float n) { return -60.0f + n * 60.0f; });
+        m_thresh->setNormFromValue([](float v) { return (v + 60.0f) / 60.0f; });
+        m_thresh->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + " dB";
+        });
+        row->addWidget(m_thresh);
+
+        m_amount = makeKnob("Amount");
+        m_amount->setRange(-24.0f, 0.0f);
+        m_amount->setDefault(-6.0f);
+        m_amount->setValueFromNorm([](float n) { return -24.0f + n * 24.0f; });
+        m_amount->setNormFromValue([](float v) { return (v + 24.0f) / 24.0f; });
+        m_amount->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + " dB";
+        });
+        row->addWidget(m_amount);
 
         outer->addLayout(row);
     }
+
+    auto wire = [this](ClientCompKnob* k, auto setter) {
+        connect(k, &ClientCompKnob::valueChanged, this, [this, setter](float v) {
+            if (!m_audio || !m_audio->clientDeEssTx()) return;
+            (m_audio->clientDeEssTx()->*setter)(v);
+            m_audio->saveClientDeEssSettings();
+        });
+    };
+    wire(m_freq,   &ClientDeEss::setFrequencyHz);
+    wire(m_q,      &ClientDeEss::setQ);
+    wire(m_thresh, &ClientDeEss::setThresholdDb);
+    wire(m_amount, &ClientDeEss::setAmountDb);
 
     m_meterTimer = new QTimer(this);
     m_meterTimer->setInterval(33);
@@ -162,11 +215,13 @@ void ClientDeEssApplet::setAudioEngine(AudioEngine* engine)
 
 void ClientDeEssApplet::syncEnableFromEngine()
 {
-    if (!m_audio || !m_enable) return;
-    ClientDeEss* d = m_audio->clientDeEssTx();
-    QSignalBlocker b(m_enable);
-    m_enable->setChecked(d && d->isEnabled());
     if (m_curve) m_curve->update();
+    if (!m_audio || !m_audio->clientDeEssTx()) return;
+    ClientDeEss* d = m_audio->clientDeEssTx();
+    if (m_freq)   { QSignalBlocker b(m_freq);   m_freq->setValue(d->frequencyHz()); }
+    if (m_q)      { QSignalBlocker b(m_q);      m_q->setValue(d->q()); }
+    if (m_thresh) { QSignalBlocker b(m_thresh); m_thresh->setValue(d->thresholdDb()); }
+    if (m_amount) { QSignalBlocker b(m_amount); m_amount->setValue(d->amountDb()); }
 }
 
 void ClientDeEssApplet::refreshEnableFromEngine()
@@ -192,6 +247,11 @@ void ClientDeEssApplet::tickMeter()
     const float gr = d->gainReductionDb();
     m_grBar->setGrDb(gr);
     m_grDb = gr;
+
+    if (m_freq)   { QSignalBlocker b(m_freq);   m_freq->setValue(d->frequencyHz()); }
+    if (m_q)      { QSignalBlocker b(m_q);      m_q->setValue(d->q()); }
+    if (m_thresh) { QSignalBlocker b(m_thresh); m_thresh->setValue(d->thresholdDb()); }
+    if (m_amount) { QSignalBlocker b(m_amount); m_amount->setValue(d->amountDb()); }
 }
 
 } // namespace AetherSDR

--- a/src/gui/ClientDeEssApplet.h
+++ b/src/gui/ClientDeEssApplet.h
@@ -8,6 +8,7 @@ class QTimer;
 namespace AetherSDR {
 
 class AudioEngine;
+class ClientCompKnob;
 class ClientDeEssCurveWidget;
 class ClientDeEssGrBar;
 
@@ -38,6 +39,12 @@ private:
     QPushButton*            m_edit{nullptr};
     ClientDeEssCurveWidget* m_curve{nullptr};
     ClientDeEssGrBar*       m_grBar{nullptr};
+    // Four-knob tuning row: sibilant band (Freq+Q), trigger threshold,
+    // and max reduction amount.  Covers the everyday workflow.
+    ClientCompKnob*         m_freq{nullptr};
+    ClientCompKnob*         m_q{nullptr};
+    ClientCompKnob*         m_thresh{nullptr};
+    ClientCompKnob*         m_amount{nullptr};
     QTimer*                 m_meterTimer{nullptr};
 
     float m_grDb{0.0f};

--- a/src/gui/ClientDeEssEditor.cpp
+++ b/src/gui/ClientDeEssEditor.cpp
@@ -13,6 +13,7 @@
 #include <QResizeEvent>
 #include <QShowEvent>
 #include <QSignalBlocker>
+#include <QTimer>
 #include <QVBoxLayout>
 #include <cmath>
 
@@ -59,29 +60,7 @@ ClientDeEssEditor::ClientDeEssEditor(AudioEngine* engine, QWidget* parent)
     root->setContentsMargins(8, 8, 8, 8);
     root->setSpacing(6);
 
-    // Header: Bypass
-    {
-        auto* row = new QHBoxLayout;
-        row->setSpacing(8);
-
-        m_bypass = new QPushButton("Bypass");
-        m_bypass->setCheckable(true);
-        m_bypass->setStyleSheet(kBypassStyle);
-        m_bypass->setFixedHeight(22);
-        m_bypass->setToolTip(
-            "Bypass the de-esser (signal passes through unfiltered)");
-        row->addWidget(m_bypass);
-
-        connect(m_bypass, &QPushButton::toggled, this, [this](bool bypassed) {
-            if (!m_audio || !m_audio->clientDeEssTx()) return;
-            m_audio->clientDeEssTx()->setEnabled(!bypassed);
-            m_audio->saveClientDeEssSettings();
-            emit bypassToggled(bypassed);
-        });
-
-        row->addStretch();
-        root->addLayout(row);
-    }
+    // Bypass moved to the CHAIN widget's single-click gesture.
 
     // Body: 3-column — left knobs | big curve | right knobs
     auto* body = new QHBoxLayout;
@@ -110,7 +89,7 @@ ClientDeEssEditor::ClientDeEssEditor(AudioEngine* engine, QWidget* parent)
             ? QString::number(v / 1000.0f, 'f', 2) + " kHz"
             : QString::number(v, 'f', 0) + " Hz";
     });
-    m_freq->setFixedSize(96, 96);
+    m_freq->setFixedSize(76, 76);
     connect(m_freq, &ClientCompKnob::valueChanged,
             this, &ClientDeEssEditor::applyFrequency);
     left->addWidget(m_freq, 0, Qt::AlignHCenter);
@@ -125,7 +104,7 @@ ClientDeEssEditor::ClientDeEssEditor(AudioEngine* engine, QWidget* parent)
     m_q->setLabelFormat([](float v) {
         return QString::number(v, 'f', 2);
     });
-    m_q->setFixedSize(96, 96);
+    m_q->setFixedSize(76, 76);
     connect(m_q, &ClientCompKnob::valueChanged,
             this, &ClientDeEssEditor::applyQ);
     left->addWidget(m_q, 0, Qt::AlignHCenter);
@@ -140,7 +119,7 @@ ClientDeEssEditor::ClientDeEssEditor(AudioEngine* engine, QWidget* parent)
     m_threshold->setLabelFormat([](float v) {
         return QString::number(v, 'f', 1) + " dB";
     });
-    m_threshold->setFixedSize(96, 96);
+    m_threshold->setFixedSize(76, 76);
     connect(m_threshold, &ClientCompKnob::valueChanged,
             this, &ClientDeEssEditor::applyThreshold);
     left->addWidget(m_threshold, 0, Qt::AlignHCenter);
@@ -169,7 +148,7 @@ ClientDeEssEditor::ClientDeEssEditor(AudioEngine* engine, QWidget* parent)
     m_amount->setLabelFormat([](float v) {
         return QString::number(v, 'f', 1) + " dB";
     });
-    m_amount->setFixedSize(96, 96);
+    m_amount->setFixedSize(76, 76);
     connect(m_amount, &ClientCompKnob::valueChanged,
             this, &ClientDeEssEditor::applyAmount);
     right->addWidget(m_amount, 0, Qt::AlignHCenter);
@@ -188,7 +167,7 @@ ClientDeEssEditor::ClientDeEssEditor(AudioEngine* engine, QWidget* parent)
     m_attack->setLabelFormat([](float v) {
         return QString::number(v, 'f', v < 10.0f ? 2 : 1) + " ms";
     });
-    m_attack->setFixedSize(96, 96);
+    m_attack->setFixedSize(76, 76);
     connect(m_attack, &ClientCompKnob::valueChanged,
             this, &ClientDeEssEditor::applyAttack);
     right->addWidget(m_attack, 0, Qt::AlignHCenter);
@@ -207,7 +186,7 @@ ClientDeEssEditor::ClientDeEssEditor(AudioEngine* engine, QWidget* parent)
     m_release->setLabelFormat([](float v) {
         return QString::number(v, 'f', v < 100.0f ? 1 : 0) + " ms";
     });
-    m_release->setFixedSize(96, 96);
+    m_release->setFixedSize(76, 76);
     connect(m_release, &ClientCompKnob::valueChanged,
             this, &ClientDeEssEditor::applyRelease);
     right->addWidget(m_release, 0, Qt::AlignHCenter);
@@ -223,6 +202,11 @@ ClientDeEssEditor::ClientDeEssEditor(AudioEngine* engine, QWidget* parent)
     }
 
     syncControlsFromEngine();
+
+    m_syncTimer = new QTimer(this);
+    m_syncTimer->setInterval(33);
+    connect(m_syncTimer, &QTimer::timeout,
+            this, &ClientDeEssEditor::syncControlsFromEngine);
 }
 
 ClientDeEssEditor::~ClientDeEssEditor() = default;
@@ -234,6 +218,7 @@ void ClientDeEssEditor::showForTx()
     show();
     raise();
     activateWindow();
+    if (m_syncTimer) m_syncTimer->start();
 }
 
 void ClientDeEssEditor::syncControlsFromEngine()
@@ -242,7 +227,6 @@ void ClientDeEssEditor::syncControlsFromEngine()
     ClientDeEss* d = m_audio->clientDeEssTx();
     m_restoring = true;
 
-    { QSignalBlocker b(m_bypass);    m_bypass->setChecked(!d->isEnabled()); }
     { QSignalBlocker b(m_freq);      m_freq->setValue(d->frequencyHz()); }
     { QSignalBlocker b(m_q);         m_q->setValue(d->q()); }
     { QSignalBlocker b(m_threshold); m_threshold->setValue(d->thresholdDb()); }

--- a/src/gui/ClientDeEssEditor.h
+++ b/src/gui/ClientDeEssEditor.h
@@ -3,6 +3,7 @@
 #include <QWidget>
 
 class QPushButton;
+class QTimer;
 
 namespace AetherSDR {
 
@@ -63,6 +64,7 @@ private:
     ClientCompKnob*         m_attack{nullptr};
     ClientCompKnob*         m_release{nullptr};
     QPushButton*            m_bypass{nullptr};
+    QTimer*                 m_syncTimer{nullptr};   // mirror engine → knobs
     bool                    m_restoring{false};
 };
 

--- a/src/gui/ClientEqApplet.cpp
+++ b/src/gui/ClientEqApplet.cpp
@@ -96,36 +96,12 @@ void ClientEqApplet::buildUI()
     // the summed response from the current path's ClientEq; B.3 adds the
     // live FFT analyzer overlay.
     m_curve = new ClientEqCurveWidget;
-    m_curve->setMinimumHeight(90);
+    m_curve->setMinimumHeight(110);
     outer->addWidget(m_curve, 1);
 
-    // Bottom row — Enable toggle on the left, Edit… on the right.
-    {
-        auto* row = new QHBoxLayout;
-        row->setSpacing(4);
-
-        m_enable = new QPushButton("Enable");
-        m_enable->setCheckable(true);
-        m_enable->setStyleSheet(kEnableStyle);
-        m_enable->setFixedHeight(22);
-        row->addWidget(m_enable);
-
-        row->addStretch();
-
-        m_edit = new QPushButton("Edit…");
-        m_edit->setStyleSheet(kEditStyle);
-        m_edit->setFixedHeight(22);
-        m_edit->setToolTip("Open the client EQ editor for the selected path");
-        row->addWidget(m_edit);
-
-        connect(m_enable, &QPushButton::toggled, this,
-                &ClientEqApplet::onEnableToggled);
-        connect(m_edit, &QPushButton::clicked, this, [this]() {
-            emit editRequested(m_currentPath);
-        });
-
-        outer->addLayout(row);
-    }
+    // Enable / Edit buttons removed — CHAIN widget handles bypass
+    // (single-click) and editor-open (double-click).  RX vs TX path
+    // selection still lives in the tab row above.
 }
 
 void ClientEqApplet::setAudioEngine(AudioEngine* engine)
@@ -156,11 +132,6 @@ void ClientEqApplet::setPath(Path p)
 
 void ClientEqApplet::syncEnableFromEngine()
 {
-    if (!m_audio || !m_enable) return;
-    ClientEq* eq = (m_currentPath == Path::Rx)
-        ? m_audio->clientEqRx() : m_audio->clientEqTx();
-    QSignalBlocker b(m_enable);
-    m_enable->setChecked(eq && eq->isEnabled());
     if (m_curve) m_curve->update();
 }
 

--- a/src/gui/ClientEqEditor.cpp
+++ b/src/gui/ClientEqEditor.cpp
@@ -16,7 +16,6 @@
 #include <QMoveEvent>
 #include <QPushButton>
 #include <QResizeEvent>
-#include <QShortcut>
 #include <QShowEvent>
 #include <QSignalBlocker>
 #include <QTimer>
@@ -125,35 +124,11 @@ ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
         });
         row->addWidget(m_familyCombo);
 
-        m_bypass = new QPushButton("BYPASS");
-        m_bypass->setCheckable(true);
-        m_bypass->setStyleSheet(kBypassStyle);
-        m_bypass->setFixedHeight(24);
-        m_bypass->setToolTip(
-            "Toggle EQ bypass for this path — A/B your changes.\n"
-            "Shortcut: B (while this window has focus)");
-        connect(m_bypass, &QPushButton::toggled, this, [this](bool bypassed) {
-            ClientEq* eq = (m_path == ClientEqApplet::Path::Rx)
-                ? m_audio->clientEqRx() : m_audio->clientEqTx();
-            if (!eq) return;
-            eq->setEnabled(!bypassed);
-            if (m_audio) m_audio->saveClientEqSettings();
-            if (m_canvas) m_canvas->update();  // curve gray when bypassed
-            emit bypassToggled(m_path, bypassed);
-        });
-        row->addWidget(m_bypass);
+        // Bypass button moved to the CHAIN widget's single-click
+        // gesture.  Keyboard shortcut retired along with the button.
 
         root->addLayout(row);
     }
-
-    // Keyboard shortcut: B toggles bypass while the editor has focus.
-    // Application-wide would collide with other shortcuts, so scope it
-    // to this window.
-    auto* shortcut = new QShortcut(QKeySequence(Qt::Key_B), this);
-    shortcut->setContext(Qt::WindowShortcut);
-    connect(shortcut, &QShortcut::activated, this, [this]() {
-        if (m_bypass) m_bypass->toggle();
-    });
 
     // Main body: icon row + canvas + param row stacked vertically, with
     // the output fader in a sibling column on the right.  The fader spans
@@ -266,12 +241,9 @@ void ClientEqEditor::tickFftAnalyzer()
 
 void ClientEqEditor::syncBypassFromEq()
 {
-    if (!m_bypass || !m_audio) return;
-    ClientEq* eq = (m_path == ClientEqApplet::Path::Rx)
-        ? m_audio->clientEqRx() : m_audio->clientEqTx();
-    if (!eq) return;
-    QSignalBlocker b(m_bypass);
-    m_bypass->setChecked(!eq->isEnabled());
+    // No in-editor bypass control — bypass lives on the CHAIN widget.
+    // Left as a no-op so existing callers compile; the canvas still
+    // recolours itself via its own enabled check.
 }
 
 void ClientEqEditor::syncSelection(int idx)

--- a/src/gui/ClientGateApplet.cpp
+++ b/src/gui/ClientGateApplet.cpp
@@ -1,4 +1,5 @@
 #include "ClientGateApplet.h"
+#include "ClientCompKnob.h"
 #include "ClientGateCurveWidget.h"
 #include "MeterSmoother.h"
 #include "core/AudioEngine.h"
@@ -122,32 +123,100 @@ void ClientGateApplet::buildUI()
     m_grBar = new ClientGateGrBar;
     outer->addWidget(m_grBar);
 
+    // Enable / Edit buttons removed — the CHAIN widget now handles
+    // bypass (single-click) and opens the editor (double-click).
+
+    // Five-knob tuning row — Thresh, Ratio, Attack, Release, Floor.
+    // Mappings mirror ClientGateEditor so turning a knob here gives
+    // identical DSP results.
     {
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
 
-        m_enable = new QPushButton("Enable");
-        m_enable->setCheckable(true);
-        m_enable->setStyleSheet(kEnableStyle);
-        m_enable->setFixedHeight(22);
-        row->addWidget(m_enable);
+        auto makeKnob = [](const QString& label) {
+            auto* k = new ClientCompKnob;
+            k->setLabel(label);
+            k->setCenterLabelMode(true);
+            k->setFixedSize(38, 48);
+            return k;
+        };
 
-        row->addStretch();
-
-        m_edit = new QPushButton("Edit…");
-        m_edit->setStyleSheet(kEditStyle);
-        m_edit->setFixedHeight(22);
-        m_edit->setToolTip("Open the client gate editor");
-        row->addWidget(m_edit);
-
-        connect(m_enable, &QPushButton::toggled, this,
-                &ClientGateApplet::onEnableToggled);
-        connect(m_edit, &QPushButton::clicked, this, [this]() {
-            emit editRequested();
+        m_thresh = makeKnob("Thresh");
+        m_thresh->setRange(-80.0f, 0.0f);
+        m_thresh->setDefault(-40.0f);
+        m_thresh->setValueFromNorm([](float n) { return -80.0f + n * 80.0f; });
+        m_thresh->setNormFromValue([](float v) { return (v + 80.0f) / 80.0f; });
+        m_thresh->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + " dB";
         });
+        row->addWidget(m_thresh);
+
+        m_ratio = makeKnob("Ratio");
+        m_ratio->setRange(1.0f, 10.0f);
+        m_ratio->setDefault(2.0f);
+        m_ratio->setValueFromNorm([](float n) { return 1.0f + n * 9.0f; });
+        m_ratio->setNormFromValue([](float v) { return (v - 1.0f) / 9.0f; });
+        m_ratio->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + ":1";
+        });
+        row->addWidget(m_ratio);
+
+        m_attack = makeKnob("Attack");
+        m_attack->setRange(0.1f, 100.0f);
+        m_attack->setDefault(0.5f);
+        m_attack->setValueFromNorm([](float n) {
+            return 0.1f * std::pow(1000.0f, n);
+        });
+        m_attack->setNormFromValue([](float v) {
+            return std::log(std::max(0.1f, v) / 0.1f) / std::log(1000.0f);
+        });
+        m_attack->setLabelFormat([](float v) {
+            return QString::number(v, 'f', v < 10.0f ? 2 : 1) + " ms";
+        });
+        row->addWidget(m_attack);
+
+        m_release = makeKnob("Release");
+        m_release->setRange(5.0f, 2000.0f);
+        m_release->setDefault(100.0f);
+        m_release->setValueFromNorm([](float n) {
+            return 5.0f * std::pow(400.0f, n);
+        });
+        m_release->setNormFromValue([](float v) {
+            return std::log(std::max(5.0f, v) / 5.0f) / std::log(400.0f);
+        });
+        m_release->setLabelFormat([](float v) {
+            return QString::number(v, 'f', v < 100.0f ? 1 : 0) + " ms";
+        });
+        row->addWidget(m_release);
+
+        m_floor = makeKnob("Floor");
+        m_floor->setRange(-80.0f, 0.0f);
+        m_floor->setDefault(-15.0f);
+        m_floor->setValueFromNorm([](float n) { return -80.0f + n * 80.0f; });
+        m_floor->setNormFromValue([](float v) { return (v + 80.0f) / 80.0f; });
+        m_floor->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + " dB";
+        });
+        row->addWidget(m_floor);
 
         outer->addLayout(row);
     }
+
+    // Knob → engine wiring.  Each setter is followed by a saveClientGate
+    // call so changes survive a restart.  Done in a helper lambda so the
+    // connect lines read cleanly.
+    auto wire = [this](ClientCompKnob* k, auto setter) {
+        connect(k, &ClientCompKnob::valueChanged, this, [this, setter](float v) {
+            if (!m_audio || !m_audio->clientGateTx()) return;
+            (m_audio->clientGateTx()->*setter)(v);
+            m_audio->saveClientGateSettings();
+        });
+    };
+    wire(m_thresh,  &ClientGate::setThresholdDb);
+    wire(m_ratio,   &ClientGate::setRatio);
+    wire(m_attack,  &ClientGate::setAttackMs);
+    wire(m_release, &ClientGate::setReleaseMs);
+    wire(m_floor,   &ClientGate::setFloorDb);
 
     m_meterTimer = new QTimer(this);
     m_meterTimer->setInterval(33);
@@ -165,11 +234,14 @@ void ClientGateApplet::setAudioEngine(AudioEngine* engine)
 
 void ClientGateApplet::syncEnableFromEngine()
 {
-    if (!m_audio || !m_enable) return;
-    ClientGate* g = m_audio->clientGateTx();
-    QSignalBlocker b(m_enable);
-    m_enable->setChecked(g && g->isEnabled());
     if (m_curve) m_curve->update();
+    if (!m_audio || !m_audio->clientGateTx()) return;
+    ClientGate* g = m_audio->clientGateTx();
+    if (m_thresh)  { QSignalBlocker b(m_thresh);  m_thresh->setValue(g->thresholdDb()); }
+    if (m_ratio)   { QSignalBlocker b(m_ratio);   m_ratio->setValue(g->ratio()); }
+    if (m_attack)  { QSignalBlocker b(m_attack);  m_attack->setValue(g->attackMs()); }
+    if (m_release) { QSignalBlocker b(m_release); m_release->setValue(g->releaseMs()); }
+    if (m_floor)   { QSignalBlocker b(m_floor);   m_floor->setValue(g->floorDb()); }
 }
 
 void ClientGateApplet::refreshEnableFromEngine()
@@ -195,6 +267,15 @@ void ClientGateApplet::tickMeter()
     const float gr = g->gainReductionDb();
     m_grBar->setGrDb(gr);
     m_grDb = gr;
+
+    // Sync knobs back from engine so changes made in the floating
+    // editor show up live here (and vice versa).  QSignalBlocker
+    // prevents the setValue from re-driving the engine.
+    if (m_thresh)  { QSignalBlocker b(m_thresh);  m_thresh->setValue(g->thresholdDb()); }
+    if (m_ratio)   { QSignalBlocker b(m_ratio);   m_ratio->setValue(g->ratio()); }
+    if (m_attack)  { QSignalBlocker b(m_attack);  m_attack->setValue(g->attackMs()); }
+    if (m_release) { QSignalBlocker b(m_release); m_release->setValue(g->releaseMs()); }
+    if (m_floor)   { QSignalBlocker b(m_floor);   m_floor->setValue(g->floorDb()); }
 }
 
 } // namespace AetherSDR

--- a/src/gui/ClientGateApplet.h
+++ b/src/gui/ClientGateApplet.h
@@ -8,6 +8,7 @@ class QTimer;
 namespace AetherSDR {
 
 class AudioEngine;
+class ClientCompKnob;
 class ClientGateCurveWidget;
 class ClientGateGrBar;
 
@@ -46,6 +47,14 @@ private:
     QPushButton*           m_edit{nullptr};
     ClientGateCurveWidget* m_curve{nullptr};
     ClientGateGrBar*       m_grBar{nullptr};
+    // Five most-tuned knobs mirroring the editor: threshold, ratio,
+    // attack, release, floor.  Saves a trip to the floating editor for
+    // everyday tuning.
+    ClientCompKnob*        m_thresh{nullptr};
+    ClientCompKnob*        m_ratio{nullptr};
+    ClientCompKnob*        m_attack{nullptr};
+    ClientCompKnob*        m_release{nullptr};
+    ClientCompKnob*        m_floor{nullptr};
     QTimer*                m_meterTimer{nullptr};
 
     float m_grDb{0.0f};

--- a/src/gui/ClientGateEditor.cpp
+++ b/src/gui/ClientGateEditor.cpp
@@ -15,6 +15,7 @@
 #include <QResizeEvent>
 #include <QShowEvent>
 #include <QSignalBlocker>
+#include <QTimer>
 #include <QVBoxLayout>
 #include <cmath>
 
@@ -82,30 +83,7 @@ ClientGateEditor::ClientGateEditor(AudioEngine* engine, QWidget* parent)
     root->setContentsMargins(8, 8, 8, 8);
     root->setSpacing(6);
 
-    // ── Header: Bypass ────────────────────────────────────────────
-    {
-        auto* row = new QHBoxLayout;
-        row->setSpacing(8);
-
-        m_bypass = new QPushButton("Bypass");
-        m_bypass->setCheckable(true);
-        m_bypass->setStyleSheet(kBypassStyle);
-        m_bypass->setFixedHeight(22);
-        m_bypass->setToolTip(
-            "Bypass the gate (signal passes through untouched)");
-        row->addWidget(m_bypass);
-
-        connect(m_bypass, &QPushButton::toggled, this, [this](bool bypassed) {
-            if (!m_audio || !m_audio->clientGateTx()) return;
-            m_audio->clientGateTx()->setEnabled(!bypassed);
-            m_audio->saveClientGateSettings();
-            emit bypassToggled(bypassed);
-        });
-
-        row->addStretch();
-
-        root->addLayout(row);
-    }
+    // Bypass moved to the CHAIN widget's single-click gesture.
 
     // ── Main body: left control column + right level view ─────────
     auto* body = new QHBoxLayout;
@@ -118,7 +96,7 @@ ClientGateEditor::ClientGateEditor(AudioEngine* engine, QWidget* parent)
     // Threshold — the single largest control, matches Ableton's big
     // top-left knob.  -80..0 dB linear.
     m_threshold = new ClientCompKnob;
-    m_threshold->setLabel("Threshold");
+    m_threshold->setLabel("Thresh");
     m_threshold->setCenterLabelMode(true);
     m_threshold->setRange(-80.0f, 0.0f);
     m_threshold->setDefault(-40.0f);
@@ -127,7 +105,7 @@ ClientGateEditor::ClientGateEditor(AudioEngine* engine, QWidget* parent)
     m_threshold->setLabelFormat([](float v) {
         return QString::number(v, 'f', 1) + " dB";
     });
-    m_threshold->setFixedSize(120, 120);
+    m_threshold->setFixedSize(76, 76);
     connect(m_threshold, &ClientCompKnob::valueChanged,
             this, &ClientGateEditor::applyThreshold);
     left->addWidget(m_threshold, 0, Qt::AlignHCenter);
@@ -143,36 +121,26 @@ ClientGateEditor::ClientGateEditor(AudioEngine* engine, QWidget* parent)
     m_returnKnob->setLabelFormat([](float v) {
         return QString::number(v, 'f', 2) + " dB";
     });
-    m_returnKnob->setFixedSize(80, 80);
+    m_returnKnob->setFixedSize(76, 76);
     connect(m_returnKnob, &ClientCompKnob::valueChanged,
             this, &ClientGateEditor::applyReturn);
     left->addWidget(m_returnKnob, 0, Qt::AlignHCenter);
 
-    // Flip / Lookahead — a narrow stacked pair sitting under the
-    // Return knob to match the Ableton footprint.
+    // Spacer pushes Peek + Flip to the bottom of the column so the
+    // Threshold/Return knobs stay anchored at the top while the mode
+    // toggle and lookahead picker hug the bottom edge.
+    left->addStretch();
+
+    // Peek (lookahead) row — sits directly above the Flip button.
     {
-        auto* flipRow = new QVBoxLayout;
-        flipRow->setSpacing(4);
-
-        m_flip = new QPushButton("Flip");
-        m_flip->setCheckable(true);
-        m_flip->setStyleSheet(kFlipStyle);
-        m_flip->setFixedHeight(22);
-        m_flip->setToolTip(
-            "Flip between downward Expander (gentle) and Gate (hard) "
-            "modes.  Snaps ratio + floor to preset pairs; other knobs "
-            "stay where you left them.");
-        connect(m_flip, &QPushButton::toggled, this, [this](bool checked) {
-            applyMode(checked ? 1 : 0);
-        });
-        flipRow->addWidget(m_flip);
-
-        auto* lookWrap = new QVBoxLayout;
-        lookWrap->setSpacing(2);
-        auto* lookLbl = new QLabel("Lookahead");
-        lookLbl->setAlignment(Qt::AlignCenter);
+        auto* lookWrap = new QHBoxLayout;
+        lookWrap->setSpacing(4);
+        auto* lookLbl = new QLabel("Peek:");
         lookWrap->addWidget(lookLbl);
         m_lookahead = new QComboBox;
+        m_lookahead->setStyleSheet(
+            "QComboBox { padding-left: 0px; padding-right: 0px; }"
+            "QComboBox::drop-down { width: 14px; }");
         for (float v : kLookaheadOptions) {
             const QString label = (v <= 0.0f)
                 ? "Off" : (QString::number(v, 'g', 2) + " ms");
@@ -184,13 +152,24 @@ ClientGateEditor::ClientGateEditor(AudioEngine* engine, QWidget* parent)
             if (i < 0 || i >= kLookaheadOptions.size()) return;
             applyLookahead(kLookaheadOptions[i]);
         });
-        lookWrap->addWidget(m_lookahead);
-        flipRow->addLayout(lookWrap);
-
-        left->addLayout(flipRow);
+        lookWrap->addWidget(m_lookahead, 1);
+        left->addLayout(lookWrap);
     }
 
-    left->addStretch();
+    // Flip button (Expander ↔ Gate) — bottom-most control.
+    m_flip = new QPushButton("Flip");
+    m_flip->setCheckable(true);
+    m_flip->setStyleSheet(kFlipStyle);
+    m_flip->setFixedHeight(22);
+    m_flip->setToolTip(
+        "Flip between downward Expander (gentle) and Gate (hard) "
+        "modes.  Snaps ratio + floor to preset pairs; other knobs "
+        "stay where you left them.");
+    connect(m_flip, &QPushButton::toggled, this, [this](bool checked) {
+        applyMode(checked ? 1 : 0);
+    });
+    left->addWidget(m_flip);
+
     body->addLayout(left, 0);
 
     // Right side: level view + bottom knob row
@@ -208,7 +187,7 @@ ClientGateEditor::ClientGateEditor(AudioEngine* engine, QWidget* parent)
         auto* k = new ClientCompKnob;
         k->setLabel(label);
         k->setCenterLabelMode(true);
-        k->setFixedSize(72, 72);
+        k->setFixedSize(76, 76);
         return k;
     };
 
@@ -304,6 +283,14 @@ ClientGateEditor::ClientGateEditor(AudioEngine* engine, QWidget* parent)
 
     // Initial sync from the engine state.
     syncControlsFromEngine();
+
+    // Continuous polling so changes in the docked applet knobs mirror
+    // here live, and vice versa.  30 Hz is cheap — each knob setValue
+    // is a short clamp + repaint when values differ.
+    m_syncTimer = new QTimer(this);
+    m_syncTimer->setInterval(33);
+    connect(m_syncTimer, &QTimer::timeout,
+            this, &ClientGateEditor::syncControlsFromEngine);
 }
 
 ClientGateEditor::~ClientGateEditor() = default;
@@ -315,6 +302,7 @@ void ClientGateEditor::showForTx()
     show();
     raise();
     activateWindow();
+    if (m_syncTimer) m_syncTimer->start();
 }
 
 void ClientGateEditor::syncControlsFromEngine()
@@ -324,10 +312,6 @@ void ClientGateEditor::syncControlsFromEngine()
 
     m_restoring = true;
 
-    {
-        QSignalBlocker b(m_bypass);
-        m_bypass->setChecked(!g->isEnabled());
-    }
     {
         QSignalBlocker b(m_flip);
         m_flip->setChecked(g->mode() == ClientGate::Mode::Gate);

--- a/src/gui/ClientGateEditor.h
+++ b/src/gui/ClientGateEditor.h
@@ -81,6 +81,7 @@ private:
     QPushButton*          m_flip{nullptr};
     QComboBox*            m_lookahead{nullptr};
     QPushButton*          m_bypass{nullptr};
+    QTimer*               m_syncTimer{nullptr};   // mirror engine → knobs
     bool                  m_restoring{false};
 };
 

--- a/src/gui/ClientPuduApplet.cpp
+++ b/src/gui/ClientPuduApplet.cpp
@@ -104,19 +104,23 @@ void ClientPuduApplet::buildUI()
         auto* group = new QButtonGroup(this);
         group->setExclusive(true);
 
-        m_modeA = new QPushButton("A");
+        m_modeA = new QPushButton("Even");
         m_modeA->setCheckable(true);
         m_modeA->setStyleSheet(kModeStyle);
         m_modeA->setFixedHeight(22);
-        m_modeA->setToolTip("Aphex Aural Exciter + Big Bottom — warm, asymmetric harmonics");
+        m_modeA->setToolTip(
+            "Aphex-lineage asymmetric shaping — predominantly even "
+            "harmonics, warmer, with Big Bottom LF saturation.");
         group->addButton(m_modeA, 0);
         row->addWidget(m_modeA);
 
-        m_modeB = new QPushButton("B");
+        m_modeB = new QPushButton("Odd");
         m_modeB->setCheckable(true);
         m_modeB->setStyleSheet(kModeStyle);
         m_modeB->setFixedHeight(22);
-        m_modeB->setToolTip("Behringer SX 3040 Sonic Exciter — tighter, compressor-based bass");
+        m_modeB->setToolTip(
+            "Behringer-lineage symmetric tanh shaping — pure odd "
+            "harmonics, brighter, with a feed-forward bass compressor.");
         group->addButton(m_modeB, 1);
         row->addWidget(m_modeB);
         row->addStretch();
@@ -236,29 +240,9 @@ void ClientPuduApplet::buildUI()
         outer->addLayout(grid);
     }
 
-    // ── Enable / Edit row ───────────────────────────────────────
-    {
-        auto* row = new QHBoxLayout;
-        row->setSpacing(4);
-        m_enable = new QPushButton("Enable");
-        m_enable->setCheckable(true);
-        m_enable->setStyleSheet(kEnableStyle);
-        m_enable->setFixedHeight(22);
-        row->addWidget(m_enable);
-        row->addStretch();
-        m_edit = new QPushButton("Edit…");
-        m_edit->setStyleSheet(kEditStyle);
-        m_edit->setFixedHeight(22);
-        m_edit->setToolTip("Open the PUDU editor");
-        row->addWidget(m_edit);
-
-        connect(m_enable, &QPushButton::toggled, this,
-                &ClientPuduApplet::onEnableToggled);
-        connect(m_edit, &QPushButton::clicked, this, [this]() {
-            emit editRequested();
-        });
-        outer->addLayout(row);
-    }
+    // Enable / Edit buttons removed — CHAIN widget handles bypass
+    // (single-click) and editor-open (double-click).  Even/Odd mode
+    // toggle above remains.
 }
 
 void ClientPuduApplet::setAudioEngine(AudioEngine* engine)
@@ -275,7 +259,6 @@ void ClientPuduApplet::syncControlsFromEngine()
     ClientPudu* p = m_audio->clientPuduTx();
 
     m_restoring = true;
-    { QSignalBlocker b(m_enable); m_enable->setChecked(p->isEnabled()); }
     {
         const bool isA = (p->mode() == ClientPudu::Mode::Aphex);
         QSignalBlocker ba(m_modeA);

--- a/src/gui/ClientPuduEditor.cpp
+++ b/src/gui/ClientPuduEditor.cpp
@@ -97,42 +97,42 @@ ClientPuduEditor::ClientPuduEditor(AudioEngine* engine, QWidget* parent)
     root->setContentsMargins(12, 10, 12, 10);
     root->setSpacing(8);
 
-    // ── Header: Bypass on the left, A/B on the right ────────────
+    // ── Logo (big in the editor) ────────────────────────────────
+    m_logo = new PooDooLogo;
+    m_logo->setMinimumHeight(80);
+    root->addWidget(m_logo);
+
+    // ── Even / Odd mode toggle — centred in the gap between the
+    // PooDoo™ wordmark and the Poo/Doo knob row.  Aphex generates
+    // even harmonics (asymmetric shape), Behringer generates odd
+    // harmonics (symmetric tanh); labelling by harmonic content is
+    // more descriptive than A/B.
     {
         auto* row = new QHBoxLayout;
-        row->setSpacing(8);
-
-        m_bypass = new QPushButton("Bypass");
-        m_bypass->setCheckable(true);
-        m_bypass->setStyleSheet(kBypassStyle);
-        m_bypass->setFixedHeight(24);
-        m_bypass->setToolTip(
-            "Bypass PUDU (signal passes through with no exciter contribution)");
-        row->addWidget(m_bypass);
-        connect(m_bypass, &QPushButton::toggled, this, [this](bool bypassed) {
-            if (!m_audio || !m_audio->clientPuduTx()) return;
-            m_audio->clientPuduTx()->setEnabled(!bypassed);
-            m_audio->saveClientPuduSettings();
-            emit bypassToggled(bypassed);
-        });
-
+        row->setSpacing(6);
         row->addStretch();
 
         auto* group = new QButtonGroup(this);
         group->setExclusive(true);
-        m_modeA = new QPushButton("A");
+        m_modeA = new QPushButton("Even");
         m_modeA->setCheckable(true);
         m_modeA->setStyleSheet(kModeStyle);
         m_modeA->setFixedHeight(24);
-        m_modeA->setToolTip("Aphex Aural Exciter + Big Bottom — warm, asymmetric harmonics");
+        m_modeA->setToolTip(
+            "Aphex-lineage asymmetric shaping — predominantly even "
+            "harmonics, warmer, diode-style character with Big Bottom "
+            "LF saturation.");
         group->addButton(m_modeA, 0);
         row->addWidget(m_modeA);
 
-        m_modeB = new QPushButton("B");
+        m_modeB = new QPushButton("Odd");
         m_modeB->setCheckable(true);
         m_modeB->setStyleSheet(kModeStyle);
         m_modeB->setFixedHeight(24);
-        m_modeB->setToolTip("Behringer SX 3040 Sonic Exciter — tight, compressor-based bass");
+        m_modeB->setToolTip(
+            "Behringer-lineage symmetric tanh shaping — pure odd "
+            "harmonics, brighter / edgier, paired with a feed-forward "
+            "bass compressor.");
         group->addButton(m_modeB, 1);
         row->addWidget(m_modeB);
 
@@ -141,17 +141,13 @@ ClientPuduEditor::ClientPuduEditor(AudioEngine* engine, QWidget* parent)
             if (checked) onModeToggled(id);
         });
 
+        row->addStretch();
         root->addLayout(row);
     }
 
-    // ── Logo (big in the editor) ────────────────────────────────
-    m_logo = new PooDooLogo;
-    m_logo->setMinimumHeight(80);
-    root->addWidget(m_logo);
-
-    // Breathing room between the wordmark's underline and the
-    // Poo/Doo bracket labels below.
-    root->addSpacing(40);
+    // Tight 4 px gap between the Even/Odd row and the Poo/Doo bracket
+    // labels below.
+    root->addSpacing(4);
 
     // ── Knob row: all 6 on one line with Poo | gap | Doo grouping ──
     //
@@ -174,7 +170,7 @@ ClientPuduEditor::ClientPuduEditor(AudioEngine* engine, QWidget* parent)
             k->setCenterLabelMode(true);
             // Tighter vertical footprint in center-label mode since
             // the label sits inside the ring now.  Ring + value row.
-            k->setFixedSize(88, 92);
+            k->setFixedSize(76, 76);
             return k;
         };
 
@@ -285,7 +281,6 @@ void ClientPuduEditor::syncControlsFromEngine()
     ClientPudu* p = m_audio->clientPuduTx();
     m_restoring = true;
 
-    { QSignalBlocker b(m_bypass); m_bypass->setChecked(!p->isEnabled()); }
     {
         const bool isA = (p->mode() == ClientPudu::Mode::Aphex);
         QSignalBlocker ba(m_modeA);

--- a/src/gui/ClientTubeApplet.cpp
+++ b/src/gui/ClientTubeApplet.cpp
@@ -1,4 +1,5 @@
 #include "ClientTubeApplet.h"
+#include "ClientCompKnob.h"
 #include "ClientTubeCurveWidget.h"
 #include "core/AudioEngine.h"
 #include "core/ClientTube.h"
@@ -7,6 +8,7 @@
 #include <QVBoxLayout>
 #include <QPushButton>
 #include <QSignalBlocker>
+#include <QTimer>
 
 namespace AetherSDR {
 
@@ -50,32 +52,95 @@ void ClientTubeApplet::buildUI()
     m_curve->setMinimumHeight(90);
     outer->addWidget(m_curve, 1);
 
+    // Enable / Edit buttons removed — CHAIN widget handles bypass
+    // (single-click) and editor-open (double-click).
+
+    // Five-knob tuning row — Drive, Tone, Bias, Output, Mix.  Mappings
+    // mirror ClientTubeEditor.
     {
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
 
-        m_enable = new QPushButton("Enable");
-        m_enable->setCheckable(true);
-        m_enable->setStyleSheet(kEnableStyle);
-        m_enable->setFixedHeight(22);
-        row->addWidget(m_enable);
+        auto makeKnob = [](const QString& label) {
+            auto* k = new ClientCompKnob;
+            k->setLabel(label);
+            k->setCenterLabelMode(true);
+            k->setFixedSize(38, 48);
+            return k;
+        };
 
-        row->addStretch();
-
-        m_edit = new QPushButton("Edit…");
-        m_edit->setStyleSheet(kEditStyle);
-        m_edit->setFixedHeight(22);
-        m_edit->setToolTip("Open the dynamic tube editor");
-        row->addWidget(m_edit);
-
-        connect(m_enable, &QPushButton::toggled, this,
-                &ClientTubeApplet::onEnableToggled);
-        connect(m_edit, &QPushButton::clicked, this, [this]() {
-            emit editRequested();
+        m_drive = makeKnob("Drive");
+        m_drive->setRange(0.0f, 24.0f);
+        m_drive->setDefault(0.0f);
+        m_drive->setValueFromNorm([](float n) { return n * 24.0f; });
+        m_drive->setNormFromValue([](float v) { return v / 24.0f; });
+        m_drive->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + " dB";
         });
+        row->addWidget(m_drive);
+
+        m_tone = makeKnob("Tone");
+        m_tone->setRange(-1.0f, 1.0f);
+        m_tone->setDefault(0.0f);
+        m_tone->setValueFromNorm([](float n) { return -1.0f + n * 2.0f; });
+        m_tone->setNormFromValue([](float v) { return (v + 1.0f) / 2.0f; });
+        m_tone->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 2);
+        });
+        row->addWidget(m_tone);
+
+        m_bias = makeKnob("Bias");
+        m_bias->setRange(0.0f, 1.0f);
+        m_bias->setDefault(0.0f);
+        m_bias->setValueFromNorm([](float n) { return n; });
+        m_bias->setNormFromValue([](float v) { return v; });
+        m_bias->setLabelFormat([](float v) {
+            return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+        });
+        row->addWidget(m_bias);
+
+        m_output = makeKnob("Output");
+        m_output->setRange(-24.0f, 12.0f);
+        m_output->setDefault(0.0f);
+        m_output->setValueFromNorm([](float n) { return -24.0f + n * 36.0f; });
+        m_output->setNormFromValue([](float v) { return (v + 24.0f) / 36.0f; });
+        m_output->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + " dB";
+        });
+        row->addWidget(m_output);
+
+        m_mix = makeKnob("Mix");
+        m_mix->setRange(0.0f, 1.0f);
+        m_mix->setDefault(1.0f);
+        m_mix->setValueFromNorm([](float n) { return n; });
+        m_mix->setNormFromValue([](float v) { return v; });
+        m_mix->setLabelFormat([](float v) {
+            return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+        });
+        row->addWidget(m_mix);
 
         outer->addLayout(row);
     }
+
+    auto wire = [this](ClientCompKnob* k, auto setter) {
+        connect(k, &ClientCompKnob::valueChanged, this, [this, setter](float v) {
+            if (!m_audio || !m_audio->clientTubeTx()) return;
+            (m_audio->clientTubeTx()->*setter)(v);
+            m_audio->saveClientTubeSettings();
+        });
+    };
+    wire(m_drive,  &ClientTube::setDriveDb);
+    wire(m_tone,   &ClientTube::setTone);
+    wire(m_bias,   &ClientTube::setBiasAmount);
+    wire(m_output, &ClientTube::setOutputGainDb);
+    wire(m_mix,    &ClientTube::setDryWet);
+
+    // 30 Hz sync timer — mirrors parameter changes made in the floating
+    // editor (or elsewhere) back onto the applet knobs.
+    m_syncTimer = new QTimer(this);
+    m_syncTimer->setInterval(33);
+    connect(m_syncTimer, &QTimer::timeout,
+            this, &ClientTubeApplet::syncEnableFromEngine);
 }
 
 void ClientTubeApplet::setAudioEngine(AudioEngine* engine)
@@ -84,15 +149,19 @@ void ClientTubeApplet::setAudioEngine(AudioEngine* engine)
     if (!m_audio) return;
     m_curve->setTube(m_audio->clientTubeTx());
     syncEnableFromEngine();
+    if (m_syncTimer) m_syncTimer->start();
 }
 
 void ClientTubeApplet::syncEnableFromEngine()
 {
-    if (!m_audio || !m_enable) return;
-    ClientTube* t = m_audio->clientTubeTx();
-    QSignalBlocker b(m_enable);
-    m_enable->setChecked(t && t->isEnabled());
     if (m_curve) m_curve->update();
+    if (!m_audio || !m_audio->clientTubeTx()) return;
+    ClientTube* t = m_audio->clientTubeTx();
+    if (m_drive)  { QSignalBlocker b(m_drive);  m_drive->setValue(t->driveDb()); }
+    if (m_tone)   { QSignalBlocker b(m_tone);   m_tone->setValue(t->tone()); }
+    if (m_bias)   { QSignalBlocker b(m_bias);   m_bias->setValue(t->biasAmount()); }
+    if (m_output) { QSignalBlocker b(m_output); m_output->setValue(t->outputGainDb()); }
+    if (m_mix)    { QSignalBlocker b(m_mix);    m_mix->setValue(t->dryWet()); }
 }
 
 void ClientTubeApplet::refreshEnableFromEngine()

--- a/src/gui/ClientTubeApplet.h
+++ b/src/gui/ClientTubeApplet.h
@@ -8,6 +8,7 @@ class QTimer;
 namespace AetherSDR {
 
 class AudioEngine;
+class ClientCompKnob;
 class ClientTubeCurveWidget;
 
 // Docked tile for the client-side TX dynamic tube saturator.  Shows
@@ -35,6 +36,15 @@ private:
     QPushButton*           m_enable{nullptr};
     QPushButton*           m_edit{nullptr};
     ClientTubeCurveWidget* m_curve{nullptr};
+    // Five-knob tuning row — Drive, Tone, Bias, Output, Mix (Dry/Wet).
+    ClientCompKnob*        m_drive{nullptr};
+    ClientCompKnob*        m_tone{nullptr};
+    ClientCompKnob*        m_bias{nullptr};
+    ClientCompKnob*        m_output{nullptr};
+    ClientCompKnob*        m_mix{nullptr};
+    // Light polling timer — keeps the knobs in sync with any changes
+    // made in the floating editor (and vice versa).
+    QTimer*                m_syncTimer{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/ClientTubeEditor.cpp
+++ b/src/gui/ClientTubeEditor.cpp
@@ -15,6 +15,7 @@
 #include <QResizeEvent>
 #include <QShowEvent>
 #include <QSignalBlocker>
+#include <QTimer>
 #include <QVBoxLayout>
 #include <cmath>
 
@@ -72,29 +73,16 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
     root->setContentsMargins(8, 8, 8, 8);
     root->setSpacing(6);
 
-    // Header: Bypass
-    {
-        auto* row = new QHBoxLayout;
-        row->setSpacing(8);
-
-        m_bypass = new QPushButton("Bypass");
-        m_bypass->setCheckable(true);
-        m_bypass->setStyleSheet(kBypassStyle);
-        m_bypass->setFixedHeight(22);
-        m_bypass->setToolTip(
-            "Bypass the tube saturator (signal passes through unshaped)");
-        row->addWidget(m_bypass);
-
-        connect(m_bypass, &QPushButton::toggled, this, [this](bool bypassed) {
-            if (!m_audio || !m_audio->clientTubeTx()) return;
-            m_audio->clientTubeTx()->setEnabled(!bypassed);
-            m_audio->saveClientTubeSettings();
-            emit bypassToggled(bypassed);
-        });
-
-        row->addStretch();
-        root->addLayout(row);
-    }
+    // Bypass moved to the CHAIN widget's single-click gesture.
+    // Exclusive model group — buttons are created below in the Tone/Bias
+    // row, but the group owner lives here so the change signal can be
+    // wired in one place regardless of button placement.
+    m_modelGroup = new QButtonGroup(this);
+    m_modelGroup->setExclusive(true);
+    connect(m_modelGroup, &QButtonGroup::idToggled, this,
+            [this](int id, bool checked) {
+        if (checked) applyModel(id);
+    });
 
     auto* body = new QHBoxLayout;
     body->setSpacing(12);
@@ -113,7 +101,7 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
     m_dryWet->setLabelFormat([](float v) {
         return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
     });
-    m_dryWet->setFixedSize(80, 80);
+    m_dryWet->setFixedSize(76, 76);
     connect(m_dryWet, &ClientCompKnob::valueChanged,
             this, &ClientTubeEditor::applyDryWet);
     left->addWidget(m_dryWet, 0, Qt::AlignHCenter);
@@ -128,7 +116,7 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
     m_output->setLabelFormat([](float v) {
         return QString::number(v, 'f', 2) + " dB";
     });
-    m_output->setFixedSize(80, 80);
+    m_output->setFixedSize(76, 76);
     connect(m_output, &ClientCompKnob::valueChanged,
             this, &ClientTubeEditor::applyOutput);
     left->addWidget(m_output, 0, Qt::AlignHCenter);
@@ -143,7 +131,7 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
     m_drive->setLabelFormat([](float v) {
         return QString::number(v, 'f', 2) + " dB";
     });
-    m_drive->setFixedSize(80, 80);
+    m_drive->setFixedSize(76, 76);
     connect(m_drive, &ClientCompKnob::valueChanged,
             this, &ClientTubeEditor::applyDrive);
     left->addWidget(m_drive, 0, Qt::AlignHCenter);
@@ -160,36 +148,9 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
     m_curve->setMinimumHeight(180);
     center->addWidget(m_curve, 1);
 
-    // Model A / B / C row
-    {
-        auto* row = new QHBoxLayout;
-        row->setSpacing(4);
-        row->addStretch();
-
-        m_modelGroup = new QButtonGroup(this);
-        m_modelGroup->setExclusive(true);
-
-        auto addModelBtn = [&](const QString& label, int idx) {
-            auto* btn = new QPushButton(label);
-            btn->setCheckable(true);
-            btn->setStyleSheet(kModelStyle);
-            btn->setFixedHeight(22);
-            m_modelGroup->addButton(btn, idx);
-            row->addWidget(btn);
-            return btn;
-        };
-        m_modelA = addModelBtn("A", 0);
-        m_modelB = addModelBtn("B", 1);
-        m_modelC = addModelBtn("C", 2);
-        row->addStretch();
-
-        connect(m_modelGroup, &QButtonGroup::idToggled, this,
-                [this](int id, bool checked) {
-            if (checked) applyModel(id);
-        });
-
-        center->addLayout(row);
-    }
+    // Model A / B / C selector now lives in the header row so it
+    // doesn't eat vertical space from the curve.  See the header block
+    // above for where the buttons are actually inserted.
 
     // Tone + Bias row
     {
@@ -207,10 +168,31 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
         m_tone->setLabelFormat([](float v) {
             return QString::number(v, 'f', 2);
         });
-        m_tone->setFixedSize(68, 68);
+        m_tone->setFixedSize(76, 76);
         connect(m_tone, &ClientCompKnob::valueChanged,
                 this, &ClientTubeEditor::applyTone);
         row->addWidget(m_tone, 0, Qt::AlignHCenter);
+
+        // A / B / C model selector — narrow vertical stack sitting
+        // between Tone and Bias.  Buttons live in m_modelGroup created
+        // earlier so the change handler stays wired.
+        {
+            auto* modelCol = new QVBoxLayout;
+            modelCol->setSpacing(3);
+            auto addModelBtn = [&](const QString& label, int idx) {
+                auto* btn = new QPushButton(label);
+                btn->setCheckable(true);
+                btn->setStyleSheet(kModelStyle);
+                btn->setFixedSize(22, 20);
+                m_modelGroup->addButton(btn, idx);
+                modelCol->addWidget(btn);
+                return btn;
+            };
+            m_modelA = addModelBtn("A", 0);
+            m_modelB = addModelBtn("B", 1);
+            m_modelC = addModelBtn("C", 2);
+            row->addLayout(modelCol, 0);
+        }
 
         m_bias = new ClientCompKnob;
         m_bias->setLabel("Bias");
@@ -222,7 +204,7 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
         m_bias->setLabelFormat([](float v) {
             return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
         });
-        m_bias->setFixedSize(68, 68);
+        m_bias->setFixedSize(76, 76);
         connect(m_bias, &ClientCompKnob::valueChanged,
                 this, &ClientTubeEditor::applyBias);
         row->addWidget(m_bias, 0, Qt::AlignHCenter);
@@ -248,7 +230,7 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
         const int pct = static_cast<int>(v * 100.0f + (v >= 0 ? 0.5f : -0.5f));
         return QString::number(pct) + " %";
     });
-    m_envelope->setFixedSize(80, 80);
+    m_envelope->setFixedSize(76, 76);
     connect(m_envelope, &ClientCompKnob::valueChanged,
             this, &ClientTubeEditor::applyEnvelope);
     right->addWidget(m_envelope, 0, Qt::AlignHCenter);
@@ -267,7 +249,7 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
     m_attack->setLabelFormat([](float v) {
         return QString::number(v, 'f', v < 10.0f ? 2 : 1) + " ms";
     });
-    m_attack->setFixedSize(72, 72);
+    m_attack->setFixedSize(76, 76);
     connect(m_attack, &ClientCompKnob::valueChanged,
             this, &ClientTubeEditor::applyAttack);
     right->addWidget(m_attack, 0, Qt::AlignHCenter);
@@ -286,7 +268,7 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
     m_release->setLabelFormat([](float v) {
         return QString::number(v, 'f', v < 100.0f ? 2 : 1) + " ms";
     });
-    m_release->setFixedSize(72, 72);
+    m_release->setFixedSize(76, 76);
     connect(m_release, &ClientCompKnob::valueChanged,
             this, &ClientTubeEditor::applyRelease);
     right->addWidget(m_release, 0, Qt::AlignHCenter);
@@ -301,6 +283,11 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
     }
 
     syncControlsFromEngine();
+
+    m_syncTimer = new QTimer(this);
+    m_syncTimer->setInterval(33);
+    connect(m_syncTimer, &QTimer::timeout,
+            this, &ClientTubeEditor::syncControlsFromEngine);
 }
 
 ClientTubeEditor::~ClientTubeEditor() = default;
@@ -312,6 +299,7 @@ void ClientTubeEditor::showForTx()
     show();
     raise();
     activateWindow();
+    if (m_syncTimer) m_syncTimer->start();
 }
 
 void ClientTubeEditor::syncControlsFromEngine()
@@ -320,7 +308,6 @@ void ClientTubeEditor::syncControlsFromEngine()
     ClientTube* t = m_audio->clientTubeTx();
     m_restoring = true;
 
-    { QSignalBlocker b(m_bypass);  m_bypass->setChecked(!t->isEnabled()); }
     {
         const int idx = static_cast<int>(t->model());
         QPushButton* btn = (idx == 1) ? m_modelB

--- a/src/gui/ClientTubeEditor.h
+++ b/src/gui/ClientTubeEditor.h
@@ -4,6 +4,7 @@
 
 class QPushButton;
 class QButtonGroup;
+class QTimer;
 
 namespace AetherSDR {
 
@@ -73,6 +74,7 @@ private:
     QPushButton*           m_modelC{nullptr};
     QButtonGroup*          m_modelGroup{nullptr};
     QPushButton*           m_bypass{nullptr};
+    QTimer*                m_syncTimer{nullptr};   // mirror engine → knobs
     bool                   m_restoring{false};
 };
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2285,6 +2285,19 @@ MainWindow::MainWindow(QWidget* parent)
         m_appletPanel->setAppletVisible(
             "PUDU", m_audio->clientPuduTx()->isEnabled());
     }
+
+    // Initial applet-stack order mirrors the persisted chain order, and
+    // stays in sync on every subsequent drag-reorder.
+    if (m_audio) {
+        m_appletPanel->setTxDspChainOrder(m_audio->txChainStages());
+    }
+    connect(m_appletPanel->clientChainApplet(),
+            &ClientChainApplet::chainReordered,
+            this, [this]() {
+        if (m_appletPanel && m_audio)
+            m_appletPanel->setTxDspChainOrder(m_audio->txChainStages());
+    });
+
     connect(m_appletPanel->clientChainApplet(),
             &ClientChainApplet::stageEnabledChanged,
             this, [this](AudioEngine::TxChainStage stage, bool enabled) {


### PR DESCRIPTION
- ClientChainWidget: single-click toggles stage bypass; double-click
  opens the editor; drag still reorders.  Deferred-click timer
  cancels bypass on double-click.
- Per-node editors: remove Bypass buttons (CHAIN handles it).
- Per-node applets: remove Enable/Edit buttons, add 4-5 knob tuning
  rows matching PUDU style (38x48 px).  GATE: Thresh/Ratio/Attack/
  Release/Floor.  DESS: Freq/Q/Thresh/Amount.  CMP: Thresh/Ratio/
  Attack/Release/Makeup.  TUBE: Drive/Tone/Bias/Output/Mix.
- 30 Hz sync polling keeps applet and editor knobs in lock-step
  when values change in either surface (QSignalBlocker-guarded).
- AppletPanel::setTxDspChainOrder: reorder tx_dsp sub-containers to
  mirror CHAIN order; wired on chainReordered + startup.
- Node editor polish: uniform 76x76 knobs in Comp/Gate/DeEss/Tube
  editors; Bypass right-aligned; chain-order combo retired from Comp.
- Gate editor: Thresh label, Peek row on same line as combo (pad
  zeroed), Flip + Peek bottom-aligned.
- Tube editor: Even/Odd label for A/B modes (A = even harmonics, B =
  odd) on applet + editor; A/B/C model buttons stacked vertically
  between Tone and Bias knobs.
- ClientCompKnob: lower initial label font to diameter/6 so long
  labels like Thresh don't ghost-shrink below neighbours.
- PUDU: Even/Odd toggle centred between wordmark and knob row, tight
  4 px pad; applet A/B buttons renamed to match.
- CEQ applet curve: +20 px minimum height (90 -> 110).
- AppletPanel: CMP sub-container titlebar -> COMPRESSOR.
- AppletPanel: TXDSP button-bar label VUDU -> PUDU (keeps TXDSP
  settings key for migration).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
