### PR TITLE
[feature] Add quick memory browse and save actions to slice overlays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,6 +487,8 @@ set(GUI_SOURCES
     src/gui/RadioSetupDialog.cpp
     src/gui/NetworkDiagnosticsDialog.cpp
     src/gui/PropDashboardDialog.cpp
+    src/gui/MemoryCommands.cpp
+    src/gui/MemoryBrowsePanel.cpp
     src/gui/MemoryDialog.cpp
     src/gui/SpotSettingsDialog.cpp
     src/gui/AetherDspDialog.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -54,6 +54,7 @@
 #include "RadioSetupDialog.h"
 #include "NetworkDiagnosticsDialog.h"
 #include "PropDashboardDialog.h"
+#include "MemoryCommands.h"
 #include "MemoryDialog.h"
 #include "DxClusterDialog.h"
 #include "CwxPanel.h"
@@ -264,6 +265,21 @@ static QString memorySpotComment(const MemoryEntry& memory)
                     .arg(memory.rxFilterHigh);
     }
     return parts.join(" | ");
+}
+
+static QPixmap buildBandStackIndicatorPixmap(bool active)
+{
+    QPixmap pixmap(10, 22);
+    pixmap.fill(Qt::transparent);
+
+    QPainter painter(&pixmap);
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(active ? QColor(0x00, 0xb4, 0xd8) : QColor(0x40, 0x48, 0x58));
+    painter.drawEllipse(2, 1, 6, 6);
+    painter.drawEllipse(2, 8, 6, 6);
+    painter.drawEllipse(2, 15, 6, 6);
+    return pixmap;
 }
 
 static bool isTextInputFocused()
@@ -800,6 +816,12 @@ MainWindow::MainWindow(QWidget* parent)
             this, &MainWindow::removeMemorySpot);
     connect(&m_radioModel, &RadioModel::memoriesCleared,
             this, &MainWindow::clearMemorySpotFeed);
+    connect(&m_radioModel, &RadioModel::memoryChanged,
+            this, [this](int) { refreshMemoryBrowsePanel(); });
+    connect(&m_radioModel, &RadioModel::memoryRemoved,
+            this, [this](int) { refreshMemoryBrowsePanel(); });
+    connect(&m_radioModel, &RadioModel::memoriesCleared,
+            this, [this]() { refreshMemoryBrowsePanel(); });
     connect(&m_radioModel, &RadioModel::panadapterLimitReached,
             this, [this](int limit, const QString& model) {
         statusBar()->showMessage(
@@ -3012,17 +3034,7 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
     if (obj == m_bandStackIndicator && event->type() == QEvent::MouseButtonPress) {
         bool show = !m_panStack->bandStackPanel()->isVisible();
         m_panStack->setBandStackVisible(show);
-        QPixmap bsPm(10, 22);
-        bsPm.fill(Qt::transparent);
-        QPainter bsPainter(&bsPm);
-        bsPainter.setRenderHint(QPainter::Antialiasing);
-        bsPainter.setPen(Qt::NoPen);
-        bsPainter.setBrush(show ? QColor(0, 180, 216) : QColor(64, 72, 88));
-        bsPainter.drawEllipse(2, 1, 6, 6);
-        bsPainter.drawEllipse(2, 8, 6, 6);
-        bsPainter.drawEllipse(2, 15, 6, 6);
-        bsPainter.end();
-        m_bandStackIndicator->setPixmap(bsPm);
+        updateBandStackIndicator();
         return true;
     }
     if (obj == m_tgxlIndicator && event->type() == QEvent::MouseButtonPress) {
@@ -3134,6 +3146,131 @@ void MainWindow::showMemoryDialog()
     });
     m_memoryDialog = dlg;
     dlg->show();
+}
+
+SliceModel* MainWindow::preferredMemorySlice(const QString& preferredPanId) const
+{
+    if (preferredPanId.isEmpty())
+        return activeSlice();
+
+    if (auto* slice = activeSlice(); slice && slice->panId() == preferredPanId)
+        return slice;
+
+    for (auto* slice : m_radioModel.slices()) {
+        if (slice && slice->panId() == preferredPanId)
+            return slice;
+    }
+
+    return nullptr;
+}
+
+void MainWindow::showQuickAddMemoryDialog(const QString& preferredPanId)
+{
+    auto* slice = preferredMemorySlice(preferredPanId);
+    if (!slice) {
+        statusBar()->showMessage(
+            preferredPanId.isEmpty()
+                ? "Open a slice before saving a memory."
+                : "Open a slice on this pan before saving a memory.",
+            3000);
+        return;
+    }
+
+    const int sliceId = slice->sliceId();
+    const QString frequencyText = QString::number(slice->frequency(), 'f', 6);
+    const QString summaryText = QString("%1  |  Filter %2 to %3 Hz")
+        .arg(slice->mode())
+        .arg(slice->filterLow())
+        .arg(slice->filterHigh());
+
+    QDialog dialog(this);
+    dialog.setWindowTitle("Save Memory");
+    dialog.setModal(true);
+    dialog.setMinimumWidth(360);
+
+    auto* root = new QVBoxLayout(&dialog);
+    root->setContentsMargins(14, 14, 14, 14);
+    root->setSpacing(10);
+
+    auto* nameLabel = new QLabel("Name:", &dialog);
+    root->addWidget(nameLabel);
+
+    auto* nameEdit = new QLineEdit(&dialog);
+    nameEdit->setPlaceholderText("Enter a memory name");
+    root->addWidget(nameEdit);
+
+    auto* freqLabel = new QLabel(QString("Current Frequency: %1 MHz").arg(frequencyText), &dialog);
+    freqLabel->setStyleSheet("QLabel { color: #c8d8e8; font-size: 12px; }");
+    root->addWidget(freqLabel);
+
+    auto* summaryLabel = new QLabel(summaryText, &dialog);
+    summaryLabel->setStyleSheet("QLabel { color: #70879b; font-size: 11px; }");
+    root->addWidget(summaryLabel);
+
+    auto* buttonRow = new QHBoxLayout;
+    buttonRow->addStretch(1);
+
+    auto* cancelButton = new QPushButton("Cancel", &dialog);
+    cancelButton->setAutoDefault(false);
+    buttonRow->addWidget(cancelButton);
+
+    auto* saveButton = new QPushButton("Save", &dialog);
+    saveButton->setDefault(true);
+    saveButton->setEnabled(false);
+    buttonRow->addWidget(saveButton);
+    root->addLayout(buttonRow);
+
+    connect(cancelButton, &QPushButton::clicked, &dialog, &QDialog::reject);
+    connect(nameEdit, &QLineEdit::textChanged, &dialog, [saveButton](const QString& text) {
+        saveButton->setEnabled(!text.trimmed().isEmpty());
+    });
+
+    const QPointer<QDialog> dialogGuard(&dialog);
+    connect(saveButton, &QPushButton::clicked, &dialog, [this,
+                                                         sliceId,
+                                                         dialogGuard,
+                                                         nameEdit,
+                                                         saveButton,
+                                                         cancelButton]() {
+        auto* currentSlice = m_radioModel.slice(sliceId);
+        if (!currentSlice) {
+            QMessageBox::warning(this, "Save Memory",
+                                 "That slice is no longer available.");
+            return;
+        }
+
+        saveButton->setEnabled(false);
+        cancelButton->setEnabled(false);
+        nameEdit->setEnabled(false);
+
+        const QString name = nameEdit->text().trimmed();
+        createMemoryFromSlice(&m_radioModel, currentSlice, name, dialogGuard.data(),
+            [this, dialogGuard, nameEdit, saveButton, cancelButton, name](int code, const QString& body, int) {
+            if (!dialogGuard)
+                return;
+
+            if (code == 0) {
+                statusBar()->showMessage(
+                    QString("Saved \"%1\" to memories.").arg(name),
+                    3000);
+                dialogGuard->accept();
+                return;
+            }
+
+            QMessageBox::warning(dialogGuard, "Save Memory",
+                                 body.isEmpty()
+                                     ? "Couldn't save the current slice to memory."
+                                     : body);
+            nameEdit->setEnabled(true);
+            saveButton->setEnabled(!nameEdit->text().trimmed().isEmpty());
+            cancelButton->setEnabled(true);
+            nameEdit->setFocus(Qt::OtherFocusReason);
+            nameEdit->selectAll();
+        });
+    });
+
+    nameEdit->setFocus(Qt::OtherFocusReason);
+    dialog.exec();
 }
 
 void MainWindow::updatePaTempLabel()
@@ -4429,6 +4566,7 @@ void MainWindow::buildUI()
         BandStackSettings::instance().save();
         m_panStack->bandStackPanel()->removeBookmark(index);
     });
+    refreshMemoryBrowsePanel();
 
     // Sync RadioModel's active pan/wf IDs when PanadapterStack focus changes.
     // This ensures display setting commands (fps, average, black_level, etc.)
@@ -4535,18 +4673,8 @@ void MainWindow::buildUI()
         pp.end();
         // Band stack toggle: 3 vertically stacked circles
         {
-            QPixmap bsPm(10, 22);
-            bsPm.fill(Qt::transparent);
-            QPainter bsPainter(&bsPm);
-            bsPainter.setRenderHint(QPainter::Antialiasing);
-            bsPainter.setPen(Qt::NoPen);
-            bsPainter.setBrush(QColor(64, 72, 88));  // grey, matches inactive indicators
-            bsPainter.drawEllipse(2, 1, 6, 6);
-            bsPainter.drawEllipse(2, 8, 6, 6);
-            bsPainter.drawEllipse(2, 15, 6, 6);
-            bsPainter.end();
             m_bandStackIndicator = new QLabel;
-            m_bandStackIndicator->setPixmap(bsPm);
+            m_bandStackIndicator->setPixmap(buildBandStackIndicatorPixmap(false));
             m_bandStackIndicator->setCursor(Qt::PointingHandCursor);
             m_bandStackIndicator->setToolTip("Open band stack panel");
             m_bandStackIndicator->installEventFilter(this);
@@ -4856,6 +4984,7 @@ void MainWindow::buildUI()
     hbox->addWidget(timeStack);
 
     statusBar()->addWidget(container, 1);
+    updateBandStackIndicator();
 }
 
 // ─── Theme ────────────────────────────────────────────────────────────────────
@@ -4977,6 +5106,8 @@ void MainWindow::onConnectionStateChanged(bool connected)
         BandStackSettings::instance().load();
         m_panStack->bandStackPanel()->loadBookmarks(
             m_radioModel.serial(), m_bandPlanMgr);
+        refreshMemoryBrowsePanel();
+        updateBandStackIndicator();
 
         // Auto-start 4-channel rigctld TCP servers if enabled
         auto& as = AppSettings::instance();
@@ -5131,6 +5262,9 @@ void MainWindow::onConnectionStateChanged(bool connected)
         m_stationLabel->setText("N0CALL");
         m_tnfIndicator->setStyleSheet("QLabel { color: #404858; font-weight: bold; font-size: 24px; }");
         m_panStack->bandStackPanel()->clear();
+        m_panStack->setBandStackVisible(false);
+        refreshMemoryBrowsePanel();
+        updateBandStackIndicator();
         m_tgxlIndicator->setVisible(false);
         m_tgxlConn.disconnect();
         m_pgxlConn.disconnect();
@@ -5281,22 +5415,66 @@ void MainWindow::rebuildMemorySpotFeed()
         syncMemorySpot(it.key());
 }
 
-void MainWindow::activateMemorySpot(int memoryIndex)
+void MainWindow::refreshMemoryBrowsePanel()
 {
-    if (auto* slice = activeSlice(); !slice || slice->isLocked())
+    if (!m_panStack)
         return;
+    for (auto* applet : m_panStack->allApplets()) {
+        if (!applet)
+            continue;
+        if (auto* menu = applet->spectrumWidget()->overlayMenu())
+            menu->setMemories(m_radioModel.memories());
+    }
+}
+
+void MainWindow::updateBandStackIndicator()
+{
+    if (!m_bandStackIndicator || !m_panStack)
+        return;
+
+    const bool visible = m_panStack->bandStackPanel()->isVisible();
+    m_bandStackIndicator->setPixmap(buildBandStackIndicatorPixmap(visible));
+    m_bandStackIndicator->setToolTip(visible ? "Close band stack panel"
+                                             : "Open band stack panel");
+}
+
+bool MainWindow::activateMemorySpot(int memoryIndex, const QString& preferredPanId)
+{
+    auto* slice = preferredMemorySlice(preferredPanId);
+    if (!slice) {
+        statusBar()->showMessage(
+            preferredPanId.isEmpty()
+                ? "Open a slice before recalling a memory."
+                : "Open a slice on this pan before recalling a memory.",
+            3000);
+        return false;
+    }
+    if (slice->isLocked()) {
+        statusBar()->showMessage("Unlock the target slice before recalling a memory.", 3000);
+        return false;
+    }
 
     const auto it = m_radioModel.memories().constFind(memoryIndex);
     if (it == m_radioModel.memories().constEnd())
-        return;
+        return false;
+
+    const int sliceId = slice->sliceId();
+    if (!activeSlice() || activeSlice()->sliceId() != sliceId)
+        setActiveSlice(sliceId);
+
+    slice = m_radioModel.slice(sliceId);
+    if (!slice)
+        return false;
 
     m_radioModel.sendCommand(QString("memory apply %1").arg(memoryIndex));
+    m_radioModel.setPanCenter(it->freq);
 
     // The radio should push the rest of the applied memory state, but keep the
     // local tuning step in sync immediately so wheel/click snap follows along.
-    if (it->step > 0 && activeSlice())
+    if (it->step > 0)
         m_radioModel.sendCommand(QString("slice set %1 step=%2")
-            .arg(activeSlice()->sliceId()).arg(it->step));
+            .arg(slice->sliceId()).arg(it->step));
+    return true;
 }
 
 void MainWindow::onSliceAdded(SliceModel* s)
@@ -6018,6 +6196,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 
     // Set panId on the overlay menu so +RX routes to the correct pan
     menu->setPanId(applet->panId());
+    menu->setMemories(m_radioModel.memories());
 
     // Antenna list → this overlay menu (per-pan, mirrors VfoWidget pattern) (#1260)
     connect(&m_radioModel, &RadioModel::antListChanged,
@@ -6466,7 +6645,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
 
     // ── Spot trigger — notify the radio when a spot label is clicked (#341)
-    connect(sw, &SpectrumWidget::spotTriggered, this, [this](int spotIndex) {
+    connect(sw, &SpectrumWidget::spotTriggered, this, [this, applet](int spotIndex) {
         const auto& spots = m_radioModel.spotModel().spots();
         auto it = spots.find(spotIndex);
         if (it == spots.end()) return;
@@ -6474,7 +6653,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         if (it->source == "Memory") {
             int memoryIndex = memoryIndexFromSpotId(spotIndex);
             if (memoryIndex >= 0)
-                activateMemorySpot(memoryIndex);
+                activateMemorySpot(memoryIndex, applet->panId());
             return;
         }
 
@@ -6606,6 +6785,14 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         double tnfFreq = s->frequency()
             + (s->filterLow() + s->filterHigh()) / 2.0 / 1.0e6;
         m_radioModel.tnfModel().createTnf(tnfFreq);
+    });
+    connect(menu, &SpectrumOverlayMenu::memoryActivated,
+            this, [this](int memoryIndex, const QString& panId) {
+        activateMemorySpot(memoryIndex, panId);
+    });
+    connect(menu, &SpectrumOverlayMenu::quickAddMemoryRequested,
+            this, [this](const QString& panId) {
+        showQuickAddMemoryDialog(panId);
     });
 
     // ── Slice marker clicks ──────────────────────────────────────────────

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -132,6 +132,7 @@ private:
     void stepUiScale(int direction);  // +1 = zoom in, -1 = zoom out
     void toggleMinimalMode(bool on);
     void showMemoryDialog();
+    void showQuickAddMemoryDialog(const QString& preferredPanId = {});
     void updateKeyerAvailability(const QString& mode);
     void showNr2ParamPopup(const QPoint& globalPos);
     void showNr4ParamPopup(const QPoint& globalPos);
@@ -149,7 +150,10 @@ private:
     void removeMemorySpot(int memoryIndex);
     void clearMemorySpotFeed();
     void rebuildMemorySpotFeed();
-    void activateMemorySpot(int memoryIndex);
+    void refreshMemoryBrowsePanel();
+    void updateBandStackIndicator();
+    SliceModel* preferredMemorySlice(const QString& preferredPanId) const;
+    bool activateMemorySpot(int memoryIndex, const QString& preferredPanId = {});
 
     BandSnapshot captureCurrentBandState() const;
     void restoreBandState(const BandSnapshot& snap);

--- a/src/gui/MemoryBrowsePanel.cpp
+++ b/src/gui/MemoryBrowsePanel.cpp
@@ -1,0 +1,200 @@
+#include "MemoryBrowsePanel.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include <QAbstractItemView>
+#include <QHeaderView>
+#include <QLabel>
+#include <QTableWidgetItem>
+#include <QTableWidget>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+namespace {
+
+QString displayMemoryName(const MemoryEntry& memory)
+{
+    if (!memory.name.trimmed().isEmpty())
+        return memory.name.trimmed();
+    if (!memory.group.trimmed().isEmpty())
+        return memory.group.trimmed();
+    return QString("Memory %1").arg(memory.index);
+}
+
+} // namespace
+
+MemoryBrowsePanel::MemoryBrowsePanel(QWidget* parent)
+    : QWidget(parent)
+{
+    setFixedSize(252, 430);
+    setStyleSheet("background: rgba(15, 15, 26, 220); border: 1px solid #304050; border-radius: 3px;");
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(3, 3, 3, 3);
+    root->setSpacing(0);
+
+    m_emptyLabel = new QLabel("No memories are available yet.", this);
+    m_emptyLabel->setAlignment(Qt::AlignCenter);
+    m_emptyLabel->setWordWrap(true);
+    m_emptyLabel->setStyleSheet(
+        "QLabel { color: #607080; font-size: 12px; padding: 12px 8px; }");
+    root->addWidget(m_emptyLabel, 1);
+
+    m_table = new QTableWidget(0, 2, this);
+    m_table->setHorizontalHeaderLabels({"Frequency", "Name"});
+    m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_table->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_table->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+    m_table->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_table->setShowGrid(false);
+    m_table->setFocusPolicy(Qt::StrongFocus);
+    m_table->setWordWrap(false);
+    m_table->setTextElideMode(Qt::ElideRight);
+    m_table->verticalHeader()->setVisible(false);
+    m_table->verticalHeader()->setDefaultSectionSize(26);
+    m_table->horizontalHeader()->setStretchLastSection(true);
+    m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
+    m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_table->setColumnWidth(0, 96);
+    m_table->setStyleSheet(
+        "QTableWidget { background: #0f1720; border: 1px solid #203040; border-radius: 2px; "
+        "color: #d2dbe4; selection-background-color: #2060a0; selection-color: #ffffff; }"
+        "QHeaderView::section { background: #101b26; color: #70879b; border: none; "
+        "border-bottom: 1px solid #203040; font-size: 11px; font-weight: bold; padding: 4px 3px; }"
+        "QScrollBar:vertical { background: #0a0a14; width: 6px; }"
+        "QScrollBar::handle:vertical { background: #304050; border-radius: 3px; }"
+        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }");
+    root->addWidget(m_table, 1);
+    m_table->hide();
+
+    connect(m_table, &QTableWidget::cellClicked, this, [this](int row, int) {
+        auto* indexItem = m_table->item(row, 0);
+        if (!indexItem)
+            return;
+        emit memoryActivated(indexItem->data(Qt::UserRole).toInt());
+    });
+
+    connect(m_table, &QTableWidget::cellActivated, this, [this](int row, int) {
+        auto* indexItem = m_table->item(row, 0);
+        if (!indexItem)
+            return;
+        emit memoryActivated(indexItem->data(Qt::UserRole).toInt());
+    });
+}
+
+void MemoryBrowsePanel::setMemories(const QMap<int, MemoryEntry>& memories)
+{
+    m_memories = memories;
+    populateTable();
+}
+
+void MemoryBrowsePanel::focusClosestToFrequency(double frequencyMhz)
+{
+    int closestMemoryIndex = -1;
+
+    if (frequencyMhz > 0.0) {
+        double bestDelta = std::numeric_limits<double>::max();
+        for (auto it = m_memories.cbegin(); it != m_memories.cend(); ++it) {
+            const MemoryEntry& memory = it.value();
+            if (memory.freq <= 0.0)
+                continue;
+
+            const double delta = std::abs(memory.freq - frequencyMhz);
+            if (delta < bestDelta
+                || (qFuzzyCompare(delta + 1.0, bestDelta + 1.0)
+                    && memory.index < closestMemoryIndex)) {
+                bestDelta = delta;
+                closestMemoryIndex = memory.index;
+            }
+        }
+    }
+
+    m_highlightedMemoryIndex = closestMemoryIndex;
+    populateTable();
+}
+
+QColor MemoryBrowsePanel::rowBackground(const MemoryEntry& memory, bool highlight) const
+{
+    if (highlight)
+        return QColor(0x24, 0x3b, 0x4d);
+    return (memory.index % 2 == 0)
+        ? QColor(0x17, 0x25, 0x34)
+        : QColor(0x11, 0x19, 0x23);
+}
+
+void MemoryBrowsePanel::scrollToHighlightedRow()
+{
+    if (m_highlightedMemoryIndex < 0 || !m_table)
+        return;
+
+    for (int row = 0; row < m_table->rowCount(); ++row) {
+        auto* freqItem = m_table->item(row, 0);
+        if (!freqItem)
+            continue;
+        if (freqItem->data(Qt::UserRole).toInt() != m_highlightedMemoryIndex)
+            continue;
+
+        m_table->scrollToItem(freqItem, QAbstractItemView::PositionAtCenter);
+        return;
+    }
+}
+
+void MemoryBrowsePanel::populateTable()
+{
+    m_table->setSortingEnabled(false);
+    m_table->setRowCount(0);
+    m_table->clearSelection();
+
+    QList<MemoryEntry> sortedMemories;
+    sortedMemories.reserve(m_memories.size());
+    for (auto it = m_memories.cbegin(); it != m_memories.cend(); ++it) {
+        if (it.value().freq > 0.0)
+            sortedMemories.append(it.value());
+    }
+
+    std::sort(sortedMemories.begin(), sortedMemories.end(),
+              [](const MemoryEntry& lhs, const MemoryEntry& rhs) {
+        if (!qFuzzyCompare(lhs.freq + 1.0, rhs.freq + 1.0))
+            return lhs.freq < rhs.freq;
+        return lhs.index < rhs.index;
+    });
+
+    for (const MemoryEntry& memory : sortedMemories) {
+        if (memory.freq <= 0.0)
+            continue;
+
+        const int row = m_table->rowCount();
+        m_table->insertRow(row);
+
+        const bool highlight = (memory.index == m_highlightedMemoryIndex);
+        const QColor bg = rowBackground(memory, highlight);
+        const QColor fg = QColor(0xd2, 0xdb, 0xe4);
+
+        auto* freqItem = new QTableWidgetItem(QString::number(memory.freq, 'f', 6));
+        freqItem->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+        freqItem->setBackground(bg);
+        freqItem->setForeground(fg);
+        freqItem->setData(Qt::UserRole, memory.index);
+        freqItem->setToolTip(QString("%1 MHz").arg(QString::number(memory.freq, 'f', 6)));
+        m_table->setItem(row, 0, freqItem);
+
+        auto* nameItem = new QTableWidgetItem(displayMemoryName(memory));
+        nameItem->setBackground(bg);
+        nameItem->setForeground(fg);
+        nameItem->setData(Qt::UserRole, memory.index);
+        nameItem->setToolTip(nameItem->text());
+        m_table->setItem(row, 1, nameItem);
+    }
+
+    const bool hasRows = m_table->rowCount() > 0;
+    m_emptyLabel->setVisible(!hasRows);
+    m_table->setVisible(hasRows);
+    if (hasRows)
+        scrollToHighlightedRow();
+}
+
+} // namespace AetherSDR

--- a/src/gui/MemoryBrowsePanel.h
+++ b/src/gui/MemoryBrowsePanel.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "models/RadioModel.h"
+
+#include <QWidget>
+
+class QLabel;
+class QTableWidget;
+
+namespace AetherSDR {
+
+class MemoryBrowsePanel : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit MemoryBrowsePanel(QWidget* parent = nullptr);
+
+    void setMemories(const QMap<int, MemoryEntry>& memories);
+    void focusClosestToFrequency(double frequencyMhz);
+
+signals:
+    void memoryActivated(int memoryIndex);
+
+private:
+    void populateTable();
+    QColor rowBackground(const MemoryEntry& memory, bool highlight) const;
+    void scrollToHighlightedRow();
+
+    QMap<int, MemoryEntry> m_memories;
+    QLabel* m_emptyLabel{nullptr};
+    QTableWidget* m_table{nullptr};
+    int m_highlightedMemoryIndex{-1};
+};
+
+} // namespace AetherSDR

--- a/src/gui/MemoryCommands.cpp
+++ b/src/gui/MemoryCommands.cpp
@@ -1,0 +1,144 @@
+#include "MemoryCommands.h"
+
+#include "models/SliceModel.h"
+
+#include <QPointer>
+
+namespace AetherSDR {
+
+QString encodeMemoryText(const QString& value)
+{
+    return QString(value).replace(' ', QChar(0x7f));
+}
+
+MemoryEntry captureMemoryFromSlice(const RadioModel& model,
+                                   const SliceModel& slice,
+                                   const QString& name)
+{
+    MemoryEntry memory;
+    memory.group = model.activeGlobalProfile();
+    memory.owner = model.callsign();
+    memory.freq = slice.frequency();
+    memory.name = name.trimmed();
+    memory.mode = slice.mode();
+    memory.step = slice.stepHz();
+    memory.offsetDir = slice.repeaterOffsetDir();
+    memory.repeaterOffset = slice.fmRepeaterOffsetFreq();
+    memory.toneMode = slice.fmToneMode();
+    memory.toneValue = slice.fmToneValue().toDouble();
+    memory.squelch = slice.squelchOn();
+    memory.squelchLevel = slice.squelchLevel();
+    memory.rxFilterLow = slice.filterLow();
+    memory.rxFilterHigh = slice.filterHigh();
+    memory.rttyMark = slice.rttyMark();
+    memory.rttyShift = slice.rttyShift();
+    memory.diglOffset = slice.diglOffset();
+    memory.diguOffset = slice.diguOffset();
+    return memory;
+}
+
+MemoryUpdateData buildMemoryUpdateData(const MemoryEntry& memory)
+{
+    MemoryUpdateData update;
+
+    auto appendField = [&update](const QString& key, const QString& value) {
+        if (!update.commandSuffix.isEmpty())
+            update.commandSuffix += ' ';
+        update.commandSuffix += key + '=' + value;
+        update.kvs[key] = value;
+    };
+
+    appendField("group", encodeMemoryText(memory.group));
+    appendField("owner", encodeMemoryText(memory.owner));
+    appendField("freq", QString::number(memory.freq, 'f', 6));
+    appendField("name", encodeMemoryText(memory.name));
+    appendField("mode", memory.mode);
+    appendField("step", QString::number(memory.step));
+    appendField("repeater", memory.offsetDir);
+    appendField("repeater_offset", QString::number(memory.repeaterOffset, 'f', 6));
+    appendField("tone_mode", memory.toneMode);
+    appendField("tone_value", QString::number(memory.toneValue, 'f', 1));
+    appendField("squelch", memory.squelch ? "1" : "0");
+    appendField("squelch_level", QString::number(memory.squelchLevel));
+    appendField("rx_filter_low", QString::number(memory.rxFilterLow));
+    appendField("rx_filter_high", QString::number(memory.rxFilterHigh));
+    appendField("rtty_mark", QString::number(memory.rttyMark));
+    appendField("rtty_shift", QString::number(memory.rttyShift));
+    appendField("digl_offset", QString::number(memory.diglOffset));
+    appendField("digu_offset", QString::number(memory.diguOffset));
+
+    return update;
+}
+
+void createMemoryFromSlice(RadioModel* model,
+                           const SliceModel* slice,
+                           const QString& name,
+                           QObject* callbackContext,
+                           MemoryCreateCallback cb)
+{
+    const bool useCallbackGuard = callbackContext != nullptr;
+    const QPointer<QObject> callbackGuard(callbackContext);
+    auto notify = [cb, useCallbackGuard, callbackGuard](int code,
+                                                        const QString& body,
+                                                        int memoryIndex) {
+        if (!cb)
+            return;
+        if (useCallbackGuard && callbackGuard.isNull())
+            return;
+        cb(code, body, memoryIndex);
+    };
+
+    if (!model || !slice) {
+        notify(-1, QStringLiteral("No active slice is available."), -1);
+        return;
+    }
+
+    const MemoryEntry memory = captureMemoryFromSlice(*model, *slice, name);
+    const MemoryUpdateData update = buildMemoryUpdateData(memory);
+
+    model->sendCmdPublic("memory create",
+        [model, update, notify](int code, const QString& body) {
+        if (code != 0) {
+            notify(code, body, -1);
+            return;
+        }
+
+        bool ok = false;
+        const int index = body.trimmed().toInt(&ok);
+        if (!ok) {
+            notify(-1,
+                   QStringLiteral("The radio returned an invalid memory id."),
+                   -1);
+            return;
+        }
+
+        model->sendCmdPublic(
+            QString("memory set %1 %2").arg(index).arg(update.commandSuffix),
+            [model, update, notify, index](int setCode, const QString& setBody) {
+            if (setCode == 0) {
+                model->handleMemoryStatus(index, update.kvs);
+                notify(0, setBody, index);
+                return;
+            }
+
+            model->sendCmdPublic(QString("memory remove %1").arg(index),
+                [model, notify, index, setCode, setBody](int removeCode, const QString& removeBody) {
+                if (removeCode == 0) {
+                    QMap<QString, QString> removed;
+                    removed["removed"] = QString{};
+                    model->handleMemoryStatus(index, removed);
+                }
+
+                QString detail = setBody.simplified();
+                if (detail.isEmpty())
+                    detail = QStringLiteral("The radio rejected one or more memory fields.");
+                if (removeCode != 0 && !removeBody.simplified().isEmpty())
+                    detail += QStringLiteral(" Cleanup also failed: %1")
+                        .arg(removeBody.simplified());
+                notify(setCode, detail, index);
+            });
+        });
+    });
+}
+
+} // namespace AetherSDR

--- a/src/gui/MemoryCommands.h
+++ b/src/gui/MemoryCommands.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "models/RadioModel.h"
+
+#include <functional>
+
+class QObject;
+
+namespace AetherSDR {
+
+class SliceModel;
+
+struct MemoryUpdateData {
+    QString commandSuffix;
+    QMap<QString, QString> kvs;
+};
+
+using MemoryCreateCallback =
+    std::function<void(int code, const QString& body, int memoryIndex)>;
+
+QString encodeMemoryText(const QString& value);
+MemoryEntry captureMemoryFromSlice(const RadioModel& model,
+                                   const SliceModel& slice,
+                                   const QString& name = QString());
+MemoryUpdateData buildMemoryUpdateData(const MemoryEntry& memory);
+void createMemoryFromSlice(RadioModel* model,
+                           const SliceModel* slice,
+                           const QString& name = QString(),
+                           QObject* callbackContext = nullptr,
+                           MemoryCreateCallback cb = {});
+
+} // namespace AetherSDR

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -1,4 +1,5 @@
 #include "MemoryDialog.h"
+#include "MemoryCommands.h"
 #include "core/AppSettings.h"
 #include "core/MemoryCsvCompat.h"
 #include "models/RadioModel.h"
@@ -53,11 +54,6 @@ public:
     }
 };
 
-QString encodeMemoryText(const QString& value)
-{
-    return QString(value).replace(' ', QChar(0x7f));
-}
-
 bool buildMemoryFieldUpdate(int col, const QTableWidgetItem* item,
                             QString& commandSuffix, QMap<QString, QString>& kvs)
 {
@@ -67,13 +63,13 @@ bool buildMemoryFieldUpdate(int col, const QTableWidgetItem* item,
     const QString value = item->text();
     switch (col) {
     case 0: {
-        const QString encoded = encodeMemoryText(value);
+        const QString encoded = AetherSDR::encodeMemoryText(value);
         commandSuffix = "group=" + encoded;
         kvs["group"] = encoded;
         return true;
     }
     case 1: {
-        const QString encoded = encodeMemoryText(value);
+        const QString encoded = AetherSDR::encodeMemoryText(value);
         commandSuffix = "owner=" + encoded;
         kvs["owner"] = encoded;
         return true;
@@ -83,7 +79,7 @@ bool buildMemoryFieldUpdate(int col, const QTableWidgetItem* item,
         kvs["freq"] = value;
         return true;
     case 3: {
-        const QString encoded = encodeMemoryText(value);
+        const QString encoded = AetherSDR::encodeMemoryText(value);
         commandSuffix = "name=" + encoded;
         kvs["name"] = encoded;
         return true;
@@ -214,44 +210,6 @@ QString formatImportIssue(const QString& rowLabel,
     return normalizedDetail.isEmpty()
         ? QString("%1: %2").arg(rowLabel, message)
         : QString("%1: %2 (%3)").arg(rowLabel, message, normalizedDetail);
-}
-
-struct MemoryUpdateData {
-    QString commandSuffix;
-    QMap<QString, QString> kvs;
-};
-
-MemoryUpdateData buildMemoryUpdateData(const MemoryEntry& memory)
-{
-    MemoryUpdateData update;
-
-    auto appendField = [&update](const QString& key, const QString& value) {
-        if (!update.commandSuffix.isEmpty())
-            update.commandSuffix += ' ';
-        update.commandSuffix += key + '=' + value;
-        update.kvs[key] = value;
-    };
-
-    appendField("group", encodeMemoryText(memory.group));
-    appendField("owner", encodeMemoryText(memory.owner));
-    appendField("freq", QString::number(memory.freq, 'f', 6));
-    appendField("name", encodeMemoryText(memory.name));
-    appendField("mode", memory.mode);
-    appendField("step", QString::number(memory.step));
-    appendField("repeater", memory.offsetDir);
-    appendField("repeater_offset", QString::number(memory.repeaterOffset, 'f', 6));
-    appendField("tone_mode", memory.toneMode);
-    appendField("tone_value", QString::number(memory.toneValue, 'f', 1));
-    appendField("squelch", memory.squelch ? "1" : "0");
-    appendField("squelch_level", QString::number(memory.squelchLevel));
-    appendField("rx_filter_low", QString::number(memory.rxFilterLow));
-    appendField("rx_filter_high", QString::number(memory.rxFilterHigh));
-    appendField("rtty_mark", QString::number(memory.rttyMark));
-    appendField("rtty_shift", QString::number(memory.rttyShift));
-    appendField("digl_offset", QString::number(memory.diglOffset));
-    appendField("digu_offset", QString::number(memory.diguOffset));
-
-    return update;
 }
 
 } // namespace
@@ -758,106 +716,30 @@ void MemoryDialog::submitCellEdit(int row, int col)
 
 void MemoryDialog::onAdd()
 {
-    // memory create returns the new index in the response body.
-    // We then populate it from the current active slice state.
-    RadioModel* const model = m_model;
-    const QPointer<MemoryDialog> dialogGuard(this);
-    m_model->sendCmdPublic("memory create",
-        [model, dialogGuard](int code, const QString& body) {
-        if (code != 0) return;
-        bool ok;
-        int idx = body.trimmed().toInt(&ok);
-        if (!ok) return;
+    const auto slices = m_model->slices();
+    if (slices.isEmpty())
+        return;
 
-        // The radio created the memory but won't push status.
-        // We need to set each field from the active slice.
-        const auto slices = model->slices();
-        if (slices.isEmpty()) return;
-        SliceModel* s = nullptr;
-        for (auto* candidate : slices) {
-            if (candidate && candidate->isActive()) {
-                s = candidate;
-                break;
-            }
+    SliceModel* active = nullptr;
+    for (auto* candidate : slices) {
+        if (candidate && candidate->isActive()) {
+            active = candidate;
+            break;
         }
-        if (!s)
-            s = slices.first();
+    }
+    if (!active)
+        active = slices.first();
+    if (!active)
+        return;
 
-        // Set memory fields from current slice
-        auto send = [model](const QString& cmd) { model->sendCommand(cmd); };
-        QString base = QString("memory set %1 ").arg(idx);
-        send(base + QString("freq=%1").arg(s->frequency(), 0, 'f', 6));
-        send(base + QString("mode=%1").arg(s->mode()));
-        send(base + QString("owner=%1").arg(encodeMemoryText(model->callsign())));
+    createMemoryFromSlice(m_model, active, QString(), this,
+        [this](int code, const QString&, int memoryIndex) {
+        if (code != 0 || memoryIndex < 0)
+            return;
 
-        // Tag the memory with the active global profile name for filtering
-        const QString activeProfile = model->activeGlobalProfile();
-        if (!activeProfile.isEmpty()) {
-            send(base + QString("group=%1").arg(encodeMemoryText(activeProfile)));
-        }
-        send(base + QString("step=%1").arg(s->stepHz()));
-        send(base + QString("rx_filter_low=%1").arg(s->filterLow()));
-        send(base + QString("rx_filter_high=%1").arg(s->filterHigh()));
-        send(base + QString("squelch=%1").arg(s->squelchOn() ? 1 : 0));
-        send(base + QString("squelch_level=%1").arg(s->squelchLevel()));
-        send(base + QString("repeater=%1").arg(s->repeaterOffsetDir()));
-        send(base + QString("repeater_offset=%1").arg(s->fmRepeaterOffsetFreq(), 0, 'f', 6));
-        send(base + QString("tone_mode=%1").arg(s->fmToneMode()));
-        send(base + QString("tone_value=%1").arg(s->fmToneValue()));
-        send(base + QString("rtty_mark=%1").arg(s->rttyMark()));
-        send(base + QString("rtty_shift=%1").arg(s->rttyShift()));
-        send(base + QString("digl_offset=%1").arg(s->diglOffset()));
-        send(base + QString("digu_offset=%1").arg(s->diguOffset()));
-
-        // Create a local cache entry immediately for the table
-        MemoryEntry m;
-        m.index = idx;
-        m.freq = s->frequency();
-        m.mode = s->mode();
-        m.owner = model->callsign();
-        m.group = activeProfile;
-        m.step = s->stepHz();
-        m.rxFilterLow = s->filterLow();
-        m.rxFilterHigh = s->filterHigh();
-        m.squelch = s->squelchOn();
-        m.squelchLevel = s->squelchLevel();
-        m.offsetDir = s->repeaterOffsetDir();
-        m.repeaterOffset = s->fmRepeaterOffsetFreq();
-        m.toneMode = s->fmToneMode();
-        m.toneValue = s->fmToneValue().toDouble();
-        m.rttyMark = s->rttyMark();
-        m.rttyShift = s->rttyShift();
-        m.diglOffset = s->diglOffset();
-        m.diguOffset = s->diguOffset();
-
-        // Insert into RadioModel's cache via handleMemoryStatus
-        QMap<QString, QString> kvs;
-        kvs["freq"] = QString::number(m.freq, 'f', 6);
-        kvs["mode"] = m.mode;
-        kvs["owner"] = encodeMemoryText(m.owner);
-        if (!activeProfile.isEmpty()) {
-            kvs["group"] = encodeMemoryText(activeProfile);
-        }
-        kvs["step"] = QString::number(m.step);
-        kvs["rx_filter_low"] = QString::number(m.rxFilterLow);
-        kvs["rx_filter_high"] = QString::number(m.rxFilterHigh);
-        kvs["squelch"] = m.squelch ? "1" : "0";
-        kvs["squelch_level"] = QString::number(m.squelchLevel);
-        kvs["repeater"] = m.offsetDir;
-        kvs["repeater_offset"] = QString::number(m.repeaterOffset, 'f', 6);
-        kvs["tone_mode"] = m.toneMode;
-        kvs["tone_value"] = QString::number(m.toneValue, 'f', 1);
-        kvs["rtty_mark"] = QString::number(m.rttyMark);
-        kvs["rtty_shift"] = QString::number(m.rttyShift);
-        kvs["digl_offset"] = QString::number(m.diglOffset);
-        kvs["digu_offset"] = QString::number(m.diguOffset);
-        model->handleMemoryStatus(idx, kvs);
-
-        if (dialogGuard) {
-            dialogGuard->m_pendingEditMemoryIndex = idx;
-            dialogGuard->m_pendingEditRetries = 3;
-            dialogGuard->populateTable();
-        }
+        m_pendingEditMemoryIndex = memoryIndex;
+        m_pendingEditRetries = 3;
+        populateTable();
     });
 }
 

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -28,7 +28,7 @@ PanadapterStack::PanadapterStack(QWidget* parent)
     hbox->setContentsMargins(0, 0, 0, 0);
     hbox->setSpacing(0);
 
-    // Band stack panel (hidden by default, left of panadapter)
+    // Left-side band stack drawer (hidden by default, left of panadapter)
     m_bandStackPanel = new BandStackPanel(this);
     m_bandStackPanel->setVisible(false);
     hbox->addWidget(m_bandStackPanel);

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -28,7 +28,7 @@ PanadapterStack::PanadapterStack(QWidget* parent)
     hbox->setContentsMargins(0, 0, 0, 0);
     hbox->setSpacing(0);
 
-    // Left-side band stack drawer (hidden by default, left of panadapter)
+    // Band stack panel (hidden by default, left of panadapter)
     m_bandStackPanel = new BandStackPanel(this);
     m_bandStackPanel->setVisible(false);
     hbox->addWidget(m_bandStackPanel);

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1,5 +1,6 @@
 #include "SpectrumOverlayMenu.h"
 #include "DspParamPopup.h"
+#include "MemoryBrowsePanel.h"
 #include "SpectrumWidget.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
@@ -115,8 +116,10 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
         {"Band",      0, nullptr},   // 2 — toggleBandPanel
         {"ANT",       1, nullptr},   // 3 — toggleAntPanel
         {"DSP",       2, nullptr},   // 4 — toggleDspPanel
-        {"Display",   4, nullptr}, // 5 — toggleDisplayPanel
-        {"DAX",       3, nullptr},   // 6 — toggleDaxPanel
+        {"Display",   4, nullptr},   // 5 — toggleDisplayPanel
+        {QStringLiteral("MEM\u25b8"), 5, nullptr},   // 6 — toggleMemoryPanel
+        {"MEM+",      6, nullptr},   // 7 — quickAddMemoryRequested
+        {"DAX",       3, nullptr},   // 8 — toggleDaxPanel
     };
 
     for (const auto& def : defs) {
@@ -131,6 +134,13 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
             connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleDaxPanel);
         else if (def.specialIdx == 4)
             connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleDisplayPanel);
+        else if (def.specialIdx == 5)
+            connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleMemoryPanel);
+        else if (def.specialIdx == 6)
+            connect(btn, &QPushButton::clicked, this, [this]() {
+                hideAllSubPanels();
+                emit quickAddMemoryRequested(m_panId);
+            });
         else if (def.text == "+RX")
             connect(btn, &QPushButton::clicked, this, [this]() { emit addRxClicked(m_panId); });
         else if (def.sig)
@@ -139,14 +149,16 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
     }
 
     // Menu button tooltips
-    if (m_menuBtns.size() >= 7) {
-        m_menuBtns[0]->setToolTip("Add a new receive slice on this panadapter.");
-        m_menuBtns[1]->setToolTip("Add a tracking notch filter at the current frequency.");
-        m_menuBtns[2]->setToolTip("Open band selector.");
-        m_menuBtns[3]->setToolTip("Open antenna and RF gain controls.");
-        m_menuBtns[4]->setToolTip("Open DSP noise reduction and filter controls.");
-        m_menuBtns[5]->setToolTip("Open panadapter and waterfall display settings.");
-        m_menuBtns[6]->setToolTip("Open DAX audio routing channel selector.");
+    if (m_menuBtns.size() >= 9) {
+        m_menuBtns[kBtnAddRx]->setToolTip("Add a new receive slice on this panadapter.");
+        m_menuBtns[kBtnAddTnf]->setToolTip("Add a tracking notch filter at the current frequency.");
+        m_menuBtns[kBtnBand]->setToolTip("Open band selector.");
+        m_menuBtns[kBtnAnt]->setToolTip("Open antenna and RF gain controls.");
+        m_menuBtns[kBtnDsp]->setToolTip("Open DSP noise reduction and filter controls.");
+        m_menuBtns[kBtnDisplay]->setToolTip("Open panadapter and waterfall display settings.");
+        m_menuBtns[kBtnMemoryBrowse]->setToolTip("Browse saved memories for quick recall.");
+        m_menuBtns[kBtnMemoryAdd]->setToolTip("Save the current slice on this panadapter as a memory.");
+        m_menuBtns[kBtnDax]->setToolTip("Open DAX audio routing channel selector.");
     }
 
     buildBandPanel();
@@ -154,9 +166,11 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
     buildDspPanel();
     buildDaxPanel();
     buildDisplayPanel();
+    buildMemoryPanel();
 
     // Prevent mouse/wheel events from falling through panels to the spectrum
-    for (auto* panel : {m_bandPanel, m_antPanel, m_dspPanel, m_daxPanel, m_displayPanel})
+    for (auto* panel : {m_bandPanel, m_antPanel, m_dspPanel, m_daxPanel, m_displayPanel,
+                        static_cast<QWidget*>(m_memoryPanel)})
         if (panel) panel->installEventFilter(this);
 
     updateLayout();
@@ -171,6 +185,13 @@ void SpectrumOverlayMenu::raiseAll()
     if (m_dspPanel)     m_dspPanel->raise();
     if (m_daxPanel)     m_daxPanel->raise();
     if (m_displayPanel) m_displayPanel->raise();
+    if (m_memoryPanel)  m_memoryPanel->raise();
+}
+
+void SpectrumOverlayMenu::setMemories(const QMap<int, MemoryEntry>& memories)
+{
+    if (m_memoryPanel)
+        m_memoryPanel->setMemories(memories);
 }
 
 // ── Band sub-panel ────────────────────────────────────────────────────────────
@@ -726,14 +747,12 @@ void SpectrumOverlayMenu::toggleDspPanel()
     if (!wasVisible) {
         syncDspPanel();
         m_dspPanelVisible = true;
-        // Center vertically on the DSP button (index 4)
-        int btnCenterY = m_menuBtns[4]->y() + m_menuBtns[4]->height() / 2;
         // Top-align DSP panel with the button menu
         int panelY = y();
         m_dspPanel->move(x() + width(), std::max(0, panelY));
         m_dspPanel->raise();
         m_dspPanel->show();
-        m_menuBtns[4]->setStyleSheet(kMenuBtnActive);
+        m_menuBtns[kBtnDsp]->setStyleSheet(kMenuBtnActive);
     }
 }
 
@@ -791,12 +810,43 @@ void SpectrumOverlayMenu::toggleDaxPanel()
     if (!wasVisible) {
         syncDaxPanel();
         m_daxPanelVisible = true;
-        int btnCenterY = m_menuBtns[6]->y() + m_menuBtns[6]->height() / 2;
+        int btnCenterY = m_menuBtns[kBtnDax]->y() + m_menuBtns[kBtnDax]->height() / 2;
         int panelY = y() + btnCenterY - m_daxPanel->sizeHint().height() / 2;
         m_daxPanel->move(x() + width(), std::max(0, panelY));
         m_daxPanel->raise();
         m_daxPanel->show();
-        m_menuBtns[6]->setStyleSheet(kMenuBtnActive);
+        m_menuBtns[kBtnDax]->setStyleSheet(kMenuBtnActive);
+    }
+}
+
+void SpectrumOverlayMenu::buildMemoryPanel()
+{
+    m_memoryPanel = new MemoryBrowsePanel(parentWidget());
+    m_memoryPanel->hide();
+    connect(m_memoryPanel, &MemoryBrowsePanel::memoryActivated, this,
+            [this](int memoryIndex) {
+        hideAllSubPanels();
+        emit memoryActivated(memoryIndex, m_panId);
+    });
+}
+
+void SpectrumOverlayMenu::toggleMemoryPanel()
+{
+    const bool wasVisible = m_memoryPanelVisible;
+    hideAllSubPanels();
+    if (!wasVisible && m_memoryPanel) {
+        m_memoryPanelVisible = true;
+        const int panelH = m_memoryPanel->sizeHint().height();
+        int panelY = y();
+        if (auto* parent = parentWidget())
+            panelY = std::clamp(panelY, 0, qMax(0, parent->height() - panelH));
+        else
+            panelY = std::max(0, panelY);
+        m_memoryPanel->move(x() + width(), panelY);
+        m_memoryPanel->raise();
+        m_memoryPanel->show();
+        m_menuBtns[kBtnMemoryBrowse]->setStyleSheet(kMenuBtnActive);
+        m_memoryPanel->focusClosestToFrequency(m_slice ? m_slice->frequency() : -1.0);
     }
 }
 
@@ -816,11 +866,13 @@ void SpectrumOverlayMenu::hideAllSubPanels()
     if (m_daxPanel) m_daxPanel->hide();
     m_displayPanelVisible = false;
     if (m_displayPanel) m_displayPanel->hide();
-    m_menuBtns[2]->setStyleSheet(kMenuBtnNormal);  // Band
-    m_menuBtns[3]->setStyleSheet(kMenuBtnNormal);  // ANT
-    m_menuBtns[4]->setStyleSheet(kMenuBtnNormal);  // DSP
-    m_menuBtns[5]->setStyleSheet(kMenuBtnNormal);  // Display
-    m_menuBtns[6]->setStyleSheet(kMenuBtnNormal);  // DAX
+    m_memoryPanelVisible = false;
+    if (m_memoryPanel) m_memoryPanel->hide();
+    for (int idx : {kBtnBand, kBtnAnt, kBtnDsp, kBtnDisplay,
+                    kBtnMemoryBrowse, kBtnMemoryAdd, kBtnDax}) {
+        if (idx >= 0 && idx < m_menuBtns.size())
+            m_menuBtns[idx]->setStyleSheet(kMenuBtnNormal);
+    }
 }
 
 void SpectrumOverlayMenu::showBandPanelAt(const QPoint& pos)
@@ -832,7 +884,7 @@ void SpectrumOverlayMenu::showBandPanelAt(const QPoint& pos)
     m_bandPanel->move(pos);
     m_bandPanel->raise();
     m_bandPanel->show();
-    m_menuBtns[2]->setStyleSheet(kMenuBtnActive);
+    m_menuBtns[kBtnBand]->setStyleSheet(kMenuBtnActive);
 }
 
 void SpectrumOverlayMenu::toggleBandPanel()
@@ -850,13 +902,12 @@ void SpectrumOverlayMenu::toggleAntPanel()
     if (!wasVisible) {
         syncAntPanel();
         m_antPanelVisible = true;
-        // Center vertically on the ANT button (index 3)
-        int antBtnCenterY = m_menuBtns[3]->y() + m_menuBtns[3]->height() / 2;
+        int antBtnCenterY = m_menuBtns[kBtnAnt]->y() + m_menuBtns[kBtnAnt]->height() / 2;
         int panelY = y() + antBtnCenterY - m_antPanel->sizeHint().height() / 2;
         m_antPanel->move(x() + width(), std::max(0, panelY));
         m_antPanel->raise();
         m_antPanel->show();
-        m_menuBtns[3]->setStyleSheet(kMenuBtnActive);
+        m_menuBtns[kBtnAnt]->setStyleSheet(kMenuBtnActive);
     }
 }
 
@@ -1355,7 +1406,7 @@ void SpectrumOverlayMenu::toggleDisplayPanel()
         m_displayPanel->move(x() + width(), std::max(0, panelY));
         m_displayPanel->raise();
         m_displayPanel->show();
-        m_menuBtns[5]->setStyleSheet(kMenuBtnActive);
+        m_menuBtns[kBtnDisplay]->setStyleSheet(kMenuBtnActive);
     }
 }
 
@@ -1517,7 +1568,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     if (bandPanelWasVisible)
         showBandPanelAt(bandPanelPos);
     else
-        m_menuBtns[2]->setStyleSheet(kMenuBtnNormal);
+        m_menuBtns[kBtnBand]->setStyleSheet(kMenuBtnNormal);
 
     // Rebuild the XVTR sub-panel (kept as fallback)
     if (m_xvtrPanel) {
@@ -1632,7 +1683,7 @@ bool SpectrumOverlayMenu::eventFilter(QObject* obj, QEvent* event)
     }
     // Consume mouse/wheel events on sub-panels so they don't reach the spectrum
     if (obj == m_bandPanel || obj == m_antPanel || obj == m_dspPanel
-        || obj == m_daxPanel || obj == m_displayPanel) {
+        || obj == m_daxPanel || obj == m_displayPanel || obj == m_memoryPanel) {
         if (event->type() == QEvent::Wheel
             || event->type() == QEvent::MouseButtonPress
             || event->type() == QEvent::MouseButtonRelease) {

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "models/RadioModel.h"
+
 #include <QWidget>
 #include <QVector>
 #include <climits>
@@ -16,6 +18,7 @@ class QLabel;
 
 namespace AetherSDR {
 
+class MemoryBrowsePanel;
 class SliceModel;
 
 // Floating overlay menu anchored to the top-left of the SpectrumWidget.
@@ -29,6 +32,7 @@ public:
 
     // Raise this widget and all floating panels above sibling widgets.
     void raiseAll();
+    void setMemories(const QMap<int, MemoryEntry>& memories);
 
     // Set the antenna list (from RadioModel::antListChanged).
     void setAntennaList(const QStringList& ants);
@@ -75,6 +79,8 @@ protected:
 signals:
     void addRxClicked(const QString& panId);
     void addTnfClicked();
+    void memoryActivated(int memoryIndex, const QString& panId);
+    void quickAddMemoryRequested(const QString& panId);
     void daxIqChannelChanged(int channel);  // 0=Off, 1-4
     void addPanClicked();
     void daxClicked();
@@ -138,9 +144,21 @@ private:
     void syncDaxPanel();
     void toggleDisplayPanel();
     void buildDisplayPanel();
+    void toggleMemoryPanel();
+    void buildMemoryPanel();
     void hideAllSubPanels();
     void showBandPanelAt(const QPoint& pos);
     void syncAntPanel();
+
+    static constexpr int kBtnAddRx = 0;
+    static constexpr int kBtnAddTnf = 1;
+    static constexpr int kBtnBand = 2;
+    static constexpr int kBtnAnt = 3;
+    static constexpr int kBtnDsp = 4;
+    static constexpr int kBtnDisplay = 5;
+    static constexpr int kBtnMemoryBrowse = 6;
+    static constexpr int kBtnMemoryAdd = 7;
+    static constexpr int kBtnDax = 8;
 
     QPushButton* m_toggleBtn{nullptr};
     QVector<QPushButton*> m_menuBtns;
@@ -177,6 +195,10 @@ private:
     QWidget*   m_daxPanel{nullptr};
     bool       m_daxPanelVisible{false};
     QComboBox* m_daxIqCmb{nullptr};
+
+    // Memory browse sub-panel
+    MemoryBrowsePanel* m_memoryPanel{nullptr};
+    bool               m_memoryPanelVisible{false};
 
     // Display sub-panel
     QWidget*     m_displayPanel{nullptr};


### PR DESCRIPTION

<img width="904" height="629" alt="Screenshot 2026-04-20 at 5 45 51 PM" src="https://github.com/user-attachments/assets/b4d48c93-1047-49e4-8e6b-34e007b1bae9" />

## Summary

This PR adds two lightweight memory actions directly to the slice overlay menu so saved frequencies are faster to browse and store without opening the full memory window.

The new `MEM▸` action lives between `Display` and `DAX` in the left overlay rail and opens a compact quick-browser drawer. The browser shows a frequency-sorted list of saved memories, uses alternating row tones for readability, opens already centered near the active slice frequency, lightly highlights the closest saved memory, and immediately recalls a memory and closes when a row is clicked.

The new `MEM+` action opens a compact save dialog for the current slice on that panadapter. It prompts for a name, shows the current frequency plus mode/filter context, and saves the same slice memory fields as the main memory flow, including mode and filter settings.

## What Changed

- added `MEM▸` and `MEM+` buttons to the slice overlay menu between `Display` and `DAX`
- added a compact `MemoryBrowsePanel` quick browser used only by the new overlay action
- sorted the quick browser by frequency instead of memory index so new quick saves land where operators expect them
- auto-positioned the quick browser near the active slice frequency and highlighted the closest matching memory row on open
- added pan-aware recall/save wiring so each overlay acts on the slice associated with that panadapter
- introduced shared memory capture/save helpers so the quick-add flow and the main memory dialog store the same memory fields
- updated `MemoryDialog` to use the shared save helper for consistency

## Why

Before this change, memory save/recall was available through the main memory workflow, but there was no fast, in-context path from the slice overlay itself. That made simple "jump to a saved frequency" and "save what I am listening to right now" actions feel heavier than they needed to.

This PR keeps the quick workflow focused on speed while preserving the richer main memory window for full management tasks.

## Impact

Operators can now:

- browse nearby saved frequencies without losing screen space to the full memory window
- save the current slice in one small modal without leaving the active operating view
- recall a memory faster because the quick browser opens close to the active slice frequency instead of at the top of the list

The main memory box behavior is not changed as a user-facing workflow in this PR; the shared helper refactor is only there to keep the saved field set consistent between the existing dialog and the new quick-add path.

## Validation

- `cmake --build build -j10`
- manual verification of `MEM▸` drawer placement, compact layout, frequency sorting, nearest-frequency auto-scroll/highlight, and click-to-recall behavior
- manual verification of `MEM+` modal save flow and persistence of mode/filter settings

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.4 Pro) and tested by @jensenpat
