### PR TITLE
PooDoo™ TX Reverb: Freeverb stage + applet + editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,6 +409,7 @@ set(CORE_SOURCES
     src/core/ClientTube.cpp
     src/core/ClientPudu.cpp
     src/core/ClientPuduMonitor.cpp
+    src/core/ClientReverb.cpp
     src/core/SpectralNR.cpp
     src/core/PanadapterStream.cpp
     src/core/RigctlProtocol.cpp
@@ -539,6 +540,8 @@ set(GUI_SOURCES
     src/gui/ClientTubeEditor.cpp
     src/gui/ClientPuduApplet.cpp
     src/gui/ClientPuduEditor.cpp
+    src/gui/ClientReverbApplet.cpp
+    src/gui/ClientReverbEditor.cpp
     src/gui/PooDooLogo.cpp
     src/gui/ClientCompLimiterButton.cpp
     src/gui/ClientCompMeter.cpp
@@ -1081,6 +1084,12 @@ add_executable(client_pudu_test
     src/core/ClientPudu.cpp
 )
 target_include_directories(client_pudu_test PRIVATE src)
+
+add_executable(client_reverb_test
+    tests/client_reverb_test.cpp
+    src/core/ClientReverb.cpp
+)
+target_include_directories(client_reverb_test PRIVATE src)
 
 # Container system Phase 1 tests — needs QApplication + Widgets.
 add_executable(container_widget_test

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -7,6 +7,7 @@
 #include "ClientTube.h"
 #include "ClientPudu.h"
 #include "ClientPuduMonitor.h"
+#include "ClientReverb.h"
 #include "LogManager.h"
 #include "OpusCodec.h"
 #include "SpectralNR.h"
@@ -61,6 +62,7 @@ AudioEngine::AudioEngine(QObject* parent)
     , m_clientDeEssTx(std::make_unique<ClientDeEss>())
     , m_clientTubeTx(std::make_unique<ClientTube>())
     , m_clientPuduTx(std::make_unique<ClientPudu>())
+    , m_clientReverbTx(std::make_unique<ClientReverb>())
 {
     // Prepare client DSP at the native 24 kHz rate. Sink resampling is
     // handled separately after EQ — EQ always runs at radio-native rate.
@@ -71,12 +73,14 @@ AudioEngine::AudioEngine(QObject* parent)
     m_clientDeEssTx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientTubeTx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientPuduTx->prepare(DEFAULT_SAMPLE_RATE);
-    loadClientEqSettings();    // restore persisted bands before first audio
-    loadClientCompSettings();  // restore persisted comp params + chain order
-    loadClientGateSettings();  // restore persisted gate params
-    loadClientDeEssSettings(); // restore persisted de-esser params
-    loadClientTubeSettings();  // restore persisted tube params
-    loadClientPuduSettings();  // restore persisted PUDU params
+    m_clientReverbTx->prepare(DEFAULT_SAMPLE_RATE);
+    loadClientEqSettings();      // restore persisted bands before first audio
+    loadClientCompSettings();    // restore persisted comp params + chain order
+    loadClientGateSettings();    // restore persisted gate params
+    loadClientDeEssSettings();   // restore persisted de-esser params
+    loadClientTubeSettings();    // restore persisted tube params
+    loadClientPuduSettings();    // restore persisted PUDU params
+    loadClientReverbSettings();  // restore persisted reverb params
 
     // Restore saved audio device selections
     auto& s = AppSettings::instance();
@@ -995,6 +999,40 @@ void AudioEngine::applyClientPuduTxFloat32(QByteArray& float32)
                             frames, channels);
 }
 
+void AudioEngine::applyClientReverbTxInt16(QByteArray& int16stereo)
+{
+    if (!m_clientReverbTx || !m_clientReverbTx->isEnabled()) return;
+    if (int16stereo.isEmpty()) return;
+
+    const int samples = int16stereo.size() / static_cast<int>(sizeof(int16_t));
+    if ((samples & 1) != 0) return;
+    const int frames = samples / 2;
+
+    m_clientReverbTxScratch.resize(samples * static_cast<int>(sizeof(float)));
+    auto* f32 = reinterpret_cast<float*>(m_clientReverbTxScratch.data());
+    const auto* i16 = reinterpret_cast<const int16_t*>(int16stereo.constData());
+    for (int i = 0; i < samples; ++i) f32[i] = i16[i] / 32768.0f;
+
+    m_clientReverbTx->process(f32, frames, 2);
+
+    auto* out = reinterpret_cast<int16_t*>(int16stereo.data());
+    for (int i = 0; i < samples; ++i) {
+        out[i] = static_cast<int16_t>(
+            std::clamp(f32[i] * 32768.0f, -32768.0f, 32767.0f));
+    }
+}
+
+void AudioEngine::applyClientReverbTxFloat32(QByteArray& float32)
+{
+    if (!m_clientReverbTx || !m_clientReverbTx->isEnabled()) return;
+    if (float32.isEmpty()) return;
+    const int samples  = float32.size() / static_cast<int>(sizeof(float));
+    const int channels = (samples % 2 == 0) ? 2 : 1;
+    const int frames   = samples / channels;
+    m_clientReverbTx->process(reinterpret_cast<float*>(float32.data()),
+                              frames, channels);
+}
+
 void AudioEngine::applyClientTxDspInt16(QByteArray& int16stereo)
 {
     // Order determines whether the compressor colours the raw mic signal
@@ -1018,6 +1056,7 @@ void AudioEngine::applyClientTxDspInt16(QByteArray& int16stereo)
             // "Enh" is the legacy enum name; the user-facing label is
             // PUDU (Phase 5 exciter, Aphex/Behringer-modelled).
             case TxChainStage::Enh:    applyClientPuduTxInt16(int16stereo);  break;
+            case TxChainStage::Reverb: applyClientReverbTxInt16(int16stereo); break;
         }
     }
 }
@@ -1035,6 +1074,7 @@ void AudioEngine::applyClientTxDspFloat32(QByteArray& float32)
             case TxChainStage::DeEss:  applyClientDeEssTxFloat32(float32); break;
             case TxChainStage::Tube:   applyClientTubeTxFloat32(float32);  break;
             case TxChainStage::Enh:    applyClientPuduTxFloat32(float32);  break;
+            case TxChainStage::Reverb: applyClientReverbTxFloat32(float32); break;
         }
     }
 }
@@ -1072,25 +1112,27 @@ QVector<AudioEngine::TxChainStage> unpackChain(uint64_t v)
 QString stageName(AudioEngine::TxChainStage s)
 {
     switch (s) {
-        case AudioEngine::TxChainStage::Gate:  return "Gate";
-        case AudioEngine::TxChainStage::Eq:    return "Eq";
-        case AudioEngine::TxChainStage::DeEss: return "DeEss";
-        case AudioEngine::TxChainStage::Comp:  return "Comp";
-        case AudioEngine::TxChainStage::Tube:  return "Tube";
-        case AudioEngine::TxChainStage::Enh:   return "Enh";
-        case AudioEngine::TxChainStage::None:  return "";
+        case AudioEngine::TxChainStage::Gate:   return "Gate";
+        case AudioEngine::TxChainStage::Eq:     return "Eq";
+        case AudioEngine::TxChainStage::DeEss:  return "DeEss";
+        case AudioEngine::TxChainStage::Comp:   return "Comp";
+        case AudioEngine::TxChainStage::Tube:   return "Tube";
+        case AudioEngine::TxChainStage::Enh:    return "Enh";
+        case AudioEngine::TxChainStage::Reverb: return "Reverb";
+        case AudioEngine::TxChainStage::None:   return "";
     }
     return "";
 }
 
 AudioEngine::TxChainStage stageFromName(const QString& name)
 {
-    if (name == "Gate")  return AudioEngine::TxChainStage::Gate;
-    if (name == "Eq")    return AudioEngine::TxChainStage::Eq;
-    if (name == "DeEss") return AudioEngine::TxChainStage::DeEss;
-    if (name == "Comp")  return AudioEngine::TxChainStage::Comp;
-    if (name == "Tube")  return AudioEngine::TxChainStage::Tube;
-    if (name == "Enh")   return AudioEngine::TxChainStage::Enh;
+    if (name == "Gate")   return AudioEngine::TxChainStage::Gate;
+    if (name == "Eq")     return AudioEngine::TxChainStage::Eq;
+    if (name == "DeEss")  return AudioEngine::TxChainStage::DeEss;
+    if (name == "Comp")   return AudioEngine::TxChainStage::Comp;
+    if (name == "Tube")   return AudioEngine::TxChainStage::Tube;
+    if (name == "Enh")    return AudioEngine::TxChainStage::Enh;
+    if (name == "Reverb") return AudioEngine::TxChainStage::Reverb;
     return AudioEngine::TxChainStage::None;
 }
 
@@ -1106,6 +1148,7 @@ QVector<AudioEngine::TxChainStage> defaultChain()
         AudioEngine::TxChainStage::Comp,
         AudioEngine::TxChainStage::Tube,
         AudioEngine::TxChainStage::Enh,
+        AudioEngine::TxChainStage::Reverb,
     };
 }
 
@@ -1449,6 +1492,42 @@ void AudioEngine::saveClientPuduSettings() const
         QString::number(m_clientPuduTx->dooHarmonicsDb()));
     s.setValue("ClientPuduTxDooMix",
         QString::number(m_clientPuduTx->dooMix()));
+}
+
+void AudioEngine::loadClientReverbSettings()
+{
+    if (!m_clientReverbTx) return;
+    auto& s = AppSettings::instance();
+    m_clientReverbTx->setEnabled(
+        s.value("ClientReverbTxEnabled", "False").toString() == "True");
+    m_clientReverbTx->setSize(
+        s.value("ClientReverbTxSize", "0.5").toFloat());
+    m_clientReverbTx->setDecayS(
+        s.value("ClientReverbTxDecayS", "1.2").toFloat());
+    m_clientReverbTx->setDamping(
+        s.value("ClientReverbTxDamping", "0.5").toFloat());
+    m_clientReverbTx->setPreDelayMs(
+        s.value("ClientReverbTxPreDelayMs", "20.0").toFloat());
+    m_clientReverbTx->setMix(
+        s.value("ClientReverbTxMix", "0.15").toFloat());
+}
+
+void AudioEngine::saveClientReverbSettings() const
+{
+    if (!m_clientReverbTx) return;
+    auto& s = AppSettings::instance();
+    auto toBool = [](bool on) { return on ? QString("True") : QString("False"); };
+    s.setValue("ClientReverbTxEnabled",    toBool(m_clientReverbTx->isEnabled()));
+    s.setValue("ClientReverbTxSize",
+        QString::number(m_clientReverbTx->size()));
+    s.setValue("ClientReverbTxDecayS",
+        QString::number(m_clientReverbTx->decayS()));
+    s.setValue("ClientReverbTxDamping",
+        QString::number(m_clientReverbTx->damping()));
+    s.setValue("ClientReverbTxPreDelayMs",
+        QString::number(m_clientReverbTx->preDelayMs()));
+    s.setValue("ClientReverbTxMix",
+        QString::number(m_clientReverbTx->mix()));
 }
 
 static QString wisdomDir()

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -38,6 +38,7 @@ class ClientDeEss;
 class ClientTube;
 class ClientPudu;
 class ClientPuduMonitor;
+class ClientReverb;
 
 // AudioEngine handles audio playback (RX) and capture (TX).
 //
@@ -192,6 +193,10 @@ public:
     // PooDoo Audio™ chain.
     ClientPudu* clientPuduTx() { return m_clientPuduTx.get(); }
 
+    // Client-side TX reverb — Freeverb-based room/hall effect, final
+    // optional stage in the PooDoo™ chain.
+    ClientReverb* clientReverbTx() { return m_clientReverbTx.get(); }
+
     // Register/unregister a monitor that taps the post-DSP TX int16
     // stream on the audio thread.  Passed pointer must outlive the
     // registration — clear to nullptr before destroying the monitor.
@@ -203,13 +208,14 @@ public:
     // Phase 2+ work (Gate, DeEss, Tube, Enh from #1661) and are no-ops
     // until their DSP classes ship.
     enum class TxChainStage : uint8_t {
-        None  = 0,   // sentinel / end-of-list marker
-        Gate  = 1,
-        Eq    = 2,
-        DeEss = 3,
-        Comp  = 4,
-        Tube  = 5,
-        Enh   = 6,
+        None   = 0,   // sentinel / end-of-list marker
+        Gate   = 1,
+        Eq     = 2,
+        DeEss  = 3,
+        Comp   = 4,
+        Tube   = 5,
+        Enh    = 6,   // PUDU slot
+        Reverb = 7,
     };
     static constexpr int kMaxTxChainStages = 8;  // packs into uint64_t
 
@@ -250,6 +256,10 @@ public:
     // Client-side TX PUDU exciter — persistence.
     void loadClientPuduSettings();
     void saveClientPuduSettings() const;
+
+    // Client-side TX reverb (Freeverb) — persistence.
+    void loadClientReverbSettings();
+    void saveClientReverbSettings() const;
 
     // Post-Client-EQ audio tap for the editor's FFT analyzer.  Exposes
     // a rolling mono buffer filled on the audio thread; UI thread copies
@@ -335,6 +345,9 @@ private:
     // Apply client-side TX PUDU exciter in-place.  No-op if disabled.
     void applyClientPuduTxInt16(QByteArray& int16stereo);
     void applyClientPuduTxFloat32(QByteArray& float32);
+    // Apply client-side TX reverb in-place.  No-op if disabled.
+    void applyClientReverbTxInt16(QByteArray& int16stereo);
+    void applyClientReverbTxFloat32(QByteArray& float32);
     // Apply the whole TX DSP chain (CMP + EQ) in the configured order.
     void applyClientTxDspInt16(QByteArray& int16stereo);
     void applyClientTxDspFloat32(QByteArray& float32);
@@ -442,6 +455,8 @@ private:
     std::unique_ptr<ClientTube> m_clientTubeTx;
     // Client-side TX PUDU exciter.
     std::unique_ptr<ClientPudu> m_clientPuduTx;
+    // Client-side TX reverb.
+    std::unique_ptr<ClientReverb> m_clientReverbTx;
     // Post-DSP TX monitor — owned by MainWindow; we just hold a
     // pointer the audio thread can load lock-free per block.
     std::atomic<ClientPuduMonitor*> m_txPostDspMonitor{nullptr};
@@ -460,6 +475,7 @@ private:
     QByteArray m_clientDeEssTxScratch;
     QByteArray m_clientTubeTxScratch;
     QByteArray m_clientPuduTxScratch;
+    QByteArray m_clientReverbTxScratch;
     // Post-EQ analyzer tap. One ring per path, mono (L+R averaged).
     // Audio thread writes via tapClientEqRxStereo() / tapClientEqTxInt16()
     // / tapClientEqTxFloat32(); UI thread snapshots via the public

--- a/src/core/ClientReverb.cpp
+++ b/src/core/ClientReverb.cpp
@@ -1,0 +1,331 @@
+#include "ClientReverb.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace AetherSDR {
+
+namespace {
+
+// Jezar's Freeverb tunings at 44.1 kHz.  L-channel lengths; R-channel
+// adds kStereoSpread to each.  Public domain (Jezar 2000).
+constexpr int kCombTuningsL44k[8] =
+    {1116, 1188, 1277, 1356, 1422, 1491, 1557, 1617};
+constexpr int kAllpassTuningsL44k[4] =
+    {556, 441, 341, 225};
+
+// Input attenuation — prevents feedback chain from blowing up when all
+// eight combs sum.
+constexpr float kFixedGain = 0.015f;
+
+float linToDb(float lin) noexcept
+{
+    return (lin > 1e-9f) ? 20.0f * std::log10(lin) : -180.0f;
+}
+
+int scaleLenForRate(int refLen, double sampleRate)
+{
+    return std::max(1, static_cast<int>(
+        std::lround(refLen * (sampleRate / 44100.0))));
+}
+
+} // namespace
+
+ClientReverb::ClientReverb() = default;
+
+void ClientReverb::prepare(double sampleRate)
+{
+    m_sampleRate = sampleRate;
+
+    // Allocate comb + allpass delay buffers at max (Size=1) lengths,
+    // per channel.  Stereo-spread adds kStereoSpread samples on the
+    // right channel.
+    // Allocate both channels at the SAME max length — L's stereo-spread
+    // variant is the upper bound for both so a single cached active-
+    // length works without overrunning either buffer.  Trades ~23
+    // unused samples per comb per channel for a simpler index loop.
+    for (int i = 0; i < kNumCombs; ++i) {
+        const int baseLen = scaleLenForRate(kCombTuningsL44k[i], sampleRate);
+        const int maxLen  = baseLen + kStereoSpread;
+        m_maxCombLen[i] = maxLen;
+        m_chL.combs[i].buffer.assign(maxLen, 0.0f);
+        m_chL.combs[i].index    = 0;
+        m_chL.combs[i].lpfState = 0.0f;
+        m_chR.combs[i].buffer.assign(maxLen, 0.0f);
+        m_chR.combs[i].index    = 0;
+        m_chR.combs[i].lpfState = 0.0f;
+    }
+    for (int i = 0; i < kNumAllpasses; ++i) {
+        const int baseLen = scaleLenForRate(kAllpassTuningsL44k[i], sampleRate);
+        const int maxLen  = baseLen + kStereoSpread;
+        m_maxAllpassLen[i] = maxLen;
+        m_chL.allpasses[i].buffer.assign(maxLen, 0.0f);
+        m_chL.allpasses[i].index = 0;
+        m_chR.allpasses[i].buffer.assign(maxLen, 0.0f);
+        m_chR.allpasses[i].index = 0;
+    }
+
+    // Pre-delay: stereo-interleaved buffer sized for kMaxPreDelayMs.
+    m_preDelayCap = static_cast<int>(
+        std::lround(kMaxPreDelayMs * 0.001 * sampleRate)) + 1;
+    m_preDelay.assign(m_preDelayCap * 2, 0.0f);
+    m_preDelayWrite = 0;
+
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+    recacheIfDirty();
+}
+
+void ClientReverb::setEnabled(bool on) noexcept
+{
+    m_atomics.enabled.store(on, std::memory_order_release);
+}
+bool ClientReverb::isEnabled() const noexcept
+{
+    return m_atomics.enabled.load(std::memory_order_acquire);
+}
+
+void ClientReverb::setSize(float s) noexcept
+{
+    m_atomics.size.store(std::clamp(s, 0.0f, 1.0f), std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientReverb::size() const noexcept
+{ return m_atomics.size.load(std::memory_order_relaxed); }
+
+void ClientReverb::setDecayS(float s) noexcept
+{
+    m_atomics.decayS.store(std::clamp(s, 0.3f, 5.0f),
+                           std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientReverb::decayS() const noexcept
+{ return m_atomics.decayS.load(std::memory_order_relaxed); }
+
+void ClientReverb::setDamping(float d) noexcept
+{
+    m_atomics.damping.store(std::clamp(d, 0.0f, 1.0f),
+                            std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientReverb::damping() const noexcept
+{ return m_atomics.damping.load(std::memory_order_relaxed); }
+
+void ClientReverb::setPreDelayMs(float ms) noexcept
+{
+    m_atomics.preDelayMs.store(
+        std::clamp(ms, 0.0f, static_cast<float>(kMaxPreDelayMs)),
+        std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientReverb::preDelayMs() const noexcept
+{ return m_atomics.preDelayMs.load(std::memory_order_relaxed); }
+
+void ClientReverb::setMix(float m) noexcept
+{
+    m_atomics.mix.store(std::clamp(m, 0.0f, 1.0f),
+                        std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientReverb::mix() const noexcept
+{ return m_atomics.mix.load(std::memory_order_relaxed); }
+
+void ClientReverb::reset() noexcept
+{
+    for (int i = 0; i < kNumCombs; ++i) {
+        std::fill(m_chL.combs[i].buffer.begin(),
+                  m_chL.combs[i].buffer.end(), 0.0f);
+        std::fill(m_chR.combs[i].buffer.begin(),
+                  m_chR.combs[i].buffer.end(), 0.0f);
+        m_chL.combs[i].index    = 0;
+        m_chR.combs[i].index    = 0;
+        m_chL.combs[i].lpfState = 0.0f;
+        m_chR.combs[i].lpfState = 0.0f;
+    }
+    for (int i = 0; i < kNumAllpasses; ++i) {
+        std::fill(m_chL.allpasses[i].buffer.begin(),
+                  m_chL.allpasses[i].buffer.end(), 0.0f);
+        std::fill(m_chR.allpasses[i].buffer.begin(),
+                  m_chR.allpasses[i].buffer.end(), 0.0f);
+        m_chL.allpasses[i].index = 0;
+        m_chR.allpasses[i].index = 0;
+    }
+    std::fill(m_preDelay.begin(), m_preDelay.end(), 0.0f);
+    m_preDelayWrite = 0;
+}
+
+float ClientReverb::inputPeakDb() const noexcept
+{ return m_inputPeakDb.load(std::memory_order_relaxed); }
+float ClientReverb::outputPeakDb() const noexcept
+{ return m_outputPeakDb.load(std::memory_order_relaxed); }
+float ClientReverb::wetRmsDb() const noexcept
+{ return m_wetRmsDb.load(std::memory_order_relaxed); }
+
+void ClientReverb::recacheIfDirty() noexcept
+{
+    const uint64_t v = m_atomics.version.load(std::memory_order_acquire);
+    if (v == m_lastVersion) return;
+    m_lastVersion = v;
+
+    const float size    = m_atomics.size.load(std::memory_order_relaxed);
+    const float decayS  = m_atomics.decayS.load(std::memory_order_relaxed);
+    const float damping = m_atomics.damping.load(std::memory_order_relaxed);
+    const float preMs   = m_atomics.preDelayMs.load(std::memory_order_relaxed);
+    const float mix     = m_atomics.mix.load(std::memory_order_relaxed);
+
+    // Size scales comb lengths between 50 % and 100 % of max.  Shorter
+    // combs → tighter room; longer → bigger space.
+    const float sizeScale = 0.5f + 0.5f * size;
+
+    // Per-comb: scale by size, convert delay time to seconds, then
+    // derive T60-style feedback coefficient.  6.91 ≈ ln(1000) so a
+    // sample at the far end of decayS seconds is attenuated by -60 dB.
+    for (int i = 0; i < kNumCombs; ++i) {
+        const int activeLen = std::max(1,
+            static_cast<int>(std::lround(m_maxCombLen[i] * sizeScale)));
+        m_cached.combLen[i] = std::min(activeLen, m_maxCombLen[i]);
+        const float delaySec =
+            static_cast<float>(m_cached.combLen[i]) /
+            static_cast<float>(m_sampleRate);
+        m_cached.combFeedback[i] =
+            std::exp(-6.91f * delaySec / std::max(0.05f, decayS));
+        // Cap well below 1 for numerical safety.
+        m_cached.combFeedback[i] = std::min(m_cached.combFeedback[i], 0.985f);
+    }
+    for (int i = 0; i < kNumAllpasses; ++i) {
+        // Allpass lengths don't depend on size (they're for diffusion,
+        // not tail length) — but they're still clamped to the
+        // pre-allocated max.
+        m_cached.allpassLen[i] = m_maxAllpassLen[i];
+    }
+
+    m_cached.damp1 = damping * 0.4f;      // freeverb's kScaleDamp
+    m_cached.damp2 = 1.0f - m_cached.damp1;
+    m_cached.mix   = mix;
+    m_cached.dryGain = 1.0f - 0.5f * mix;  // gentle equal-ish-power blend
+    m_cached.wetGain = mix;
+    m_cached.preDelaySamples = std::clamp(
+        static_cast<int>(std::lround(preMs * 0.001 * m_sampleRate)),
+        0, m_preDelayCap - 1);
+}
+
+namespace {
+
+// Process one sample through a single lowpass-feedback comb.  The LPF
+// is a one-pole smoother in the feedback path: damp1 + damp2 = 1.
+// Templated on the struct type so we don't need friend access.
+template <typename CombT>
+inline float processCombImpl(CombT& c, float in,
+                             float feedback, float damp1, float damp2,
+                             int activeLen)
+{
+    const float out = c.buffer[c.index];
+    c.lpfState = out * damp2 + c.lpfState * damp1;
+    c.buffer[c.index] = in + c.lpfState * feedback;
+    c.index = (c.index + 1) % activeLen;
+    return out;
+}
+
+// Process one sample through a Schroeder allpass.  Feedback fixed at 0.5.
+template <typename ApT>
+inline float processAllpassImpl(ApT& a, float in, int activeLen)
+{
+    const float bufOut = a.buffer[a.index];
+    const float out    = -in + bufOut;
+    a.buffer[a.index]  = in + bufOut * 0.5f;
+    a.index = (a.index + 1) % activeLen;
+    return out;
+}
+
+} // namespace
+
+void ClientReverb::process(float* interleaved, int frames, int channels) noexcept
+{
+    if (frames <= 0) return;
+    if (channels != 1 && channels != 2) return;
+
+    recacheIfDirty();
+    const bool enabled = m_atomics.enabled.load(std::memory_order_acquire);
+
+    float inPeakLin  = 0.0f;
+    float outPeakLin = 0.0f;
+    float wetSumSq   = 0.0f;
+
+    const float dryGain   = m_cached.dryGain;
+    const float wetGain   = m_cached.wetGain;
+    const float damp1     = m_cached.damp1;
+    const float damp2     = m_cached.damp2;
+    const int   preDelayN = m_cached.preDelaySamples;
+
+    for (int f = 0; f < frames; ++f) {
+        const float inL = interleaved[f * channels];
+        const float inR = (channels == 2) ? interleaved[f * channels + 1] : inL;
+
+        const float inAbs = std::max(std::fabs(inL), std::fabs(inR));
+        if (inAbs > inPeakLin) inPeakLin = inAbs;
+
+        if (!enabled) {
+            // Bypass path — leave sample untouched.
+            const float oAbs = std::max(std::fabs(inL), std::fabs(inR));
+            if (oAbs > outPeakLin) outPeakLin = oAbs;
+            continue;
+        }
+
+        // Pre-delay stage.  Write raw input to ring buffer; read the
+        // sample that entered preDelayN frames ago.
+        m_preDelay[m_preDelayWrite * 2]     = inL;
+        m_preDelay[m_preDelayWrite * 2 + 1] = inR;
+        int readIdx = m_preDelayWrite - preDelayN;
+        if (readIdx < 0) readIdx += m_preDelayCap;
+        const float delL = m_preDelay[readIdx * 2];
+        const float delR = m_preDelay[readIdx * 2 + 1];
+        m_preDelayWrite = (m_preDelayWrite + 1) % m_preDelayCap;
+
+        // Feed reverb with attenuated delayed signal.
+        const float inputL = delL * kFixedGain;
+        const float inputR = delR * kFixedGain;
+
+        // 8 parallel combs, summed per channel.
+        float wetL = 0.0f;
+        float wetR = 0.0f;
+        for (int i = 0; i < kNumCombs; ++i) {
+            wetL += processCombImpl(m_chL.combs[i], inputL,
+                                m_cached.combFeedback[i], damp1, damp2,
+                                m_cached.combLen[i]);
+            wetR += processCombImpl(m_chR.combs[i], inputR,
+                                m_cached.combFeedback[i], damp1, damp2,
+                                m_cached.combLen[i]);
+        }
+
+        // 4 series allpasses diffuse the comb sum.
+        for (int i = 0; i < kNumAllpasses; ++i) {
+            wetL = processAllpassImpl(m_chL.allpasses[i], wetL,
+                                  m_cached.allpassLen[i]);
+            wetR = processAllpassImpl(m_chR.allpasses[i], wetR,
+                                  m_cached.allpassLen[i]);
+        }
+
+        wetSumSq += wetL * wetL + wetR * wetR;
+
+        // Dry + wet blend.
+        const float outL = inL * dryGain + wetL * wetGain;
+        const float outR = inR * dryGain + wetR * wetGain;
+
+        interleaved[f * channels] = outL;
+        if (channels == 2) interleaved[f * channels + 1] = outR;
+
+        const float oAbs = std::max(std::fabs(outL), std::fabs(outR));
+        if (oAbs > outPeakLin) outPeakLin = oAbs;
+    }
+
+    m_inputPeakDb.store(linToDb(std::max(inPeakLin, 1e-6f)),
+                        std::memory_order_relaxed);
+    m_outputPeakDb.store(linToDb(std::max(outPeakLin, 1e-6f)),
+                         std::memory_order_relaxed);
+    const float wetRms = (enabled && frames > 0)
+        ? std::sqrt(wetSumSq / (2.0f * frames)) : 0.0f;
+    m_wetRmsDb.store(linToDb(std::max(wetRms, 1e-6f)),
+                     std::memory_order_relaxed);
+}
+
+} // namespace AetherSDR

--- a/src/core/ClientReverb.h
+++ b/src/core/ClientReverb.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+
+namespace AetherSDR {
+
+// Client-side reverb — TX DSP chain Phase 6 (Freeverb).  Eight parallel
+// lowpass-feedback comb filters in parallel summed through four series
+// allpass filters, stereo-spread by 23 samples between L and R.  A
+// pre-delay ring buffer sits in front of the reverb core.  Voice-
+// oriented knob set; no "studio" parameters.
+//
+// Thread model mirrors ClientTube / ClientGate / ClientDeEss: UI
+// thread writes atomics + bumps a version counter; the audio thread
+// reads the version once per block and recaches derived values.  No
+// locks, no allocations in process(), no exceptions.
+//
+// Buffer sizes are fixed in prepare() based on sample rate — max comb
+// length + stereo-spread headroom for Size=1, plus max pre-delay of
+// 100 ms.  Typical TX path runs at 24 kHz; total buffer budget per
+// ClientReverb instance is ~12 kB of float samples.
+class ClientReverb {
+public:
+    ClientReverb();
+    ~ClientReverb() = default;
+
+    ClientReverb(const ClientReverb&)            = delete;
+    ClientReverb& operator=(const ClientReverb&) = delete;
+
+    // Main thread — call before first process() and on sample-rate change.
+    void prepare(double sampleRate);
+
+    void  setEnabled(bool on) noexcept;
+    bool  isEnabled() const noexcept;
+
+    void  setSize(float s) noexcept;          float size() const noexcept;       // 0..1
+    void  setDecayS(float s) noexcept;        float decayS() const noexcept;     // 0.3..5
+    void  setDamping(float d) noexcept;       float damping() const noexcept;    // 0..1
+    void  setPreDelayMs(float ms) noexcept;   float preDelayMs() const noexcept; // 0..100
+    void  setMix(float m) noexcept;           float mix() const noexcept;        // 0..1
+
+    // Audio thread — process in place.  channels must be 1 or 2.
+    void process(float* interleaved, int frames, int channels) noexcept;
+    void reset() noexcept;
+
+    // UI-thread meter snapshots.
+    float inputPeakDb() const noexcept;
+    float outputPeakDb() const noexcept;
+    float wetRmsDb()   const noexcept;
+
+    double sampleRate() const noexcept { return m_sampleRate; }
+
+private:
+    struct Atomics {
+        std::atomic<bool>     enabled{false};
+        std::atomic<float>    size{0.5f};
+        std::atomic<float>    decayS{1.2f};
+        std::atomic<float>    damping{0.5f};
+        std::atomic<float>    preDelayMs{20.0f};
+        std::atomic<float>    mix{0.15f};
+        std::atomic<uint64_t> version{0};
+    };
+
+    struct Cached {
+        float combFeedback[8]{};   // per-comb feedback coefficient
+        int   combLen[8]{};        // active comb length (size-scaled)
+        int   allpassLen[4]{};     // active allpass length
+        float damp1{0.5f};         // damping filter coefficients
+        float damp2{0.5f};
+        float mix{0.15f};
+        int   preDelaySamples{0};
+        float dryGain{0.85f};
+        float wetGain{0.15f};
+    };
+
+    // A single lowpass-feedback comb filter.  Internal LPF state is a
+    // one-pole filter applied to the feedback path — what makes this
+    // "Freeverb" and not a plain Schroeder comb.
+    struct Comb {
+        std::vector<float> buffer;   // per-channel delay line
+        int                index{0};
+        float              lpfState{0.0f};
+    };
+
+    struct Allpass {
+        std::vector<float> buffer;
+        int                index{0};
+    };
+
+    void recacheIfDirty() noexcept;
+
+    // Reference comb + allpass lengths at 44.1 kHz (Jezar's original
+    // public-domain Freeverb tunings).  Scaled by sampleRate/44100 in
+    // prepare(), further scaled by Size in recacheIfDirty.
+    static constexpr int kNumCombs     = 8;
+    static constexpr int kNumAllpasses = 4;
+    static constexpr int kStereoSpread = 23;
+
+    struct Channel {
+        Comb    combs[kNumCombs];
+        Allpass allpasses[kNumAllpasses];
+    };
+
+    double   m_sampleRate{24000.0};
+    Atomics  m_atomics;
+    Cached   m_cached;
+
+    // Allocated once in prepare().
+    Channel  m_chL;
+    Channel  m_chR;
+
+    // Pre-delay: stereo-interleaved ring buffer sized for kMaxPreDelayMs.
+    static constexpr int kMaxPreDelayMs = 100;
+    std::vector<float> m_preDelay;       // frames × 2
+    int m_preDelayCap{0};                // capacity in frames
+    int m_preDelayWrite{0};
+
+    // Sample-rate-scaled maxima (set in prepare()).  The size-scaled
+    // active lengths in Cached can't exceed these.
+    int m_maxCombLen[kNumCombs]{};
+    int m_maxAllpassLen[kNumAllpasses]{};
+
+    uint64_t m_lastVersion{0};
+
+    // Meters (UI-thread readable).
+    std::atomic<float> m_inputPeakDb{-120.0f};
+    std::atomic<float> m_outputPeakDb{-120.0f};
+    std::atomic<float> m_wetRmsDb{-120.0f};
+};
+
+} // namespace AetherSDR

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -18,6 +18,7 @@
 #include "ClientDeEssApplet.h"
 #include "ClientTubeApplet.h"
 #include "ClientPuduApplet.h"
+#include "ClientReverbApplet.h"
 #include "ClientChainApplet.h"
 #include "CatControlApplet.h"
 #include "DaxApplet.h"
@@ -607,6 +608,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_clientDeEssApplet = new ClientDeEssApplet;
     m_clientTubeApplet  = new ClientTubeApplet;
     m_clientPuduApplet  = new ClientPuduApplet;
+    m_clientReverbApplet = new ClientReverbApplet;
     m_clientChainApplet = new ClientChainApplet;
 
     auto* txDsp = m_containerMgr->createContainer(
@@ -633,6 +635,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     makeChildContainer("cmp",   "COMPRESSOR",   m_clientCompApplet,   -1);
     makeChildContainer("tube",  "TUBE",  m_clientTubeApplet,   -1);
     makeChildContainer("pudu",  "PUDU",  m_clientPuduApplet,   -1);
+    makeChildContainer("reverb","REVERB",m_clientReverbApplet, -1);
 
     // One-shot settings migration (#1713 Phase 4b): carry over the
     // legacy Applet_CHAIN visibility to the new Applet_TXDSP key so
@@ -888,13 +891,14 @@ void AppletPanel::setTxDspChainOrder(
     // should have been hidden via stageEnabledChanged anyway).
     auto idFor = [](AudioEngine::TxChainStage s) -> QString {
         switch (s) {
-            case AudioEngine::TxChainStage::Gate:  return "gate";
-            case AudioEngine::TxChainStage::Eq:    return "ceq";
-            case AudioEngine::TxChainStage::DeEss: return "dess";
-            case AudioEngine::TxChainStage::Comp:  return "cmp";
-            case AudioEngine::TxChainStage::Tube:  return "tube";
-            case AudioEngine::TxChainStage::Enh:   return "pudu";
-            case AudioEngine::TxChainStage::None:  return {};
+            case AudioEngine::TxChainStage::Gate:   return "gate";
+            case AudioEngine::TxChainStage::Eq:     return "ceq";
+            case AudioEngine::TxChainStage::DeEss:  return "dess";
+            case AudioEngine::TxChainStage::Comp:   return "cmp";
+            case AudioEngine::TxChainStage::Tube:   return "tube";
+            case AudioEngine::TxChainStage::Enh:    return "pudu";
+            case AudioEngine::TxChainStage::Reverb: return "reverb";
+            case AudioEngine::TxChainStage::None:   return {};
         }
         return {};
     };

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -34,6 +34,7 @@ class ClientGateApplet;
 class ClientDeEssApplet;
 class ClientTubeApplet;
 class ClientPuduApplet;
+class ClientReverbApplet;
 class ClientChainApplet;
 class CatControlApplet;
 class DaxApplet;
@@ -72,6 +73,7 @@ public:
     ClientDeEssApplet* clientDeEssApplet() { return m_clientDeEssApplet; }
     ClientTubeApplet* clientTubeApplet() { return m_clientTubeApplet; }
     ClientPuduApplet* clientPuduApplet() { return m_clientPuduApplet; }
+    ClientReverbApplet* clientReverbApplet() { return m_clientReverbApplet; }
     ClientChainApplet* clientChainApplet() { return m_clientChainApplet; }
     CatControlApplet* catControlApplet() { return m_catControlApplet; }
     DaxApplet*      daxApplet()      { return m_daxApplet; }
@@ -163,6 +165,7 @@ private:
     ClientDeEssApplet* m_clientDeEssApplet{nullptr};
     ClientTubeApplet* m_clientTubeApplet{nullptr};
     ClientPuduApplet* m_clientPuduApplet{nullptr};
+    ClientReverbApplet* m_clientReverbApplet{nullptr};
     ClientChainApplet* m_clientChainApplet{nullptr};
     CatControlApplet* m_catControlApplet{nullptr};
     DaxApplet*     m_daxApplet{nullptr};

--- a/src/gui/ClientChainApplet.cpp
+++ b/src/gui/ClientChainApplet.cpp
@@ -5,6 +5,7 @@
 #include "core/ClientEq.h"
 #include "core/ClientGate.h"
 #include "core/ClientPudu.h"
+#include "core/ClientReverb.h"
 #include "core/ClientTube.h"
 
 #include <QButtonGroup>
@@ -387,6 +388,12 @@ void ClientChainApplet::onBypassToggled(bool checked)
                     m_audio->saveClientPuduSettings();
                 }
                 break;
+            case AudioEngine::TxChainStage::Reverb:
+                if (auto* d = m_audio->clientReverbTx()) {
+                    d->setEnabled(on);
+                    m_audio->saveClientReverbSettings();
+                }
+                break;
             case AudioEngine::TxChainStage::None:
                 break;
         }
@@ -407,6 +414,8 @@ void ClientChainApplet::onBypassToggled(bool checked)
                 return m_audio->clientTubeTx() && m_audio->clientTubeTx()->isEnabled();
             case AudioEngine::TxChainStage::Enh:
                 return m_audio->clientPuduTx() && m_audio->clientPuduTx()->isEnabled();
+            case AudioEngine::TxChainStage::Reverb:
+                return m_audio->clientReverbTx() && m_audio->clientReverbTx()->isEnabled();
             case AudioEngine::TxChainStage::None:
                 return false;
         }
@@ -420,6 +429,7 @@ void ClientChainApplet::onBypassToggled(bool checked)
         AudioEngine::TxChainStage::DeEss,
         AudioEngine::TxChainStage::Tube,
         AudioEngine::TxChainStage::Enh,
+        AudioEngine::TxChainStage::Reverb,
     };
 
     if (checked) {

--- a/src/gui/ClientChainWidget.cpp
+++ b/src/gui/ClientChainWidget.cpp
@@ -5,6 +5,7 @@
 #include "core/ClientDeEss.h"
 #include "core/ClientTube.h"
 #include "core/ClientPudu.h"
+#include "core/ClientReverb.h"
 
 #include <QAction>
 #include <QApplication>
@@ -83,13 +84,14 @@ const QColor kDropIndicator("#4db8d4");
 QString stageLabel(AudioEngine::TxChainStage s)
 {
     switch (s) {
-        case AudioEngine::TxChainStage::Gate:  return "GATE";
-        case AudioEngine::TxChainStage::Eq:    return "EQ";
-        case AudioEngine::TxChainStage::DeEss: return "DESS";
-        case AudioEngine::TxChainStage::Comp:  return "COMP";
-        case AudioEngine::TxChainStage::Tube:  return "TUBE";
-        case AudioEngine::TxChainStage::Enh:   return "PUDU";
-        case AudioEngine::TxChainStage::None:  return "";
+        case AudioEngine::TxChainStage::Gate:   return "GATE";
+        case AudioEngine::TxChainStage::Eq:     return "EQ";
+        case AudioEngine::TxChainStage::DeEss:  return "DESS";
+        case AudioEngine::TxChainStage::Comp:   return "COMP";
+        case AudioEngine::TxChainStage::Tube:   return "TUBE";
+        case AudioEngine::TxChainStage::Enh:    return "PUDU";
+        case AudioEngine::TxChainStage::Reverb: return "VERB";
+        case AudioEngine::TxChainStage::None:   return "";
     }
     return "";
 }
@@ -166,7 +168,8 @@ bool ClientChainWidget::isStageImplemented(AudioEngine::TxChainStage s) const
         || s == AudioEngine::TxChainStage::Gate
         || s == AudioEngine::TxChainStage::DeEss
         || s == AudioEngine::TxChainStage::Tube
-        || s == AudioEngine::TxChainStage::Enh;
+        || s == AudioEngine::TxChainStage::Enh
+        || s == AudioEngine::TxChainStage::Reverb;
 }
 
 bool ClientChainWidget::isStageBypassed(AudioEngine::TxChainStage s) const
@@ -185,6 +188,8 @@ bool ClientChainWidget::isStageBypassed(AudioEngine::TxChainStage s) const
             return !(m_audio->clientTubeTx() && m_audio->clientTubeTx()->isEnabled());
         case AudioEngine::TxChainStage::Enh:   // PUDU slot
             return !(m_audio->clientPuduTx() && m_audio->clientPuduTx()->isEnabled());
+        case AudioEngine::TxChainStage::Reverb:
+            return !(m_audio->clientReverbTx() && m_audio->clientReverbTx()->isEnabled());
         default:
             return true;
     }
@@ -653,6 +658,12 @@ void ClientChainWidget::toggleStageBypass(int boxIdx)
                 m_audio->saveClientPuduSettings();
             }
             break;
+        case AudioEngine::TxChainStage::Reverb:
+            if (m_audio->clientReverbTx()) {
+                m_audio->clientReverbTx()->setEnabled(newEnabled);
+                m_audio->saveClientReverbSettings();
+            }
+            break;
         default:
             return;
     }
@@ -708,6 +719,9 @@ void ClientChainWidget::contextMenuEvent(QContextMenuEvent* ev)
         } else if (stage == AudioEngine::TxChainStage::Enh && m_audio->clientPuduTx()) {
             m_audio->clientPuduTx()->setEnabled(newEnabled);
             m_audio->saveClientPuduSettings();
+        } else if (stage == AudioEngine::TxChainStage::Reverb && m_audio->clientReverbTx()) {
+            m_audio->clientReverbTx()->setEnabled(newEnabled);
+            m_audio->saveClientReverbSettings();
         }
         emit stageEnabledChanged(stage, newEnabled);
         update();

--- a/src/gui/ClientReverbApplet.cpp
+++ b/src/gui/ClientReverbApplet.cpp
@@ -1,0 +1,143 @@
+#include "ClientReverbApplet.h"
+#include "ClientCompKnob.h"
+#include "core/AudioEngine.h"
+#include "core/ClientReverb.h"
+
+#include <QHBoxLayout>
+#include <QSignalBlocker>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+ClientReverbApplet::ClientReverbApplet(QWidget* parent) : QWidget(parent)
+{
+    buildUI();
+    hide();
+}
+
+void ClientReverbApplet::buildUI()
+{
+    setStyleSheet("QWidget { background: transparent; }");
+
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(4, 4, 4, 4);
+    outer->setSpacing(4);
+
+    auto* row = new QHBoxLayout;
+    row->setSpacing(4);
+    row->addStretch();
+
+    auto makeKnob = [](const QString& label) {
+        auto* k = new ClientCompKnob;
+        k->setLabel(label);
+        k->setCenterLabelMode(true);
+        k->setFixedSize(38, 48);
+        return k;
+    };
+
+    m_size = makeKnob("Size");
+    m_size->setRange(0.0f, 1.0f);
+    m_size->setDefault(0.5f);
+    m_size->setValueFromNorm([](float n) { return n; });
+    m_size->setNormFromValue([](float v) { return v; });
+    m_size->setLabelFormat([](float v) {
+        return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+    });
+    row->addWidget(m_size);
+
+    m_decay = makeKnob("Decay");
+    m_decay->setRange(0.3f, 5.0f);
+    m_decay->setDefault(1.2f);
+    m_decay->setValueFromNorm([](float n) {
+        // Exponential 0.3 → 5.0 (~16.7x)
+        return 0.3f * std::pow(5.0f / 0.3f, n);
+    });
+    m_decay->setNormFromValue([](float v) {
+        if (v <= 0.3f) return 0.0f;
+        return std::log(v / 0.3f) / std::log(5.0f / 0.3f);
+    });
+    m_decay->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 2) + " s";
+    });
+    row->addWidget(m_decay);
+
+    m_damping = makeKnob("Damp");
+    m_damping->setRange(0.0f, 1.0f);
+    m_damping->setDefault(0.5f);
+    m_damping->setValueFromNorm([](float n) { return n; });
+    m_damping->setNormFromValue([](float v) { return v; });
+    m_damping->setLabelFormat([](float v) {
+        return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+    });
+    row->addWidget(m_damping);
+
+    m_preDly = makeKnob("Pre");
+    m_preDly->setRange(0.0f, 100.0f);
+    m_preDly->setDefault(20.0f);
+    m_preDly->setValueFromNorm([](float n) { return n * 100.0f; });
+    m_preDly->setNormFromValue([](float v) { return v / 100.0f; });
+    m_preDly->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 0) + " ms";
+    });
+    row->addWidget(m_preDly);
+
+    m_mix = makeKnob("Mix");
+    m_mix->setRange(0.0f, 1.0f);
+    m_mix->setDefault(0.15f);
+    m_mix->setValueFromNorm([](float n) { return n; });
+    m_mix->setNormFromValue([](float v) { return v; });
+    m_mix->setLabelFormat([](float v) {
+        return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+    });
+    row->addWidget(m_mix);
+
+    row->addStretch();
+    outer->addLayout(row);
+
+    auto wire = [this](ClientCompKnob* k, auto setter) {
+        connect(k, &ClientCompKnob::valueChanged, this, [this, setter](float v) {
+            if (!m_audio || !m_audio->clientReverbTx()) return;
+            (m_audio->clientReverbTx()->*setter)(v);
+            m_audio->saveClientReverbSettings();
+        });
+    };
+    wire(m_size,    &ClientReverb::setSize);
+    wire(m_decay,   &ClientReverb::setDecayS);
+    wire(m_damping, &ClientReverb::setDamping);
+    wire(m_preDly,  &ClientReverb::setPreDelayMs);
+    wire(m_mix,     &ClientReverb::setMix);
+
+    // 30 Hz sync with the floating editor.
+    m_syncTimer = new QTimer(this);
+    m_syncTimer->setInterval(33);
+    connect(m_syncTimer, &QTimer::timeout,
+            this, &ClientReverbApplet::syncKnobsFromEngine);
+}
+
+void ClientReverbApplet::setAudioEngine(AudioEngine* engine)
+{
+    m_audio = engine;
+    if (!m_audio) return;
+    syncKnobsFromEngine();
+    if (m_syncTimer) m_syncTimer->start();
+}
+
+void ClientReverbApplet::refreshEnableFromEngine()
+{
+    syncKnobsFromEngine();
+}
+
+void ClientReverbApplet::syncKnobsFromEngine()
+{
+    if (!m_audio || !m_audio->clientReverbTx()) return;
+    ClientReverb* r = m_audio->clientReverbTx();
+    if (m_size)    { QSignalBlocker b(m_size);    m_size->setValue(r->size()); }
+    if (m_decay)   { QSignalBlocker b(m_decay);   m_decay->setValue(r->decayS()); }
+    if (m_damping) { QSignalBlocker b(m_damping); m_damping->setValue(r->damping()); }
+    if (m_preDly)  { QSignalBlocker b(m_preDly);  m_preDly->setValue(r->preDelayMs()); }
+    if (m_mix)     { QSignalBlocker b(m_mix);     m_mix->setValue(r->mix()); }
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientReverbApplet.h
+++ b/src/gui/ClientReverbApplet.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QWidget>
+
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompKnob;
+
+// Docked tile for the client-side TX reverb (Freeverb).  Compact
+// 5-knob row — Size, Decay, Damping, PreDly, Mix — matches the PUDU
+// applet footprint.  Enable/Edit live on the CHAIN widget gestures
+// (single-click / double-click).  Interactive editor is
+// ClientReverbEditor.
+class ClientReverbApplet : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientReverbApplet(QWidget* parent = nullptr);
+
+    void setAudioEngine(AudioEngine* engine);
+    void refreshEnableFromEngine();
+
+signals:
+    void editRequested();
+
+private:
+    void buildUI();
+    void syncKnobsFromEngine();
+
+    AudioEngine*    m_audio{nullptr};
+    ClientCompKnob* m_size{nullptr};
+    ClientCompKnob* m_decay{nullptr};
+    ClientCompKnob* m_damping{nullptr};
+    ClientCompKnob* m_preDly{nullptr};
+    ClientCompKnob* m_mix{nullptr};
+    QTimer*         m_syncTimer{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientReverbEditor.cpp
+++ b/src/gui/ClientReverbEditor.cpp
@@ -1,0 +1,205 @@
+#include "ClientReverbEditor.h"
+#include "ClientCompKnob.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ClientReverb.h"
+
+#include <QCloseEvent>
+#include <QHBoxLayout>
+#include <QHideEvent>
+#include <QMoveEvent>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr const char* kWindowStyle =
+    "QWidget { background: #08121d; color: #d7e7f2; }"
+    "QLabel  { background: transparent; color: #8aa8c0; font-size: 11px; }";
+
+} // namespace
+
+ClientReverbEditor::ClientReverbEditor(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent, Qt::Window)
+    , m_audio(engine)
+{
+    setWindowTitle(QString::fromUtf8("Client Reverb"));
+    setStyleSheet(kWindowStyle);
+    resize(480, 180);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(16, 14, 16, 14);
+    root->setSpacing(8);
+
+    auto* row = new QHBoxLayout;
+    row->setSpacing(12);
+    row->addStretch();
+
+    auto makeKnob = [](const QString& label) {
+        auto* k = new ClientCompKnob;
+        k->setLabel(label);
+        k->setCenterLabelMode(true);
+        k->setFixedSize(76, 76);
+        return k;
+    };
+
+    m_size = makeKnob("Size");
+    m_size->setRange(0.0f, 1.0f);
+    m_size->setDefault(0.5f);
+    m_size->setValueFromNorm([](float n) { return n; });
+    m_size->setNormFromValue([](float v) { return v; });
+    m_size->setLabelFormat([](float v) {
+        return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+    });
+    row->addWidget(m_size);
+
+    m_decay = makeKnob("Decay");
+    m_decay->setRange(0.3f, 5.0f);
+    m_decay->setDefault(1.2f);
+    m_decay->setValueFromNorm([](float n) {
+        return 0.3f * std::pow(5.0f / 0.3f, n);
+    });
+    m_decay->setNormFromValue([](float v) {
+        if (v <= 0.3f) return 0.0f;
+        return std::log(v / 0.3f) / std::log(5.0f / 0.3f);
+    });
+    m_decay->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 2) + " s";
+    });
+    row->addWidget(m_decay);
+
+    m_damping = makeKnob("Damp");
+    m_damping->setRange(0.0f, 1.0f);
+    m_damping->setDefault(0.5f);
+    m_damping->setValueFromNorm([](float n) { return n; });
+    m_damping->setNormFromValue([](float v) { return v; });
+    m_damping->setLabelFormat([](float v) {
+        return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+    });
+    row->addWidget(m_damping);
+
+    m_preDly = makeKnob("PreDly");
+    m_preDly->setRange(0.0f, 100.0f);
+    m_preDly->setDefault(20.0f);
+    m_preDly->setValueFromNorm([](float n) { return n * 100.0f; });
+    m_preDly->setNormFromValue([](float v) { return v / 100.0f; });
+    m_preDly->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 0) + " ms";
+    });
+    row->addWidget(m_preDly);
+
+    m_mix = makeKnob("Mix");
+    m_mix->setRange(0.0f, 1.0f);
+    m_mix->setDefault(0.15f);
+    m_mix->setValueFromNorm([](float n) { return n; });
+    m_mix->setNormFromValue([](float v) { return v; });
+    m_mix->setLabelFormat([](float v) {
+        return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+    });
+    row->addWidget(m_mix);
+
+    row->addStretch();
+    root->addLayout(row);
+
+    auto wire = [this](ClientCompKnob* k, auto setter) {
+        connect(k, &ClientCompKnob::valueChanged, this, [this, setter](float v) {
+            if (!m_audio || !m_audio->clientReverbTx()) return;
+            (m_audio->clientReverbTx()->*setter)(v);
+            m_audio->saveClientReverbSettings();
+        });
+    };
+    wire(m_size,    &ClientReverb::setSize);
+    wire(m_decay,   &ClientReverb::setDecayS);
+    wire(m_damping, &ClientReverb::setDamping);
+    wire(m_preDly,  &ClientReverb::setPreDelayMs);
+    wire(m_mix,     &ClientReverb::setMix);
+
+    syncControlsFromEngine();
+
+    m_syncTimer = new QTimer(this);
+    m_syncTimer->setInterval(33);
+    connect(m_syncTimer, &QTimer::timeout,
+            this, &ClientReverbEditor::syncControlsFromEngine);
+}
+
+ClientReverbEditor::~ClientReverbEditor() = default;
+
+void ClientReverbEditor::showForTx()
+{
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+    if (m_syncTimer) m_syncTimer->start();
+}
+
+void ClientReverbEditor::syncControlsFromEngine()
+{
+    if (!m_audio || !m_audio->clientReverbTx()) return;
+    ClientReverb* r = m_audio->clientReverbTx();
+    m_restoring = true;
+    if (m_size)    { QSignalBlocker b(m_size);    m_size->setValue(r->size()); }
+    if (m_decay)   { QSignalBlocker b(m_decay);   m_decay->setValue(r->decayS()); }
+    if (m_damping) { QSignalBlocker b(m_damping); m_damping->setValue(r->damping()); }
+    if (m_preDly)  { QSignalBlocker b(m_preDly);  m_preDly->setValue(r->preDelayMs()); }
+    if (m_mix)     { QSignalBlocker b(m_mix);     m_mix->setValue(r->mix()); }
+    m_restoring = false;
+}
+
+void ClientReverbEditor::saveGeometryToSettings()
+{
+    auto& s = AppSettings::instance();
+    s.setValue("ClientReverbEditorGeometry", saveGeometry().toBase64());
+}
+
+void ClientReverbEditor::restoreGeometryFromSettings()
+{
+    auto& s = AppSettings::instance();
+    const QByteArray geom = QByteArray::fromBase64(
+        s.value("ClientReverbEditorGeometry", "").toByteArray());
+    if (!geom.isEmpty()) {
+        m_restoring = true;
+        restoreGeometry(geom);
+        m_restoring = false;
+    }
+}
+
+void ClientReverbEditor::closeEvent(QCloseEvent* ev)
+{
+    if (m_syncTimer) m_syncTimer->stop();
+    saveGeometryToSettings();
+    QWidget::closeEvent(ev);
+}
+
+void ClientReverbEditor::moveEvent(QMoveEvent* ev)
+{
+    QWidget::moveEvent(ev);
+    if (!m_restoring) saveGeometryToSettings();
+}
+
+void ClientReverbEditor::resizeEvent(QResizeEvent* ev)
+{
+    QWidget::resizeEvent(ev);
+    if (!m_restoring) saveGeometryToSettings();
+}
+
+void ClientReverbEditor::showEvent(QShowEvent* ev)
+{
+    QWidget::showEvent(ev);
+    if (m_syncTimer) m_syncTimer->start();
+}
+
+void ClientReverbEditor::hideEvent(QHideEvent* ev)
+{
+    QWidget::hideEvent(ev);
+    if (m_syncTimer) m_syncTimer->stop();
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientReverbEditor.h
+++ b/src/gui/ClientReverbEditor.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QWidget>
+
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompKnob;
+
+// Floating editor for the client-side TX reverb.  Five 76×76 knobs in
+// a single row — Size, Decay, Damping, Pre-delay, Mix.  No preset
+// picker (small room / hall / plate are a future iteration).
+// Geometry persists via AppSettings (`ClientReverbEditorGeometry`).
+class ClientReverbEditor : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientReverbEditor(AudioEngine* engine, QWidget* parent = nullptr);
+    ~ClientReverbEditor() override;
+
+    void showForTx();
+
+signals:
+    // Present for API symmetry with the other editors; unused now that
+    // bypass lives on the CHAIN widget.
+    void bypassToggled(bool bypassed);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+    void syncControlsFromEngine();
+
+    AudioEngine*    m_audio{nullptr};
+    ClientCompKnob* m_size{nullptr};
+    ClientCompKnob* m_decay{nullptr};
+    ClientCompKnob* m_damping{nullptr};
+    ClientCompKnob* m_preDly{nullptr};
+    ClientCompKnob* m_mix{nullptr};
+    QTimer*         m_syncTimer{nullptr};
+    bool            m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -36,6 +36,8 @@
 #include "ClientTubeEditor.h"
 #include "ClientPuduApplet.h"
 #include "ClientPuduEditor.h"
+#include "ClientReverbApplet.h"
+#include "ClientReverbEditor.h"
 #include "ClientChainApplet.h"
 #include "core/ClientComp.h"
 #include "core/ClientEq.h"
@@ -43,6 +45,7 @@
 #include "core/ClientDeEss.h"
 #include "core/ClientTube.h"
 #include "core/ClientPudu.h"
+#include "core/ClientReverb.h"
 #include "CatControlApplet.h"
 #include "DaxApplet.h"
 #include "TciApplet.h"
@@ -2154,6 +2157,9 @@ MainWindow::MainWindow(QWidget* parent)
         m_clientTubeEditor->showForTx();
     });
 
+    // ── Client Reverb applet: TX reverb (Freeverb) ─
+    m_appletPanel->clientReverbApplet()->setAudioEngine(m_audio);
+
     // ── Client PUDU applet: TX exciter — PooDoo™ centrepiece (#1661 Phase 5) ─
     m_appletPanel->clientPuduApplet()->setAudioEngine(m_audio);
     connect(m_appletPanel->clientPuduApplet(), &ClientPuduApplet::editRequested,
@@ -2285,6 +2291,10 @@ MainWindow::MainWindow(QWidget* parent)
         m_appletPanel->setAppletVisible(
             "PUDU", m_audio->clientPuduTx()->isEnabled());
     }
+    if (m_audio && m_audio->clientReverbTx()) {
+        m_appletPanel->setAppletVisible(
+            "REVERB", m_audio->clientReverbTx()->isEnabled());
+    }
 
     // Initial applet-stack order mirrors the persisted chain order, and
     // stays in sync on every subsequent drag-reorder.
@@ -2326,6 +2336,10 @@ MainWindow::MainWindow(QWidget* parent)
             m_appletPanel->setAppletVisible("PUDU", enabled);
             if (m_appletPanel->clientPuduApplet())
                 m_appletPanel->clientPuduApplet()->refreshEnableFromEngine();
+        } else if (stage == AudioEngine::TxChainStage::Reverb) {
+            m_appletPanel->setAppletVisible("REVERB", enabled);
+            if (m_appletPanel->clientReverbApplet())
+                m_appletPanel->clientReverbApplet()->refreshEnableFromEngine();
         }
     });
     connect(m_appletPanel->clientChainApplet(),
@@ -2425,6 +2439,21 @@ MainWindow::MainWindow(QWidget* parent)
                     });
                 }
                 m_clientPuduEditor->showForTx();
+                break;
+            case AudioEngine::TxChainStage::Reverb:
+                if (!m_clientReverbEditor) {
+                    m_clientReverbEditor = new ClientReverbEditor(m_audio, this);
+                    connect(m_clientReverbEditor, &ClientReverbEditor::bypassToggled,
+                            this, [this](bool bypassed) {
+                        if (m_appletPanel && m_appletPanel->clientReverbApplet())
+                            m_appletPanel->clientReverbApplet()->refreshEnableFromEngine();
+                        if (m_appletPanel && m_appletPanel->clientChainApplet())
+                            m_appletPanel->clientChainApplet()->refreshFromEngine();
+                        if (m_appletPanel)
+                            m_appletPanel->setAppletVisible("REVERB", !bypassed);
+                    });
+                }
+                m_clientReverbEditor->showForTx();
                 break;
             default:
                 break;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -312,6 +312,7 @@ private:
     class ClientDeEssEditor* m_clientDeEssEditor{nullptr}; // lazy — created on first Edit… click
     class ClientTubeEditor* m_clientTubeEditor{nullptr}; // lazy — created on first Edit… click
     class ClientPuduEditor* m_clientPuduEditor{nullptr}; // lazy — created on first Edit… click
+    class ClientReverbEditor* m_clientReverbEditor{nullptr}; // lazy — created on first Edit… click
 
     // Applet-panel pop-out support (#1713 Phase 6).  When floating,
     // the panel lives inside m_appletPanelFloatWindow and its splitter

--- a/tests/client_reverb_test.cpp
+++ b/tests/client_reverb_test.cpp
@@ -1,0 +1,252 @@
+// Standalone test harness for ClientReverb DSP (Freeverb).
+// Build: CMake target `client_reverb_test`.  Exit 0 = pass.
+
+#include "core/ClientReverb.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using AetherSDR::ClientReverb;
+
+namespace {
+
+constexpr double kSampleRate = 24000.0;
+constexpr int    kBlockSize  = 128;
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-54s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+std::vector<float> makeImpulse(int frames, float amplitude = 0.9f)
+{
+    std::vector<float> buf(frames * 2, 0.0f);
+    buf[0] = amplitude;
+    buf[1] = amplitude;
+    return buf;
+}
+
+std::vector<float> makeTone(double freq, int frames, float amplitude)
+{
+    std::vector<float> buf(frames * 2);
+    const double twoPi = 6.283185307179586476;
+    for (int i = 0; i < frames; ++i) {
+        const float s = amplitude * static_cast<float>(
+            std::sin(twoPi * freq * i / kSampleRate));
+        buf[i * 2]     = s;
+        buf[i * 2 + 1] = s;
+    }
+    return buf;
+}
+
+float l2NormStereo(const float* data, int frames)
+{
+    double sumSq = 0.0;
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) sumSq += data[i] * data[i];
+    return static_cast<float>(std::sqrt(sumSq));
+}
+
+float peakAbsStereo(const float* data, int frames)
+{
+    float peak = 0.0f;
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) {
+        peak = std::max(peak, std::fabs(data[i]));
+    }
+    return peak;
+}
+
+void processBlocks(ClientReverb& r, float* buf, int frames)
+{
+    int remaining = frames;
+    float* p = buf;
+    while (remaining > 0) {
+        const int n = std::min(kBlockSize, remaining);
+        r.process(p, n, 2);
+        p += n * 2;
+        remaining -= n;
+    }
+}
+
+bool anyNaNorInf(const float* data, int frames)
+{
+    const int samples = frames * 2;
+    for (int i = 0; i < samples; ++i) {
+        if (!std::isfinite(data[i])) return true;
+    }
+    return false;
+}
+
+} // namespace
+
+int main()
+{
+    // ── Test 1: default construction ──────────────────────────────────
+    {
+        ClientReverb r;
+        r.prepare(kSampleRate);
+        report("constructor starts disabled", !r.isEnabled());
+    }
+
+    // ── Test 2: enable toggle ─────────────────────────────────────────
+    {
+        ClientReverb r;
+        r.prepare(kSampleRate);
+        r.setEnabled(true);
+        const bool gotOn = r.isEnabled();
+        r.setEnabled(false);
+        const bool gotOff = !r.isEnabled();
+        report("enable toggle", gotOn && gotOff);
+    }
+
+    // ── Test 3: impulse response produces non-trivial tail ────────────
+    {
+        ClientReverb r;
+        r.prepare(kSampleRate);
+        r.setEnabled(true);
+        r.setMix(1.0f);                // fully wet
+        r.setDecayS(2.0f);
+        r.setPreDelayMs(0.0f);
+        // Longer buffer so the tail has room to manifest.
+        const int totalFrames = static_cast<int>(kSampleRate * 1.0);
+        std::vector<float> buf = makeImpulse(totalFrames, 0.9f);
+        processBlocks(r, buf.data(), totalFrames);
+        // Tail region: skip the first 10 ms (direct + initial echoes)
+        // and measure L2 norm of the next ~100 ms.
+        const int tailStart = static_cast<int>(kSampleRate * 0.01);
+        const int tailLen   = static_cast<int>(kSampleRate * 0.10);
+        const float tailEnergy = l2NormStereo(
+            buf.data() + tailStart * 2, tailLen);
+        report("impulse → non-zero tail", tailEnergy > 1e-4f,
+               "energy=" + std::to_string(tailEnergy));
+        report("impulse → finite output",
+               !anyNaNorInf(buf.data(), totalFrames));
+    }
+
+    // ── Test 4: tail energy decays over time ──────────────────────────
+    {
+        ClientReverb r;
+        r.prepare(kSampleRate);
+        r.setEnabled(true);
+        r.setMix(1.0f);
+        r.setDecayS(1.5f);
+        r.setPreDelayMs(0.0f);
+        const int totalFrames = static_cast<int>(kSampleRate * 2.0);
+        std::vector<float> buf = makeImpulse(totalFrames, 0.9f);
+        processBlocks(r, buf.data(), totalFrames);
+        const int halfLen = totalFrames / 2;
+        const float firstHalf = l2NormStereo(buf.data(), halfLen);
+        const float lastHalf  = l2NormStereo(buf.data() + halfLen * 2,
+                                             totalFrames - halfLen);
+        report("tail energy decays", firstHalf > lastHalf * 1.5f,
+               "first=" + std::to_string(firstHalf) +
+               " last=" + std::to_string(lastHalf));
+    }
+
+    // ── Test 5: mix=0 → essentially dry passthrough ───────────────────
+    // With mix=0 the wet path is silenced and dryGain becomes 1.0
+    // (see recacheIfDirty: dryGain = 1 - 0.5 * mix → 1.0 at mix=0).
+    {
+        ClientReverb r;
+        r.prepare(kSampleRate);
+        r.setEnabled(true);
+        r.setMix(0.0f);
+        r.setPreDelayMs(0.0f);
+        const int frames = 2048;
+        std::vector<float> ref  = makeTone(440.0, frames, 0.3f);
+        std::vector<float> work = ref;
+        processBlocks(r, work.data(), frames);
+        double diffSumSq = 0.0;
+        for (int i = 0; i < frames * 2; ++i) {
+            const float d = work[i] - ref[i];
+            diffSumSq += d * d;
+        }
+        const float rms = static_cast<float>(
+            std::sqrt(diffSumSq / (frames * 2)));
+        report("mix=0 → dry passthrough", rms < 1e-4f,
+               "rms diff=" + std::to_string(rms));
+    }
+
+    // ── Test 6: mix=1 reduces dry level meaningfully ──────────────────
+    // Freeverb's fixed gain (0.015) attenuates the wet path, so a pure
+    // tone at mix=1 should be noticeably quieter than the dry input.
+    {
+        ClientReverb r;
+        r.prepare(kSampleRate);
+        r.setEnabled(true);
+        r.setMix(1.0f);
+        r.setPreDelayMs(0.0f);
+        const int frames = 4096;
+        std::vector<float> buf = makeTone(440.0, frames, 0.5f);
+        const float dryPeak = peakAbsStereo(buf.data(), frames);
+        processBlocks(r, buf.data(), frames);
+        const float wetPeak = peakAbsStereo(buf.data(), frames);
+        // dryGain = 1 - 0.5*1 = 0.5 → a pure-tone mix-1 output should
+        // sit well below the original dry peak.
+        report("mix=1 attenuates direct signal",
+               wetPeak < dryPeak * 0.9f,
+               "dry=" + std::to_string(dryPeak) +
+               " wet=" + std::to_string(wetPeak));
+    }
+
+    // ── Test 7: pre-delay shifts the wet tail start ───────────────────
+    // With an impulse at t=0 and pre-delay=50 ms, the first 40 ms
+    // of output (dry=0 after impulse frame) should be silent apart
+    // from the impulse itself.
+    {
+        ClientReverb r;
+        r.prepare(kSampleRate);
+        r.setEnabled(true);
+        r.setMix(1.0f);
+        r.setPreDelayMs(50.0f);
+        r.setDecayS(2.0f);
+        const int totalFrames = static_cast<int>(kSampleRate * 0.3);
+        std::vector<float> buf = makeImpulse(totalFrames, 0.9f);
+        processBlocks(r, buf.data(), totalFrames);
+        // Measure energy BEFORE the pre-delay period kicks in.  Skip
+        // the first 2 frames (the impulse itself × dryGain may leak
+        // through).
+        const int preGapEnd  = static_cast<int>(kSampleRate * 0.04);
+        const float preEnergy = l2NormStereo(buf.data() + 4,
+                                             preGapEnd - 2);
+        const int postStart   = static_cast<int>(kSampleRate * 0.06);
+        const int postLen     = static_cast<int>(kSampleRate * 0.10);
+        const float postEnergy = l2NormStereo(
+            buf.data() + postStart * 2, postLen);
+        report("pre-delay holds back the wet tail",
+               postEnergy > preEnergy * 3.0f,
+               "pre=" + std::to_string(preEnergy) +
+               " post=" + std::to_string(postEnergy));
+    }
+
+    // ── Test 8: mono input works (channels=1) ─────────────────────────
+    {
+        ClientReverb r;
+        r.prepare(kSampleRate);
+        r.setEnabled(true);
+        r.setMix(1.0f);
+        const int frames = 2048;
+        std::vector<float> buf(frames, 0.0f);
+        buf[0] = 0.9f;   // impulse
+        r.process(buf.data(), frames, 1);
+        report("mono process does not crash / corrupt",
+               !anyNaNorInf(buf.data(), frames / 2));
+    }
+
+    if (g_failed == 0) {
+        std::printf("\nAll tests passed.\n");
+        return 0;
+    }
+    std::printf("\n%d test(s) failed.\n", g_failed);
+    return 1;
+}


### PR DESCRIPTION
New ClientReverb DSP (Freeverb — 8 LBCF combs + 4 allpasses per
channel, stereo-spread 23 samples, pre-delay ring buffer).  Ships
disabled by default — users opt in by clicking [VERB] in CHAIN.

- Chain stage: TxChainStage::Reverb = 7, appended to default chain.
  Chain label "VERB"; single-click / double-click / drag gestures
  match the other stages; applet tile follows chain order.
- Applet tile: 5 knobs at 38×48 (Size · Decay · Damp · Pre · Mix).
- Floating editor: 5 knobs at 76×76, bypass lives on the CHAIN.
- 30 Hz sync between applet and editor knobs.
- Settings persisted as ClientReverbTx* in AppSettings.
- client_reverb_test: 9 cases covering impulse tail, decay, mix,
  pre-delay, mono processing, finite output.

Defaults: Size 50 %, Decay 1.20 s, Damping 50 %, Pre-delay 20 ms,
Mix 15 %.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
