### PR TITLE
Fix applet pop-out persistence and app-exit regression

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -458,8 +458,12 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         // the container manager so the float state carries over.
         // The key is read once; the new ContainerManager persistence
         // takes over from that point.
+        // Sanitize '/' in IDs like "P/CW" — System A's floatKey() helper
+        // replaced '/' with '_', so match that exact key format here.
+        QString safeId = id;
+        safeId.replace('/', '_');
         const QString legacyFloatKey =
-            QStringLiteral("FloatingApplet_%1_IsFloating").arg(id);
+            QStringLiteral("FloatingApplet_%1_IsFloating").arg(safeId);
         if (settings.value(legacyFloatKey, "False").toString() == "True" && on) {
             QTimer::singleShot(0, this, [this, id]() {
                 if (m_containerMgr) m_containerMgr->floatContainer(id);

--- a/src/gui/containers/ContainerManager.cpp
+++ b/src/gui/containers/ContainerManager.cpp
@@ -30,9 +30,13 @@ ContainerWidget::DockMode dockModeFromString(const QString& s)
 
 // Build the AppSettings key for a floating container's geometry.
 // Stable across launches so saved geometry survives rename-free.
+// Sanitize '/' in IDs like "P/CW" — slashes are invalid in the
+// AppSettings XML element names and cause silent save/load failures.
 QString geometryKeyFor(const QString& id)
 {
-    return QStringLiteral("ContainerGeometry_%1").arg(id);
+    QString safe = id;
+    safe.replace('/', '_');
+    return QStringLiteral("ContainerGeometry_%1").arg(safe);
 }
 
 } // namespace

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -27,6 +27,11 @@ FloatingContainerWindow::FloatingContainerWindow(QWidget* parent)
     m_layout = new QVBoxLayout(this);
     m_layout->setContentsMargins(0, 0, 0, 0);
     m_layout->setSpacing(0);
+
+    m_saveTimer.setSingleShot(true);
+    m_saveTimer.setInterval(400);
+    connect(&m_saveTimer, &QTimer::timeout, this,
+            &FloatingContainerWindow::saveGeometryToKey);
 }
 
 FloatingContainerWindow::~FloatingContainerWindow() = default;
@@ -131,13 +136,13 @@ void FloatingContainerWindow::closeEvent(QCloseEvent* ev)
 void FloatingContainerWindow::moveEvent(QMoveEvent* ev)
 {
     QWidget::moveEvent(ev);
-    if (!m_restoring) saveGeometryToKey();
+    if (!m_restoring) m_saveTimer.start();
 }
 
 void FloatingContainerWindow::resizeEvent(QResizeEvent* ev)
 {
     QWidget::resizeEvent(ev);
-    if (!m_restoring) saveGeometryToKey();
+    if (!m_restoring) m_saveTimer.start();
 }
 
 } // namespace AetherSDR

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -23,6 +23,7 @@ FloatingContainerWindow::FloatingContainerWindow(QWidget* parent)
     : QWidget(parent, Qt::Window)
 {
     setAttribute(Qt::WA_DeleteOnClose, false);
+    setAttribute(Qt::WA_QuitOnClose, false);
     setStyleSheet("QWidget { background: #08121d; }");
     m_layout = new QVBoxLayout(this);
     m_layout->setContentsMargins(0, 0, 0, 0);

--- a/src/gui/containers/FloatingContainerWindow.h
+++ b/src/gui/containers/FloatingContainerWindow.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QString>
+#include <QTimer>
 #include <QWidget>
 
 class QVBoxLayout;
@@ -67,6 +68,7 @@ private:
     QVBoxLayout*     m_layout{nullptr};
     QString          m_geometryKey;
     bool             m_restoring{false};
+    QTimer           m_saveTimer;
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
Four bugs introduced when the applet system migrated from
`FloatingAppletWindow` (System A) to `ContainerManager` (System B):

---

## Root causes fixed

### 1 — `ContainerGeometry_P/CW` is an invalid AppSettings XML key (ContainerManager.cpp)

`geometryKeyFor("P/CW")` produced the key `ContainerGeometry_P/CW`.
The forward slash is not a valid XML element-name character, so
`AppSettings` silently fails to save or load geometry for the P/CW
applet — position is lost on every restart.

**Fix:** Sanitize `/` → `_` in `geometryKeyFor()` before building
the key string, producing `ContainerGeometry_P_CW`. This matches the
`floatKey()` sanitizer that existed in System A.

### 2 — Legacy float-state migration reads wrong key for P/CW (AppletPanel.cpp)

The one-shot migration in `makeEntry()` that carries float state from
the old `FloatingApplet_<ID>_IsFloating` key reads the raw ID, so it
looked for `FloatingApplet_P/CW_IsFloating`. System A's `floatKey()`
helper wrote `FloatingApplet_P_CW_IsFloating` (sanitized). The keys
never matched, so users who had P/CW floating under System A would see
it docked on first launch under System B.

**Fix:** Apply the same `/` → `_` sanitization to `safeId` before
constructing `legacyFloatKey`.

### 3 — Floating windows prevent app exit (FloatingContainerWindow.cpp)

`FloatingContainerWindow` is created as a parentless top-level widget.
Qt's `quitOnLastWindowClosed` mechanism fires when the last window with
`WA_QuitOnClose=true` closes — but floating applet windows carry that
flag (the default), so closing the main window leaves the process alive
as long as any applet is popped out.

**Fix:** `setAttribute(Qt::WA_QuitOnClose, false)` in the constructor.
Marks floating applet windows as secondary so the main window's close
is sufficient to exit the application.

### 4 — No debounce on geometry saves hammers AppSettings (FloatingContainerWindow.cpp)

`moveEvent` and `resizeEvent` each called `saveGeometryToKey()`
directly, firing on every pixel of a window drag or resize. At
~60 Hz this can produce thousands of AppSettings writes per second
and cause noticeable I/O during any window move.

**Fix:** Route both events through a 400 ms single-shot `QTimer`
(`m_saveTimer`). The timer restarts on each event; geometry is written
once, 400 ms after the user stops moving or resizing — matching the
debounce approach used in System A's `FloatingAppletWindow`.

---

## Files changed

| File | Change |
|---|---|
| `src/gui/containers/ContainerManager.cpp` | Sanitize `/` → `_` in `geometryKeyFor()` |
| `src/gui/AppletPanel.cpp` | Sanitize ID before building `legacyFloatKey` in `makeEntry()` |
| `src/gui/containers/FloatingContainerWindow.h` | Add `QTimer m_saveTimer` member; `#include <QTimer>` |
| `src/gui/containers/FloatingContainerWindow.cpp` | `WA_QuitOnClose=false` in constructor; wire 400 ms debounce timer; `moveEvent`/`resizeEvent` start timer instead of saving directly |

---

## Scope note

All applets — including the newer CAT, DAX, TCI, IQ, MTR, AG, MQTT,
and PUDU sub-containers — already go through `makeEntry()` and receive
a `ContainerWidget` with a float button. The pop-out affordance was
architecturally present; these fixes restore correct persistence for
any ID containing `/` and reduce write pressure for all floating applets.

---

## Verification checklist

- [ ] **P/CW pop out** — Click the float button on the Phone/CW applet.
  Window appears. Close app and reopen — window re-appears at the same
  position.
- [ ] **P/CW dock** — Click the dock button. Applet returns to the
  sidebar at its original position.
- [ ] **Phone applet pop out / dock / position persistence** — Same
  steps as above for the PHNE applet.
- [ ] **Newer applets** — Verify CAT, DAX, TCI, IQ, MTR pop out and
  restore position correctly.
- [ ] **No geometry loss on reconnect** — Float an applet, disconnect
  from radio, reconnect. Floating window reappears at saved position.
- [ ] **No I/O burst during drag** — Float any applet, drag its window
  slowly. Protocol log / system monitor should not show continuous disk
  writes during the drag.
- [ ] **App exits cleanly with floated applets** — Pop out one or more
  applets, then close the main window. The process should exit fully
  rather than lingering with orphaned floating windows.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
