### PR TITLE
Update hint text: CHAIN applet gesture order; drop CEQ add-band tip

### DIFF
--- a/src/gui/ClientChainApplet.cpp
+++ b/src/gui/ClientChainApplet.cpp
@@ -194,7 +194,7 @@ ClientChainApplet::ClientChainApplet(QWidget* parent) : QWidget(parent)
 
     // ── Hint (below the chain) ──────────────────────────────────
     m_hint = new QLabel(
-        "Click to edit · drag to reorder · right-click to bypass");
+        "Click to bypass · Double click to edit · Drag to reorder");
     m_hint->setStyleSheet(
         "QLabel { color: #607888; font-size: 9px;"
         " background: transparent; border: none; }");

--- a/src/gui/ClientEqEditor.cpp
+++ b/src/gui/ClientEqEditor.cpp
@@ -76,7 +76,7 @@ ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
             "QLabel { color: #d7e7f2; font-size: 12px; font-weight: bold; }");
         row->addWidget(m_pathLabel);
         auto* hint = new QLabel(
-            "Double-click to add · drag peak/shelf = freq + gain · "
+            "Drag peak/shelf = freq + gain · "
             "drag HP/LP = freq + Q · Shift + drag for Q · "
             "click icon to cycle type");
         hint->setStyleSheet("QLabel { color: #506070; font-size: 10px; }");


### PR DESCRIPTION
- ClientChainApplet: hint now reflects the new single-click-bypass /
  double-click-edit gesture set ("Click to bypass · Double click to
  edit · Drag to reorder").
- ClientEqEditor: remove stale "Double-click to add" prefix from the
  icon-row hint (bands are fixed — no user-adds).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
