### PR TITLE
Fix TCI RX gain default fallback: "1.0" → "0.5" to match TciApplet and DAX

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -66,7 +66,7 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                 s.setValue(key, legacy);
             }
             m_rxChannelGain[ch - 1] = std::clamp(
-                s.value(key, "1.0").toString().toFloat(), 0.0f, 1.0f);
+                s.value(key, "0.5").toString().toFloat(), 0.0f, 1.0f);
         }
         s.save();
     }


### PR DESCRIPTION
## Summary

- `TciServer` constructor reads `TciRxGain<n>` from AppSettings with a fallback of `"1.0"`, but `TciApplet` initialises its slider with `"0.5"` as the default — the same value used by all DAX gain paths.
- On a fresh install or after the `DaxRxGain` → `TciRxGain` key migration, if `TciRxGain` is absent from AppSettings the server runs at full gain (1.0) while the applet slider shows 0.5, making TCI RX audio 2× louder than DAX at nominally equal slider positions.
- Fix: change the `s.value(key, "1.0")` fallback to `"0.5"` to match every other gain path in the codebase.

## Test plan

- [ ] Fresh AppSettings (delete `~/.config/AetherSDR/AetherSDR.settings`): connect, open TCI applet — RX gain slider initialises at 0.5 and audio level matches DAX at equal slider position
- [ ] Existing AppSettings with `TciRxGain` present: no change in behaviour — stored value is read normally
- [ ] Existing AppSettings without `TciRxGain` (pre-migration): fallback now 0.5 instead of 1.0

## Notes

This is distinct from the closed PR #1559 ("Apply DAX RX gain to TCI audio output"), which proposed mirroring DAX gain into TCI and was superseded by the full TCI/DAX applet split in #1631. This PR only fixes the AppSettings default value — no change to gain application logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)