### PR TITLE
Consolidate Low-Latency DAX TX routing into RADE mode

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -2600,6 +2600,7 @@ void AudioEngine::setAllowBluetoothTelephonyOutput(bool on)
 
 void AudioEngine::setRadeMode(bool on)
 {
+    if (m_radeMode == on) return;
     m_radeMode = on;
     // RADE outputs decoded speech — client-side DSP has no effect.
     // Disable any active DSP when entering RADE mode.
@@ -2612,6 +2613,19 @@ void AudioEngine::setRadeMode(bool on)
         if (m_dfnrEnabled) setDfnrEnabled(false);
 #endif
     }
+
+    // RADE wants the low-latency DAX TX route: float32 stereo packet
+    // format via feedDaxTxAudio's non-radio-route branch, and the radio
+    // set to mic-path routing (dax=0) so its own dax_tx demodulation
+    // pipeline doesn't add latency on top of the RADE codec.  On exit,
+    // restore the default radio-native route (dax=1, int16 mono).
+    //
+    // This replaces the retired "Low-Latency DAX (FreeDV)" menu — RADE
+    // mode is the only consumer of that low-latency route, so the
+    // toggle now lives with the RADE on/off state.
+    setDaxTxUseRadioRoute(!on);
+    clearTxAccumulators();
+    emit daxRouteRequested(on ? 0 : 1);
 }
 
 void AudioEngine::sendModemTxAudio(const QByteArray& float32pcm)

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -320,6 +320,12 @@ signals:
     void dfnrEnabledChanged(bool on);
     void txRawPcmReady(const QByteArray& pcm);  // raw 24kHz stereo int16 PCM for RADEEngine
     void txPacketReady(const QByteArray& vitaPacket);  // VITA-49 TX packet for PanadapterStream
+
+    // Emitted from setRadeMode() so MainWindow can send the matching
+    // `transmit set dax=N` command to the radio.  Value is 0 when RADE
+    // is enabled (radio uses mic-path routing), 1 when disabled
+    // (radio routes our dax_tx VITA-49 stream to the modulator).
+    void daxRouteRequested(int daxValue);
     void pcMicLevelChanged(float peakDbfs, float avgDbfs);  // client-side PC mic metering
 
 private slots:

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -340,6 +340,11 @@ void TciServer::onTextMessage(const QString& msg)
 
     auto& client = m_clients[clientIdx];
 
+    // Raw inbound log — helps diagnose TCI-variant dialects where WSJT-X
+    // forks (Improved, Improved Plus, KN4CRD fork…) send commands our
+    // parser doesn't match.  Truncate long ones to keep logs readable.
+    qCDebug(lcCat) << "TCI rx:" << msg.left(256);
+
     // TCI messages are semicolon-terminated; may contain multiple commands
     const QStringList cmds = msg.split(';', Qt::SkipEmptyParts);
     for (const auto& cmd : cmds) {
@@ -1044,9 +1049,13 @@ void TciServer::startTxChrono(QWebSocket* client, int trx)
     m_txChronoClient = client;
     m_txChronoTrx = trx;
 
-    const bool lowLatencyRoute =
-        AppSettings::instance().value("DaxTxLowLatency", "False").toString() == "True";
-    m_txUseRadioRoute = !lowLatencyRoute;
+    // TCI always uses the radio-native DAX TX route (dax=1, int16 mono).
+    // The legacy DaxTxLowLatency AppSettings key is retired — its only
+    // real consumer was RADE mode, which now controls the route itself
+    // via AudioEngine::setRadeMode().  Leaving TCI's route here unconditional
+    // guarantees every WSJT-X / digital-mode client keeps the path that
+    // works on firmware v4.1.5.
+    m_txUseRadioRoute = true;
     // TCI has its own TX gain (decoupled from DaxTxGain) so users who split
     // DAX and TCI routing get independent slider control.  On first read,
     // copy DaxTxGain into TciTxGain so upgrading users see no behavior
@@ -1071,9 +1080,8 @@ void TciServer::startTxChrono(QWebSocket* client, int trx)
     m_txAudioPeak = 0.0f;
     m_txSawDuplicatedStereo = false;
 
-    // DaxTxLowLatency selects VITA-49 packet format only (PCC 0x03E3 float32
-    // stereo vs PCC 0x0123 int16 mono in feedDaxTxAudio). Both formats require
-    // dax=1 on the radio side — see the sendCmdPublic call below.
+    // TCI always routes through the radio-native DAX stream (int16 mono,
+    // PCC 0x0123) — matches the dax=1 command sent below.
     if (m_audio) {
         m_audio->setDaxTxUseRadioRoute(m_txUseRadioRoute);
         m_audio->setDaxTxMode(true);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -824,6 +824,15 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_audio, &AudioEngine::txPacketReady,
             m_radioModel.panStream(), &PanadapterStream::sendToRadio);
 
+    // RADE mode asks for its preferred DAX TX routing on the radio side.
+    // Emitted from AudioEngine::setRadeMode() so toggling the RADE
+    // button does the whole routing consolidation in one place.
+    connect(m_audio, &AudioEngine::daxRouteRequested, this,
+            [this](int daxValue) {
+        m_radioModel.sendCommand(
+            QString("transmit set dax=%1").arg(daxValue));
+    });
+
     connect(&m_radioModel, &RadioModel::txAudioStreamReady,
             this, [this](quint32 streamId) {
         m_audio->setTxStreamId(streamId);
@@ -3809,22 +3818,10 @@ void MainWindow::buildMenuBar()
     });
 #endif
 
-    auto* lowLatencyDaxTxAction =
-        settingsMenu->addAction("Low-Latency DAX (FreeDV)");
-    lowLatencyDaxTxAction->setCheckable(true);
-    lowLatencyDaxTxAction->setChecked(
-        AppSettings::instance().value("DaxTxLowLatency", "False").toString() == "True");
-    connect(lowLatencyDaxTxAction, &QAction::toggled, this, [this](bool on) {
-        auto& s = AppSettings::instance();
-        s.setValue("DaxTxLowLatency", on ? "True" : "False");
-        s.save();
-        m_audio->setDaxTxUseRadioRoute(!on);
-        m_audio->clearTxAccumulators();
-#if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
-        if (m_daxBridge)
-            m_radioModel.sendCommand(QString("transmit set dax=%1").arg(on ? 0 : 1));
-#endif
-    });
+    // "Low-Latency DAX (FreeDV)" menu retired in v0.8.19 — the toggle
+    // it used to drive is now applied automatically by RADE mode, since
+    // RADE was the only consumer that ever actually wanted that route.
+    // See AudioEngine::setRadeMode().
 
     // Connect placeholder items to show "not implemented" message
     for (auto* action : settingsMenu->actions()) {
@@ -3846,7 +3843,7 @@ void MainWindow::buildMenuBar()
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
             && action != autoDaxAction
 #endif
-            && action != lowLatencyDaxTxAction) {
+            ) {
             connect(action, &QAction::triggered, this, [this, action] {
                 statusBar()->showMessage(action->text().remove("...") + " — not yet implemented", 3000);
             });
@@ -8507,9 +8504,10 @@ bool MainWindow::startDax()
     // Save current mic selection before forcing PC audio source.
     m_savedMicSelection = m_radioModel.transmitModel().micSelection();
 
-    const bool lowLatencyRoute =
-        AppSettings::instance().value("DaxTxLowLatency", "False").toString() == "True";
-    m_audio->setDaxTxUseRadioRoute(!lowLatencyRoute);
+    // Default to the radio-native DAX route (dax=1, int16 mono).  RADE
+    // mode overrides this to the low-latency route via setRadeMode()
+    // when the user enters RADE — see AudioEngine::setRadeMode().
+    m_audio->setDaxTxUseRadioRoute(true);
     m_radioModel.sendCommand("transmit set mic_selection=PC");
     // Don't force dax=1 here — radio-side DAX flag follows mode changes
     // via updateDaxTxMode(). Bridge up ≠ DAX TX active. (#534)


### PR DESCRIPTION
The "Low-Latency DAX (FreeDV)" Settings menu item existed for one real
consumer — RADE mode — which needs the radio to drop its dax_tx ingestion
so RADE can take the mic-path for SSB modulation. No other code path ever
required users to flip the setting manually, and the menu caption misled
non-RADE users into toggling it.

Changes:

- AudioEngine::setRadeMode() emits new signal daxRouteRequested(int):
  0 when RADE is turned on (radio uses mic-path), 1 when turned off
  (radio consumes our dax_tx VITA-49 stream again).
- MainWindow wires that signal to `transmit set dax=N`, replacing the
  ad-hoc menu handler.  All routing now flips atomically with the RADE
  button — no second place to remember.
- Remove the menu item entirely from Settings → the stale AppSettings
  key `DaxTxLowLatency` is no longer read anywhere.
- TciServer::startTxChrono always uses the radio-native DAX route
  (dax=1, PCC 0x0123 int16 mono).  WSJT-X / digital-mode clients need
  exactly that on firmware v4.1.5 — the old DaxTxLowLatency toggle had
  no legitimate TCI path and only caused regressions.
- Add raw inbound TCI message logging at qCDebug level.  Helps
  triage WSJT-X forks (Improved, KN4CRD) whose dialects send commands
  our parser doesn't recognise.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
