### PR TITLE
Fix missing HAVE_SERIALPORT guard on m_flexCoalesceTimer (#1606 partial)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5689,7 +5689,10 @@ void MainWindow::onSliceAdded(SliceModel* s)
     connect(s, &SliceModel::frequencyChanged, this, [this, s](double mhz) {
         // Don't snap overlay back to stale radio-confirmed freq during active
         // encoder tuning — the optimistic VFO position is already ahead (#1524)
-        bool activeTuning = m_flexCoalesceTimer.isActive();
+        bool activeTuning = false;
+#ifdef HAVE_SERIALPORT
+        activeTuning = activeTuning || m_flexCoalesceTimer.isActive();
+#endif
 #ifdef HAVE_HIDAPI
         activeTuning = activeTuning || m_hidCoalesceTimer.isActive();
 #endif


### PR DESCRIPTION
## Summary

PR #1606 guarded `m_hidCoalesceTimer` behind `#ifdef HAVE_HIDAPI` but left `m_flexCoalesceTimer` unguarded on the line immediately above. `m_flexCoalesceTimer` is declared inside `#ifdef HAVE_SERIALPORT` in `MainWindow.h` (line 217), so the unguarded reference in `MainWindow.cpp` breaks any build where `HAVE_SERIALPORT` is not defined — specifically Windows without `Qt6::SerialPort` installed.

**Before (broken):**
```cpp
bool activeTuning = m_flexCoalesceTimer.isActive();  // ← unguarded
#ifdef HAVE_HIDAPI
activeTuning = activeTuning || m_hidCoalesceTimer.isActive();
#endif
```

**After:**
```cpp
bool activeTuning = false;
#ifdef HAVE_SERIALPORT
activeTuning = activeTuning || m_flexCoalesceTimer.isActive();
#endif
#ifdef HAVE_HIDAPI
activeTuning = activeTuning || m_hidCoalesceTimer.isActive();
#endif
```

This was flagged in a comment on #1606 at the time of merge.

## Test plan

- [ ] Build on Windows without `Qt6::SerialPort` — previously failed with `'m_flexCoalesceTimer' was not declared in this scope`, now compiles clean
- [ ] Build on Linux (HAVE_SERIALPORT defined) — no change in behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)