### PR TITLE
PUDU Monitor: dedicated QAudioSink pull-mode playback

### DIFF
--- a/src/core/ClientPuduMonitor.cpp
+++ b/src/core/ClientPuduMonitor.cpp
@@ -1,24 +1,21 @@
 #include "ClientPuduMonitor.h"
+#include "Resampler.h"
 
+#include <QAudioDevice>
+#include <QAudioFormat>
+#include <QAudioSink>
 #include <QDir>
 #include <QFile>
 #include <QIODevice>
+#include <QMediaDevices>
 
 #include <algorithm>
 #include <cstring>
+#include <vector>
 
 namespace AetherSDR {
 
 namespace {
-
-// 10 ms playback cadence — 240 frames × 2 ch × 2 B = 960 B per chunk.
-// Match QsoRecorder exactly: longer intervals starve the audio sink
-// when Qt's timer scheduler coarsens (typical real intervals of
-// 16-33 ms under light load), producing dropouts / garbled output.
-constexpr int kPlaybackIntervalMs = 10;
-constexpr int kPlaybackChunkBytes =
-    kPlaybackIntervalMs * ClientPuduMonitor::kSampleRate / 1000
-    * ClientPuduMonitor::kBytesPerFrame;
 
 // Standard 44-byte RIFF/WAVE header for int16 stereo 24 kHz PCM.
 QByteArray makeWavHeader(quint32 payloadBytes)
@@ -61,12 +58,6 @@ ClientPuduMonitor::ClientPuduMonitor(QObject* parent) : QObject(parent)
     // QByteArray grows on demand; fill with zeros to force the
     // allocation now rather than on first write.
     m_buffer.fill('\0', kMaxBytes);
-
-    m_playTimer = new QTimer(this);
-    m_playTimer->setInterval(kPlaybackIntervalMs);
-    m_playTimer->setTimerType(Qt::PreciseTimer);
-    connect(m_playTimer, &QTimer::timeout,
-            this, &ClientPuduMonitor::onPlaybackTick);
 }
 
 int ClientPuduMonitor::recordedMs() const noexcept
@@ -129,19 +120,123 @@ void ClientPuduMonitor::onAutoStop()
     emit recordingStopped(m_recordedMs);
 }
 
+bool ClientPuduMonitor::preparePlaybackPcm(int sinkRateHz)
+{
+    // Source payload — int16 stereo 24 kHz, exactly what we captured.
+    const char* src = m_buffer.constData();
+    const int srcBytes = m_recordedBytes;
+    if (srcBytes <= 0) return false;
+
+    if (sinkRateHz == kSampleRate) {
+        // Passthrough — sink opens at 24 kHz so int16 bytes transfer
+        // 1:1.  Most PipeWire / ALSA sinks take this on Linux.
+        m_playPcm = QByteArray(src, srcBytes);
+        return true;
+    }
+
+    // Sink wants a different rate — resample via r8brain.  Run L and
+    // R channels independently so the stereo image is preserved
+    // (Resampler::processStereoToStereo down-mixes to mono first,
+    // which would collapse PUDU's Behringer-mode all-pass rotator).
+    const int srcFrames = srcBytes / kBytesPerFrame;
+    if (srcFrames <= 0) return false;
+
+    std::vector<float> lIn(srcFrames);
+    std::vector<float> rIn(srcFrames);
+    const auto* s16 = reinterpret_cast<const int16_t*>(src);
+    for (int i = 0; i < srcFrames; ++i) {
+        lIn[i] = s16[i * 2]     / 32768.0f;
+        rIn[i] = s16[i * 2 + 1] / 32768.0f;
+    }
+
+    // maxBlockSamples must be >= the block size we pass.  +slack so
+    // r8brain's internal pipelining never truncates.
+    const int blockCap = srcFrames + 16;
+    Resampler lResampler(kSampleRate, sinkRateHz, blockCap);
+    Resampler rResampler(kSampleRate, sinkRateHz, blockCap);
+    const QByteArray lOut = lResampler.process(lIn.data(), srcFrames);
+    const QByteArray rOut = rResampler.process(rIn.data(), srcFrames);
+
+    const int lOutFrames = lOut.size() / static_cast<int>(sizeof(float));
+    const int rOutFrames = rOut.size() / static_cast<int>(sizeof(float));
+    const int outFrames  = std::min(lOutFrames, rOutFrames);
+    if (outFrames <= 0) return false;
+
+    m_playPcm.resize(outFrames * kBytesPerFrame);
+    auto* dst = reinterpret_cast<int16_t*>(m_playPcm.data());
+    const auto* lf = reinterpret_cast<const float*>(lOut.constData());
+    const auto* rf = reinterpret_cast<const float*>(rOut.constData());
+    for (int i = 0; i < outFrames; ++i) {
+        dst[i * 2]     = static_cast<int16_t>(
+            std::clamp(lf[i] * 32768.0f, -32768.0f, 32767.0f));
+        dst[i * 2 + 1] = static_cast<int16_t>(
+            std::clamp(rf[i] * 32768.0f, -32768.0f, 32767.0f));
+    }
+    return true;
+}
+
 void ClientPuduMonitor::startPlayback()
 {
     if (m_playing) return;
     if (m_recordedBytes <= 0) return;
-    m_playPos = 0;
+
+    // ── Pick an output device + format ─────────────────────────────
+    // int16 stereo at the sink's native rate.  Try 24 kHz first (zero-
+    // resample fast path — typical on Linux); fall back to 48 kHz
+    // (typical on macOS and Windows) with a one-shot r8brain upsample
+    // of the whole captured buffer up-front.
+    QAudioDevice dev = QMediaDevices::defaultAudioOutput();
+    if (dev.isNull()) return;
+
+    QAudioFormat fmt;
+    fmt.setChannelCount(kChannels);
+    fmt.setSampleFormat(QAudioFormat::Int16);
+    fmt.setSampleRate(kSampleRate);
+    int sinkRate = kSampleRate;
+
+    if (!dev.isFormatSupported(fmt)) {
+        fmt.setSampleRate(48000);
+        sinkRate = 48000;
+        if (!dev.isFormatSupported(fmt)) {
+            // Neither 24 kHz nor 48 kHz int16 — extremely rare.  Give up
+            // quietly; playback was best-effort anyway.
+            return;
+        }
+    }
+
+    if (!preparePlaybackPcm(sinkRate)) return;
+
+    // ── QBuffer → QAudioSink (pull mode) ───────────────────────────
+    // Sink pulls from QBuffer at its own cadence.  No timer, no
+    // feedDecodedSpeech, no RX-buffer routing — the sink's internal
+    // ring buffer absorbs scheduler jitter so the audio comes out
+    // cleanly on every platform.  When QBuffer hits end-of-data the
+    // sink transitions to IdleState and we stop cleanly.
+    m_playBuffer.close();
+    m_playBuffer.setBuffer(&m_playPcm);
+    if (!m_playBuffer.open(QIODevice::ReadOnly)) return;
+
+    m_playSink = new QAudioSink(dev, fmt, this);
+    // Ask for a generous 300 ms internal ring buffer before start().
+    // Qt's defaults are ~40-80 ms which is fine on Linux/macOS but
+    // chops on Windows when the main event loop hiccups (painting,
+    // UI events, GC) — WASAPI shared-mode pulls on a tight 10 ms
+    // schedule and if we miss a refill the device inserts silence.
+    // 300 ms gives ~30 pulls of margin.  Backend may clamp to the
+    // device's period granularity; not an error if the effective
+    // size is slightly smaller.
+    m_playSink->setBufferSize(fmt.bytesForDuration(300'000));
+    connect(m_playSink, &QAudioSink::stateChanged,
+            this, &ClientPuduMonitor::onPlaybackSinkState);
+    m_playSink->start(&m_playBuffer);
+
     m_playing = true;
-    m_playTimer->start();
     // When playback is triggered as part of auto-play after a
-    // record (the record → stop → play transition), muteRxRequested
-    // was already fired at record start and the mute is still held,
-    // so this is a no-op.  When the user triggers playback manually
-    // from idle, this is the one that installs the mute.  Either
-    // way it's safe — MainWindow's handler is idempotent.
+    // record, muteRxRequested was already fired at record start and
+    // the mute is still held, so this is a no-op.  When the user
+    // triggers playback manually from idle, this is the one that
+    // installs the mute.  Either way it's safe — MainWindow's
+    // handler is idempotent.
     emit muteRxRequested(true);
     emit playbackStarted();
 }
@@ -150,40 +245,26 @@ void ClientPuduMonitor::stopPlayback()
 {
     if (!m_playing) return;
     m_playing = false;
-    m_playTimer->stop();
+
+    if (m_playSink) {
+        m_playSink->stop();
+        m_playSink->disconnect(this);
+        m_playSink->deleteLater();
+        m_playSink = nullptr;
+    }
+    if (m_playBuffer.isOpen()) m_playBuffer.close();
+
     // End of the record+playback cycle — restore live RX audio.
     emit muteRxRequested(false);
     emit playbackStopped();
 }
 
-void ClientPuduMonitor::onPlaybackTick()
+void ClientPuduMonitor::onPlaybackSinkState(QAudio::State state)
 {
-    if (!m_playing) return;
-    const int remaining = m_recordedBytes - m_playPos;
-    if (remaining <= 0) {
-        stopPlayback();
-        return;
-    }
-    const int take = std::min(remaining, kPlaybackChunkBytes);
-
-    // AudioEngine::feedDecodedSpeech() expects float32 interleaved
-    // stereo — not int16 (the sink is configured for float samples).
-    // QsoRecorder::onPlaybackTick does the same conversion.  Emitting
-    // raw int16 bytes would get reinterpreted as float32 by the sink
-    // and blow out speakers with garbage values.
-    const auto* src = reinterpret_cast<const int16_t*>(
-        m_buffer.constData() + m_playPos);
-    const int numSamples = take / static_cast<int>(sizeof(int16_t));
-    QByteArray floatPcm(numSamples * static_cast<int>(sizeof(float)),
-                        Qt::Uninitialized);
-    auto* dst = reinterpret_cast<float*>(floatPcm.data());
-    for (int i = 0; i < numSamples; ++i) {
-        dst[i] = static_cast<float>(src[i]) / 32768.0f;
-    }
-    emit playbackAudio(floatPcm);
-
-    m_playPos += take;
-    if (m_playPos >= m_recordedBytes) {
+    // QAudioSink transitions to IdleState when its source (QBuffer)
+    // stops returning data — i.e. the full capture has been drained.
+    // StoppedState also arrives on explicit stop() or device error.
+    if (state == QAudio::IdleState || state == QAudio::StoppedState) {
         stopPlayback();
     }
 }

--- a/src/core/ClientPuduMonitor.h
+++ b/src/core/ClientPuduMonitor.h
@@ -1,12 +1,17 @@
 #pragma once
 
+#include <QAudio>
+#include <QBuffer>
 #include <QByteArray>
 #include <QElapsedTimer>
 #include <QObject>
+#include <QPointer>
 #include <QTimer>
 
 #include <atomic>
 #include <cstdint>
+
+class QAudioSink;
 
 namespace AetherSDR {
 
@@ -62,10 +67,6 @@ signals:
     void recordingStopped(int durationMs);
     void playbackStarted();
     void playbackStopped();
-    // Playback tick payload — chunked float32 stereo 24 kHz (same
-    // format QsoRecorder feeds so it flows cleanly into
-    // AudioEngine::feedDecodedSpeech).
-    void playbackAudio(const QByteArray& float32stereo);
     // Ask MainWindow to toggle the live RX audio feed off/on.  True
     // = disconnect live RX (so we don't hear over our capture or
     // playback), false = restore.  Held from recordingStarted
@@ -75,11 +76,15 @@ signals:
 private slots:
     // Posted from the audio thread when the 30-s buffer fills.
     void onAutoStop();
-    // Playback QTimer tick — emits the next 20 ms chunk.
-    void onPlaybackTick();
+    // Fires when the dedicated playback sink finishes draining.
+    void onPlaybackSinkState(QAudio::State state);
 
 private:
     void writeWavFile();
+    // Materialise the captured buffer at the sink's native rate so
+    // QAudioSink's pull-mode can consume it directly.  Returns true
+    // on success with m_playPcm populated.
+    bool preparePlaybackPcm(int sinkRateHz);
 
     // ── Audio-thread-visible state ──────────────────────────────────
     std::atomic<bool>     m_recording{false};
@@ -93,9 +98,18 @@ private:
     int                   m_recordedBytes{0};     // snapshot of m_writeBytes after stop
     int                   m_recordedMs{0};
     bool                  m_playing{false};
-    int                   m_playPos{0};
-    QTimer*               m_playTimer{nullptr};
     QElapsedTimer         m_recElapsed;
+
+    // Dedicated playback pipeline.  Owns its own QAudioSink so the
+    // monitor is fully decoupled from the RX sink's resample path and
+    // timer cadence — sink's pull-mode consumes at its native rate,
+    // which means macOS/Windows CoreAudio/WASAPI glitches from
+    // timer jitter go away.  m_playPcm holds the full captured
+    // buffer pre-converted to the sink's preferred rate.
+    QAudioSink*            m_playSink{nullptr};
+    QPointer<QIODevice>    m_playSource;
+    QByteArray             m_playPcm;
+    QBuffer                m_playBuffer;
 };
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -322,8 +322,10 @@ MainWindow::MainWindow(QWidget* parent)
     // AudioEngine so its tap hook picks it up on the audio thread.
     m_puduMonitor = new ClientPuduMonitor(this);
     m_audio->setTxPostDspMonitor(m_puduMonitor);
-    connect(m_puduMonitor, &ClientPuduMonitor::playbackAudio,
-            m_audio, &AudioEngine::feedDecodedSpeech);
+    // Monitor owns a dedicated QAudioSink in pull mode — no
+    // feedDecodedSpeech routing, no timer pacing.  Keeps playback
+    // glitch-free on macOS/Windows where QTimer jitter was starving
+    // the shared RX sink.
     // Disconnect live RX audio while the monitor is recording or
     // playing so the user hears ONLY the captured PooDoo audio.
     // Mirrors QsoRecorder's muteRxRequested handling — merely setting


### PR DESCRIPTION
## Summary

Fixes choppy / garbled PUDU monitor playback on macOS and Windows by decoupling the monitor from the shared RX sink + QTimer pacing.

- `ClientPuduMonitor` owns a dedicated `QAudioSink` in pull mode backed by a `QBuffer`.
- Prefers 24 kHz int16 stereo (Linux fast path); falls back to 48 kHz with a one-shot r8brain upsample of the full capture (macOS/Windows).
- Stereo channels resampled independently so PUDU Behringer-mode all-pass rotator survives conversion.
- Sink requests 300 ms internal ring buffer to absorb Windows WASAPI scheduler jitter.
- `MainWindow` obsolete `playbackAudio → feedDecodedSpeech` connection removed.

## Test plan

- [x] Linux: record + play, clean audio
- [x] macOS: record + play, clean audio
- [x] Windows: record + play, clean audio (validated on remote laptop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)