### PR TITLE
View: add Frameless Window toggle (Ctrl+Shift+F)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -303,6 +303,12 @@ MainWindow::MainWindow(QWidget* parent)
     setMinimumSize(1024, 600);
     resize(1400, 800);
 
+    // Apply frameless flag before first show() so the window is created
+    // without chrome from the start — avoids the flash + re-create that
+    // setWindowFlags() after show would cause (#framleess via View menu).
+    if (AppSettings::instance().value("FramelessWindow", "False").toString() == "True")
+        setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
+
     applyDarkTheme();
 
     // Audio worker thread (#502) — AudioEngine runs on its own thread so
@@ -4181,6 +4187,18 @@ void MainWindow::buildMenuBar()
         toggleMinimalMode(on);
     });
 
+    auto* framelessAct = viewMenu->addAction("Frameless Window");
+    framelessAct->setCheckable(true);
+    framelessAct->setShortcut(QKeySequence("Ctrl+Shift+F"));
+    framelessAct->setToolTip(
+        "Hide the OS title bar to gain screen space.\n"
+        "When enabled, move/close via keyboard shortcuts or taskbar.");
+    framelessAct->setChecked(
+        AppSettings::instance().value("FramelessWindow", "False").toString() == "True");
+    connect(framelessAct, &QAction::toggled, this, [this](bool on) {
+        setFramelessWindow(on);
+    });
+
     auto* propForecastAct = viewMenu->addAction("Propagation Conditions");
     propForecastAct->setCheckable(true);
     propForecastAct->setChecked(
@@ -7435,6 +7453,27 @@ void MainWindow::stepUiScale(int direction)
     }
     if (best != current)
         applyUiScale(best);
+}
+
+void MainWindow::setFramelessWindow(bool on)
+{
+    auto& s = AppSettings::instance();
+    s.setValue("FramelessWindow", on ? "True" : "False");
+    s.save();
+
+    // setWindowFlags() re-creates the native window — save and restore
+    // geometry so the window stays where the user put it.
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+    Qt::WindowFlags flags = windowFlags();
+    if (on)
+        flags |= Qt::FramelessWindowHint;
+    else
+        flags &= ~Qt::FramelessWindowHint;
+    setWindowFlags(flags);
+    setGeometry(geom);
+    if (wasVisible)
+        show();
 }
 
 void MainWindow::toggleMinimalMode(bool on)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -131,6 +131,10 @@ private:
     void applyUiScale(int pct);
     void stepUiScale(int direction);  // +1 = zoom in, -1 = zoom out
     void toggleMinimalMode(bool on);
+    // Toggle OS window-chrome on/off (Qt::FramelessWindowHint).  Persists
+    // to AppSettings("FramelessWindow"). When on, users move/close the
+    // window via keyboard shortcuts or taskbar.
+    void setFramelessWindow(bool on);
     void showMemoryDialog();
     void showQuickAddMemoryDialog(const QString& preferredPanId = {});
     void updateKeyerAvailability(const QString& mode);


### PR DESCRIPTION
Adds a View → Frameless Window checkable action that applies
Qt::FramelessWindowHint to MainWindow.  Persists to AppSettings key
"FramelessWindow" (default False).  When on, users gain ~32 px of
vertical screen space and lose the OS title bar; move/close via WM
keyboard shortcuts or taskbar.

Works cross-platform (X11, Wayland, Windows, macOS) — KDE/KWin
window rules for the same effect are unreliable on Wayland because
Qt6 uses client-side decorations the compositor can't strip.

The flag is applied in the MainWindow ctor *before* the first show()
when the saved setting is True, so the window is created frameless
from the start — no flash-of-chrome + re-create on startup.  Runtime
toggles save geometry, re-flag, and restore geometry so the window
doesn't jump.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
