### PR TITLE
Fix RADE TX no-waveform regression from #1780

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -2685,18 +2685,18 @@ void AudioEngine::setRadeMode(bool on)
 #endif
     }
 
-    // RADE wants the low-latency DAX TX route: float32 stereo packet
-    // format via feedDaxTxAudio's non-radio-route branch, and the radio
-    // set to mic-path routing (dax=0) so its own dax_tx demodulation
-    // pipeline doesn't add latency on top of the RADE codec.  On exit,
-    // restore the default radio-native route (dax=1, int16 mono).
-    //
-    // This replaces the retired "Low-Latency DAX (FreeDV)" menu — RADE
-    // mode is the only consumer of that low-latency route, so the
-    // toggle now lives with the RADE on/off state.
-    setDaxTxUseRadioRoute(!on);
+    // RADE TX: onTxAudioReady() emits txRawPcmReady (float32) then returns
+    // early — the Opus voice TX path never runs. RADEEngine receives the
+    // raw PCM, encodes it to a modem waveform, and emits it via
+    // sendModemTxAudio() → buildVitaTxPacket() → dax_tx VITA-49 stream.
+    // The radio routes that stream to the TX modulator only when dax=1.
+    // activateRADE() sets the slice to DIGU/DIGL, which fires
+    // updateDaxTxMode() → setDax(true) → transmit set dax=1 before PTT.
+    // Do NOT emit daxRouteRequested(0) here — dax=0 tells the radio to
+    // use the physical mic and discard every dax_tx packet, producing no
+    // TX waveform. feedDaxTxAudio/m_daxTxUseRadioRoute are irrelevant:
+    // RADE bypasses feedDaxTxAudio entirely.
     clearTxAccumulators();
-    emit daxRouteRequested(on ? 0 : 1);
 }
 
 void AudioEngine::sendModemTxAudio(const QByteArray& float32pcm)

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -331,11 +331,6 @@ signals:
     void txRawPcmReady(const QByteArray& pcm);  // raw 24kHz stereo int16 PCM for RADEEngine
     void txPacketReady(const QByteArray& vitaPacket);  // VITA-49 TX packet for PanadapterStream
 
-    // Emitted from setRadeMode() so MainWindow can send the matching
-    // `transmit set dax=N` command to the radio.  Value is 0 when RADE
-    // is enabled (radio uses mic-path routing), 1 when disabled
-    // (radio routes our dax_tx VITA-49 stream to the modulator).
-    void daxRouteRequested(int daxValue);
     void pcMicLevelChanged(float peakDbfs, float avgDbfs);  // client-side PC mic metering
 
 private slots:

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -862,15 +862,6 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_audio, &AudioEngine::txPacketReady,
             m_radioModel.panStream(), &PanadapterStream::sendToRadio);
 
-    // RADE mode asks for its preferred DAX TX routing on the radio side.
-    // Emitted from AudioEngine::setRadeMode() so toggling the RADE
-    // button does the whole routing consolidation in one place.
-    connect(m_audio, &AudioEngine::daxRouteRequested, this,
-            [this](int daxValue) {
-        m_radioModel.sendCommand(
-            QString("transmit set dax=%1").arg(daxValue));
-    });
-
     connect(&m_radioModel, &RadioModel::txAudioStreamReady,
             this, [this](quint32 streamId) {
         m_audio->setTxStreamId(streamId);


### PR DESCRIPTION
## Summary

PR #1780 broke RADE TX by sending `transmit set dax=0` on every PTT. With `dax=0` the radio routes the physical mic to the TX modulator and **silently discards every dax_tx VITA-49 packet**, producing no RF waveform despite the RADE engine running and generating audio.

## How RADE TX actually works

Understanding the full TX chain is necessary to see why `dax=0` is wrong.

### Step 1 — Mic capture → RADE engine (local, never sent to radio as voice)

```
QAudioSource (PC mic)
  │
  ▼
AudioEngine::onTxAudioReady()
  │
  ├── if (m_radeMode) {
  │       convert int16 → float32
  │       emit txRawPcmReady(f32)   ← raw PCM to RADE encoder
  │       return;                   ← EARLY RETURN: Opus voice TX never runs
  │   }
  │
  └── [normal voice path — never reached in RADE mode]
```

**Key point:** `onTxAudioReady` returns early when `m_radeMode` is true. The Opus `remote_audio_tx` stream carries **nothing** during RADE TX. The physical mic/Opus path on the radio side is silent.

### Step 2 — RADE encoding (worker thread)

```
txRawPcmReady (float32 PCM)
  │
  ▼ Qt::QueuedConnection
RADEEngine::feedTxAudio()   ← runs on RADEEngine worker thread
  │   (OFDM modem encoding)
  ▼
RADEEngine::txModemReady(QByteArray)  ← encoded modem waveform
```

### Step 3 — modem waveform → radio via dax_tx VITA-49 stream

```
txModemReady
  │
  ▼ Qt::QueuedConnection
AudioEngine::sendModemTxAudio()
  │
  ├── if (m_txStreamId == 0) return;   ← guard: needs active dax_tx stream
  │
  ▼
buildVitaTxPacket()
  PCC = 0x03E3  (PCC_IF_NARROW, float32 stereo big-endian)
  stream ID = m_txStreamId  (from "stream create type=dax_tx" at connection)
  │
  ▼
emit txPacketReady(pkt)
  │
  ▼
PanadapterStream::sendToRadio() → UDP → radio dax_tx stream
```

**Key point:** RADE modem audio goes entirely through the `dax_tx` VITA-49 stream (PCC 0x03E3), using `sendModemTxAudio()`. It never touches `feedDaxTxAudio()` or `m_daxTxUseRadioRoute`.

### Step 4 — radio routes dax_tx to TX modulator (requires dax=1)

The `dax_tx` stream is only routed to the TX modulator when `transmit set dax=1` is active. With `dax=0` the radio routes the physical mic / `remote_audio_tx` Opus stream to the modulator and ignores every `dax_tx` packet.

Before PTT, `activateRADE()` sets the slice mode to DIGU/DIGL → `updateDaxTxMode()` fires → `TransmitModel::setDax(true)` → `transmit set dax=1`. This is correct and sufficient.

## What #1780 added (incorrectly)

```cpp
// In setRadeMode(bool on):
setDaxTxUseRadioRoute(!on);     // ← only affects feedDaxTxAudio, which RADE never calls
clearTxAccumulators();
emit daxRouteRequested(on ? 0 : 1);  // ← on PTT: dax=0 → radio ignores dax_tx packets → no TX
```

The PTT handler (`moxChanged`) calls `m_audio->setRadeMode(tx)`. So every time the user keys up in RADE mode, `setRadeMode(true)` fires → `daxRouteRequested(0)` → `transmit set dax=0` is sent — overriding the correct `dax=1` that `updateDaxTxMode` set when the slice entered DIGU/DIGL. The radio then transmits silence (physical mic) instead of the RADE modem waveform.

The commit message stated RADE "needs the radio to drop its dax_tx ingestion so RADE can take the mic-path for SSB modulation." This model is wrong on two counts:

1. RADE does **not** use the mic path — `onTxAudioReady()` returns early, the Opus path carries nothing
2. RADE **does** use the dax_tx VITA-49 stream via `sendModemTxAudio()` — which requires `dax=1`

The "feedDaxTxAudio non-radio-route branch" mentioned in the code comment is the **old** Low-Latency DAX (FreeDV) virtual-cable path. The new RADEEngine bypasses `feedDaxTxAudio` entirely.

## Observable symptom

Log excerpt from a reported case:
```
[20:05:46.634] transmit set dax=0    ← setRadeMode(true) on moxChanged
               xmit 1                ← radio enters TX, using physical mic → no waveform
[20:05:49.084] transmit set dax=1    ← setRadeMode(false) on moxChanged
               xmit 0                ← radio exits TX
```

## Fix

Remove the two incorrect additions from `setRadeMode()`:

- `setDaxTxUseRadioRoute(!on)` — `feedDaxTxAudio`/`m_daxTxUseRadioRoute` are unrelated to RADE TX
- `emit daxRouteRequested(on ? 0 : 1)` — the `dax=0` override on PTT is the direct cause of no TX waveform

The `daxRouteRequested` signal is now dead (never emitted) so also remove its declaration from `AudioEngine.h` and its `connect()` from `MainWindow`.

`updateDaxTxMode()` remains the single source of truth for `dax=` state, driven by slice mode (DIGU/DIGL → `dax=1`; USB/LSB/CW/AM/FM → `dax=0`). RADE sets the slice to DIGU/DIGL at activation, so the correct `dax=1` is always in place before PTT.

## Test plan

- [ ] Enable RADE mode, key up — modem waveform visible in waterfall/spectrum
- [ ] Check log: `dax=1` (from `updateDaxTxMode` on DIGU/DIGL mode set) appears before `xmit 1`, no subsequent `dax=0`
- [ ] Deactivate RADE, switch slice back to USB, key up — normal SSB TX works; `dax=0` sent on mode change
- [ ] TCI WSJT-X FT8 TX — `startTxChrono` still sends `dax=1`; no regression from removing `daxRouteRequested`
- [ ] PipeWire DAX digital mode TX (non-RADE) — `dax=1` from `updateDaxTxMode` on DIGU/DIGL; unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)