### PR TITLE
[core] Unify recenter policy across tuning and pan/zoom workflows

### DIFF
--- a/RECENTER.md
+++ b/RECENTER.md
@@ -1,0 +1,526 @@
+# Recenter Architecture
+
+This document describes the current pan-follow / recenter architecture implemented in the `aether/recenter-policy` worktree.
+
+It is intentionally a description of the code as it exists today, not an aspirational rewrite. The goal is to give future review and iteration work a stable reference point.
+
+## Why This Exists
+
+The current implementation centralizes tuning and reveal policy in `MainWindow` so we can make pan-follow and recenter behavior more consistent across input modalities without rewriting the radio/tuning subsystem before 1.0.
+
+The architecture is deliberately:
+
+- low risk
+- localized
+- Qt-native
+- cross-platform
+- compatible with existing `SliceModel`, `PanadapterModel`, and `SpectrumWidget` responsibilities
+
+## Primary Files
+
+- `src/gui/MainWindow.h`
+- `src/gui/MainWindow.cpp`
+- `src/gui/SpectrumWidget.h`
+- `src/gui/SpectrumWidget.cpp`
+- `src/gui/VfoWidget.h`
+- `src/gui/VfoWidget.cpp`
+- `src/models/SliceModel.h`
+- `src/models/SliceModel.cpp`
+- `src/models/PanadapterModel.h`
+- `src/models/PanadapterModel.cpp`
+
+## High-Level Structure
+
+At a high level:
+
+1. UI surfaces emit intent-shaped tuning signals.
+2. `MainWindow` resolves the target slice and applies a shared tuning policy.
+3. `SliceModel` performs the actual frequency command.
+4. `MainWindow` optionally applies reveal/pan-follow on the owning panadapter.
+5. `PanadapterModel` and `SpectrumWidget` handle center/bandwidth state and animation.
+
+```mermaid
+flowchart LR
+    A["Input Sources\nSpectrum click / ordinary spot click\nSpectrum wheel / trackpad\nVFO wheel\nVFO direct entry\nKeyboard / Go To Frequency\nFlexControl\nHID encoder\nMIDI\nMemory recall / memory spot\nDX / BandStack\nZero beat / split swap"] --> B["MainWindow shared policy\napplyTuneRequest(...)\nrevealFrequencyIfNeeded(...)\npanFollowVfo(...)"]
+    B --> C["SliceModel\nsetFrequency(... autopan=0)\nor tuneAndRecenter(...) for hard-center paths"]
+    B --> D["PanadapterModel\napplyPanStatus(center/bandwidth)\nsend pan command(s)"]
+    D --> E["SpectrumWidget\nsetFrequencyRange(...)\n110 ms small follow animation\nsnap for large shifts"]
+    C --> F["Radio command path"]
+    C --> G["frequencyChanged echoes\nVFO label / overlay refresh"]
+```
+
+## Core Policy Object
+
+The shared policy lives in `MainWindow` and is expressed through:
+
+- `TuneIntent`
+- `applyTuneRequest(...)`
+- `applyPanRangeRequest(...)`
+- `revealFrequencyIfNeeded(...)`
+- `panFollowVfo(...)`
+- `logTunePolicyDecision(...)`
+
+### `TuneIntent`
+
+`MainWindow::TuneIntent` currently has five values:
+
+- `IncrementalTune`
+- `AbsoluteJump`
+- `CommandedTargetCenter`
+- `ExplicitPan`
+- `RevealOffscreen`
+
+The important architectural decision is that the tuning subsystem itself was not rewritten. Instead, `MainWindow` classifies caller intent and decides whether the requested frequency should only tune, tune-and-follow, tune-and-reveal, tune-and-center a commanded target, or remain a pure user-driven pan action.
+
+## Ownership Boundaries
+
+### `SpectrumWidget`
+
+`SpectrumWidget` is responsible for:
+
+- converting user gestures into signals
+- maintaining local visual pan state
+- animating small center nudges in `setFrequencyRange(...)`
+- preserving explicit pan and zoom behavior
+
+It is not responsible for deciding whether a gesture should reveal or recenter. That policy decision was moved upward into `MainWindow`.
+
+### `VfoWidget`
+
+`VfoWidget` is responsible for:
+
+- emitting incremental wheel tuning via `stepTuneRequested(...)`
+- emitting committed direct entry via `directEntryCommitted(...)`, including the source tag used for policy logging
+- letting both ordinary VFO entry and keyboard `Go To Frequency` share the same commanded-center commit behavior
+- leaving reveal / recenter policy to `MainWindow`
+
+### `SliceModel`
+
+`SliceModel` still owns the actual frequency command behavior:
+
+- `setFrequency(...)` sends `slice tune <id> <freq> autopan=0`
+- `tuneAndRecenter(...)` sends `slice tune <id> <freq>` without `autopan=0`
+
+This is a critical architectural boundary: the shared policy prefers `setFrequency(...)` plus client-side reveal logic, and only leaves a few intentional hard-center paths on `tuneAndRecenter(...)`.
+
+### `PanadapterModel`
+
+`PanadapterModel` remains the source of center/bandwidth state and emits `infoChanged(center, bandwidth)`. `MainWindow` may optimistically call `applyPanStatus(...)` before the radio echo arrives so the UI can repaint immediately.
+
+## End-to-End Tuning Flow
+
+### Shared path
+
+For the policy-controlled paths, the flow is:
+
+1. Resolve a target slice.
+2. Call `applyTuneRequest(slice, mhz, intent, source)`.
+3. If unlocked, update the active overlay/VFO immediately when appropriate.
+4. Call `SliceModel::setFrequency(...)`.
+5. Mirror diversity-child visuals if needed.
+6. Apply either:
+   - `panFollowVfo(...)` for `IncrementalTune`
+   - `revealFrequencyIfNeeded(...)` for all non-incremental shared reveal / center paths
+7. Emit concise debug logging.
+
+### Explicit pan/zoom path
+
+Explicit pan/zoom interactions do not use `applyTuneRequest(...)`. They continue to emit:
+
+- `centerChangeRequested(...)`
+- `bandwidthChangeRequested(...)`
+- `frequencyRangeChangeRequested(...)`
+
+Those signals now route through a small explicit pan/zoom path in `MainWindow` so combined center+bandwidth changes can be sent as one coherent radio command while preserving current user-driven semantics.
+
+## Intent Semantics
+
+### 1. `IncrementalTune`
+
+Used for stepwise tuning inputs where the user expects frequency motion without repeated dead-centering.
+
+Current examples:
+
+- spectrum wheel
+- spectrum trackpad scroll
+- VFO drag in spectrum
+- VFO wheel
+- keyboard arrows
+- FlexControl
+- HID encoder
+- MIDI relative
+- MIDI absolute fallback
+- zero beat
+- split swap
+
+Current behavior:
+
+- tune via `SliceModel::setFrequency(...)`
+- use client-side reveal/pan-follow
+- do not dead-center
+- obey the `PanFollowVfo` setting
+
+Current constants in `MainWindow.cpp`:
+
+- incremental trigger edge margin: `0.12`
+- incremental settle edge margin: `0.18`
+- small follow animation target: `110 ms`
+
+Operationally:
+
+- if the tuned frequency remains inside the trigger window, no recenter happens
+- once it crosses the trigger fence, pan follow uses the configured step size as its nudge quantum when that step is available
+- the center moves in step-sized increments only far enough to bring the slice back to the trigger boundary, instead of jumping straight to the settle boundary
+- the older settle target is still used as a safety cap and as the fallback when no step size is available
+
+### 2. `AbsoluteJump`
+
+Used for jump-style frequency requests where the destination may be far away but should not always be hard-centered.
+
+Current examples:
+
+- same-pan click-to-tune
+- cross-pan click-to-tune
+- ordinary spot click
+- DX cluster tune
+- BandStack recall
+- off-screen "Move Slice Here"
+
+Current behavior:
+
+- prefer `SliceModel::setFrequency(...)`
+- call shared reveal logic only if the target is off-screen or too close to the visible edge
+- avoid double-centering
+- keep already-visible spot clicks and other contextual jumps from being forced back to pan center
+
+Reveal behavior uses the current comfort edge margin:
+
+- reveal comfort edge margin: `0.18`
+
+### 3. `CommandedTargetCenter`
+
+Used for deliberate command-style jumps where the target frequency should become the pan center, not merely be revealed.
+
+Current examples:
+
+- VFO direct entry commit
+- keyboard `Go To Frequency` commit
+- memory quick recall
+- Memory dialog recall
+- memory spot click
+- memory post-apply timeout fallback
+
+Current behavior:
+
+- tune via `SliceModel::setFrequency(...)`
+- apply a single shared center decision in `MainWindow` after the tune request
+- keep tune and center ordering coupled inside the shared policy path
+- reuse the same optimistic pan update and `SpectrumWidget::setFrequencyRange(...)` animation/snap behavior as other shared center changes
+- use the same intent whether the commanded target came from VFO direct entry, keyboard `Go To Frequency`, a memory UI surface, or a memory spot on the panadapter
+
+### 4. `ExplicitPan`
+
+This exists in the enum as a policy category, and current explicit pan and zoom gestures intentionally stay outside the shared tune helper path.
+
+Those gestures still operate through:
+
+- `SpectrumWidget::frequencyRangeChangeRequested(...)`
+- `SpectrumWidget::centerChangeRequested(...)`
+- `SpectrumWidget::bandwidthChangeRequested(...)`
+
+Current behavior:
+
+- combined zoom operations use `applyPanRangeRequest(...)` in `MainWindow`
+- `MainWindow` optimistically updates `PanadapterModel` with both center and bandwidth together
+- `MainWindow` sends one `display pan set ... center=... bandwidth=...` command for that explicit range change
+- pure pan drags still use center-only commands
+- pure bandwidth-only controls can still use bandwidth-only commands when no center change is involved
+- combined center+bandwidth updates were added specifically to avoid the waterfall-loss / zoom-drift bug class caused by sending those two values separately for one visual operation
+
+This preserves user-driven pan/zoom semantics rather than layering auto-follow on top of them, while avoiding transient split states between center and bandwidth during explicit zoom operations.
+
+### 5. `RevealOffscreen`
+
+Used when a slice becomes the active context but is not currently visible.
+
+Current example:
+
+- `setActiveSliceInternal(..., revealOffscreen=true)`
+
+Current behavior:
+
+- active slice changes still happen through the existing active-slice machinery
+- if the slice is off-screen, `revealFrequencyIfNeeded(...)` is used to bring it into view predictably
+- explicit "Center Slice" actions remain hard-center and are not downgraded to reveal-only behavior
+
+## Current Signal Map
+
+### `SpectrumWidget` -> `MainWindow`
+
+Current signal split:
+
+- `frequencyClicked(double mhz)` -> absolute jump
+- `incrementalTuneRequested(double mhz)` -> incremental tune
+- `frequencyRangeChangeRequested(double center, double bw)` -> explicit combined pan/zoom
+- `centerChangeRequested(double center)` -> explicit pan
+- `bandwidthChangeRequested(double bw)` -> explicit zoom / bandwidth control
+- `sliceTuneRequested(int sliceId, double freqMhz)` -> absolute jump for "Move Slice Here"
+
+Notable gesture sources in `SpectrumWidget`:
+
+- non-memory spot click emits `frequencyClicked(...)`
+- memory spot click emits `spotTriggered(...)` so the recall path can own tune-and-center ordering
+- memory spots intentionally bypass the generic `frequencyClicked(...)` path to avoid an immediate reveal followed by a delayed centered memory confirm
+- single-click tune emits `frequencyClicked(...)`
+- double-click tune emits `frequencyClicked(...)`
+- VFO drag emits `incrementalTuneRequested(...)`
+- wheel and trackpad scroll emit `incrementalTuneRequested(...)`
+- pan drag emits `centerChangeRequested(...)`
+- pinch zoom emits `frequencyRangeChangeRequested(...)`
+- bandwidth drag emits `frequencyRangeChangeRequested(...)`
+- zoom buttons emit `frequencyRangeChangeRequested(...)`
+- off-screen "Center Slice" emits `centerChangeRequested(...)` directly and remains an explicit center
+
+### `VfoWidget` -> `MainWindow`
+
+- `stepTuneRequested(double mhz)` -> `IncrementalTune`
+- `directEntryCommitted(double mhz, QString source)` -> `CommandedTargetCenter`
+- `zeroBeatRequested()` -> tuned through shared incremental behavior in `MainWindow`
+- `swapRequested()` -> tuned through shared incremental behavior in `MainWindow`
+
+## Cross-Pan Target Resolution
+
+Cross-pan tuning is resolved in `wirePanadapter(...)` using a local `resolveSpectrumTuneTarget` helper.
+
+Current behavior:
+
+- determine the panadapter that owns the gesture
+- if the active slice is already on that pan, use it
+- otherwise choose a slice whose `panId()` matches that pan
+
+Important implementation detail:
+
+- cross-pan spectrum tune now defers the active-slice switch using `queueActiveSliceForSpectrumTarget(...)`
+- the tune itself is still applied immediately to the resolved slice
+- the visible active-slice handoff happens on the next event-loop turn
+
+This was added as a low-risk mitigation to avoid synchronous active-pan/widget churn inside the spectrum event handler.
+
+## Reveal Algorithm
+
+`revealFrequencyIfNeeded(...)` is the central reveal helper.
+
+It currently:
+
+1. reads the owning `PanadapterModel`
+2. derives the visible half-bandwidth
+3. computes trigger and settle distances based on intent
+4. decides whether the target is too close to an edge
+5. computes a new center only when needed
+6. applies the center optimistically with `PanadapterModel::applyPanStatus(...)`
+7. sends the matching radio command
+
+For small shifts:
+
+- `SpectrumWidget::setFrequencyRange(...)` animates the center change over `110 ms`
+
+For larger shifts or bandwidth changes:
+
+- `SpectrumWidget::setFrequencyRange(...)` snaps immediately
+
+The widget already has architecture to distinguish a small follow nudge from a large shift:
+
+- small shift -> animate
+- large shift or bandwidth change -> cancel animation and snap
+
+## Logging
+
+`logTunePolicyDecision(...)` emits policy diagnostics with:
+
+- source
+- intent
+- old frequency
+- new frequency
+- old center
+- new center
+- bandwidth
+- whether follow/reveal triggered
+- whether a hard center was used
+- animation duration
+
+This is meant for behavior verification and regression tracing rather than permanent analytics.
+
+## Current Call-Site Classification
+
+### Shared incremental policy
+
+These currently route through `applyTuneRequest(..., IncrementalTune, ...)`:
+
+- FlexControl
+- MIDI relative
+- HID encoder
+- spectrum wheel / trackpad scroll
+- spectrum VFO drag
+- VFO wheel
+- keyboard arrows
+- zero beat
+- split swap
+- MIDI absolute fallback
+
+### Shared absolute jump/reveal policy
+
+These currently route through `applyTuneRequest(..., AbsoluteJump, ...)`:
+
+- spectrum click-to-tune
+- cross-pan click-to-tune
+- ordinary spot click
+- DX cluster tune
+- BandStack recall
+- off-screen "Move Slice Here"
+
+### Shared commanded-center policy
+
+These currently route through `applyTuneRequest(..., CommandedTargetCenter, ...)` or the same intent after radio confirmation:
+
+- VFO direct entry
+- keyboard `Go To Frequency`
+- quick memory recall
+- Memory dialog recall
+- memory spot click
+- memory recall post-apply reveal / timeout
+
+### Shared reveal-only path
+
+These currently route through shared reveal logic without becoming hard-center:
+
+- active-slice switch when the slice is off-screen
+
+### Shared explicit pan/zoom path
+
+These currently route through `applyPanRangeRequest(...)` when center and bandwidth should move together:
+
+- spectrum zoom buttons
+- spectrum pinch zoom
+- spectrum bandwidth drag
+- keyboard panadapter zoom `+` / `-`
+
+### Explicit center actions that stay hard-center
+
+These remain true center operations:
+
+- `centerActiveSliceInPanadapter(...)`
+- off-screen "Center Slice"
+- off-screen double-click center
+
+## Memory Recall Architecture
+
+Memory recall needed special treatment because the final tuned frequency may not be locally authoritative at the moment the memory is applied.
+
+Current approach:
+
+- `activateMemorySpot(...)` sends `memory apply`
+- it records `m_pendingMemoryRevealSliceId`
+- if a `frequencyChanged(...)` arrives for that slice, shared commanded-center logic runs using the actual resulting frequency
+- a timeout fallback runs if the radio echo is delayed
+
+This avoids guessing the post-memory frequency too early.
+
+Important signal-routing detail:
+
+- ordinary spots and memory spots no longer share the same first-hop tune signal
+- ordinary spots stay on the reveal-oriented `AbsoluteJump` path
+- memory spots go straight to memory recall handling so the eventual centered recall is the only tune/recenter decision for that click
+
+## Spot Behavior Summary
+
+The current design intentionally splits spot behavior into two categories:
+
+- ordinary spots are contextual tune targets and use `AbsoluteJump`
+- memory spots are command-style recall targets and use `CommandedTargetCenter`
+
+Practical effect:
+
+- clicking a visible ordinary spot should usually keep the current pan unless the target is too close to an edge
+- clicking an ordinary spot near an edge should reveal it once, without a hard center
+- clicking a memory spot should behave like recalling a known target and end with the target centered
+- memory spots should not first do a generic reveal and then later do a second center motion
+
+## Settings and Guards
+
+### `PanFollowVfo`
+
+Current meaning:
+
+- gates incremental auto-follow / reveal
+- does not block explicit center actions
+- does not block absolute jump reveal behavior where the goal is to make the target visible
+
+### `m_updatingFromModel`
+
+Used to suppress client-side echo loops while applying model-driven UI updates.
+
+### `m_pendingMemoryRevealSliceId`
+
+Tracks a slice waiting for post-memory reveal.
+
+### `m_pendingSpectrumTargetSliceId`
+
+Tracks a queued cross-pan active-slice handoff created from a spectrum gesture.
+
+## Intentional Hard-Center Paths Kept
+
+For lowest risk before 1.0, several paths intentionally remain hard-center:
+
+- band shortcuts
+- `restoreBandState(...)`
+- unrecognized band fallback in band selection
+- explicit center actions
+
+These still use `tuneAndRecenter(...)` or direct center commands on purpose.
+
+## Known Gaps / Remaining Inconsistencies
+
+These paths are still outside the shared policy and should be treated as known follow-up items:
+
+- `src/gui/RxApplet.cpp` still contains a direct-entry `tuneAndRecenter(...)` path
+
+## Design Constraints Preserved
+
+The current architecture intentionally does not:
+
+- redesign the radio/tuning subsystem
+- move policy into `SliceModel`
+- introduce OS-specific scroll physics
+- add spring/inertia behavior beyond existing Qt animation
+
+It does preserve:
+
+- existing `SpectrumWidget::setFrequencyRange(...)` architecture
+- `SliceModel` as the owner of tune command emission
+- radio-authoritative pan state
+- direct user pan/zoom control
+
+## Practical Review Checklist
+
+When reviewing future changes, use this checklist:
+
+- Does the path clearly map to one of the five intents?
+- Is the target slice resolved once and consistently?
+- Does the path use `setFrequency(...)` unless a true hard-center is intended?
+- Could the user see two center operations for one action?
+- Does the path preserve explicit pan/zoom semantics?
+- Does the path respect `PanFollowVfo` where incremental follow is implied?
+- If the target slice is off-screen, is reveal happening with shared logic rather than bespoke code?
+- If the path is a spot action, is it clearly classified as ordinary spot reveal or memory spot commanded-center?
+- If the path is a memory action, does it avoid an initial generic tune signal plus a second delayed center?
+- If a path still hard-centers, is that intentional and documented?
+
+## Suggested Next Iteration Topics
+
+Good follow-up areas for iteration:
+
+- fold remaining direct-entry paths into the shared policy
+- decide whether explicit pan/zoom should eventually reuse the tune-policy logging format for consistency
+- tighten the boundary between optimistic local UI updates and radio echo updates
+- continue validating cross-pan behavior, especially under rapid wheel/trackpad input on macOS
+- decide whether hard-center exceptions should shrink further after 1.0 risk drops

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -85,6 +85,8 @@
 #include "AetherDspDialog.h"
 #include "DspParamPopup.h"
 
+#include <algorithm>
+#include <cmath>
 #include <memory>
 #include <functional>
 #include <QApplication>
@@ -151,6 +153,24 @@
 #include <QLocale>
 
 namespace AetherSDR {
+
+namespace {
+
+constexpr double kIncrementalTriggerEdgeMarginFrac = 0.12;
+constexpr double kIncrementalSettleEdgeMarginFrac = 0.18;
+constexpr double kRevealComfortEdgeMarginFrac = 0.18;
+constexpr int kPanFollowAnimationDurationMs = 110;
+
+double quantizeIncrementalFollowDelta(double overshootMhz, double stepMhz)
+{
+    if (overshootMhz <= 0.0)
+        return 0.0;
+    if (stepMhz <= 0.0)
+        return overshootMhz;
+    return std::ceil((overshootMhz - 1e-12) / stepMhz) * stepMhz;
+}
+
+}  // namespace
 
 static bool macDaxDriverInstalled()
 {
@@ -1809,9 +1829,7 @@ MainWindow::MainWindow(QWidget* parent)
         auto* s = activeSlice();
         if (!s || s->isLocked()) { m_flexTargetMhz = -1.0; return; }
         double target = m_flexTargetMhz;
-        // Use slice tune (not slice m) — doesn't recenter pan, correct for encoder
-        s->setFrequency(target);
-        panFollowVfo(s, target);  // re-center pan if VFO stepped outside visible window (#989)
+        applyTuneRequest(s, target, TuneIntent::IncrementalTune, "flexcontrol");
     });
     // FlexControl signals (auto-queued from worker → main)
     connect(m_flexControl, &FlexControlManager::tuneSteps,
@@ -1965,8 +1983,7 @@ MainWindow::MainWindow(QWidget* parent)
             long long curHz = static_cast<long long>(std::round(s->frequency() * 1e6));
             long long snapped = ((curHz + stepHz / 2) / stepHz) * stepHz;
             double newMhz = (snapped + steps * stepHz) / 1e6;
-            s->setFrequency(newMhz);
-            panFollowVfo(s, newMhz);  // re-center pan if VFO stepped outside visible window (#989)
+            applyTuneRequest(s, newMhz, TuneIntent::IncrementalTune, "midi-relative");
         }
     });
 
@@ -1990,11 +2007,7 @@ MainWindow::MainWindow(QWidget* parent)
         int stepHz = spectrum() ? spectrum()->stepSize() : 100;
         double newMhz = s->frequency() + m_hidPendingSteps * stepHz / 1e6;
         m_hidPendingSteps = 0;
-        QString panId = m_panStack ? m_panStack->activePanId() : m_radioModel.panId();
-        if (!panId.isEmpty())
-            m_radioModel.sendCommand(
-                QString("slice m %1 pan=%2").arg(newMhz, 0, 'f', 6).arg(panId));
-        if (spectrum()) spectrum()->setVfoFrequency(newMhz);
+        applyTuneRequest(s, newMhz, TuneIntent::IncrementalTune, "hid-encoder");
     });
 
     connect(m_hidEncoder, &HidEncoderManager::tuneSteps,
@@ -3177,6 +3190,8 @@ void MainWindow::showMemoryDialog()
 
     auto* dlg = new MemoryDialog(&m_radioModel, this);
     dlg->setAttribute(Qt::WA_DeleteOnClose);
+    connect(dlg, &MemoryDialog::memoryActivated,
+            this, [this](int memoryIndex) { activateMemorySpot(memoryIndex); });
     connect(dlg, &QObject::destroyed, this, [this] {
         if (m_shuttingDown)
             return;
@@ -3588,7 +3603,7 @@ void MainWindow::buildMenuBar()
         connect(dlg, &DxClusterDialog::tuneRequested,
                 this, [this](double freqMhz) {
             if (auto* sl = activeSlice())
-                sl->tuneAndRecenter(freqMhz);
+                applyTuneRequest(sl, freqMhz, TuneIntent::AbsoluteJump, "dx-cluster");
         });
         connect(dlg, &QDialog::finished, this, refreshSpots);  // refresh on close
         dlg->show();
@@ -4557,8 +4572,8 @@ void MainWindow::buildUI()
         if (slice->mode() != e.mode) {
             slice->setMode(e.mode);
         }
-        // Frequency + recenter pan
-        slice->tuneAndRecenter(e.frequencyMhz);
+        applyTuneRequest(slice, e.frequencyMhz,
+                         TuneIntent::AbsoluteJump, "bandstack-recall");
         // Filter
         if (e.filterLow != 0 || e.filterHigh != 0) {
             slice->setFilterWidth(e.filterLow, e.filterHigh);
@@ -5533,14 +5548,28 @@ bool MainWindow::activateMemorySpot(int memoryIndex, const QString& preferredPan
     if (!slice)
         return false;
 
+    m_pendingMemoryRevealSliceId = sliceId;
     m_radioModel.sendCommand(QString("memory apply %1").arg(memoryIndex));
-    m_radioModel.setPanCenter(it->freq);
+    QTimer::singleShot(750, this, [this, sliceId]() {
+        if (m_pendingMemoryRevealSliceId != sliceId)
+            return;
+        m_pendingMemoryRevealSliceId = -1;
+        if (auto* pendingSlice = m_radioModel.slice(sliceId)) {
+            const TuneCenteringResult result =
+                revealFrequencyIfNeeded(pendingSlice, pendingSlice->frequency(),
+                                        TuneIntent::CommandedTargetCenter,
+                                        "memory-apply-timeout");
+            logTunePolicyDecision("memory-apply-timeout", TuneIntent::CommandedTargetCenter,
+                                  pendingSlice->frequency(), pendingSlice->frequency(),
+                                  result);
+        }
+    });
 
     // The radio should push the rest of the applied memory state, but keep the
     // local tuning step in sync immediately so wheel/click snap follows along.
     if (it->step > 0)
         m_radioModel.sendCommand(QString("slice set %1 step=%2")
-            .arg(slice->sliceId()).arg(it->step));
+            .arg(sliceId).arg(it->step));
     return true;
 }
 
@@ -5697,7 +5726,8 @@ void MainWindow::onSliceAdded(SliceModel* s)
 #ifdef HAVE_HIDAPI
         activeTuning = activeTuning || m_hidCoalesceTimer.isActive();
 #endif
-        if (activeTuning && s->sliceId() == m_activeSliceId)
+        const bool memoryRevealPending = (m_pendingMemoryRevealSliceId == s->sliceId());
+        if (activeTuning && s->sliceId() == m_activeSliceId && !memoryRevealPending)
             return;
 
         m_updatingFromModel = true;
@@ -5708,6 +5738,14 @@ void MainWindow::onSliceAdded(SliceModel* s)
                 s->mode(), s->rttyMark(), s->rttyShift(),
                 s->ritOn(), s->ritFreq(), s->xitOn(), s->xitFreq());
         m_updatingFromModel = false;
+
+        if (memoryRevealPending) {
+            m_pendingMemoryRevealSliceId = -1;
+            const TuneCenteringResult result =
+                revealFrequencyIfNeeded(s, mhz, TuneIntent::CommandedTargetCenter, "memory-apply");
+            logTunePolicyDecision("memory-apply", TuneIntent::CommandedTargetCenter,
+                                  mhz, mhz, result);
+        }
 
         // Feed frequency to Antenna Genius for band→antenna recall
         if (s->sliceId() == m_activeSliceId)
@@ -6008,7 +6046,155 @@ SliceModel* MainWindow::activeSlice() const
     return m_radioModel.slice(m_activeSliceId);
 }
 
+const char* MainWindow::tuneIntentName(TuneIntent intent)
+{
+    switch (intent) {
+    case TuneIntent::IncrementalTune: return "IncrementalTune";
+    case TuneIntent::AbsoluteJump:    return "AbsoluteJump";
+    case TuneIntent::CommandedTargetCenter: return "CommandedTargetCenter";
+    case TuneIntent::ExplicitPan:     return "ExplicitPan";
+    case TuneIntent::RevealOffscreen: return "RevealOffscreen";
+    }
+    return "Unknown";
+}
+
+bool MainWindow::panFollowEnabled() const
+{
+    return AppSettings::instance().value("PanFollowVfo", "True").toString() == "True";
+}
+
+void MainWindow::logTunePolicyDecision(const char* source, TuneIntent intent,
+                                       double oldFreqMhz, double newFreqMhz,
+                                       const TuneCenteringResult& result) const
+{
+    qDebug().nospace()
+        << "TunePolicy:"
+        << " source=" << source
+        << " intent=" << tuneIntentName(intent)
+        << " oldFreq=" << oldFreqMhz
+        << " newFreq=" << newFreqMhz
+        << " oldCenter=" << result.oldCenterMhz
+        << " newCenter=" << result.newCenterMhz
+        << " bandwidth=" << result.bandwidthMhz
+        << " followRevealTriggered=" << result.followRevealTriggered
+        << " hardCenterUsed=" << result.hardCenterUsed
+        << " animationMs=" << result.animationDurationMs;
+}
+
+void MainWindow::mirrorDiversityChildFrequency(SliceModel* slice, double mhz)
+{
+    if (!slice || !slice->isDiversityParent())
+        return;
+
+    long long hz = static_cast<long long>(std::round(mhz * 1e6));
+    const QString freqStr = QString("%1.%2.%3")
+        .arg(static_cast<int>(hz / 1000000))
+        .arg(static_cast<int>((hz / 1000) % 1000), 3, 10, QChar('0'))
+        .arg(static_cast<int>(hz % 1000), 3, 10, QChar('0'));
+
+    for (auto* other : m_radioModel.slices()) {
+        if (!other->isDiversityChild() || other->sliceId() == slice->sliceId())
+            continue;
+        auto* sw = spectrumForSlice(other);
+        if (!sw)
+            continue;
+        if (auto* vfo = sw->vfoWidget(other->sliceId()))
+            vfo->freqLabel()->setText(freqStr);
+        sw->setSliceOverlay(other->sliceId(), mhz,
+            other->filterLow(), other->filterHigh(),
+            other->isTxSlice(), false,
+            other->mode(), other->rttyMark(), other->rttyShift(),
+            other->ritOn(), other->ritFreq(),
+            other->xitOn(), other->xitFreq());
+    }
+}
+
+void MainWindow::applyTuneRequest(SliceModel* slice, double mhz,
+                                  TuneIntent intent, const char* source)
+{
+    if (!slice)
+        return;
+
+    const double oldFreqMhz = slice->frequency();
+    auto* sw = spectrumForSlice(slice);
+    if (slice->isLocked()) {
+        if (slice->sliceId() == m_activeSliceId && sw) {
+            m_updatingFromModel = true;
+            sw->setVfoFrequency(oldFreqMhz);
+            m_updatingFromModel = false;
+        }
+        return;
+    }
+
+    if (slice->sliceId() == m_activeSliceId && sw)
+        sw->setVfoFrequency(mhz);
+
+    slice->setFrequency(mhz);
+    mirrorDiversityChildFrequency(slice, mhz);
+
+    const TuneCenteringResult result =
+        (intent == TuneIntent::IncrementalTune)
+            ? panFollowVfo(slice, mhz, source)
+            : revealFrequencyIfNeeded(slice, mhz, intent, source);
+    logTunePolicyDecision(source, intent, oldFreqMhz, mhz, result);
+}
+
+void MainWindow::applyPanRangeRequest(const QString& panId, double centerMhz,
+                                      double bandwidthMhz, const char* source)
+{
+    if (panId.isEmpty() || bandwidthMhz <= 0.0)
+        return;
+
+    auto* pan = m_radioModel.panadapter(panId);
+    const QString centerStr = QString::number(centerMhz, 'f', 6);
+    const QString bandwidthStr = QString::number(bandwidthMhz, 'f', 6);
+
+    if (pan) {
+        if (qFuzzyCompare(pan->centerMhz(), centerMhz)
+            && qFuzzyCompare(pan->bandwidthMhz(), bandwidthMhz)) {
+            return;
+        }
+        // Update both values together before the radio echo arrives. Explicit
+        // zoom workflows are especially sensitive to center/bandwidth skew;
+        // splitting them produced the P1/P2 waterfall-loss and zoom-drift bugs.
+        pan->applyPanStatus({
+            {"center", centerStr},
+            {"bandwidth", bandwidthStr},
+        });
+    }
+
+    m_radioModel.sendCommand(
+        QString("display pan set %1 center=%2 bandwidth=%3")
+            .arg(panId, centerStr, bandwidthStr));
+
+    qDebug() << "Pan range request:" << source
+             << "center" << centerMhz
+             << "bandwidth" << bandwidthMhz;
+}
+
 void MainWindow::setActiveSlice(int sliceId)
+{
+    setActiveSliceInternal(sliceId, true);
+}
+
+void MainWindow::queueActiveSliceForSpectrumTarget(int sliceId)
+{
+    if (sliceId < 0 || sliceId == m_activeSliceId) {
+        m_pendingSpectrumTargetSliceId = -1;
+        return;
+    }
+
+    m_pendingSpectrumTargetSliceId = sliceId;
+    QTimer::singleShot(0, this, [this, sliceId]() {
+        if (m_pendingSpectrumTargetSliceId != sliceId)
+            return;
+        m_pendingSpectrumTargetSliceId = -1;
+        if (auto* s = m_radioModel.slice(sliceId))
+            setActiveSliceInternal(s->sliceId(), false);
+    });
+}
+
+void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
 {
     auto* s = m_radioModel.slice(sliceId);
     if (!s) return;
@@ -6051,14 +6237,13 @@ void MainWindow::setActiveSlice(int sliceId)
     m_appletPanel->updateSliceButtons(m_radioModel.slices(), sliceId);
     auto* sw = spectrum();
     if (sw) {
-        // Recenter panadapter if the newly active slice is off-screen (#1554)
-        double sliceFreq = s->frequency();
-        double halfBw = sw->bandwidthMhz() / 2.0;
-        double lo = sw->centerMhz() - halfBw;
-        double hi = sw->centerMhz() + halfBw;
-        if (sliceFreq < lo || sliceFreq > hi) {
-            sw->setFrequencyRange(sliceFreq, sw->bandwidthMhz());
-            emit sw->centerChangeRequested(sliceFreq);
+        if (revealOffscreen) {
+            const TuneCenteringResult result =
+                revealFrequencyIfNeeded(s, s->frequency(),
+                                        TuneIntent::RevealOffscreen,
+                                        "setActiveSlice");
+            logTunePolicyDecision("setActiveSlice", TuneIntent::RevealOffscreen,
+                                  s->frequency(), s->frequency(), result);
         }
 
         sw->overlayMenu()->setSlice(s);
@@ -6354,6 +6539,10 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
 
     // ── User drag actions from spectrum → radio (per-pan) ──────────────────
+    connect(sw, &SpectrumWidget::frequencyRangeChangeRequested,
+            this, [this, applet](double center, double bandwidth) {
+        applyPanRangeRequest(applet->panId(), center, bandwidth, "explicit-pan-range");
+    });
     connect(sw, &SpectrumWidget::bandwidthChangeRequested,
             this, [this, applet](double bw) {
         m_radioModel.sendCommand(
@@ -6676,46 +6865,44 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         menu->syncExtraDisplaySettings(false, 1.15f, 80, 0);
     });
 
-    // ── Click-to-tune ────────────────────────────────────────────────────
-    // Uses "slice m <freq> pan=<panId>" (matches SmartSDR protocol).
-    // The radio routes the tune to the correct slice for that pan.
-    connect(sw, &SpectrumWidget::frequencyClicked,
-            this, [this, sw](double mhz) {
-        // Find the panId for this spectrum widget
+    auto resolveSpectrumTuneTarget = [this, sw]() -> SliceModel* {
         QString panId;
-        for (auto* applet : m_panStack->allApplets()) {
-            if (applet->spectrumWidget() == sw) {
-                panId = applet->panId();
+        for (auto* panApplet : m_panStack->allApplets()) {
+            if (panApplet->spectrumWidget() == sw) {
+                panId = panApplet->panId();
                 break;
             }
         }
 
-        if (!panId.isEmpty()) {
-            // Check if the active slice is on a DIFFERENT pan — if so, switch
-            // to a slice on the clicked pan. Don't switch when multiple slices
-            // share the same pan (that causes alternating tune targets).
-            auto* curSlice = activeSlice();
-            bool differentPan = curSlice && curSlice->panId() != panId;
+        if (panId.isEmpty())
+            return activeSlice();
 
-            if (differentPan) {
-                for (auto* s : m_radioModel.slices()) {
-                    if (s->panId() == panId) {
-                        setActiveSlice(s->sliceId());
-                        break;
-                    }
-                }
-                m_panStack->setActivePan(panId);
+        if (auto* current = activeSlice(); current && current->panId() == panId)
+            return current;
 
-                if (auto* s = activeSlice(); s && !s->isLocked()) {
-                    m_radioModel.sendCommand(
-                        QString("slice m %1 pan=%2").arg(mhz, 0, 'f', 6).arg(panId));
-                    sw->setVfoFrequency(mhz);
-                }
-            } else {
-                onFrequencyChanged(mhz);
-            }
-        } else {
-            onFrequencyChanged(mhz);
+        for (auto* candidate : m_radioModel.slices()) {
+            if (candidate->panId() == panId)
+                return candidate;
+        }
+
+        return activeSlice();
+    };
+
+    // ── Click-to-tune ────────────────────────────────────────────────────
+    // Same-pan and cross-pan tune requests both resolve a target slice first,
+    // then run through the shared absolute/incremental tuning policy.
+    connect(sw, &SpectrumWidget::frequencyClicked,
+            this, [this, resolveSpectrumTuneTarget](double mhz) {
+        if (auto* target = resolveSpectrumTuneTarget()) {
+            queueActiveSliceForSpectrumTarget(target->sliceId());
+            applyTuneRequest(target, mhz, TuneIntent::AbsoluteJump, "spectrum-click");
+        }
+    });
+    connect(sw, &SpectrumWidget::incrementalTuneRequested,
+            this, [this, resolveSpectrumTuneTarget](double mhz) {
+        if (auto* target = resolveSpectrumTuneTarget()) {
+            queueActiveSliceForSpectrumTarget(target->sliceId());
+            applyTuneRequest(target, mhz, TuneIntent::IncrementalTune, "spectrum-incremental");
         }
     });
 
@@ -6886,7 +7073,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     connect(sw, &SpectrumWidget::sliceTuneRequested,
             this, [this](int sliceId, double freqMhz) {
         if (auto* s = m_radioModel.slice(sliceId))
-            s->setFrequency(freqMhz);
+            applyTuneRequest(s, freqMhz, TuneIntent::AbsoluteJump, "slice-move-here");
     });
 
     // ── Band selection ───────────────────────────────────────────────────
@@ -6942,6 +7129,16 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             if (!s) s = activeSlice();
             if (s) {
                 if (!mode.isEmpty() && s->mode() != mode) s->setMode(mode);
+                TuneCenteringResult result;
+                if (auto* pan = m_radioModel.panadapter(s->panId())) {
+                    result.oldCenterMhz = pan->centerMhz();
+                    result.bandwidthMhz = pan->bandwidthMhz();
+                }
+                result.newCenterMhz = freqMhz;
+                result.followRevealTriggered = true;
+                result.hardCenterUsed = true;
+                logTunePolicyDecision("band-fallback", TuneIntent::AbsoluteJump,
+                                      s->frequency(), freqMhz, result);
                 s->tuneAndRecenter(freqMhz);
             }
         } else {
@@ -7049,52 +7246,122 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             this, [this](const QPoint& pos) { showDfnrParamPopup(pos); });
 }
 
-void MainWindow::panFollowVfo(SliceModel* s, double mhz)
+MainWindow::TuneCenteringResult MainWindow::revealFrequencyIfNeeded(
+    SliceModel* slice, double mhz, TuneIntent intent, const char* /*source*/)
 {
-    // Pan-follow-VFO is toggleable via View menu (#1476). On by default —
-    // matches the historical behavior users expect, but can be disabled
-    // for operators who prefer a fixed panadapter window.
-    if (AppSettings::instance().value("PanFollowVfo", "True").toString() != "True")
-        return;
+    TuneCenteringResult result;
+    if (!slice)
+        return result;
 
-    // Note: centerActiveSliceInPanadapter() is intentionally not reused here.
-    // That helper snaps to dead center and does extra work (pan stack activation,
-    // VFO widget update) that is redundant or wrong for incremental step-tuning.
-    PanadapterModel* pan = m_radioModel.panadapter(s->panId());
-    if (!pan) return;
-    const double halfBw = pan->bandwidthMhz() / 2.0;
-    if (halfBw <= 0.0) return;  // guard: bandwidth not yet received from radio
+    auto* pan = m_radioModel.panadapter(slice->panId());
+    if (!pan)
+        return result;
 
-    // "Fence" behavior (#1476): VFO slides freely inside the middle 90% of
-    // the pan window.  When it crosses the 5% boundary on either edge of
-    // the *full* window, the pan scrolls by exactly the overshoot so the
-    // VFO stays pinned to that boundary.  Continuous tuning past the fence
-    // feels like the pan scrolls by the step size — no sudden jumps, the
-    // VFO never visibly leaves the window.
-    //
-    // Express the boundary relative to halfBw: fence is 5% of the full
-    // window = 10% of halfBw.
-    static constexpr double kMarginFrac = 0.10;
-    const double deadZoneHalfBw = halfBw * (1.0 - kMarginFrac);
-    // Read the *visible* center from the spectrum widget, not the model —
-    // PanadapterModel may lag behind after a manual drag (#1643).
-    auto* sw = spectrumForSlice(s);
-    const double center = sw ? sw->centerMhz() : pan->centerMhz();
-    double newCenter;
-    if (mhz > center + deadZoneHalfBw) {
-        newCenter = mhz - deadZoneHalfBw;   // VFO pinned to right fence
-    } else if (mhz < center - deadZoneHalfBw) {
-        newCenter = mhz + deadZoneHalfBw;   // VFO pinned to left fence
-    } else {
-        return;  // VFO inside dead zone — pan stays put
+    // Prefer the visible spectrum state when available so reveal/follow stays
+    // aligned with recent manual pan/zoom gestures even if the model echo lags.
+    auto* sw = spectrumForSlice(slice);
+    result.oldCenterMhz = sw ? sw->centerMhz() : pan->centerMhz();
+    result.newCenterMhz = result.oldCenterMhz;
+    result.bandwidthMhz = sw ? sw->bandwidthMhz() : pan->bandwidthMhz();
+
+    const double bandwidthMhz = result.bandwidthMhz;
+    const double halfBw = bandwidthMhz / 2.0;
+    if (halfBw <= 0.0)
+        return result;
+
+    if (intent == TuneIntent::CommandedTargetCenter) {
+        result.newCenterMhz = mhz;
+        if (qFuzzyCompare(result.oldCenterMhz, result.newCenterMhz))
+            return result;
+
+        result.followRevealTriggered = true;
+        result.hardCenterUsed = true;
+        const double centerDelta = std::abs(result.newCenterMhz - result.oldCenterMhz);
+        result.animationDurationMs = (centerDelta <= halfBw * 0.25)
+            ? kPanFollowAnimationDurationMs
+            : 0;
+
+        pan->applyPanStatus({{"center", QString::number(result.newCenterMhz, 'f', 6)}});
+        m_radioModel.sendCommand(
+            QString("display pan set %1 center=%2")
+                .arg(pan->panId()).arg(result.newCenterMhz, 0, 'f', 6));
+        return result;
     }
 
-    // Optimistic local update: apply new center immediately so SpectrumWidget
-    // repaints without waiting for the radio echo-back round-trip. (#989)
-    pan->applyPanStatus({{"center", QString::number(newCenter, 'f', 6)}});
+    const bool incremental = (intent == TuneIntent::IncrementalTune);
+    if (incremental && !panFollowEnabled())
+        return result;
+
+    const double triggerEdgeMarginFrac =
+        incremental ? kIncrementalTriggerEdgeMarginFrac : kRevealComfortEdgeMarginFrac;
+    const double settleEdgeMarginFrac =
+        incremental ? kIncrementalSettleEdgeMarginFrac : kRevealComfortEdgeMarginFrac;
+    const double triggerDistanceFromCenter = halfBw - bandwidthMhz * triggerEdgeMarginFrac;
+    const double settleDistanceFromCenter = halfBw - bandwidthMhz * settleEdgeMarginFrac;
+    const double center = result.oldCenterMhz;
+    const int stepHz = incremental
+        ? (slice->stepHz() > 0 ? slice->stepHz() : (sw ? sw->stepSize() : 0))
+        : 0;
+    const double stepMhz = stepHz > 0 ? stepHz / 1e6 : 0.0;
+
+    auto incrementalFollowCenter = [&](double triggerBoundaryCenter,
+                                       double settleCenterTarget) {
+        const double direction = (triggerBoundaryCenter >= center) ? 1.0 : -1.0;
+        const double overshootMhz = std::abs(triggerBoundaryCenter - center);
+        const double quantizedDeltaMhz = quantizeIncrementalFollowDelta(overshootMhz, stepMhz);
+        const double cappedDeltaMhz =
+            std::min(quantizedDeltaMhz, std::abs(settleCenterTarget - center));
+        return center + direction * cappedDeltaMhz;
+    };
+
+    if (mhz > center + triggerDistanceFromCenter) {
+        const double settleCenterTarget = mhz - settleDistanceFromCenter;
+        if (incremental && stepMhz > 0.0) {
+            const double triggerBoundaryCenter = mhz - triggerDistanceFromCenter;
+            result.newCenterMhz =
+                incrementalFollowCenter(triggerBoundaryCenter, settleCenterTarget);
+        } else {
+            result.newCenterMhz = settleCenterTarget;
+        }
+    } else if (mhz < center - triggerDistanceFromCenter) {
+        const double settleCenterTarget = mhz + settleDistanceFromCenter;
+        if (incremental && stepMhz > 0.0) {
+            const double triggerBoundaryCenter = mhz + triggerDistanceFromCenter;
+            result.newCenterMhz =
+                incrementalFollowCenter(triggerBoundaryCenter, settleCenterTarget);
+        } else {
+            result.newCenterMhz = settleCenterTarget;
+        }
+    } else {
+        return result;
+    }
+
+    if (qFuzzyCompare(result.oldCenterMhz, result.newCenterMhz))
+        return result;
+
+    result.followRevealTriggered = true;
+    const double centerDelta = std::abs(result.newCenterMhz - result.oldCenterMhz);
+    result.animationDurationMs = (centerDelta <= halfBw * 0.25)
+        ? kPanFollowAnimationDurationMs
+        : 0;
+
+    // Apply the center optimistically so the owning spectrum repaints
+    // immediately; SpectrumWidget decides whether that becomes a short
+    // retargetable animation or an immediate snap based on shift size.
+    pan->applyPanStatus({{"center", QString::number(result.newCenterMhz, 'f', 6)}});
     m_radioModel.sendCommand(
         QString("display pan set %1 center=%2")
-            .arg(pan->panId()).arg(newCenter, 0, 'f', 6));
+            .arg(pan->panId()).arg(result.newCenterMhz, 0, 'f', 6));
+    return result;
+}
+
+MainWindow::TuneCenteringResult MainWindow::panFollowVfo(
+    SliceModel* s, double mhz, const char* source)
+{
+    // Incremental tuning uses a trigger margin and a slightly wider settle
+    // margin so the slice glides back into a comfortable visible area without
+    // dead-centering or waiting until it actually crosses the pan edge.
+    return revealFrequencyIfNeeded(s, mhz, TuneIntent::IncrementalTune, source);
 }
 
 void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
@@ -7108,11 +7375,15 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
         if (m_radioModel.slices().size() <= 1) return;
         m_radioModel.sendCommand(QString("slice remove %1").arg(sliceId));
     });
-    // Pan-follow-VFO (#989): wheel uses setFrequency(autopan=0) so re-center
-    // the pan explicitly when the stepped frequency falls outside the window.
-    connect(w, &VfoWidget::stepTuned, this, [this, sliceId](double mhz) {
+    connect(w, &VfoWidget::stepTuneRequested, this, [this, sliceId](double mhz) {
         if (auto* sl = m_radioModel.slice(sliceId))
-            panFollowVfo(sl, mhz);
+            applyTuneRequest(sl, mhz, TuneIntent::IncrementalTune, "vfo-wheel");
+    });
+    connect(w, &VfoWidget::directEntryCommitted, this, [this, sliceId](double mhz, const QString& source) {
+        if (auto* sl = m_radioModel.slice(sliceId)) {
+            const QByteArray sourceUtf8 = source.toUtf8();
+            applyTuneRequest(sl, mhz, TuneIntent::CommandedTargetCenter, sourceUtf8.constData());
+        }
     });
     connect(w, &VfoWidget::lockToggled, this, [this, sliceId](bool locked) {
         if (auto* sl = m_radioModel.slice(sliceId))
@@ -7175,7 +7446,8 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
         if (detected <= 0.0f) return;
         int configured = m_radioModel.transmitModel().cwPitch();
         double offsetMhz = (detected - configured) / 1.0e6;
-        slice->setFrequency(slice->frequency() + offsetMhz);
+        applyTuneRequest(slice, slice->frequency() + offsetMhz,
+                         TuneIntent::IncrementalTune, "zero-beat");
     });
     connect(w, &VfoWidget::addSpotRequested, this, [this](double freqMhz) {
         if (auto* sw = spectrum()) sw->showAddSpotDialog(freqMhz);
@@ -7195,8 +7467,8 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
         if (!rx || !tx) return;
         double rxFreq = rx->frequency();
         double txFreq = tx->frequency();
-        rx->setFrequency(txFreq);
-        tx->setFrequency(rxFreq);
+        applyTuneRequest(rx, txFreq, TuneIntent::IncrementalTune, "split-swap-rx");
+        applyTuneRequest(tx, rxFreq, TuneIntent::IncrementalTune, "split-swap-tx");
     });
 
     // Split toggle — per-widget, slice-aware (#328)
@@ -7639,23 +7911,29 @@ void MainWindow::centerActiveSliceInPanadapter(bool forceRadioCenter, double cen
             QString("display pan set %1 center=%2")
                 .arg(s->panId()).arg(targetMhz, 0, 'f', 6));
     }
+
+    TuneCenteringResult result;
+    result.oldCenterMhz = pan ? pan->centerMhz() : targetMhz;
+    result.newCenterMhz = targetMhz;
+    result.bandwidthMhz = bandwidthMhz;
+    result.followRevealTriggered = true;
+    result.hardCenterUsed = true;
+    logTunePolicyDecision("center-active-slice", TuneIntent::AbsoluteJump,
+                          s->frequency(), s->frequency(), result);
 }
 
 void MainWindow::registerShortcutActions()
 {
     // Helper: nudge active slice frequency by N steps.
-    // Uses tuneAndRecenter() so m_frequency is updated immediately (no stale
-    // base on rapid presses) and the radio keeps the slice centered in the pan.
+    // Share the incremental tune policy with wheel/knob/VFO tuning so pan
+    // follow uses the same trigger + settle margins everywhere.
     auto nudgeFreq = [this](int steps) {
         if (!m_radioModel.isConnected()) return;
         auto* s = activeSlice();
         if (!s || s->isLocked()) return;
         int stepHz = spectrum() ? spectrum()->stepSize() : 100;
         double newMhz = s->frequency() + steps * stepHz / 1e6;
-        // Use setFrequency (autopan=0) + panFollowVfo so all step-tuning paths
-        // (keyboard, wheel, FlexControl, MIDI) share the same pan-follow logic. (#989)
-        s->setFrequency(newMhz);
-        panFollowVfo(s, newMhz);
+        applyTuneRequest(s, newMhz, TuneIntent::IncrementalTune, "keyboard-step");
     };
 
     // Step cycle helper
@@ -7693,11 +7971,10 @@ void MainWindow::registerShortcutActions()
             auto* sw = s ? spectrumForSlice(s) : nullptr;
             auto* vfo = (s && sw) ? sw->vfoWidget(s->sliceId()) : nullptr;
             if (!s || !vfo) return;
-            centerActiveSliceInPanadapter(true);
             QPointer<VfoWidget> vfoGuard = vfo;
             QTimer::singleShot(0, this, [vfoGuard]() {
                 if (vfoGuard)
-                    vfoGuard->beginDirectEntry();
+                    vfoGuard->beginDirectEntry("go-to-frequency");
             });
         });
 
@@ -7717,7 +7994,19 @@ void MainWindow::registerShortcutActions()
             QKeySequence(), [this, freq]() {
                 if (!m_radioModel.isConnected()) return;
                 auto* s = activeSlice();
-                if (s && !s->isLocked()) s->tuneAndRecenter(freq);
+                if (s && !s->isLocked()) {
+                    TuneCenteringResult result;
+                    if (auto* pan = m_radioModel.panadapter(s->panId())) {
+                        result.oldCenterMhz = pan->centerMhz();
+                        result.bandwidthMhz = pan->bandwidthMhz();
+                    }
+                    result.newCenterMhz = freq;
+                    result.followRevealTriggered = true;
+                    result.hardCenterUsed = true;
+                    logTunePolicyDecision("band-shortcut", TuneIntent::AbsoluteJump,
+                                          s->frequency(), freq, result);
+                    s->tuneAndRecenter(freq);
+                }
             });
     }
 
@@ -7872,10 +8161,10 @@ void MainWindow::registerShortcutActions()
         }
 
         sw->setFrequencyRange(newCenter, newBw);
-        m_radioModel.sendCommand(
-            QString("display pan set %1 bandwidth=%2").arg(s->panId()).arg(newBw, 0, 'f', 6));
-        m_radioModel.sendCommand(
-            QString("display pan set %1 center=%2").arg(s->panId()).arg(newCenter, 0, 'f', 6));
+        // Keep keyboard zoom on the same combined pan-range path as trackpad /
+        // on-screen zoom so mode/frequency jumps do not reintroduce stale
+        // center-versus-bandwidth transitions.
+        applyPanRangeRequest(s->panId(), newCenter, newBw, "keyboard-pan-zoom");
     };
 
     // ── DSP ─────────────────────────────────────────────────────────────
@@ -8519,6 +8808,16 @@ void MainWindow::restoreBandState(const BandSnapshot& snap)
     m_updatingFromModel = true;
     if (auto* s = activeSlice()) {
         s->setMode(snap.mode);
+        TuneCenteringResult result;
+        if (auto* pan = m_radioModel.panadapter(s->panId())) {
+            result.oldCenterMhz = pan->centerMhz();
+            result.bandwidthMhz = pan->bandwidthMhz();
+        }
+        result.newCenterMhz = snap.frequencyMhz;
+        result.followRevealTriggered = true;
+        result.hardCenterUsed = true;
+        logTunePolicyDecision("restore-band-state", TuneIntent::AbsoluteJump,
+                              s->frequency(), snap.frequencyMhz, result);
         s->tuneAndRecenter(snap.frequencyMhz);
         if (!snap.rxAntenna.isEmpty())
             s->setRxAntenna(snap.rxAntenna);
@@ -8548,52 +8847,6 @@ void MainWindow::restoreBandState(const BandSnapshot& snap)
 }
 
 // ─── GUI control handlers ─────────────────────────────────────────────────────
-
-void MainWindow::onFrequencyChanged(double mhz)
-{
-    auto* sw = spectrum();
-    if (!sw) return;  // pan may be absent during band change (#1146)
-
-    // If the slice is locked, snap spectrum back to the current freq.
-    if (auto* s = activeSlice(); s && s->isLocked()) {
-        m_updatingFromModel = true;
-        sw->setVfoFrequency(s->frequency());
-        m_updatingFromModel = false;
-        return;
-    }
-
-    sw->setVfoFrequency(mhz);
-    if (!m_updatingFromModel) {
-        if (auto* s = activeSlice()) {
-            s->setFrequency(mhz);
-            panFollowVfo(s, mhz);  // re-center pan if VFO stepped outside visible window (#989)
-
-            // Diversity: immediately mirror freq to child VFO (no radio round-trip)
-            if (s->isDiversityParent()) {
-                long long hz = static_cast<long long>(std::round(mhz * 1e6));
-                QString freqStr = QString("%1.%2.%3")
-                    .arg(static_cast<int>(hz / 1000000))
-                    .arg(static_cast<int>((hz / 1000) % 1000), 3, 10, QChar('0'))
-                    .arg(static_cast<int>(hz % 1000), 3, 10, QChar('0'));
-                for (auto* other : m_radioModel.slices()) {
-                    if (other->isDiversityChild() && other->sliceId() != s->sliceId()) {
-                        auto* csw = spectrumForSlice(other);
-                        if (!csw) continue;
-                        auto* cv = csw->vfoWidget(other->sliceId());
-                        if (cv) cv->freqLabel()->setText(freqStr);
-                        // Also update the overlay marker position
-                        csw->setSliceOverlay(other->sliceId(), mhz,
-                            other->filterLow(), other->filterHigh(),
-                            other->isTxSlice(), false,
-                            other->mode(), other->rttyMark(), other->rttyShift(),
-                            other->ritOn(), other->ritFreq(),
-                            other->xitOn(), other->xitFreq());
-                    }
-                }
-            }
-        }
-    }
-}
 
 #ifdef HAVE_RADE
 void MainWindow::activateRADE(int sliceId)
@@ -9078,7 +9331,7 @@ void MainWindow::registerMidiParams()
             if (steps == 0) return;
             int stepHz = spectrum() ? spectrum()->stepSize() : 100;
             double newMhz = s->frequency() + steps * stepHz / 1e6;
-            s->setFrequency(newMhz);
+            applyTuneRequest(s, newMhz, TuneIntent::IncrementalTune, "midi-absolute");
         });
 
     // ── TX ──────────────────────────────────────────────────────────────

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -96,10 +96,24 @@ private slots:
     void onSliceAdded(SliceModel* slice);
     void onSliceRemoved(int id);
 
-    // Spectrum click-to-tune
-    void onFrequencyChanged(double mhz);
-
 private:
+    enum class TuneIntent {
+        IncrementalTune,
+        AbsoluteJump,
+        CommandedTargetCenter,
+        ExplicitPan,
+        RevealOffscreen,
+    };
+
+    struct TuneCenteringResult {
+        double oldCenterMhz{0.0};
+        double newCenterMhz{0.0};
+        double bandwidthMhz{0.0};
+        bool followRevealTriggered{false};
+        bool hardCenterUsed{false};
+        int animationDurationMs{0};
+    };
+
     void buildUI();
     void buildMenuBar();
     void applyDarkTheme();
@@ -110,11 +124,25 @@ private:
     void audioStartTx(const QHostAddress& addr, quint16 port);
     void audioStopTx();
     SliceModel* activeSlice() const;
+    static const char* tuneIntentName(TuneIntent intent);
+    bool panFollowEnabled() const;
+    void applyTuneRequest(SliceModel* slice, double mhz,
+                          TuneIntent intent, const char* source);
+    void applyPanRangeRequest(const QString& panId, double centerMhz,
+                              double bandwidthMhz, const char* source);
+    TuneCenteringResult revealFrequencyIfNeeded(SliceModel* slice, double mhz,
+                                                TuneIntent intent, const char* source);
+    void logTunePolicyDecision(const char* source, TuneIntent intent,
+                               double oldFreqMhz, double newFreqMhz,
+                               const TuneCenteringResult& result) const;
+    void mirrorDiversityChildFrequency(SliceModel* slice, double mhz);
     // Pan-follow-VFO (#989): if mhz is outside the visible pan window, apply
     // the new center locally (immediate repaint) and send the radio command.
-    void panFollowVfo(SliceModel* s, double mhz);
+    TuneCenteringResult panFollowVfo(SliceModel* s, double mhz, const char* source);
     SpectrumWidget* spectrum() const;
     void setActiveSlice(int sliceId);
+    void setActiveSliceInternal(int sliceId, bool revealOffscreen);
+    void queueActiveSliceForSpectrumTarget(int sliceId);
     void updateFilterLimitsForMode(const QString& mode);
     void centerActiveSliceInPanadapter(bool forceRadioCenter, double centerMhz = -1.0);
     void pushSliceOverlay(SliceModel* s);
@@ -303,9 +331,11 @@ private:
     bool m_splitActive{false};
     int  m_splitRxSliceId{-1};
     int  m_splitTxSliceId{-1};
+    int  m_pendingMemoryRevealSliceId{-1};
+    int  m_pendingSpectrumTargetSliceId{-1};
 
-    // Guard: set true while updating controls from the model, so that
-    // onFrequencyChanged doesn't echo the change back to the radio.
+    // Guard: set true while updating controls from the model so shared tune
+    // helpers do not echo model-driven changes back to the radio.
     bool m_updatingFromModel{false};
     bool m_shuttingDown{false};
     void toggleConnectionDialog();

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -483,15 +483,13 @@ void MemoryDialog::activateMemoryRow(int row)
         return;
 
     const int idx = indexItem->data(Qt::UserRole).toInt();
-    const auto memoryIt = m_model->memories().constFind(idx);
-    if (memoryIt == m_model->memories().constEnd())
+    if (m_model->memories().constFind(idx) == m_model->memories().constEnd())
         return;
 
     setInlineEditMode(false);
     m_table->setCurrentCell(row, 0);
     focusTableOnCurrentRow();
-    m_model->sendCommand(QString("memory apply %1").arg(idx));
-    m_model->setPanCenter(memoryIt->freq);
+    emit memoryActivated(idx);
 }
 
 void MemoryDialog::beginEditingMemoryName(int memoryIndex)

--- a/src/gui/MemoryDialog.h
+++ b/src/gui/MemoryDialog.h
@@ -24,6 +24,9 @@ class MemoryDialog : public QDialog {
 public:
     explicit MemoryDialog(RadioModel* model, QWidget* parent = nullptr);
 
+Q_SIGNALS:
+    void memoryActivated(int memoryIndex);
+
 protected:
     void closeEvent(QCloseEvent* event) override;
     bool eventFilter(QObject* watched, QEvent* event) override;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -251,8 +251,7 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
         m_centerMhz = newCenter;
         m_bandwidthMhz = newBw;
         markOverlayDirty();
-        emit bandwidthChangeRequested(newBw);
-        emit centerChangeRequested(newCenter);
+        emit frequencyRangeChangeRequested(newCenter, newBw);
     };
     connect(m_zoomOutBtn, &QPushButton::clicked, this, [emitZoom]() { emitZoom(1.5); });
     connect(m_zoomInBtn,  &QPushButton::clicked, this, [emitZoom]() { emitZoom(1.0 / 1.5); });
@@ -1030,8 +1029,9 @@ void SpectrumWidget::setFrequencyRange(double centerMhz, double bandwidthMhz)
     const double halfBw = bandwidthMhz / 2.0;
     const bool bwChanged = (bandwidthMhz != m_bandwidthMhz);
     // Compare incoming center against the animation's *destination* (m_panCenterTarget),
-    // not the mid-animation position (m_centerMhz).  During a 200 ms nudge the animated
-    // center is far from its start, so a subsequent nudge of similar magnitude would
+    // not the mid-animation position (m_centerMhz). During a short retargetable
+    // nudge, the animated center is far from its start, so a subsequent nudge
+    // of similar magnitude would
     // falsely exceed the 25 % threshold and trigger a large-shift clear+blank.
     const double refForShiftCheck = (m_panCenterAnim &&
         m_panCenterAnim->state() != QAbstractAnimation::Stopped)
@@ -1120,7 +1120,7 @@ void SpectrumWidget::setFrequencyRange(double centerMhz, double bandwidthMhz)
     }
     m_panCenterAnim->setStartValue(m_centerMhz);
     m_panCenterAnim->setEndValue(centerMhz);
-    m_panCenterAnim->setDuration(200);
+    m_panCenterAnim->setDuration(110);
     m_panCenterAnim->start();
 }
 
@@ -1624,10 +1624,18 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
         const QPoint pos(static_cast<int>(ev->position().x()), y);
         for (const auto& hr : m_spotClickRects) {
             if (hr.rect.contains(pos)) {
-                emit frequencyClicked(hr.freqMhz);
-                // Notify the radio that a spot was clicked (#341)
-                if (hr.markerIndex >= 0 && hr.markerIndex < m_spotMarkers.size())
-                    emit spotTriggered(m_spotMarkers[hr.markerIndex].index);
+                if (hr.markerIndex >= 0 && hr.markerIndex < m_spotMarkers.size()) {
+                    const auto& marker = m_spotMarkers[hr.markerIndex];
+                    if (marker.source == "Memory") {
+                        emit spotTriggered(marker.index);
+                    } else {
+                        emit frequencyClicked(hr.freqMhz);
+                        // Notify the radio that a spot was clicked (#341)
+                        emit spotTriggered(marker.index);
+                    }
+                } else {
+                    emit frequencyClicked(hr.freqMhz);
+                }
                 m_spotClickConsumed = true;  // suppress release-to-tune (#530)
                 ev->accept();
                 return;
@@ -1802,8 +1810,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
                 const QString title = hitSpotCall.isEmpty()
                     ? QStringLiteral("Apply Memory")
                     : QString("Apply %1").arg(hitSpotCall);
-                menu.addAction(title, this, [this, hitSpotFreq, hitSpotIdx]{
-                    emit frequencyClicked(hitSpotFreq);
+                menu.addAction(title, this, [this, hitSpotIdx]{
                     emit spotTriggered(hitSpotIdx);
                 });
             } else {
@@ -2154,7 +2161,10 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         m_bandwidthMhz = newBw;
         m_centerMhz = zoomCenter;
         markOverlayDirty();
-        emit bandwidthChangeRequested(newBw);
+        // Keep center and bandwidth coupled while dragging. Sending only the
+        // bandwidth and waiting to send center on release caused the radio and
+        // client waterfall to diverge under trackpad-heavy zoom workflows.
+        emit frequencyRangeChangeRequested(zoomCenter, newBw);
         ev->accept();
         return;
     }
@@ -2181,7 +2191,7 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
     if (m_draggingVfo) {
         const int mx = static_cast<int>(ev->position().x());
         const double mhz = snapToStep(xToMhz(mx) - m_vfoDragOffsetHz / 1.0e6, m_stepHz);
-        emit frequencyClicked(mhz);
+        emit incrementalTuneRequested(mhz);
         ev->accept();
         return;
     }
@@ -2388,9 +2398,9 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
     if (m_draggingBandwidth) {
         m_draggingBandwidth = false;
         setCursor(Qt::CrossCursor);
-        // Emit final center after drag completes — not during drag to avoid
-        // flooding the radio with commands on every mouse move (#1313).
-        emit centerChangeRequested(m_centerMhz);
+        // Re-send the final combined range so the release lands on the same
+        // coherent center/bandwidth pair as the in-flight drag updates.
+        emit frequencyRangeChangeRequested(m_centerMhz, m_bandwidthMhz);
         ev->accept();
         return;
     }
@@ -2606,8 +2616,7 @@ bool SpectrumWidget::event(QEvent* ev)
             m_bandwidthMhz = newBw;
             m_centerMhz = newCenter;
             markOverlayDirty();
-            emit bandwidthChangeRequested(newBw);
-            emit centerChangeRequested(newCenter);
+            emit frequencyRangeChangeRequested(newCenter, newBw);
             return true;
         }
     }
@@ -2679,7 +2688,7 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
     // scroll (e.g. step=500 Hz at .100 MHz → effective 400 Hz jump).
     const double baseMhz = snapToStep(vfoMhz, m_stepHz);
     const double newMhz  = baseMhz + steps * m_stepHz / 1e6;
-    emit frequencyClicked(newMhz);
+    emit incrementalTuneRequested(newMhz);
     ev->accept();
 }
 
@@ -4659,10 +4668,11 @@ void SpectrumWidget::showSpotClusterPopup(const SpotCluster& cluster, const QPoi
             text += "  " + spot.mode;
         auto* action = menu->addAction(text);
         connect(action, &QAction::triggered, this, [this, spot] {
-            const double freq = spot.freqMhz;
-            emit frequencyClicked(freq);
-            if (spot.source == "Memory")
+            if (spot.source == "Memory") {
                 emit spotTriggered(spot.index);
+            } else {
+                emit frequencyClicked(spot.freqMhz);
+            }
         });
     }
 

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -322,9 +322,17 @@ public:
 signals:
     // Emitted when user clicks on an inactive slice marker.
     void sliceClicked(int sliceId);
-    // Emitted when the user clicks or scrolls in the panadapter area.
+    // Emitted when the user requests an absolute jump in the panadapter area.
     void frequencyClicked(double mhz);
+    // Emitted when the user makes an incremental tuning gesture such as
+    // wheel tuning or VFO drag.
+    void incrementalTuneRequested(double mhz);
     void spotTriggered(int spotIndex);
+    // Emitted when the user changes both center and bandwidth as one explicit
+    // pan/zoom operation and the radio should apply them coherently. Splitting
+    // those into separate commands was a known source of waterfall edge loss
+    // and zoom drift during bandwidth drag / keyboard zoom.
+    void frequencyRangeChangeRequested(double newCenterMhz, double newBandwidthMhz);
     // Emitted when the user drags the frequency scale bar to change bandwidth.
     void bandwidthChangeRequested(double newBandwidthMhz);
     // Band/segment zoom: radio handles center/bandwidth (SmartSDR pcap: "band_zoom=1" / "segment_zoom=1")

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -208,8 +208,7 @@ void VfoWidget::wheelEvent(QWheelEvent* ev)
             int steps = qBound(-1, delta / 120, 1);
             if (steps != 0) {
                 double newMhz = m_slice->frequency() + steps * stepHz / 1e6;
-                m_slice->setFrequency(newMhz);
-                emit stepTuned(newMhz);
+                emit stepTuneRequested(newMhz);
             }
         }
         ev->accept();
@@ -227,8 +226,7 @@ void VfoWidget::wheelEvent(QWheelEvent* ev)
             int steps = qBound(-1, delta / 120, 1);
             if (steps != 0) {
                 double newMhz = m_slice->frequency() + steps * stepHz / 1e6;
-                m_slice->setFrequency(newMhz);
-                emit stepTuned(newMhz);
+                emit stepTuneRequested(newMhz);
             }
             ev->accept();
             return;
@@ -536,11 +534,13 @@ void VfoWidget::buildUI()
             }
 
             if (ok && freqMhz >= 0.001 && freqMhz <= maxMhz && m_slice)
-                m_slice->tuneAndRecenter(freqMhz);
+                emit directEntryCommitted(freqMhz, m_directEntrySource);
         }
+        m_directEntrySource = "vfo-direct-entry";
         m_freqStack->setCurrentIndex(0);  // back to label
     });
     connect(m_freqEdit, &QLineEdit::editingFinished, this, [this] {
+        m_directEntrySource = "vfo-direct-entry";
         m_freqStack->setCurrentIndex(0);
     });
 
@@ -2714,8 +2714,9 @@ void VfoWidget::setPlayEnabled(bool enabled)
         m_playBtn->setEnabled(enabled);
 }
 
-void VfoWidget::beginDirectEntry()
+void VfoWidget::beginDirectEntry(QString source)
 {
+    m_directEntrySource = source;
     if (m_slice) {
         m_freqEdit->setText(QString::number(m_slice->frequency(), 'f', 6));
         m_freqEdit->selectAll();

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -65,7 +65,7 @@ public:
     void setRecordOn(bool on);
     void setPlayOn(bool on);
     void setPlayEnabled(bool enabled);
-    void beginDirectEntry();
+    void beginDirectEntry(QString source = QStringLiteral("vfo-direct-entry"));
     QLabel* freqLabel() const { return m_freqLabel; }
 
     bool isCollapsed() const { return m_collapsed; }
@@ -106,9 +106,10 @@ Q_SIGNALS:
     void zeroBeatRequested();                   // client-side CW zero-beat
     void addSpotRequested(double freqMhz);
     void sliceActivationRequested(int sliceId);
-    // Emitted when the wheel tunes by step (autopan=0 path) — MainWindow uses
-    // this to explicitly re-center the pan if the new freq is outside the window.
-    void stepTuned(double mhz);
+    // Emitted when the wheel tunes by step so MainWindow can apply the shared
+    // tuning/reveal policy.
+    void stepTuneRequested(double mhz);
+    void directEntryCommitted(double mhz, const QString& source);
     // Per-slice VFO marker style changed (#1526)
     void markerStyleChanged(bool markerThin, bool filterEdgesHidden);
 
@@ -176,6 +177,7 @@ private:
     QLineEdit* m_freqEdit{nullptr};
     QStackedWidget* m_freqStack{nullptr};
     QLabel* m_dbmLabel{nullptr};
+    QString m_directEntrySource{"vfo-direct-entry"};
 
     // Sub-menu tabs (QLabels with click via event filter)
     QVector<QLabel*> m_tabBtns;


### PR DESCRIPTION

<img width="1536" height="1024" alt="ig_00e22791955e04e50169e96eddf798819aa72197b42d906105" src="https://github.com/user-attachments/assets/b6e951be-b054-4609-99b5-ddad94837ea1" />

## Summary

This PR makes pan-follow / recenter behavior consistent across tuning modalities without redesigning the radio/tuning subsystem before 1.0.

The core change is to move tuning intent policy into a shared `MainWindow` path so that different input surfaces stop making independent pan/center decisions. The result is that incremental tuning, jump-style tuning, commanded recalls, off-screen reveals, and explicit pan/zoom now behave predictably and use the same centering rules.

It also fixes a second class of bugs on the explicit zoom side: center and bandwidth are now kept coherent during combined pan/zoom operations instead of being sent as unrelated radio commands.

## Why This Change Was Needed

Before this work, several user-visible problems were all variations of the same root issue: different call sites were deciding for themselves when to tune, when to recenter, when to reveal, and when to pan.

That showed up as multiple real usability problems:

- Incremental tuning could feel like a page-flip instead of a follow. Trackpad scroll, keyboard arrows, MIDI/FlexControl/HID knobs, and other stepwise inputs could push the slice to an edge and then snap the center a long distance back across the pan.
- Same-pan and cross-pan click-to-tune were not consistently using the same policy.
- Direct frequency entry, `Go To Frequency`, memories, and memory spots were not all expressing the same semantic intent even though the user experience strongly suggested they should.
- Ordinary spots and memory spots were mixed together even though they are different user intents: an ordinary spot is a contextual tune target, while a memory recall is a commanded destination.
- Several zoom paths updated center and bandwidth separately, which could temporarily leave the client and radio in different states.

The most important user-facing failures from that last class were already showing up in bug reports:

- P1: bandwidth drag / trackpad zoom could cause waterfall lag and edge loss, including cases where roughly 30% of both sides of the waterfall were effectively lost until restart.
- P2: keyboard panadapter zoom `+/-` could drift or glitch after memory recalls and mode jumps such as `USB <-> SAM`, especially when the zoom path and the recalled pan state did not land coherently.

In short: the app was not missing one isolated recenter fix. It had a policy-fragmentation problem.

## Design Approach

This change keeps the fix low-risk and localized before 1.0:

- no radio/tuning subsystem rewrite
- no OS-specific gesture behavior
- reuse existing Qt animation and `SpectrumWidget::setFrequencyRange(...)` machinery
- prefer client-side reveal/follow using `setFrequency(... autopan=0)` where appropriate
- retain a small, explicit list of intentional hard-center paths

## Main Architecture Changes

### 1. Shared tuning intents in `MainWindow`

`MainWindow` now classifies tune requests using a small intent model:

- `IncrementalTune`
- `AbsoluteJump`
- `CommandedTargetCenter`
- `ExplicitPan`
- `RevealOffscreen`

These intents feed shared helpers instead of letting each UI surface improvise its own center behavior.

### 2. Shared tune/reveal path

Most tuning now routes through shared `MainWindow` helpers:

- `applyTuneRequest(...)`
- `revealFrequencyIfNeeded(...)`
- `panFollowVfo(...)`

This keeps tune ordering, optimistic local UI updates, and pan/reveal decisions coupled in one place.

### 3. Step-quantized incremental follow

Incremental tuning now uses trigger-based pan follow with a smoother, deterministic nudge model:

- trigger margin: 12% per side
- settle margin: 18% per side
- small follow animation: 110 ms

Instead of jumping straight back to the wider settle fence, incremental follow now uses the configured step size as the pan nudge quantum when available. That keeps trackpad, keyboard, wheel, and encoder behavior smooth at the edge rather than book-page-like.

### 4. Commanded-target centering

A new `CommandedTargetCenter` intent is used for cases where the user is explicitly commanding a known destination and expects it to become the center of attention.

This now covers:

- VFO direct entry
- keyboard `Go To Frequency`
- quick memory recall
- Memory dialog recall
- memory spot click
- memory post-apply confirm / timeout fallback

### 5. Ordinary spots remain reveal-only

Ordinary spots remain on `AbsoluteJump` rather than being promoted to commanded-center behavior.

That means:

- visible ordinary spots do not get hard-centered unnecessarily
- near-edge ordinary spots reveal once to a comfortable visible position
- memory spots are handled separately as true recall targets

### 6. Explicit pan/zoom coherence

A shared explicit pan/zoom helper now keeps center and bandwidth coherent for combined range changes:

- `applyPanRangeRequest(...)`

This path updates `PanadapterModel` optimistically with both center and bandwidth together and sends a single combined `display pan set ... center=... bandwidth=...` command.

That change is specifically aimed at the P1/P2 bug class where one user-visible zoom action used to be split into multiple radio state transitions.

## Changed Call Sites

### IncrementalTune

These now use the shared incremental policy:

- spectrum wheel / trackpad scroll
- spectrum VFO drag
- VFO wheel
- keyboard arrows
- FlexControl
- HID encoder
- MIDI relative tuning
- MIDI absolute fallback
- zero beat
- split swap

### AbsoluteJump

These remain reveal-oriented jumps:

- same-pan click-to-tune
- cross-pan click-to-tune
- ordinary spot click
- DX cluster tune
- BandStack recall
- off-screen “Move Slice Here”

### CommandedTargetCenter

These now center a known commanded destination through the shared policy path:

- VFO direct entry
- keyboard `Go To Frequency`
- quick memory recall
- Memory dialog recall
- memory spot click
- memory apply confirm / timeout fallback

### RevealOffscreen

These still use shared reveal behavior rather than bespoke code:

- active-slice switch when the slice is off-screen

### ExplicitPan / explicit range changes

These now keep center/bandwidth coherent for combined zoom operations:

- spectrum bandwidth drag
- spectrum pinch zoom
- spectrum zoom buttons
- keyboard panadapter zoom `+/-`

## Memory / Spot Behavior

Memory and spot handling needed special cleanup because several bugs came from treating them as the same thing.

This PR preserves an intentional split:

- ordinary spots are contextual tune targets and stay reveal-oriented
- memory recalls are commanded destinations and center the result

A memory-spot-specific double-dispatch bug was also fixed:

- memory spots no longer go through a generic spot-tune path first and then later perform a second centered memory recall
- they now go straight to the memory recall path so the click produces one coherent tune/center decision

## Explicit Hard-Center Paths Intentionally Kept

For lowest risk before 1.0, these paths remain radio-authoritative / hard-center paths on purpose:

- band shortcuts
- `restoreBandState(...)`
- unrecognized band fallback during band selection
- explicit center actions such as “Center Slice”

## Remaining Gaps / Deliberately Unchanged Paths

These were intentionally left outside this pass:

- `src/gui/RxApplet.cpp` still has its own direct-entry `tuneAndRecenter(...)` path
- external CAT/TCI frequency-set paths still use `tuneAndRecenter(...)` because they are still expressing radio-authoritative external control semantics rather than the new local UI policy

## Documentation And Guardrails

This PR also adds reviewer/developer guidance so the behavior is easier to preserve:

- `RECENTER.md` documents the current architecture, intent model, signal flow, call-site classification, and intentional hard-center exceptions
- source comments were added at the former P1/P2 fault lines to warn future editors not to split center and bandwidth again for one visual zoom action

## Validation

### Automated

- `cmake --build build -j10`
- `ctest --output-on-failure -j10`
  - result: `No tests were found!!!`

### Manual

Manually tested by @jensenpat across the recenter-policy branch and again after merging latest `main`, including:

- same-pan click-to-tune
- cross-pan click-to-tune
- VFO drag
- spectrum wheel / trackpad tuning
- VFO wheel
- keyboard arrows
- FlexControl
- HID encoder
- MIDI relative / absolute fallback
- `Go To Frequency`
- VFO direct frequency entry
- memory recall
- memory spots
- ordinary spots near center and near edge
- zero beat
- split swap
- bandwidth drag
- keyboard zoom `+/-`
- mode-jump cases around memory recall and `USB <-> SAM`

## Reviewer Notes

The two areas worth the closest review are:

1. the intent classification in `MainWindow`, because that is now the main policy boundary
2. the explicit pan/zoom combined-range path, because it protects against the waterfall-loss / zoom-drift class of bugs

The goal of this PR is not to make everything center. The goal is to make each action express the right intent consistently:

- incremental controls follow smoothly
- contextual jumps reveal predictably
- commanded destinations center once
- explicit pan/zoom stays user-driven but center/bandwidth-coherent

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.4 Pro) and tested by @jensenpat
